### PR TITLE
fix: auto-install JS parser npm deps on first run

### DIFF
--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -174,8 +174,9 @@ func CheckOpenantInstalled(pythonPath string) error {
 }
 
 // EnsureRuntime is a convenience that detects a runtime, ensures openant
-// is installed (creating a venv if necessary), and returns the final
-// RuntimeInfo pointing to the correct Python binary.
+// is installed (creating a venv if necessary), installs JS parser npm
+// dependencies if needed, and returns the final RuntimeInfo pointing to
+// the correct Python binary.
 func EnsureRuntime() (*RuntimeInfo, error) {
 	rt, err := DetectRuntime()
 	if err != nil {
@@ -184,6 +185,12 @@ func EnsureRuntime() (*RuntimeInfo, error) {
 
 	if err := CheckOpenantInstalled(rt.Path); err != nil {
 		return nil, err
+	}
+
+	// Ensure JS parser npm dependencies are installed.
+	if err := ensureNodeDeps(); err != nil {
+		// Non-fatal: only affects JavaScript/TypeScript scanning.
+		fmt.Fprintf(os.Stderr, "Warning: JS parser deps not installed: %v\n", err)
 	}
 
 	// After CheckOpenantInstalled, the venv may have been created.
@@ -196,6 +203,48 @@ func EnsureRuntime() (*RuntimeInfo, error) {
 	}
 
 	return rt, nil
+}
+
+// ensureNodeDeps checks whether the JavaScript parser's npm dependencies
+// are installed and runs `npm install` if they are not.
+//
+// The JS parser (parsers/javascript/) requires ts-morph and other npm
+// packages listed in its package.json. Unlike Python dependencies which
+// are installed via pip during venv setup, these npm packages must be
+// installed separately.
+func ensureNodeDeps() error {
+	corePath, err := findOpenantCore()
+	if err != nil {
+		return nil // Can't locate core — skip silently, will fail later if JS is used.
+	}
+
+	parserDir := filepath.Join(corePath, "parsers", "javascript")
+	packageJSON := filepath.Join(parserDir, "package.json")
+	if !fileExists(packageJSON) {
+		return nil // No JS parser — nothing to install.
+	}
+
+	// Fast path: check if node_modules already exists with key dependency.
+	marker := filepath.Join(parserDir, "node_modules", "ts-morph")
+	if info, err := os.Stat(marker); err == nil && info.IsDir() {
+		return nil // Already installed.
+	}
+
+	// Check that npm is available.
+	npmPath, err := exec.LookPath("npm")
+	if err != nil {
+		return fmt.Errorf("npm not found on PATH (required for JavaScript/TypeScript scanning)")
+	}
+
+	fmt.Fprintln(os.Stderr, "Installing JS parser dependencies...")
+	cmd := exec.Command(npmPath, "install", "--prefix", parserDir)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("npm install failed in %s: %w", parserDir, err)
+	}
+
+	return nil
 }
 
 // createVenv creates a new venv at ~/.openant/venv/ using the given Python.


### PR DESCRIPTION
## Summary

Fixes #6 — the JavaScript/TypeScript parser fails on fresh installs because `npm install` is never run for `parsers/javascript/`.

- Adds `ensureNodeDeps()` to `EnsureRuntime()` in the Go CLI, mirroring the existing Python auto-install pattern
- Uses `node_modules/ts-morph` as a fast-path existence check (zero overhead on subsequent runs)
- Non-fatal: prints a warning if npm is unavailable, so Python/Go/C workflows are unaffected

## Context

Found while running OpenAnt against a TypeScript codebase. The `typescript_analyzer.js` requires `ts-morph` (declared in `parsers/javascript/package.json`), but unlike the Python deps which are auto-installed via `pip install -e` during venv setup, the npm deps had no equivalent bootstrap step.

## Test plan

- [x] `go build` and `go vet` pass
- [x] Fresh run (deleted `node_modules/`): prints "Installing JS parser dependencies..." and succeeds
- [x] Second run: skips install silently (fast path)
- [x] Verified on a 57-file TypeScript project — full parse pipeline completes