### PR TITLE
release: Python parser dedent fix

### DIFF
--- a/.publish-exclude
+++ b/.publish-exclude
@@ -1,0 +1,14 @@
+# Patterns of tracked file paths that must NOT exist on a public release branch.
+# Format: extended regex (ERE) per line, matched against `git ls-files` output.
+# Lines starting with # and blank lines are ignored.
+# Used by scripts/check-public-release.sh.
+
+# Internal docs subtree (sessions, runbooks, postmortems, triage, etc.)
+^docs/internal/
+
+# Working-state files anywhere in the tree
+\.wip\.md$
+\.todo\.md$
+
+# Internal session log at repo root
+^last-opencode-sess\.md$

--- a/.publish-forbidden-strings
+++ b/.publish-forbidden-strings
@@ -1,0 +1,13 @@
+# Case-insensitive fixed-string substrings that must NOT appear in tracked
+# file content on a public release branch. One pattern per line.
+# Lines starting with # and blank lines are ignored.
+# Used by scripts/check-public-release.sh.
+
+# Internal product name — must not leak into public source/docs
+sastinel
+
+# Jira ticket prefix — internal-only references
+KIR-
+
+# Dead-link references to internal-only docs
+docs/internal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to OpenAnt are documented in this file.
 
-## [Unreleased]
+## [2026-04-29] — Python parser dedent fix
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,19 @@
 
 # OpenAnt
 
-[OpenAnt](https://knostic.ai/openant) from [Knostic](https://knostic.ai) is the leading open source LLM-based vulnerability discovery product, helping defenders proactively find verified security flaws while minimizing both false positives and false negatives. Stage 1 detects. Stage 2 attacks. What survives is real.
+[OpenAnt](https://knostic.ai/openant) from [Knostic](https://knostic.ai) is an open source LLM-based vulnerability discovery product that helps defenders proactively find verified security flaws while minimizing both false positives and false negatives. Stage 1 detects. Stage 2 attacks. What survives is real.
 
 We're pretty proud of this product and are in the vulnerability disclosure process for its findings, but do keep in mind that this started as a research project, and some of its features are still in beta. We welcome contributions to make it better.
 
 ## Why open source?
+
 Considering the explosion of AI-discovered vulnerabilities, we hope OpenAnt will be the tool helping open source maintainers stay ahead of attackers, where they can use it themselves or submit their repo for scanning at no cost.
 
-While we do provide OpenAnt as a service, you may have heard about Aardvark from OpenAI (now Codex Security) and Claude Code Security from Anthropic, and we have zero intention of competing with them.
+Then, since Knostic's focus is on protecting agents and coding assistants and not vulnerability research or application security, and we like open source, we decided to release OpenAnt under the Apache 2 license.
+Besides, you may have heard about Aardvark from OpenAI (now Codex Security) and Claude Code Security from Anthropic, and we have zero intention of competing with them.
 
 ## Technical details and free scanning for open source projects
+
 For technical details, limitations, and token costs, check out this blog post:
 [https://knostic.ai/blog/openant](https://knostic.ai/blog/openant)
 
@@ -21,6 +24,7 @@ To submit your repo for scanning:
 [https://knostic.ai/blog/oss-scan](https://knostic.ai/blog/oss-scan)
 
 ## Supported languages
+
 - Go
 - Python
 - JavaScript/TypeScript (beta)
@@ -29,15 +33,16 @@ To submit your repo for scanning:
 - Ruby (beta)
 
 ## Credits
+
 Research and ideation: [Nahum Korda](https://github.com/NahumKorda/).
 
-Productization: Alex Raihelgaus, Daniel Geyshis.
+Productization: [Alex Raihelgaus](https://github.com/ar7casper/), [Daniel Geyshis](https://github.com/dgeyshis).
 
 With thanks to: [Michal Kamensky](https://github.com/kamenskymic/), [Imri Goldberg](https://github.com/lorg), [Gadi Evron](https://github.com/gadievron/), Daniel Cuthbert. Josh Grossman, and Avi Douglen.
 
 ## Check out Knostic
-**If you like our work**, check out what we do at [Knostic](https://knostic.ai) to defend your agents and coding assistants, prevent them from deleting your hard drive and code, and control associated supply chain risks such as MCP servers, extensions, and skills.
 
+**If you like our work**, check out what we do at [Knostic](https://knostic.ai) to defend your agents and coding assistants, prevent them from deleting your hard drive and code, and control associated supply chain risks such as MCP servers, extensions, and skills.
 
 ## Local setup
 
@@ -133,12 +138,12 @@ openant project show              # details of active project
 openant project switch <org/repo> # switch active project
 ```
 
-
 ## LICENSE
+
 This project is licensed under Apache 2. See the LICENSE file for details.
 
-
 ## Disclaimer and legal notice
+
 This project is intended for defensive and research purposes only. OpenAnt is still in the research phase, use it carefully and at your own risk. Knostic, OpenAnt, and associated developers, researchers, and maintainers assume no responsibility whatsoever for any misuse, damage, or consequences arising from the use of this tool.
 
 Only scan code you own or have explicit permission to test. If you discover a vulnerability in someone else's project through legitimate means, please follow coordinated vulnerability disclosure practices and report it to the maintainers before making it public.

--- a/apps/openant-cli/cmd/diff.go
+++ b/apps/openant-cli/cmd/diff.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"os"
+
+	"github.com/knostic/open-ant-cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var diffCmd = &cobra.Command{
+	Use:   "diff [repository-path]",
+	Short: "Scan only the code changed vs a base ref or GitHub PR",
+	Long: `Diff runs the full scan pipeline but filters to units whose bodies
+overlap a git diff hunk. One of --diff-base or --pr is required.
+
+Examples:
+  openant diff --diff-base origin/main
+  openant diff --pr 123
+  openant diff --diff-base HEAD~5 --diff-scope callers --verify
+
+All scan flags (--level, --workers, --verify, etc.) work the same here.`,
+	Args: cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		if scanDiffBase == "" && scanPR == 0 {
+			output.PrintError("openant diff requires --diff-base <ref> or --pr <N>")
+			os.Exit(2)
+		}
+		runScan(cmd, args)
+	},
+}
+
+func init() {
+	registerScanFlags(diffCmd)
+}

--- a/apps/openant-cli/cmd/diff_shared.go
+++ b/apps/openant-cli/cmd/diff_shared.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/knostic/open-ant-cli/internal/git"
+	"github.com/knostic/open-ant-cli/internal/output"
+)
+
+// diffOpts collects the three diff-mode flags that scan/parse/diff all share.
+type diffOpts struct {
+	base   string
+	pr     int
+	scope  string
+}
+
+// isSet reports whether any diff flag was provided.
+func (o diffOpts) isSet() bool {
+	return o.base != "" || o.pr > 0
+}
+
+// validate enforces flag rules common to all entry points.
+func (o diffOpts) validate() error {
+	if o.base != "" && o.pr > 0 {
+		return fmt.Errorf("--diff-base and --pr are mutually exclusive")
+	}
+	if o.isSet() {
+		if o.scope == "" {
+			return fmt.Errorf("--diff-scope must not be empty in diff mode")
+		}
+		if !git.IsValidScope(o.scope) {
+			return fmt.Errorf("invalid --diff-scope %q (expected changed_files|changed_functions|callers)", o.scope)
+		}
+	}
+	return nil
+}
+
+// prepareDiffManifest resolves the base ref (via --pr or --diff-base),
+// builds the manifest, and writes it under outputDir. Returns the manifest
+// path, or "" if not in diff mode.
+//
+// outputDir must already exist (the caller should mkdir it). repoPath is
+// the absolute path to the working copy the diff is computed against.
+//
+// For --pr, the working tree is mutated (checkout of pr-head). Callers that
+// care about HEAD stability must be aware.
+func prepareDiffManifest(repoPath, outputDir string, opts diffOpts) (string, error) {
+	if !opts.isSet() {
+		return "", nil
+	}
+	if err := opts.validate(); err != nil {
+		return "", err
+	}
+	if outputDir == "" {
+		return "", fmt.Errorf("diff mode requires an output directory (use --output or `openant init` to set up a project)")
+	}
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return "", fmt.Errorf("create output dir %s: %w", outputDir, err)
+	}
+
+	baseRef := opts.base
+	if opts.pr > 0 {
+		fetched, err := git.FetchPR(repoPath, opts.pr, nil)
+		if err != nil {
+			return "", err
+		}
+		baseRef = fetched
+		if !quiet {
+			fmt.Fprintf(os.Stderr, "PR #%d: base=%s (fetched and checked out pr-head)\n", opts.pr, baseRef)
+		}
+	}
+
+	m, err := git.BuildManifest(repoPath, baseRef, opts.scope, opts.pr)
+	if err != nil {
+		return "", fmt.Errorf("build diff manifest: %w", err)
+	}
+
+	manifestPath := filepath.Join(outputDir, "diff_manifest.json")
+	if err := git.WriteManifest(manifestPath, m); err != nil {
+		return "", err
+	}
+
+	if !quiet {
+		output.PrintKeyValue("Diff base", fmt.Sprintf("%s (%s)", m.BaseRef, shortSHA(m.BaseSHA)))
+		output.PrintKeyValue("Diff head", shortSHA(m.HeadSHA))
+		output.PrintKeyValue("Diff scope", m.Scope)
+		output.PrintKeyValue("Changed files", fmt.Sprintf("%d", len(m.ChangedFiles)))
+	}
+
+	return manifestPath, nil
+}
+
+func shortSHA(sha string) string {
+	if len(sha) >= 7 {
+		return sha[:7]
+	}
+	return sha
+}

--- a/apps/openant-cli/cmd/docker.go
+++ b/apps/openant-cli/cmd/docker.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"time"
+)
+
+// errDockerUnavailable is returned by checkDockerAvailable when neither
+// the binary nor a running daemon is reachable. Phrased so the error
+// message guides the user to --skip-dynamic-test.
+var errDockerUnavailable = errors.New(
+	"dynamic testing requires Docker, which is not available.\n" +
+		"If you can't or don't want to run Docker, use --skip-dynamic-test")
+
+// checkDockerAvailable confirms that the docker CLI is on PATH and the
+// daemon responds to `docker info`. Used at scan startup before the
+// pipeline runs, so users with no Docker get an immediate, actionable
+// error rather than burning the whole scan only to fail at the
+// dynamic-test step.
+//
+// The daemon probe is bounded to a few seconds — a hung daemon should
+// surface as "unavailable" rather than block forever.
+func checkDockerAvailable() error {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return errDockerUnavailable
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "docker", "info", "--format", "{{.ServerVersion}}")
+	if err := cmd.Run(); err != nil {
+		return errDockerUnavailable
+	}
+	return nil
+}

--- a/apps/openant-cli/cmd/init.go
+++ b/apps/openant-cli/cmd/init.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/knostic/open-ant-cli/internal/config"
+	"github.com/knostic/open-ant-cli/internal/git"
 	"github.com/knostic/open-ant-cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -32,15 +33,25 @@ Examples:
 }
 
 var (
-	initLanguage string
-	initCommit   string
-	initName     string
+	initLanguage    string
+	initCommit      string
+	initName        string
+	initFull        bool
+	initIncremental bool
+	initDiffBase    string
+	initPR          int
+	initDiffScope   string
 )
 
 func init() {
 	initCmd.Flags().StringVarP(&initLanguage, "language", "l", "", "Language to analyze: python, javascript, go, c, ruby, php (required)")
 	initCmd.Flags().StringVar(&initCommit, "commit", "", "Specific commit SHA (default: HEAD)")
 	initCmd.Flags().StringVar(&initName, "name", "", "Override project name (default: derived from URL/path)")
+	initCmd.Flags().BoolVar(&initFull, "full", false, "Force full scan (rejects --incremental/--diff-base/--pr)")
+	initCmd.Flags().BoolVar(&initIncremental, "incremental", false, "Incremental against the last successful scan on this project")
+	initCmd.Flags().StringVar(&initDiffBase, "diff-base", "", "Incremental against this ref (e.g. origin/main, HEAD~5)")
+	initCmd.Flags().IntVar(&initPR, "pr", 0, "Incremental against a GitHub PR number (requires gh; mutex with --diff-base)")
+	initCmd.Flags().StringVar(&initDiffScope, "diff-scope", "", "Diff scope: changed_files, changed_functions, callers (default changed_functions)")
 	_ = initCmd.MarkFlagRequired("language")
 }
 
@@ -159,6 +170,35 @@ func runInit(cmd *cobra.Command, args []string) {
 	if err := os.MkdirAll(scanDir, 0755); err != nil {
 		output.PrintError(fmt.Sprintf("Failed to create scan directory: %s", err))
 		os.Exit(1)
+	}
+
+	// Decide full vs incremental. selectMode handles flag validation,
+	// baseline lookup, TTY prompt, and non-TTY error.
+	decision, err := selectMode(modeOpts{
+		full:        initFull,
+		incremental: initIncremental,
+		diffBase:    initDiffBase,
+		pr:          initPR,
+		scope:       initDiffScope,
+		projectName: name,
+		repoPath:    repoPath,
+	})
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+
+	// Write scan-run meta.json reflecting the decision.
+	meta := config.NewScanMeta(
+		decision.Kind,
+		project.CommitSHA,
+		git.CurrentBranch(repoPath),
+		initLanguage,
+	)
+	meta.Base = decision.Base
+	meta.Scope = decision.Scope
+	if err := config.SaveScanMeta(name, project.CommitSHAShort, meta); err != nil {
+		output.PrintWarning(fmt.Sprintf("Failed to write scan meta: %s", err))
 	}
 
 	// Set as active project

--- a/apps/openant-cli/cmd/mode.go
+++ b/apps/openant-cli/cmd/mode.go
@@ -1,0 +1,231 @@
+package cmd
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/knostic/open-ant-cli/internal/config"
+	"github.com/knostic/open-ant-cli/internal/git"
+	isatty "github.com/mattn/go-isatty"
+)
+
+// modeOpts collects the inputs to selectMode. Flag values come from the
+// caller's cobra command; projectName / repoPath come from the resolved
+// project context.
+type modeOpts struct {
+	full        bool
+	incremental bool
+	diffBase    string
+	pr          int
+	scope       string
+	projectName string
+	repoPath    string
+}
+
+// modeDecision is the resolved mode for a scan-run. Fields beyond Kind
+// are only set when Kind == ScanKindDiff.
+type modeDecision struct {
+	Kind  string
+	Base  string // ref used for diff (may be a SHA or named ref)
+	Scope string
+}
+
+// errBaselineNonInteractive is returned when init/scan is invoked without
+// any mode flag, has a baseline to fall back on, and stdin is not a TTY
+// so we cannot prompt.
+var errBaselineNonInteractive = errors.New(
+	"this project has a previous scan; specify one of --full, --incremental, --diff-base <ref>, or --pr <n>")
+
+// selectMode is the single source of truth for "full vs incremental?".
+// Used by `openant init` today; will be reused by `openant scan` once the
+// chain refactor lands.
+//
+// Decision precedence:
+//  1. Validate flag combinations.
+//  2. --full → full
+//  3. --pr → diff against PR base (mutates working tree)
+//  4. --diff-base → diff against ref
+//  5. --incremental → diff against last successful scan (errors if none)
+//  6. No flag, no baseline → full (silent)
+//  7. No flag, baseline + TTY → prompt (Enter = full)
+//  8. No flag, baseline + non-TTY → error
+func selectMode(o modeOpts) (modeDecision, error) {
+	if err := validateModeFlags(o); err != nil {
+		return modeDecision{}, err
+	}
+
+	if o.full {
+		return modeDecision{Kind: config.ScanKindFull}, nil
+	}
+
+	scope := o.scope
+	if scope == "" {
+		scope = git.ScopeChangedFunctions
+	}
+
+	if o.pr > 0 {
+		baseRef, err := git.FetchPR(o.repoPath, o.pr, nil)
+		if err != nil {
+			return modeDecision{}, err
+		}
+		return modeDecision{Kind: config.ScanKindDiff, Base: baseRef, Scope: scope}, nil
+	}
+
+	if o.diffBase != "" {
+		return modeDecision{Kind: config.ScanKindDiff, Base: o.diffBase, Scope: scope}, nil
+	}
+
+	if o.incremental {
+		baseline, _, err := config.LatestScanMeta(o.projectName)
+		if err != nil {
+			return modeDecision{}, fmt.Errorf("--incremental: %w", err)
+		}
+		if baseline == nil {
+			return modeDecision{}, errors.New(
+				"--incremental: no successful prior scan found for this project; run a full scan first")
+		}
+		return modeDecision{Kind: config.ScanKindDiff, Base: baseline.Commit, Scope: scope}, nil
+	}
+
+	// No flags. Look for a baseline.
+	baseline, _, err := config.LatestScanMeta(o.projectName)
+	if err != nil {
+		return modeDecision{}, err
+	}
+	if baseline == nil {
+		// First scan on this project — full, silent.
+		return modeDecision{Kind: config.ScanKindFull}, nil
+	}
+
+	// Baseline exists. Prompt or error.
+	if !isStdinTTY() {
+		return modeDecision{}, errBaselineNonInteractive
+	}
+	return promptMode(baseline, scope, os.Stdin, os.Stderr)
+}
+
+// validateModeFlags checks for conflicting flag combinations. Pure
+// (no I/O), unit-tested.
+func validateModeFlags(o modeOpts) error {
+	diffFlagCount := 0
+	if o.diffBase != "" {
+		diffFlagCount++
+	}
+	if o.pr > 0 {
+		diffFlagCount++
+	}
+	if o.incremental {
+		diffFlagCount++
+	}
+	if o.full && diffFlagCount > 0 {
+		return errors.New("--full cannot be combined with --incremental, --diff-base, or --pr")
+	}
+	if diffFlagCount > 1 {
+		return errors.New("--incremental, --diff-base, and --pr are mutually exclusive")
+	}
+	if o.scope != "" && !git.IsValidScope(o.scope) {
+		return fmt.Errorf(
+			"invalid --diff-scope %q (expected changed_files|changed_functions|callers)", o.scope)
+	}
+	return nil
+}
+
+// isStdinTTY reports whether stdin is connected to a terminal.
+// Uses go-isatty (already a dep via cmd/report.go) — a naive
+// os.ModeCharDevice check would falsely treat /dev/null as a TTY,
+// since /dev/null is also a character device.
+func isStdinTTY() bool {
+	return isatty.IsTerminal(os.Stdin.Fd())
+}
+
+// promptMode prints a recap of the prior scan and reads the user's choice.
+// Default on bare Enter: full (the safer choice — accidental Enter gives
+// the more thorough scan, not the cheaper one).
+func promptMode(prev *config.ScanMeta, scope string, in io.Reader, out io.Writer) (modeDecision, error) {
+	short := config.ShortSHA(prev.Commit)
+	when := humanizeTimestamp(prev.StartedAt)
+	fmt.Fprintf(out, "Found previous scan: %s at %s on %s.\n", prev.Kind, short, when)
+	fmt.Fprintf(out, "Run [f]ull scan or [i]ncremental from %s? [F/i]: ", short)
+
+	reader := bufio.NewReader(in)
+	line, err := reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return modeDecision{}, fmt.Errorf("read prompt: %w", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	switch answer {
+	case "", "f", "full":
+		return modeDecision{Kind: config.ScanKindFull}, nil
+	case "i", "incremental":
+		return modeDecision{Kind: config.ScanKindDiff, Base: prev.Commit, Scope: scope}, nil
+	default:
+		return modeDecision{}, fmt.Errorf("invalid answer %q (expected f or i)", answer)
+	}
+}
+
+// resolveStepDiffOpts produces the diff opts for a standalone step verb
+// (parse, etc.). Step verbs are silent power-user surfaces: explicit
+// flags win, otherwise honor the project's meta.json (so a prior
+// `openant init --incremental` flows through), otherwise no incremental.
+// Never prompts.
+//
+// Empty defaultScope is treated as "changed_functions" (matching the flag
+// default on each verb).
+func resolveStepDiffOpts(ctx *projectContext, flagBase string, flagPR int, flagScope string) (diffOpts, error) {
+	scope := flagScope
+	if scope == "" {
+		scope = git.ScopeChangedFunctions
+	}
+
+	// Explicit flags win.
+	if flagBase != "" || flagPR > 0 {
+		opts := diffOpts{base: flagBase, pr: flagPR, scope: scope}
+		if err := opts.validate(); err != nil {
+			return diffOpts{}, err
+		}
+		return opts, nil
+	}
+
+	// No explicit flags — fall back to meta.json from init.
+	if ctx == nil || ctx.Project == nil {
+		return diffOpts{}, nil
+	}
+	meta, err := config.LoadScanMeta(ctx.Project.Name, ctx.Project.CommitSHAShort)
+	if err != nil {
+		// No meta (legacy / not yet inited under new scheme) — silent full.
+		return diffOpts{}, nil
+	}
+	if meta.Kind != config.ScanKindDiff {
+		return diffOpts{}, nil
+	}
+	return diffOpts{base: meta.Base, scope: meta.Scope}, nil
+}
+
+// humanizeTimestamp formats a stored RFC3339 timestamp into something
+// human-friendly for the prompt recap. Returns the input unchanged when
+// parsing fails.
+func humanizeTimestamp(rfc3339 string) string {
+	t, err := time.Parse(time.RFC3339, rfc3339)
+	if err != nil {
+		return rfc3339
+	}
+	delta := time.Since(t)
+	switch {
+	case delta < 2*time.Minute:
+		return "just now"
+	case delta < time.Hour:
+		mins := int(delta.Minutes())
+		return fmt.Sprintf("%s (%d min ago)", t.Format("2006-01-02"), mins)
+	case delta < 24*time.Hour:
+		hours := int(delta.Hours())
+		return fmt.Sprintf("%s (%d h ago)", t.Format("2006-01-02"), hours)
+	default:
+		days := int(delta.Hours() / 24)
+		return fmt.Sprintf("%s (%d days ago)", t.Format("2006-01-02"), days)
+	}
+}

--- a/apps/openant-cli/cmd/mode_test.go
+++ b/apps/openant-cli/cmd/mode_test.go
@@ -1,0 +1,283 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/knostic/open-ant-cli/internal/config"
+)
+
+func TestValidateModeFlags(t *testing.T) {
+	cases := []struct {
+		name    string
+		opts    modeOpts
+		wantErr string
+	}{
+		{name: "all empty", opts: modeOpts{}, wantErr: ""},
+		{name: "full alone", opts: modeOpts{full: true}, wantErr: ""},
+		{name: "incremental alone", opts: modeOpts{incremental: true}, wantErr: ""},
+		{name: "diffBase alone", opts: modeOpts{diffBase: "origin/main"}, wantErr: ""},
+		{name: "pr alone", opts: modeOpts{pr: 42}, wantErr: ""},
+
+		{name: "full + incremental", opts: modeOpts{full: true, incremental: true}, wantErr: "cannot be combined"},
+		{name: "full + diffBase", opts: modeOpts{full: true, diffBase: "x"}, wantErr: "cannot be combined"},
+		{name: "full + pr", opts: modeOpts{full: true, pr: 1}, wantErr: "cannot be combined"},
+
+		{name: "diffBase + pr", opts: modeOpts{diffBase: "x", pr: 1}, wantErr: "mutually exclusive"},
+		{name: "incremental + diffBase", opts: modeOpts{incremental: true, diffBase: "x"}, wantErr: "mutually exclusive"},
+		{name: "incremental + pr", opts: modeOpts{incremental: true, pr: 1}, wantErr: "mutually exclusive"},
+
+		{name: "invalid scope", opts: modeOpts{scope: "everything"}, wantErr: "invalid --diff-scope"},
+		{name: "valid scope", opts: modeOpts{scope: "callers"}, wantErr: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateModeFlags(tc.opts)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("expected error containing %q, got %q", tc.wantErr, err.Error())
+			}
+		})
+	}
+}
+
+func TestSelectModeExplicitFull(t *testing.T) {
+	withTempHome(t)
+	got, err := selectMode(modeOpts{full: true, projectName: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != config.ScanKindFull {
+		t.Errorf("expected full, got %+v", got)
+	}
+}
+
+func TestSelectModeExplicitDiffBase(t *testing.T) {
+	withTempHome(t)
+	got, err := selectMode(modeOpts{diffBase: "origin/main", projectName: "p"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != config.ScanKindDiff || got.Base != "origin/main" {
+		t.Errorf("unexpected decision: %+v", got)
+	}
+	if got.Scope == "" {
+		t.Error("expected default scope to be applied")
+	}
+}
+
+func TestSelectModeIncrementalUsesLatestSuccess(t *testing.T) {
+	withTempHome(t)
+	prev := &config.ScanMeta{
+		Kind:      config.ScanKindFull,
+		Commit:    "fullsha",
+		StartedAt: time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339),
+		Status:    config.ScanStatusSuccess,
+		Language:  "python",
+	}
+	if err := config.SaveScanMeta("p", "fullshrt", prev); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := selectMode(modeOpts{incremental: true, projectName: "p"})
+	if err != nil {
+		t.Fatalf("selectMode: %v", err)
+	}
+	if got.Kind != config.ScanKindDiff {
+		t.Errorf("expected diff, got %s", got.Kind)
+	}
+	if got.Base != "fullsha" {
+		t.Errorf("expected base=fullsha, got %s", got.Base)
+	}
+}
+
+func TestSelectModeIncrementalErrorsWithoutBaseline(t *testing.T) {
+	withTempHome(t)
+	_, err := selectMode(modeOpts{incremental: true, projectName: "fresh"})
+	if err == nil {
+		t.Fatal("expected error when --incremental and no baseline")
+	}
+	if !strings.Contains(err.Error(), "no successful prior scan") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestSelectModeNoFlagsNoBaselineGoesFull(t *testing.T) {
+	withTempHome(t)
+	got, err := selectMode(modeOpts{projectName: "fresh"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != config.ScanKindFull {
+		t.Errorf("first scan with no baseline should be full, got %s", got.Kind)
+	}
+}
+
+// Reuse helper from scan_meta_test.go's withTempHome. The cmd package
+// can't import _test.go files from another package, so we redeclare a
+// minimal copy here.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	return dir
+}
+
+func TestPromptModeDefaultEnterIsFull(t *testing.T) {
+	prev := &config.ScanMeta{
+		Kind:      config.ScanKindFull,
+		Commit:    "abc1234567890",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+		Status:    config.ScanStatusSuccess,
+	}
+	in := bytes.NewBufferString("\n") // user just hits Enter
+	out := &bytes.Buffer{}
+	got, err := promptMode(prev, "changed_functions", in, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != config.ScanKindFull {
+		t.Errorf("expected full on Enter, got %s", got.Kind)
+	}
+	if !strings.Contains(out.String(), "Found previous scan") {
+		t.Errorf("expected recap in prompt output, got: %q", out.String())
+	}
+}
+
+func TestPromptModeIncrementalAnswer(t *testing.T) {
+	prev := &config.ScanMeta{
+		Kind:      config.ScanKindFull,
+		Commit:    "abc1234567890",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+		Status:    config.ScanStatusSuccess,
+	}
+	in := bytes.NewBufferString("i\n")
+	out := &bytes.Buffer{}
+	got, err := promptMode(prev, "changed_functions", in, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Kind != config.ScanKindDiff {
+		t.Errorf("expected diff, got %s", got.Kind)
+	}
+	if got.Base != "abc1234567890" {
+		t.Errorf("expected base from prev commit, got %s", got.Base)
+	}
+}
+
+func TestResolveStepDiffOptsExplicitFlagsWin(t *testing.T) {
+	withTempHome(t)
+	// Create a meta.json kind=diff with one base, then pass an explicit
+	// --diff-base override; the override must win.
+	prev := &config.ScanMeta{
+		Kind:      config.ScanKindDiff,
+		Commit:    "current",
+		Base:      "from-meta",
+		Scope:     "callers",
+		StartedAt: "2026-04-28T00:00:00Z",
+		Status:    config.ScanStatusRunning,
+		Language:  "python",
+	}
+	if err := config.SaveScanMeta("p", "currshort", prev); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &projectContext{Project: &config.Project{Name: "p", CommitSHAShort: "currshort"}}
+
+	got, err := resolveStepDiffOpts(ctx, "explicit-base", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.base != "explicit-base" {
+		t.Errorf("explicit flag should win, got base=%s", got.base)
+	}
+}
+
+func TestResolveStepDiffOptsFallsBackToMeta(t *testing.T) {
+	withTempHome(t)
+	prev := &config.ScanMeta{
+		Kind:      config.ScanKindDiff,
+		Commit:    "current",
+		Base:      "from-meta",
+		Scope:     "callers",
+		StartedAt: "2026-04-28T00:00:00Z",
+		Status:    config.ScanStatusRunning,
+		Language:  "python",
+	}
+	if err := config.SaveScanMeta("p", "currshort", prev); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &projectContext{Project: &config.Project{Name: "p", CommitSHAShort: "currshort"}}
+
+	got, err := resolveStepDiffOpts(ctx, "", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.base != "from-meta" {
+		t.Errorf("expected base from meta, got %s", got.base)
+	}
+	if got.scope != "callers" {
+		t.Errorf("expected scope from meta, got %s", got.scope)
+	}
+}
+
+func TestResolveStepDiffOptsFullMetaIsSilentFull(t *testing.T) {
+	withTempHome(t)
+	prev := &config.ScanMeta{
+		Kind:      config.ScanKindFull,
+		Commit:    "current",
+		StartedAt: "2026-04-28T00:00:00Z",
+		Status:    config.ScanStatusSuccess,
+		Language:  "python",
+	}
+	if err := config.SaveScanMeta("p", "currshort", prev); err != nil {
+		t.Fatal(err)
+	}
+	ctx := &projectContext{Project: &config.Project{Name: "p", CommitSHAShort: "currshort"}}
+
+	got, err := resolveStepDiffOpts(ctx, "", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.base != "" || got.pr != 0 {
+		t.Errorf("kind=full meta should produce empty diffOpts, got %+v", got)
+	}
+}
+
+func TestResolveStepDiffOptsNoMetaIsSilentFull(t *testing.T) {
+	withTempHome(t)
+	ctx := &projectContext{Project: &config.Project{Name: "no-meta-here", CommitSHAShort: "deadbeef"}}
+	got, err := resolveStepDiffOpts(ctx, "", 0, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.base != "" {
+		t.Errorf("missing meta should produce empty diffOpts, got %+v", got)
+	}
+}
+
+func TestPromptModeRejectsBadAnswer(t *testing.T) {
+	prev := &config.ScanMeta{
+		Kind:      config.ScanKindFull,
+		Commit:    "abc1234567890",
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	in := bytes.NewBufferString("maybe\n")
+	out := &bytes.Buffer{}
+	_, err := promptMode(prev, "changed_functions", in, out)
+	if err == nil {
+		t.Fatal("expected error for bogus answer")
+	}
+	if !strings.Contains(err.Error(), "invalid answer") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/apps/openant-cli/cmd/parse.go
+++ b/apps/openant-cli/cmd/parse.go
@@ -23,15 +23,21 @@ If no repository path is given, the active project is used (see: openant init).`
 }
 
 var (
-	parseOutput   string
-	parseLanguage string
-	parseLevel    string
+	parseOutput    string
+	parseLanguage  string
+	parseLevel     string
+	parseDiffBase  string
+	parsePR        int
+	parseDiffScope string
 )
 
 func init() {
 	parseCmd.Flags().StringVarP(&parseOutput, "output", "o", "", "Output directory (default: project scan dir)")
 	parseCmd.Flags().StringVarP(&parseLanguage, "language", "l", "", "Language: python, javascript, go, c, ruby, php, auto")
 	parseCmd.Flags().StringVar(&parseLevel, "level", "all", "Processing level: all, reachable, codeql, exploitable")
+	parseCmd.Flags().StringVar(&parseDiffBase, "diff-base", "", "Incremental mode: tag units overlapping diff vs this ref")
+	parseCmd.Flags().IntVar(&parsePR, "pr", 0, "Incremental mode against a GitHub PR number (mutex with --diff-base)")
+	parseCmd.Flags().StringVar(&parseDiffScope, "diff-scope", "changed_functions", "Diff scope: changed_files, changed_functions, callers")
 }
 
 func runParse(cmd *cobra.Command, args []string) {
@@ -64,6 +70,17 @@ func runParse(cmd *cobra.Command, args []string) {
 		os.Exit(2)
 	}
 
+	stepOpts, err := resolveStepDiffOpts(ctx, parseDiffBase, parsePR, parseDiffScope)
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+	manifestPath, err := prepareDiffManifest(repoPath, parseOutput, stepOpts)
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+
 	// Construct dataset name from project metadata: org-repo-shortSHA
 	var datasetName string
 	if ctx != nil && ctx.Project != nil {
@@ -84,6 +101,9 @@ func runParse(cmd *cobra.Command, args []string) {
 	}
 	if parseLevel != "all" {
 		pyArgs = append(pyArgs, "--level", parseLevel)
+	}
+	if manifestPath != "" {
+		pyArgs = append(pyArgs, "--diff-manifest", manifestPath)
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, resolvedAPIKey())

--- a/apps/openant-cli/cmd/root.go
+++ b/apps/openant-cli/cmd/root.go
@@ -32,6 +32,7 @@ Stage 2: Simulate an attacker to eliminate false positives
 
 Commands:
   scan          Full pipeline: parse → enhance → detect → verify → report
+  diff          Scan only code changed vs a base ref or GitHub PR
   parse         Extract code units from a repository
   enhance       Add security context to a parsed dataset
   analyze       Run Stage 1 vulnerability detection
@@ -79,6 +80,7 @@ func init() {
 
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(scanCmd)
+	rootCmd.AddCommand(diffCmd)
 	rootCmd.AddCommand(parseCmd)
 	rootCmd.AddCommand(enhanceCmd)
 	rootCmd.AddCommand(analyzeCmd)

--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -5,6 +5,8 @@ import (
 	"os"
 
 	"github.com/knostic/open-ant-cli/internal/checkpoint"
+	"github.com/knostic/open-ant-cli/internal/config"
+	"github.com/knostic/open-ant-cli/internal/git"
 	"github.com/knostic/open-ant-cli/internal/output"
 	"github.com/knostic/open-ant-cli/internal/python"
 	"github.com/spf13/cobra"
@@ -14,12 +16,15 @@ var scanCmd = &cobra.Command{
 	Use:   "scan [repository-path]",
 	Short: "Scan a repository for vulnerabilities (full pipeline)",
 	Long: `Scan runs the full pipeline:
-  parse → app context → enhance → detect → verify → report → dynamic test
+  init → parse → app-context → enhance → analyze → verify → build-output → dynamic-test → report
 
 This is the recommended command for most users. It produces a complete
 vulnerability report with false positive elimination.
 
 If no repository path is given, the active project is used (see: openant init).
+
+Dynamic testing runs by default and requires Docker. Use --skip-dynamic-test
+to opt out.
 
 Each step writes a {step}.report.json file with timing, cost, and metadata.
 A final scan.report.json aggregates all step reports.`,
@@ -35,31 +40,58 @@ var (
 	scanNoContext   bool
 	scanNoEnhance   bool
 	scanEnhanceMode string
-	scanNoReport    bool
-	scanDynamicTest bool
-	scanLimit       int
+	scanNoReport        bool
+	scanSkipDynamicTest bool
+	scanLimit           int
 	scanModel       string
 	scanWorkers     int
 	scanBackoff     int
+	scanFull        bool
+	scanIncremental bool
+	scanDiffBase    string
+	scanPR          int
+	scanDiffScope   string
 )
 
 func init() {
-	scanCmd.Flags().StringVarP(&scanOutput, "output", "o", "", "Output directory (default: project scan dir or temp dir)")
-	scanCmd.Flags().StringVarP(&scanLanguage, "language", "l", "", "Language: python, javascript, go, c, ruby, php, auto")
-	scanCmd.Flags().StringVar(&scanLevel, "level", "reachable", "Processing level: all, reachable, codeql, exploitable")
-	scanCmd.Flags().BoolVar(&scanVerify, "verify", false, "Enable Stage 2 attacker simulation")
-	scanCmd.Flags().BoolVar(&scanNoContext, "no-context", false, "Skip application context generation")
-	scanCmd.Flags().BoolVar(&scanNoEnhance, "no-enhance", false, "Skip context enhancement step")
-	scanCmd.Flags().StringVar(&scanEnhanceMode, "enhance-mode", "agentic", "Enhancement mode: agentic (thorough) or single-shot (fast)")
-	scanCmd.Flags().BoolVar(&scanNoReport, "no-report", false, "Skip report generation")
-	scanCmd.Flags().BoolVar(&scanDynamicTest, "dynamic-test", false, "Enable Docker-isolated dynamic testing (off by default)")
-	scanCmd.Flags().IntVar(&scanLimit, "limit", 0, "Max units to analyze (0 = no limit)")
-	scanCmd.Flags().StringVar(&scanModel, "model", "opus", "Model: opus or sonnet")
-	scanCmd.Flags().IntVar(&scanWorkers, "workers", 8, "Number of parallel workers for LLM steps (default: 8)")
-	scanCmd.Flags().IntVar(&scanBackoff, "backoff", 30, "Seconds to wait when rate-limited (default: 30)")
+	registerScanFlags(scanCmd)
+}
+
+// registerScanFlags wires the full scan-pipeline flag set onto cmd. Used by
+// scanCmd and by the thin diffCmd wrapper so that both surfaces accept the
+// same knobs.
+func registerScanFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&scanOutput, "output", "o", "", "Output directory (default: project scan dir or temp dir)")
+	cmd.Flags().StringVarP(&scanLanguage, "language", "l", "", "Language: python, javascript, go, c, ruby, php, auto")
+	cmd.Flags().StringVar(&scanLevel, "level", "reachable", "Processing level: all, reachable, codeql, exploitable")
+	cmd.Flags().BoolVar(&scanVerify, "verify", false, "Enable Stage 2 attacker simulation")
+	cmd.Flags().BoolVar(&scanNoContext, "no-context", false, "Skip application context generation")
+	cmd.Flags().BoolVar(&scanNoEnhance, "no-enhance", false, "Skip context enhancement step")
+	cmd.Flags().StringVar(&scanEnhanceMode, "enhance-mode", "agentic", "Enhancement mode: agentic (thorough) or single-shot (fast)")
+	cmd.Flags().BoolVar(&scanNoReport, "no-report", false, "Skip report generation")
+	cmd.Flags().BoolVar(&scanSkipDynamicTest, "skip-dynamic-test", false, "Skip Docker-isolated dynamic testing (default: run dynamic tests)")
+	cmd.Flags().IntVar(&scanLimit, "limit", 0, "Max units to analyze (0 = no limit)")
+	cmd.Flags().StringVar(&scanModel, "model", "opus", "Model: opus or sonnet")
+	cmd.Flags().IntVar(&scanWorkers, "workers", 8, "Number of parallel workers for LLM steps (default: 8)")
+	cmd.Flags().IntVar(&scanBackoff, "backoff", 30, "Seconds to wait when rate-limited (default: 30)")
+	cmd.Flags().BoolVar(&scanFull, "full", false, "Force full scan (rejects --incremental/--diff-base/--pr)")
+	cmd.Flags().BoolVar(&scanIncremental, "incremental", false, "Incremental against the last successful scan on this project")
+	cmd.Flags().StringVar(&scanDiffBase, "diff-base", "", "Incremental mode: filter pipeline to units overlapping diff vs this ref (e.g. origin/main, HEAD~5)")
+	cmd.Flags().IntVar(&scanPR, "pr", 0, "Incremental mode against a GitHub PR number (requires gh; mutex with --diff-base)")
+	cmd.Flags().StringVar(&scanDiffScope, "diff-scope", "changed_functions", "Diff scope: changed_files, changed_functions, callers")
 }
 
 func runScan(cmd *cobra.Command, args []string) {
+	// Fail-fast on missing Docker when dynamic-test will run, before we
+	// resolve the project, write meta.json, or shell to Python. Otherwise
+	// the user burns the whole pipeline only to error at the last step.
+	if !scanSkipDynamicTest {
+		if err := checkDockerAvailable(); err != nil {
+			output.PrintError(err.Error())
+			os.Exit(2)
+		}
+	}
+
 	repoPath, ctx, err := resolveRepoArg(args)
 	if err != nil {
 		output.PrintError(err.Error())
@@ -80,6 +112,28 @@ func runScan(cmd *cobra.Command, args []string) {
 	}
 
 	rt, err := ensurePython()
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+
+	// Decide full vs incremental, honoring init's running meta.json if
+	// present (init was just run for this commit and recorded the choice).
+	decision, err := resolveScanMode(ctx, repoPath)
+	if err != nil {
+		output.PrintError(err.Error())
+		os.Exit(2)
+	}
+
+	// Build the diff manifest from the decision before checkpoint
+	// detection so that any PR-mode checkout happens first and the scan
+	// dir is up-to-date.
+	manifestOpts := diffOpts{}
+	if decision.Kind == config.ScanKindDiff {
+		manifestOpts.base = decision.Base
+		manifestOpts.scope = decision.Scope
+	}
+	manifestPath, err := prepareDiffManifest(repoPath, scanOutput, manifestOpts)
 	if err != nil {
 		output.PrintError(err.Error())
 		os.Exit(2)
@@ -125,7 +179,7 @@ func runScan(cmd *cobra.Command, args []string) {
 	if scanNoReport {
 		pyArgs = append(pyArgs, "--no-report")
 	}
-	if scanDynamicTest {
+	if !scanSkipDynamicTest {
 		pyArgs = append(pyArgs, "--dynamic-test")
 	}
 	if scanLimit > 0 {
@@ -139,6 +193,9 @@ func runScan(cmd *cobra.Command, args []string) {
 	}
 	if scanBackoff != 30 {
 		pyArgs = append(pyArgs, "--backoff", fmt.Sprintf("%d", scanBackoff))
+	}
+	if manifestPath != "" {
+		pyArgs = append(pyArgs, "--diff-manifest", manifestPath)
 	}
 
 	// Pass repository metadata from project context so reports don't show
@@ -157,8 +214,18 @@ func runScan(cmd *cobra.Command, args []string) {
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())
 	if err != nil {
+		finalizeScanMetaIfProject(ctx, config.ScanStatusFailed)
 		output.PrintError(err.Error())
 		os.Exit(2)
+	}
+
+	switch result.Envelope.Status {
+	case "interrupted":
+		finalizeScanMetaIfProject(ctx, config.ScanStatusInterrupted)
+	case "success":
+		finalizeScanMetaIfProject(ctx, config.ScanStatusSuccess)
+	default:
+		finalizeScanMetaIfProject(ctx, config.ScanStatusFailed)
 	}
 
 	if result.Envelope.Status == "interrupted" {
@@ -174,4 +241,71 @@ func runScan(cmd *cobra.Command, args []string) {
 	}
 
 	os.Exit(result.ExitCode)
+}
+
+// finalizeScanMetaIfProject updates the scan-run meta.json with a terminal
+// status when the scan ran against a known project. Ad-hoc scans without
+// project context have no meta.json and are silently skipped.
+func finalizeScanMetaIfProject(ctx *projectContext, status string) {
+	if ctx == nil || ctx.Project == nil {
+		return
+	}
+	if err := config.FinalizeScanMeta(ctx.Project.Name, ctx.Project.CommitSHAShort, status); err != nil {
+		output.PrintWarning(fmt.Sprintf("Failed to update scan meta: %s", err))
+	}
+}
+
+// resolveScanMode produces the modeDecision for this scan run. Honors a
+// running meta.json from a recent `openant init` (so the user is not
+// re-prompted), otherwise calls selectMode with the scan flags.
+//
+// When running against a project, also writes meta.json status=running
+// reflecting the decision so step verbs and finalizeScanMetaIfProject
+// have something to read/update.
+func resolveScanMode(ctx *projectContext, repoPath string) (modeDecision, error) {
+	flagsPassed := scanFull || scanIncremental || scanDiffBase != "" || scanPR > 0
+
+	// Reuse init's pending decision when no flags override it.
+	if !flagsPassed && ctx != nil && ctx.Project != nil {
+		existing, err := config.LoadScanMeta(ctx.Project.Name, ctx.Project.CommitSHAShort)
+		if err == nil && existing.Status == config.ScanStatusRunning {
+			return modeDecision{Kind: existing.Kind, Base: existing.Base, Scope: existing.Scope}, nil
+		}
+	}
+
+	projectName := ""
+	if ctx != nil && ctx.Project != nil {
+		projectName = ctx.Project.Name
+	}
+
+	decision, err := selectMode(modeOpts{
+		full:        scanFull,
+		incremental: scanIncremental,
+		diffBase:    scanDiffBase,
+		pr:          scanPR,
+		scope:       scanDiffScope,
+		projectName: projectName,
+		repoPath:    repoPath,
+	})
+	if err != nil {
+		return modeDecision{}, err
+	}
+
+	// Record the decision in meta.json status=running if we have a project.
+	// finalizeScanMetaIfProject will flip it terminal when the pipeline ends.
+	if ctx != nil && ctx.Project != nil {
+		meta := config.NewScanMeta(
+			decision.Kind,
+			ctx.Project.CommitSHA,
+			git.CurrentBranch(repoPath),
+			ctx.Project.Language,
+		)
+		meta.Base = decision.Base
+		meta.Scope = decision.Scope
+		if err := config.SaveScanMeta(ctx.Project.Name, ctx.Project.CommitSHAShort, meta); err != nil {
+			output.PrintWarning(fmt.Sprintf("Failed to write scan meta: %s", err))
+		}
+	}
+
+	return decision, nil
 }

--- a/apps/openant-cli/internal/config/scan_meta.go
+++ b/apps/openant-cli/internal/config/scan_meta.go
@@ -1,0 +1,225 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// Scan kinds. A scan-run is one of these.
+const (
+	ScanKindFull = "full"
+	ScanKindDiff = "diff"
+)
+
+// Scan statuses. Lifecycle: running → (success | failed | interrupted).
+const (
+	ScanStatusRunning     = "running"
+	ScanStatusSuccess     = "success"
+	ScanStatusFailed      = "failed"
+	ScanStatusInterrupted = "interrupted"
+)
+
+// scanMetaFilename is the filename written into each scan-run dir.
+const scanMetaFilename = "meta.json"
+
+// DiffStats summarizes how many units the diff filter selected for analysis.
+// Populated by the parse step when a diff manifest is present.
+type DiffStats struct {
+	UnitsSelected int `json:"units_selected"`
+	UnitsTotal    int `json:"units_total"`
+}
+
+// ScanMeta describes a single scan-run. One file per scan-run dir at
+// ~/.openant/projects/<name>/scans/<short_sha>/meta.json.
+//
+// The dir is the source of truth for "what scans exist on this project";
+// project.json carries only static identity. To find the latest run, walk
+// scans/, read each meta.json, sort by StartedAt.
+type ScanMeta struct {
+	Kind            string     `json:"kind"`             // ScanKindFull or ScanKindDiff
+	Commit          string     `json:"commit"`           // full SHA scanned
+	Branch          string     `json:"branch,omitempty"` // best-effort, may be empty for detached HEAD
+	StartedAt       string     `json:"started_at"`       // RFC3339
+	FinishedAt      string     `json:"finished_at,omitempty"`
+	Status          string     `json:"status"`
+	Language        string     `json:"language"`
+	AnalyzerVersion string     `json:"analyzer_version,omitempty"`
+	Model           string     `json:"model,omitempty"`
+	Base            string     `json:"base,omitempty"`  // diff base SHA, only when Kind == ScanKindDiff
+	Scope           string     `json:"scope,omitempty"` // diff scope, only when Kind == ScanKindDiff
+	DiffStats       *DiffStats `json:"diff_stats,omitempty"`
+}
+
+// ScanRunDir returns the per-run directory (without the language subdir).
+// ~/.openant/projects/<name>/scans/<short_sha>/
+//
+// meta.json lives here. Language-specific dataset/report output continues
+// to live at <run-dir>/<language>/ via ScanDir.
+func ScanRunDir(projectName, shortSHA string) (string, error) {
+	projDir, err := ProjectDir(projectName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(projDir, "scans", shortSHA), nil
+}
+
+// scanMetaPath returns the path to meta.json for a given run.
+func scanMetaPath(projectName, shortSHA string) (string, error) {
+	runDir, err := ScanRunDir(projectName, shortSHA)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(runDir, scanMetaFilename), nil
+}
+
+// SaveScanMeta writes meta.json atomically (temp + rename) into the run dir.
+// Creates the run dir if missing.
+func SaveScanMeta(projectName, shortSHA string, m *ScanMeta) error {
+	runDir, err := ScanRunDir(projectName, shortSHA)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		return fmt.Errorf("create scan run dir: %w", err)
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("serialize scan meta: %w", err)
+	}
+	data = append(data, '\n')
+
+	finalPath := filepath.Join(runDir, scanMetaFilename)
+	tmp, err := os.CreateTemp(runDir, scanMetaFilename+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("create temp meta file: %w", err)
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("write temp meta file: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("close temp meta file: %w", err)
+	}
+	if err := os.Rename(tmpPath, finalPath); err != nil {
+		_ = os.Remove(tmpPath)
+		return fmt.Errorf("rename meta file: %w", err)
+	}
+	return nil
+}
+
+// LoadScanMeta reads meta.json for a given run. Returns os.ErrNotExist
+// (wrapped) when missing — callers can treat that as "legacy / no meta".
+func LoadScanMeta(projectName, shortSHA string) (*ScanMeta, error) {
+	path, err := scanMetaPath(projectName, shortSHA)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("scan meta not found at %s: %w", path, err)
+		}
+		return nil, fmt.Errorf("read scan meta: %w", err)
+	}
+	var m ScanMeta
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse scan meta at %s: %w", path, err)
+	}
+	return &m, nil
+}
+
+// LatestScanMeta walks scans/ for the project and returns the most recent
+// run that has a parseable meta.json with status == success. Returns
+// (nil, "", nil) when no qualifying run exists (no scans dir, all dirs are
+// legacy / missing meta, or all runs failed).
+//
+// shortSHA returned is the directory name, useful for callers that want to
+// reference the run dir.
+//
+// Failed/interrupted runs are skipped — they are not a valid baseline.
+// The recap UI may surface them separately in the future; baseline
+// resolution does not.
+func LatestScanMeta(projectName string) (*ScanMeta, string, error) {
+	projDir, err := ProjectDir(projectName)
+	if err != nil {
+		return nil, "", err
+	}
+	scansDir := filepath.Join(projDir, "scans")
+	entries, err := os.ReadDir(scansDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, "", nil
+		}
+		return nil, "", fmt.Errorf("list scans dir: %w", err)
+	}
+
+	type candidate struct {
+		shortSHA string
+		meta     *ScanMeta
+		ts       time.Time
+	}
+	var candidates []candidate
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		m, err := LoadScanMeta(projectName, e.Name())
+		if err != nil {
+			// Missing or malformed — treat as legacy and skip.
+			continue
+		}
+		if m.Status != ScanStatusSuccess {
+			continue
+		}
+		ts, err := time.Parse(time.RFC3339, m.StartedAt)
+		if err != nil {
+			continue
+		}
+		candidates = append(candidates, candidate{shortSHA: e.Name(), meta: m, ts: ts})
+	}
+	if len(candidates) == 0 {
+		return nil, "", nil
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ts.After(candidates[j].ts)
+	})
+	top := candidates[0]
+	return top.meta, top.shortSHA, nil
+}
+
+// NewScanMeta builds a ScanMeta for a freshly-started run, with
+// StartedAt set to now and Status set to running.
+func NewScanMeta(kind, commit, branch, language string) *ScanMeta {
+	return &ScanMeta{
+		Kind:      kind,
+		Commit:    commit,
+		Branch:    branch,
+		StartedAt: time.Now().UTC().Format(time.RFC3339),
+		Status:    ScanStatusRunning,
+		Language:  language,
+	}
+}
+
+// FinalizeScanMeta loads the meta for a run, sets its terminal status and
+// FinishedAt to now, and saves. No-ops (returning nil) when meta.json does
+// not exist — callers may invoke this on legacy runs or ad-hoc scans where
+// no meta was ever written.
+func FinalizeScanMeta(projectName, shortSHA, status string) error {
+	m, err := LoadScanMeta(projectName, shortSHA)
+	if err != nil {
+		// Treat missing meta as a no-op so ad-hoc scans don't error here.
+		return nil
+	}
+	m.Status = status
+	m.FinishedAt = time.Now().UTC().Format(time.RFC3339)
+	return SaveScanMeta(projectName, shortSHA, m)
+}

--- a/apps/openant-cli/internal/config/scan_meta_test.go
+++ b/apps/openant-cli/internal/config/scan_meta_test.go
@@ -1,0 +1,204 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// withTempHome points HOME at a temp dir for the duration of the test so
+// ProjectDir / ScanRunDir resolve under there. Restores HOME on cleanup.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	return dir
+}
+
+func TestSaveLoadScanMetaRoundTrip(t *testing.T) {
+	withTempHome(t)
+
+	want := &ScanMeta{
+		Kind:            ScanKindFull,
+		Commit:          "abc123def456",
+		Branch:          "master",
+		StartedAt:       "2026-04-28T11:53:30Z",
+		FinishedAt:      "2026-04-28T11:55:12Z",
+		Status:          ScanStatusSuccess,
+		Language:        "python",
+		AnalyzerVersion: "0.1.0",
+		Model:           "opus",
+	}
+	if err := SaveScanMeta("test/proj", "abc123de", want); err != nil {
+		t.Fatalf("SaveScanMeta: %v", err)
+	}
+	got, err := LoadScanMeta("test/proj", "abc123de")
+	if err != nil {
+		t.Fatalf("LoadScanMeta: %v", err)
+	}
+	if *got != *want {
+		t.Errorf("round-trip mismatch:\n want=%+v\n  got=%+v", want, got)
+	}
+}
+
+func TestSaveScanMetaWritesAtPredictablePath(t *testing.T) {
+	home := withTempHome(t)
+	m := &ScanMeta{Kind: ScanKindFull, Commit: "x", StartedAt: "2026-04-28T00:00:00Z", Status: ScanStatusRunning, Language: "python"}
+	if err := SaveScanMeta("p", "shortsha", m); err != nil {
+		t.Fatalf("SaveScanMeta: %v", err)
+	}
+	expected := filepath.Join(home, ".openant", "projects", "p", "scans", "shortsha", "meta.json")
+	if _, err := os.Stat(expected); err != nil {
+		t.Fatalf("meta.json not at expected path %s: %v", expected, err)
+	}
+}
+
+func TestLoadScanMetaMissing(t *testing.T) {
+	withTempHome(t)
+	_, err := LoadScanMeta("never/initialized", "deadbeef")
+	if err == nil {
+		t.Fatal("expected error loading missing meta, got nil")
+	}
+}
+
+func TestLatestScanMetaReturnsNewestSuccess(t *testing.T) {
+	withTempHome(t)
+	older := &ScanMeta{
+		Kind:      ScanKindFull,
+		Commit:    "older",
+		StartedAt: time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339),
+		Status:    ScanStatusSuccess,
+		Language:  "python",
+	}
+	newer := &ScanMeta{
+		Kind:      ScanKindDiff,
+		Commit:    "newer",
+		Base:      "older",
+		Scope:     "changed_functions",
+		StartedAt: time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
+		Status:    ScanStatusSuccess,
+		Language:  "python",
+	}
+	if err := SaveScanMeta("p", "older0000", older); err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveScanMeta("p", "newer1111", newer); err != nil {
+		t.Fatal(err)
+	}
+
+	got, sha, err := LatestScanMeta("p")
+	if err != nil {
+		t.Fatalf("LatestScanMeta: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected a meta, got nil")
+	}
+	if sha != "newer1111" {
+		t.Errorf("expected newer1111, got %s", sha)
+	}
+	if got.Commit != "newer" {
+		t.Errorf("expected commit=newer, got %s", got.Commit)
+	}
+}
+
+func TestLatestScanMetaSkipsFailedAndLegacyDirs(t *testing.T) {
+	home := withTempHome(t)
+
+	// Successful run.
+	good := &ScanMeta{
+		Kind: ScanKindFull, Commit: "good",
+		StartedAt: time.Now().UTC().Add(-3 * time.Hour).Format(time.RFC3339),
+		Status:    ScanStatusSuccess, Language: "python",
+	}
+	if err := SaveScanMeta("p", "goodshort", good); err != nil {
+		t.Fatal(err)
+	}
+
+	// Failed run, more recent — should be skipped.
+	failed := &ScanMeta{
+		Kind: ScanKindFull, Commit: "failed",
+		StartedAt: time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
+		Status:    ScanStatusFailed, Language: "python",
+	}
+	if err := SaveScanMeta("p", "failedshrt", failed); err != nil {
+		t.Fatal(err)
+	}
+
+	// Legacy run: a scans/<sha>/ dir with no meta.json. Should be skipped.
+	legacyDir := filepath.Join(home, ".openant", "projects", "p", "scans", "legacysha")
+	if err := os.MkdirAll(legacyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, sha, err := LatestScanMeta("p")
+	if err != nil {
+		t.Fatalf("LatestScanMeta: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected the successful meta, got nil")
+	}
+	if sha != "goodshort" {
+		t.Errorf("expected goodshort, got %s", sha)
+	}
+}
+
+func TestLatestScanMetaNoProject(t *testing.T) {
+	withTempHome(t)
+	got, sha, err := LatestScanMeta("does/not/exist")
+	if err != nil {
+		t.Fatalf("expected no error for missing project, got %v", err)
+	}
+	if got != nil || sha != "" {
+		t.Errorf("expected nil/empty for missing project, got meta=%+v sha=%q", got, sha)
+	}
+}
+
+func TestFinalizeScanMetaSetsTerminalStatus(t *testing.T) {
+	withTempHome(t)
+	m := NewScanMeta(ScanKindFull, "abc", "master", "python")
+	if err := SaveScanMeta("p", "abcshort", m); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := FinalizeScanMeta("p", "abcshort", ScanStatusSuccess); err != nil {
+		t.Fatalf("FinalizeScanMeta: %v", err)
+	}
+
+	got, err := LoadScanMeta("p", "abcshort")
+	if err != nil {
+		t.Fatalf("LoadScanMeta: %v", err)
+	}
+	if got.Status != ScanStatusSuccess {
+		t.Errorf("expected status=success, got %s", got.Status)
+	}
+	if got.FinishedAt == "" {
+		t.Error("expected FinishedAt to be set")
+	}
+	if _, err := time.Parse(time.RFC3339, got.FinishedAt); err != nil {
+		t.Errorf("FinishedAt is not RFC3339: %v", err)
+	}
+}
+
+func TestFinalizeScanMetaIsNoOpWhenMissing(t *testing.T) {
+	withTempHome(t)
+	if err := FinalizeScanMeta("never/seen", "deadbeef", ScanStatusSuccess); err != nil {
+		t.Errorf("expected no error finalizing missing meta, got %v", err)
+	}
+}
+
+func TestNewScanMetaSetsRunningAndTimestamp(t *testing.T) {
+	m := NewScanMeta(ScanKindFull, "sha123", "master", "python")
+	if m.Status != ScanStatusRunning {
+		t.Errorf("expected status=running, got %s", m.Status)
+	}
+	if m.StartedAt == "" {
+		t.Error("expected StartedAt to be set")
+	}
+	if _, err := time.Parse(time.RFC3339, m.StartedAt); err != nil {
+		t.Errorf("StartedAt is not RFC3339: %v", err)
+	}
+	if m.Kind != ScanKindFull || m.Commit != "sha123" || m.Branch != "master" || m.Language != "python" {
+		t.Errorf("fields not set correctly: %+v", m)
+	}
+}

--- a/apps/openant-cli/internal/git/diff.go
+++ b/apps/openant-cli/internal/git/diff.go
@@ -1,0 +1,205 @@
+package git
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// ResolveBase resolves baseRef and HEAD to full SHAs within repoPath.
+func ResolveBase(repoPath, baseRef string) (baseSHA, headSHA string, err error) {
+	baseSHA, err = gitRevParse(repoPath, baseRef)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve base %q: %w", baseRef, err)
+	}
+	headSHA, err = gitRevParse(repoPath, "HEAD")
+	if err != nil {
+		return "", "", fmt.Errorf("resolve HEAD: %w", err)
+	}
+	return baseSHA, headSHA, nil
+}
+
+func gitRevParse(repoPath, ref string) (string, error) {
+	cmd := exec.Command("git", "-C", repoPath, "rev-parse", ref)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse %s: %w: %s", ref, err, strings.TrimSpace(stderr.String()))
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// CurrentBranch returns the name of the branch HEAD points at, or "" if
+// HEAD is detached. Callers treat the empty result as "no branch info" —
+// it is informational metadata, not load-bearing.
+func CurrentBranch(repoPath string) string {
+	cmd := exec.Command("git", "-C", repoPath, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	branch := strings.TrimSpace(string(out))
+	if branch == "HEAD" {
+		return ""
+	}
+	return branch
+}
+
+// FetchPR resolves a GitHub PR number to its base ref via `gh`, fetches
+// pull/N/head into a local branch, checks it out, and fetches the base ref
+// so it's available locally for diffing. Returns the fully qualified base
+// ref (e.g. "origin/main").
+func FetchPR(repoPath string, prNumber int, stderr *bytes.Buffer) (string, error) {
+	viewCmd := exec.Command("gh", "pr", "view", strconv.Itoa(prNumber), "--json", "baseRefName")
+	viewCmd.Dir = repoPath
+	var viewErr bytes.Buffer
+	viewCmd.Stderr = &viewErr
+	viewOut, err := viewCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("gh pr view %d: %w (is gh installed and authenticated? %s)",
+			prNumber, err, strings.TrimSpace(viewErr.String()))
+	}
+	var meta struct {
+		BaseRefName string `json:"baseRefName"`
+	}
+	if err := json.Unmarshal(viewOut, &meta); err != nil {
+		return "", fmt.Errorf("parse gh pr view output: %w", err)
+	}
+	if meta.BaseRefName == "" {
+		return "", fmt.Errorf("gh pr view returned empty baseRefName for PR %d", prNumber)
+	}
+
+	prSpec := fmt.Sprintf("pull/%d/head:pr-head", prNumber)
+	if err := runGit(repoPath, stderr, "fetch", "origin", prSpec, "--force"); err != nil {
+		return "", fmt.Errorf("git fetch %s: %w", prSpec, err)
+	}
+	if err := runGit(repoPath, stderr, "checkout", "pr-head"); err != nil {
+		return "", fmt.Errorf("git checkout pr-head: %w", err)
+	}
+	// Best-effort fetch of the base ref. If it's already local this is a no-op.
+	_ = runGit(repoPath, stderr, "fetch", "origin", meta.BaseRefName)
+
+	return "origin/" + meta.BaseRefName, nil
+}
+
+func runGit(repoPath string, stderr *bytes.Buffer, args ...string) error {
+	cmd := exec.Command("git", append([]string{"-C", repoPath}, args...)...)
+	var localErr bytes.Buffer
+	if stderr != nil {
+		cmd.Stderr = stderr
+	} else {
+		cmd.Stderr = &localErr
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(localErr.String()))
+	}
+	return nil
+}
+
+// ChangedFiles returns the files changed between baseSHA and HEAD using the
+// symmetric diff BASE...HEAD. Rename detection is enabled; the new-side path
+// is returned for renamed files.
+func ChangedFiles(repoPath, baseSHA string) ([]string, error) {
+	cmd := exec.Command("git", "-C", repoPath, "diff",
+		baseSHA+"...HEAD", "--name-only", "--find-renames")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff --name-only: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	var files []string
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
+// hunkHeaderRe captures the new-side start and count from a unified-diff
+// hunk header. `@@ -a[,b] +c[,d] @@` — capture group 1 is c, group 2 is d.
+// Count defaults to 1 when omitted.
+var hunkHeaderRe = regexp.MustCompile(`^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@`)
+
+// HunksForFile returns the new-side [start, end] line ranges for changes to
+// a single file. Pure-deletion hunks (count=0 on the new side) are skipped.
+func HunksForFile(repoPath, baseSHA, file string) ([][2]int, error) {
+	cmd := exec.Command("git", "-C", repoPath, "diff",
+		baseSHA+"...HEAD", "--unified=0", "--", file)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("git diff --unified=0 -- %s: %w: %s", file, err, strings.TrimSpace(stderr.String()))
+	}
+	var ranges [][2]int
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	for scanner.Scan() {
+		m := hunkHeaderRe.FindStringSubmatch(scanner.Text())
+		if m == nil {
+			continue
+		}
+		start, _ := strconv.Atoi(m[1])
+		count := 1
+		if m[2] != "" {
+			count, _ = strconv.Atoi(m[2])
+		}
+		if count == 0 {
+			// Pure deletion on the new side — nothing to select.
+			continue
+		}
+		ranges = append(ranges, [2]int{start, start + count - 1})
+	}
+	return ranges, nil
+}
+
+// BuildManifest assembles a Manifest by shelling git commands against
+// repoPath. scope must be a valid scope (see IsValidScope). For
+// ScopeChangedFiles, the Hunks map is left nil.
+func BuildManifest(repoPath, baseRef, scope string, prNumber int) (*Manifest, error) {
+	if !IsValidScope(scope) {
+		return nil, fmt.Errorf("invalid scope %q", scope)
+	}
+	baseSHA, headSHA, err := ResolveBase(repoPath, baseRef)
+	if err != nil {
+		return nil, err
+	}
+	files, err := ChangedFiles(repoPath, baseSHA)
+	if err != nil {
+		return nil, err
+	}
+	m := &Manifest{
+		BaseRef:      baseRef,
+		BaseSHA:      baseSHA,
+		HeadSHA:      headSHA,
+		Scope:        scope,
+		PRNumber:     prNumber,
+		ChangedFiles: files,
+	}
+	if scope == ScopeChangedFiles {
+		return m, nil
+	}
+	hunks := make(map[string][][2]int, len(files))
+	for _, f := range files {
+		r, err := HunksForFile(repoPath, baseSHA, f)
+		if err != nil {
+			return nil, err
+		}
+		if len(r) > 0 {
+			hunks[f] = r
+		}
+	}
+	m.Hunks = hunks
+	return m, nil
+}

--- a/apps/openant-cli/internal/git/diff_test.go
+++ b/apps/openant-cli/internal/git/diff_test.go
@@ -1,0 +1,256 @@
+package git
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// initTestRepo creates a throwaway git repo at dir and commits a single
+// initial file so HEAD exists. Subsequent commits are made by the test.
+func initTestRepo(t *testing.T, dir string) {
+	t.Helper()
+	runCmd(t, dir, "git", "init", "-q", "-b", "main")
+	runCmd(t, dir, "git", "config", "user.email", "test@example.com")
+	runCmd(t, dir, "git", "config", "user.name", "Test")
+	runCmd(t, dir, "git", "config", "commit.gpgsign", "false")
+}
+
+func runCmd(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("%s %s: %v: %s", name, strings.Join(args, " "), err, stderr.String())
+	}
+}
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	full := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestChangedFilesAndHunks(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+
+	// Commit 1: initial state.
+	writeFile(t, dir, "a.txt", "line1\nline2\nline3\nline4\nline5\n")
+	writeFile(t, dir, "b.txt", "hello\nworld\n")
+	runCmd(t, dir, "git", "add", ".")
+	runCmd(t, dir, "git", "commit", "-q", "-m", "init")
+
+	base, err := gitRevParse(dir, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit 2: modify a.txt (add/change lines), delete b.txt entirely,
+	// add a new file c.txt.
+	writeFile(t, dir, "a.txt", "line1\nline2 MODIFIED\nline3\nline4\nline5\nline6 ADDED\n")
+	if err := os.Remove(filepath.Join(dir, "b.txt")); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, dir, "c.txt", "brand new\n")
+	runCmd(t, dir, "git", "add", "-A")
+	runCmd(t, dir, "git", "commit", "-q", "-m", "changes")
+
+	files, err := ChangedFiles(dir, base)
+	if err != nil {
+		t.Fatalf("ChangedFiles: %v", err)
+	}
+	want := []string{"a.txt", "b.txt", "c.txt"}
+	sort.Strings(files)
+	if !reflect.DeepEqual(files, want) {
+		t.Errorf("ChangedFiles = %v, want %v", files, want)
+	}
+
+	// a.txt: one hunk for the modified line (line 2), one hunk for the
+	// added line (line 6). Exact count=0 hunks should be filtered; a.txt
+	// has no pure-deletion hunks on the new side.
+	hunksA, err := HunksForFile(dir, base, "a.txt")
+	if err != nil {
+		t.Fatalf("HunksForFile a.txt: %v", err)
+	}
+	if len(hunksA) == 0 {
+		t.Fatalf("expected hunks on a.txt, got none")
+	}
+	// Ensure every returned range is positive and non-degenerate.
+	for _, h := range hunksA {
+		if h[0] < 1 || h[1] < h[0] {
+			t.Errorf("bad hunk range %v", h)
+		}
+	}
+
+	// b.txt is fully deleted on the new side — no content survives in
+	// HEAD. Every hunk should be count=0 and therefore skipped.
+	hunksB, err := HunksForFile(dir, base, "b.txt")
+	if err != nil {
+		t.Fatalf("HunksForFile b.txt: %v", err)
+	}
+	if len(hunksB) != 0 {
+		t.Errorf("expected no hunks for deleted file b.txt, got %v", hunksB)
+	}
+
+	// c.txt is brand new — one hunk starting at line 1.
+	hunksC, err := HunksForFile(dir, base, "c.txt")
+	if err != nil {
+		t.Fatalf("HunksForFile c.txt: %v", err)
+	}
+	if len(hunksC) != 1 || hunksC[0][0] != 1 {
+		t.Errorf("unexpected hunks on c.txt: %v", hunksC)
+	}
+}
+
+func TestChangedFilesDetectsRenames(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+
+	// Commit 1: file at old path.
+	writeFile(t, dir, "old.txt", strings.Repeat("same content line\n", 20))
+	runCmd(t, dir, "git", "add", ".")
+	runCmd(t, dir, "git", "commit", "-q", "-m", "init")
+
+	base, err := gitRevParse(dir, "HEAD")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Commit 2: rename only (no content change).
+	runCmd(t, dir, "git", "mv", "old.txt", "new.txt")
+	runCmd(t, dir, "git", "commit", "-q", "-m", "rename")
+
+	files, err := ChangedFiles(dir, base)
+	if err != nil {
+		t.Fatalf("ChangedFiles: %v", err)
+	}
+	// With --find-renames, git reports only the new path.
+	if len(files) != 1 || files[0] != "new.txt" {
+		t.Errorf("want [new.txt], got %v", files)
+	}
+}
+
+func TestBuildManifestChangedFilesScope(t *testing.T) {
+	dir := t.TempDir()
+	initTestRepo(t, dir)
+
+	writeFile(t, dir, "a.txt", "one\ntwo\n")
+	runCmd(t, dir, "git", "add", ".")
+	runCmd(t, dir, "git", "commit", "-q", "-m", "init")
+
+	writeFile(t, dir, "a.txt", "one\ntwo changed\nthree\n")
+	runCmd(t, dir, "git", "commit", "-aq", "-m", "edit")
+
+	m, err := BuildManifest(dir, "HEAD~1", ScopeChangedFiles, 0)
+	if err != nil {
+		t.Fatalf("BuildManifest: %v", err)
+	}
+	if m.Scope != ScopeChangedFiles {
+		t.Errorf("scope = %q, want %q", m.Scope, ScopeChangedFiles)
+	}
+	if m.Hunks != nil {
+		t.Errorf("hunks should be nil for changed_files scope, got %v", m.Hunks)
+	}
+	if len(m.ChangedFiles) != 1 || m.ChangedFiles[0] != "a.txt" {
+		t.Errorf("ChangedFiles = %v", m.ChangedFiles)
+	}
+	if m.BaseSHA == "" || m.HeadSHA == "" || m.BaseSHA == m.HeadSHA {
+		t.Errorf("unexpected shas base=%s head=%s", m.BaseSHA, m.HeadSHA)
+	}
+}
+
+func TestManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "diff_manifest.json")
+
+	want := &Manifest{
+		BaseRef:      "origin/main",
+		BaseSHA:      "abc",
+		HeadSHA:      "def",
+		Scope:        ScopeChangedFunctions,
+		PRNumber:     123,
+		ChangedFiles: []string{"a.py", "b.py"},
+		Hunks: map[string][][2]int{
+			"a.py": {{10, 20}, {30, 31}},
+			"b.py": {{1, 1}},
+		},
+	}
+	if err := WriteManifest(path, want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadManifest(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+func TestIsValidScope(t *testing.T) {
+	valid := []string{ScopeChangedFiles, ScopeChangedFunctions, ScopeCallers}
+	for _, s := range valid {
+		if !IsValidScope(s) {
+			t.Errorf("IsValidScope(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"", "foo", "CHANGED_FILES"} {
+		if IsValidScope(s) {
+			t.Errorf("IsValidScope(%q) = true, want false", s)
+		}
+	}
+}
+
+func TestHunkHeaderRegex(t *testing.T) {
+	cases := []struct {
+		line      string
+		wantStart int
+		wantCount int // 0 = no match expected
+	}{
+		{"@@ -1,3 +1,5 @@", 1, 5},
+		{"@@ -10 +20 @@", 20, 1},          // implicit count=1
+		{"@@ -5,0 +12,3 @@", 12, 3},
+		{"@@ -5,2 +0,0 @@", 0, 0},          // pure deletion — count=0
+		{"not a hunk header", 0, 0},
+	}
+	for _, c := range cases {
+		m := hunkHeaderRe.FindStringSubmatch(c.line)
+		if m == nil {
+			if c.wantCount != 0 || strings.HasPrefix(c.line, "@@") {
+				// Only fail when we expected a match or it really did look
+				// like a hunk header.
+				if c.wantStart != 0 {
+					t.Errorf("regex failed on %q", c.line)
+				}
+			}
+			continue
+		}
+		if got := m[1]; got == "" || itoaEq(got, c.wantStart) == false {
+			t.Errorf("%q: start = %q, want %d", c.line, m[1], c.wantStart)
+		}
+	}
+}
+
+func itoaEq(s string, n int) bool {
+	var acc int
+	for _, ch := range s {
+		if ch < '0' || ch > '9' {
+			return false
+		}
+		acc = acc*10 + int(ch-'0')
+	}
+	return acc == n
+}

--- a/apps/openant-cli/internal/git/manifest.go
+++ b/apps/openant-cli/internal/git/manifest.go
@@ -1,0 +1,65 @@
+// Package git provides git helpers for PR-diff / incremental scanning.
+//
+// It computes a diff_manifest.json that the Python core reads to filter the
+// pipeline to units whose bodies overlap the diff between a base ref and HEAD.
+package git
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// Scope values for Manifest.Scope.
+const (
+	ScopeChangedFiles     = "changed_files"
+	ScopeChangedFunctions = "changed_functions"
+	ScopeCallers          = "callers"
+)
+
+// IsValidScope reports whether s is one of the three supported scopes.
+func IsValidScope(s string) bool {
+	return s == ScopeChangedFiles || s == ScopeChangedFunctions || s == ScopeCallers
+}
+
+// Manifest is the on-disk contract between the Go CLI (producer) and the
+// Python core (consumer). Written to <scan_dir>/diff_manifest.json.
+//
+// Hunks is omitted for the ScopeChangedFiles scope (not needed). Each value
+// in Hunks is a slice of [start_line, end_line] pairs on the new side
+// (inclusive). Pure-deletion hunks are dropped at build time.
+type Manifest struct {
+	BaseRef      string          `json:"base_ref"`
+	BaseSHA      string          `json:"base_sha"`
+	HeadSHA      string          `json:"head_sha"`
+	Scope        string          `json:"scope"`
+	PRNumber     int             `json:"pr_number,omitempty"`
+	ChangedFiles []string        `json:"changed_files"`
+	Hunks        map[string][][2]int `json:"hunks,omitempty"`
+}
+
+// WriteManifest writes m to path as indented JSON.
+func WriteManifest(path string, m *Manifest) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return fmt.Errorf("write manifest %s: %w", path, err)
+	}
+	return nil
+}
+
+// ReadManifest reads and parses a manifest from path. Primarily used by tests.
+func ReadManifest(path string) (*Manifest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parse manifest %s: %w", path, err)
+	}
+	return &m, nil
+}

--- a/apps/openant-cli/internal/output/formatter.go
+++ b/apps/openant-cli/internal/output/formatter.go
@@ -345,6 +345,21 @@ func PrintScanSummaryV2(data map[string]any) {
 
 	PrintHeader("Scan Results")
 
+	// Mode line: surfaces incremental-scan range so the user sees
+	// "what was compared" without diving into pipeline_output.json.
+	if diff, ok := data["diff"].(map[string]any); ok && diff != nil {
+		if mode, _ := diff["mode"].(string); mode == "incremental" {
+			base := shortSHA8(diff["base_sha"])
+			head := shortSHA8(diff["head_sha"])
+			unitsIn := intFromAny(diff["units_in_diff"])
+			unitsTotal := intFromAny(diff["units_total_parsed"])
+			modeLine := fmt.Sprintf("Incremental (%s..%s, %d/%d units)", base, head, unitsIn, unitsTotal)
+			PrintKeyValue("Mode", modeLine)
+		} else {
+			PrintKeyValue("Mode", "Full")
+		}
+	}
+
 	total := intFromAny(metrics["total"])
 	vulnerable := intFromAny(metrics["vulnerable"])
 	bypassable := intFromAny(metrics["bypassable"])
@@ -448,6 +463,20 @@ func intFromAny(v any) int {
 	default:
 		return 0
 	}
+}
+
+// shortSHA8 returns the first 8 characters of a SHA from a JSON-decoded
+// string field. Returns "?" for missing/empty input so the rendered Mode
+// line never looks malformed.
+func shortSHA8(v any) string {
+	s, _ := v.(string)
+	if len(s) >= 8 {
+		return s[:8]
+	}
+	if s == "" {
+		return "?"
+	}
+	return s
 }
 
 // floatFromAny extracts a float64 from a JSON-decoded any value.

--- a/apps/openant-cli/internal/report/report_test.go
+++ b/apps/openant-cli/internal/report/report_test.go
@@ -1,0 +1,123 @@
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func baseReportData() ReportData {
+	return ReportData{
+		Title:     "Security Analysis Report",
+		Timestamp: "2026-04-28 10:00:00",
+		RepoName:  "python-vuln",
+		CommitSHA: "55cc12c59a6d7d159c1f64cd5f712a304f32d559",
+		Language:  "python",
+		Stats:     Stats{TotalUnits: 8, TotalFiles: 1, Vulnerable: 6, Bypassable: 0, Secure: 2},
+		Categories: []Category{
+			{Verdict: "vulnerable", Color: "#dc3545", Description: "x"},
+		},
+	}
+}
+
+func TestRenderOverviewFullScan(t *testing.T) {
+	data := baseReportData()
+	var buf bytes.Buffer
+	if err := RenderOverview(data, &buf); err != nil {
+		t.Fatalf("RenderOverview: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "python-vuln") {
+		t.Error("expected repo name in output")
+	}
+	if !strings.Contains(out, data.ShortCommit()) {
+		t.Error("expected short commit in output for full scan")
+	}
+	if strings.Contains(out, "Incremental") {
+		t.Error("did not expect Incremental badge on full scan")
+	}
+}
+
+func TestRenderOverviewIncrementalScan(t *testing.T) {
+	data := baseReportData()
+	data.Diff = &DiffInfo{
+		Mode:             "incremental",
+		BaseSHA:          "c9f255bb6e92d6f14ed34a769898a51ca6ccc112",
+		HeadSHA:          "55cc12c59a6d7d159c1f64cd5f712a304f32d559",
+		Scope:            "changed_functions",
+		UnitsInDiff:      2,
+		UnitsTotalParsed: 8,
+		ChangedFiles:     1,
+	}
+
+	var buf bytes.Buffer
+	if err := RenderOverview(data, &buf); err != nil {
+		t.Fatalf("RenderOverview: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Incremental") {
+		t.Error("expected Incremental badge")
+	}
+	if !strings.Contains(out, "c9f255bb..55cc12c5") {
+		t.Errorf("expected git-style range c9f255bb..55cc12c5, got: %s", excerpt(out, "Incremental"))
+	}
+	if !strings.Contains(out, "2/8 units") {
+		t.Errorf("expected '2/8 units', got: %s", excerpt(out, "Incremental"))
+	}
+}
+
+func TestRenderReskinIncrementalScan(t *testing.T) {
+	data := baseReportData()
+	data.Diff = &DiffInfo{
+		Mode:             "incremental",
+		BaseSHA:          "c9f255bb6e92d6f14ed34a769898a51ca6ccc112",
+		HeadSHA:          "55cc12c59a6d7d159c1f64cd5f712a304f32d559",
+		Scope:            "callers",
+		UnitsInDiff:      3,
+		UnitsTotalParsed: 8,
+		ChangedFiles:     1,
+	}
+	var buf bytes.Buffer
+	if err := RenderReskin(data, &buf); err != nil {
+		t.Fatalf("RenderReskin: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Incremental") {
+		t.Error("reskin: expected Incremental badge")
+	}
+	if !strings.Contains(out, "c9f255bb..55cc12c5") {
+		t.Error("reskin: expected git-style range")
+	}
+	if !strings.Contains(out, "3/8 units") {
+		t.Error("reskin: expected '3/8 units'")
+	}
+}
+
+func TestIsIncrementalAndRange(t *testing.T) {
+	d := ReportData{}
+	if d.IsIncremental() {
+		t.Error("expected IsIncremental false on empty data")
+	}
+	d.Diff = &DiffInfo{Mode: "incremental", BaseSHA: "abcdef0123456789", HeadSHA: "fedcba9876543210"}
+	if !d.IsIncremental() {
+		t.Error("expected IsIncremental true")
+	}
+	if got := d.DiffRange(); got != "abcdef01..fedcba98" {
+		t.Errorf("expected abcdef01..fedcba98, got %q", got)
+	}
+}
+
+// excerpt returns a small slice of `out` around the first occurrence of `key`,
+// for friendlier failure messages.
+func excerpt(out, key string) string {
+	idx := strings.Index(out, key)
+	if idx < 0 {
+		return "(not found)"
+	}
+	start := idx
+	end := idx + 200
+	if end > len(out) {
+		end = len(out)
+	}
+	return out[start:end]
+}

--- a/apps/openant-cli/internal/report/templates/overview.gohtml
+++ b/apps/openant-cli/internal/report/templates/overview.gohtml
@@ -81,7 +81,15 @@
                     <h1 class="text-2xl sm:text-3xl lg:text-4xl font-bold text-accent mb-1">{{.Title}}</h1>
                     <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-gray-400 mt-2">
                         {{if .RepoName}}<span title="Repository"><strong class="text-gray-100">{{.RepoName}}</strong></span>{{end}}
-                        {{if .ShortCommit}}<code class="text-xs bg-navy-900 px-2 py-0.5 rounded text-gray-200">{{.ShortCommit}}</code>{{end}}
+                        {{if .IsIncremental}}
+                            <span class="inline-flex items-center gap-2">
+                                <span class="text-xs font-bold uppercase tracking-wider bg-accent text-white px-2 py-0.5 rounded">Incremental</span>
+                                <code class="text-xs bg-navy-900 px-2 py-0.5 rounded text-gray-200" title="base..head">{{.DiffRange}}</code>
+                                <span class="text-xs text-gray-400" title="Diff scope: {{.Diff.Scope}}, {{.Diff.ChangedFiles}} file(s) changed">{{.Diff.UnitsInDiff}}/{{.Diff.UnitsTotalParsed}} units</span>
+                            </span>
+                        {{else if .ShortCommit}}
+                            <code class="text-xs bg-navy-900 px-2 py-0.5 rounded text-gray-200">{{.ShortCommit}}</code>
+                        {{end}}
                         {{if .Language}}<span class="capitalize">{{.Language}}</span>{{end}}
                     </div>
                 </div>

--- a/apps/openant-cli/internal/report/templates/report-reskin.gohtml
+++ b/apps/openant-cli/internal/report/templates/report-reskin.gohtml
@@ -106,7 +106,15 @@
                     <h1 class="text-2xl sm:text-3xl lg:text-4xl font-bold text-knostic-navy mb-1">{{.Title}}</h1>
                     <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-knostic-muted mt-2">
                         {{if .RepoName}}<span title="Repository"><strong class="text-knostic-navy">{{.RepoName}}</strong></span>{{end}}
-                        {{if .ShortCommit}}<code class="text-xs bg-knostic-card-bg border border-knostic-border-light px-2 py-0.5 rounded text-knostic-navy">{{.ShortCommit}}</code>{{end}}
+                        {{if .IsIncremental}}
+                            <span class="inline-flex items-center gap-2">
+                                <span class="text-xs font-bold uppercase tracking-wider bg-knostic-purple text-white px-2 py-0.5 rounded">Incremental</span>
+                                <code class="text-xs bg-knostic-card-bg border border-knostic-border-light px-2 py-0.5 rounded text-knostic-navy" title="base..head">{{.DiffRange}}</code>
+                                <span class="text-xs text-knostic-muted" title="Diff scope: {{.Diff.Scope}}, {{.Diff.ChangedFiles}} file(s) changed">{{.Diff.UnitsInDiff}}/{{.Diff.UnitsTotalParsed}} units</span>
+                            </span>
+                        {{else if .ShortCommit}}
+                            <code class="text-xs bg-knostic-card-bg border border-knostic-border-light px-2 py-0.5 rounded text-knostic-navy">{{.ShortCommit}}</code>
+                        {{end}}
                         {{if .Language}}<span class="capitalize">{{.Language}}</span>{{end}}
                     </div>
                 </div>

--- a/apps/openant-cli/internal/report/types.go
+++ b/apps/openant-cli/internal/report/types.go
@@ -26,6 +26,58 @@ type ReportData struct {
 	FindingsByVerdict []FindingGroup `json:"findings_by_verdict"`
 	StepReports       []StepReport   `json:"step_reports"`
 	Categories        []Category     `json:"categories"`
+	Diff              *DiffInfo      `json:"diff,omitempty"`
+}
+
+// DiffInfo carries the incremental-scan range info to the report templates.
+// Nil for full scans. Mirrors the "diff" block on pipeline_output.json,
+// trimmed to the fields the templates actually render.
+type DiffInfo struct {
+	Mode             string `json:"mode"` // "incremental"
+	BaseSHA          string `json:"base_sha"`
+	HeadSHA          string `json:"head_sha"`
+	Scope            string `json:"scope"`
+	UnitsInDiff      int    `json:"units_in_diff"`
+	UnitsTotalParsed int    `json:"units_total_parsed"`
+	ChangedFiles     int    `json:"changed_files"`
+	PRNumber         int    `json:"pr_number,omitempty"`
+}
+
+// IsIncremental reports whether this report is for an incremental scan.
+// Templates check this to decide between the "full" and "incremental"
+// header renderings.
+func (d ReportData) IsIncremental() bool {
+	return d.Diff != nil && d.Diff.Mode == "incremental"
+}
+
+// ShortBaseSHA returns the first 8 characters of the diff base SHA, or "".
+func (d ReportData) ShortBaseSHA() string {
+	if d.Diff == nil {
+		return ""
+	}
+	if len(d.Diff.BaseSHA) > 8 {
+		return d.Diff.BaseSHA[:8]
+	}
+	return d.Diff.BaseSHA
+}
+
+// ShortHeadSHA returns the first 8 characters of the diff head SHA, or "".
+func (d ReportData) ShortHeadSHA() string {
+	if d.Diff == nil {
+		return ""
+	}
+	if len(d.Diff.HeadSHA) > 8 {
+		return d.Diff.HeadSHA[:8]
+	}
+	return d.Diff.HeadSHA
+}
+
+// DiffRange returns the git-style "<base8>..<head8>" string, or "".
+func (d ReportData) DiffRange() string {
+	if d.Diff == nil {
+		return ""
+	}
+	return d.ShortBaseSHA() + ".." + d.ShortHeadSHA()
 }
 
 // SafeRemediation returns the remediation HTML as a template.HTML

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -335,6 +335,14 @@ def run_analysis(
 
     units = dataset.get("units", [])
 
+    # Diff filter: if upstream parse stamped diff_selected on units (PR-diff
+    # mode), drop the unselected ones. Pre-diff datasets have no field and
+    # are processed unchanged.
+    if any("diff_selected" in u for u in units):
+        _pre = len(units)
+        units = [u for u in units if u.get("diff_selected")]
+        print(f"[Analyze] Diff filter: {_pre} -> {len(units)} units", file=sys.stderr)
+
     # Optional: filter by enhancement security classification
     if exploitable_filter:
         original_count = len(units)

--- a/libs/openant-core/core/diff_filter.py
+++ b/libs/openant-core/core/diff_filter.py
@@ -1,0 +1,224 @@
+"""
+Diff-based unit filter for incremental (PR-diff) scanning.
+
+Consumes a diff_manifest.json produced by the Go CLI
+(apps/openant-cli/internal/git) and annotates each unit in the dataset with
+`diff_selected: bool`. Downstream pipeline stages skip units where
+`diff_selected is False` — units without the field (pre-diff datasets) are
+processed unchanged.
+
+Manifest contract (see internal/git/manifest.go):
+
+    {
+      "base_ref": "origin/main",
+      "base_sha": "...",
+      "head_sha": "...",
+      "scope": "changed_functions",      # or "changed_files" | "callers"
+      "pr_number": 123,                   # optional, 0 means none
+      "changed_files": ["a.py", "b.py"],
+      "hunks": {                          # omitted for changed_files scope
+        "a.py": [[42, 78], [110, 115]]
+      }
+    }
+
+Scopes:
+  - changed_files      -> all units in a changed file
+  - changed_functions  -> units whose [start_line, end_line] overlaps a hunk
+  - callers            -> changed_functions plus any unit whose direct_calls
+                          contains a selected unit id (1-hop)
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, asdict
+
+
+# Scope constants (must match internal/git/manifest.go).
+SCOPE_CHANGED_FILES = "changed_files"
+SCOPE_CHANGED_FUNCTIONS = "changed_functions"
+SCOPE_CALLERS = "callers"
+_VALID_SCOPES = (SCOPE_CHANGED_FILES, SCOPE_CHANGED_FUNCTIONS, SCOPE_CALLERS)
+
+
+@dataclass
+class DiffStats:
+    """Summary of what apply_diff_filter selected.
+
+    Attached to the parse step report so users see scope impact at a glance.
+    """
+    total: int = 0
+    selected: int = 0
+    scope: str = ""
+    base_ref: str = ""
+    base_sha: str = ""
+    head_sha: str = ""
+    pr_number: int = 0
+    changed_files: int = 0
+    fallback_file_match: int = 0   # units that lacked line info, matched by file only
+    callers_added: int = 0          # units added by the 1-hop callers pass
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def load_manifest(path: str) -> dict:
+    """Read and minimally validate a diff manifest file."""
+    with open(path, "r", encoding="utf-8") as f:
+        m = json.load(f)
+    scope = m.get("scope")
+    if scope not in _VALID_SCOPES:
+        raise ValueError(
+            f"invalid scope {scope!r} in {path}; expected one of {_VALID_SCOPES}"
+        )
+    if not isinstance(m.get("changed_files"), list):
+        raise ValueError(f"manifest {path} missing or invalid 'changed_files' list")
+    return m
+
+
+def apply_diff_filter(units: list[dict], manifest: dict) -> DiffStats:
+    """Annotate each unit in `units` with `diff_selected: bool` per manifest.
+
+    Mutates the list in place (adds a field to each unit dict). Returns
+    DiffStats for the step report.
+    """
+    scope = manifest["scope"]
+    if scope not in _VALID_SCOPES:
+        raise ValueError(f"invalid scope {scope!r}")
+
+    changed_files = set(_norm_path(p) for p in manifest.get("changed_files", []))
+    hunks = {
+        _norm_path(k): v
+        for k, v in (manifest.get("hunks") or {}).items()
+    }
+
+    stats = DiffStats(
+        total=len(units),
+        scope=scope,
+        base_ref=manifest.get("base_ref", ""),
+        base_sha=manifest.get("base_sha", ""),
+        head_sha=manifest.get("head_sha", ""),
+        pr_number=int(manifest.get("pr_number") or 0),
+        changed_files=len(changed_files),
+    )
+
+    # First pass: mark units based on file + (for function/callers) hunk overlap.
+    for unit in units:
+        unit_file = _resolve_unit_file(unit)
+        if not unit_file or unit_file not in changed_files:
+            unit["diff_selected"] = False
+            continue
+
+        if scope == SCOPE_CHANGED_FILES:
+            unit["diff_selected"] = True
+            continue
+
+        start, end = _resolve_line_range(unit)
+        if start is None or end is None:
+            # No line info — safest behavior is to include (avoid false
+            # negatives). Log once per unit to stderr so users know.
+            print(
+                f"[diff_filter] unit {unit.get('id')!r} in {unit_file} "
+                f"has no start/end line; falling back to file-level match",
+                file=sys.stderr,
+            )
+            unit["diff_selected"] = True
+            stats.fallback_file_match += 1
+            continue
+
+        file_hunks = hunks.get(unit_file, [])
+        unit["diff_selected"] = _any_overlap(start, end, file_hunks)
+
+    # Second pass: callers scope adds 1-hop reverse (units whose direct_calls
+    # point at a selected unit).
+    if scope == SCOPE_CALLERS:
+        selected_ids = {
+            u.get("id") for u in units if u.get("diff_selected") and u.get("id")
+        }
+        if selected_ids:
+            for unit in units:
+                if unit.get("diff_selected"):
+                    continue
+                calls = _unit_direct_calls(unit)
+                if any(c in selected_ids for c in calls):
+                    unit["diff_selected"] = True
+                    stats.callers_added += 1
+
+    stats.selected = sum(1 for u in units if u.get("diff_selected"))
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _norm_path(p: str) -> str:
+    if p.startswith("./"):
+        return p[2:]
+    return p
+
+
+def _resolve_unit_file(unit: dict) -> str | None:
+    """Return the file path for a unit, trying the known shapes in order."""
+    code = unit.get("code") or {}
+    origin = code.get("primary_origin")
+    if isinstance(origin, dict) and origin.get("file_path"):
+        return _norm_path(origin["file_path"])
+
+    # Fallback: top-level primary_origin (older parsers)
+    origin = unit.get("primary_origin")
+    if isinstance(origin, dict) and origin.get("file_path"):
+        return _norm_path(origin["file_path"])
+
+    # Last resort: split id on the last ':' — format "path/file.py:func"
+    unit_id = unit.get("id") or ""
+    if ":" in unit_id:
+        # rsplit handles ids like "C:/Users/... :func" on Windows only if we
+        # assume repo paths are POSIX; openant repos always are.
+        return _norm_path(unit_id.rsplit(":", 1)[0])
+    return None
+
+
+def _resolve_line_range(unit: dict) -> tuple[int | None, int | None]:
+    """Return (start_line, end_line) for a unit, trying the known shapes."""
+    code = unit.get("code") or {}
+    origin = code.get("primary_origin")
+    if isinstance(origin, dict):
+        s, e = origin.get("start_line"), origin.get("end_line")
+        if isinstance(s, int) and isinstance(e, int):
+            return s, e
+
+    origin = unit.get("primary_origin")
+    if isinstance(origin, dict):
+        s, e = origin.get("start_line"), origin.get("end_line")
+        if isinstance(s, int) and isinstance(e, int):
+            return s, e
+
+    meta = unit.get("metadata") or {}
+    s, e = meta.get("start_line"), meta.get("end_line")
+    if isinstance(s, int) and isinstance(e, int):
+        return s, e
+
+    return None, None
+
+
+def _unit_direct_calls(unit: dict) -> list:
+    """Return the unit's direct_calls list (supports both snake_case and camelCase)."""
+    meta = unit.get("metadata") or {}
+    calls = meta.get("direct_calls")
+    if calls is None:
+        calls = meta.get("directCalls")
+    return calls or []
+
+
+def _any_overlap(start: int, end: int, hunks: list) -> bool:
+    """Whether [start, end] overlaps any [a, b] pair in hunks."""
+    for h in hunks:
+        if len(h) != 2:
+            continue
+        a, b = h[0], h[1]
+        if end < a or start > b:
+            continue
+        return True
+    return False

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -75,6 +75,7 @@ def parse_repository(
     processing_level: str = "reachable",
     skip_tests: bool = True,
     name: str = None,
+    diff_manifest: str | None = None,
 ) -> ParseResult:
     """Parse a repository into an OpenAnt dataset.
 
@@ -107,21 +108,85 @@ def parse_repository(
 
     # Dispatch to the right parser
     if language == "python":
-        return _parse_python(repo_path, output_dir, processing_level, skip_tests, name)
+        result = _parse_python(repo_path, output_dir, processing_level, skip_tests, name)
     elif language == "javascript":
-        return _parse_javascript(repo_path, output_dir, processing_level, skip_tests, name)
+        result = _parse_javascript(repo_path, output_dir, processing_level, skip_tests, name)
     elif language == "go":
-        return _parse_go(repo_path, output_dir, processing_level, skip_tests, name)
+        result = _parse_go(repo_path, output_dir, processing_level, skip_tests, name)
     elif language == "c":
-        return _parse_c(repo_path, output_dir, processing_level, skip_tests, name)
+        result = _parse_c(repo_path, output_dir, processing_level, skip_tests, name)
     elif language == "ruby":
-        return _parse_ruby(repo_path, output_dir, processing_level, skip_tests, name)
+        result = _parse_ruby(repo_path, output_dir, processing_level, skip_tests, name)
     elif language == "php":
-        return _parse_php(repo_path, output_dir, processing_level, skip_tests, name)
+        result = _parse_php(repo_path, output_dir, processing_level, skip_tests, name)
     elif language == "zig":
-        return _parse_zig(repo_path, output_dir, processing_level, skip_tests, name)
+        result = _parse_zig(repo_path, output_dir, processing_level, skip_tests, name)
     else:
         raise ValueError(f"Unsupported language: {language}")
+
+    _maybe_apply_diff_filter(result, output_dir, diff_manifest)
+    return result
+
+
+def _maybe_apply_diff_filter(
+    result: ParseResult,
+    output_dir: str,
+    diff_manifest: str | None,
+) -> None:
+    """Apply the diff filter to the dataset on disk if a manifest is provided.
+
+    Annotates every unit with `diff_selected: bool` and rewrites dataset.json.
+    Writes stats to {output_dir}/diff_filter.report.json for the step report
+    (picked up alongside parse.report.json). If `diff_manifest` is None and
+    no default manifest exists in output_dir, this is a no-op so legacy runs
+    behave exactly as before.
+    """
+    # Resolve manifest path: explicit arg wins, else look for the default.
+    if diff_manifest is None:
+        default = os.path.join(output_dir, "diff_manifest.json")
+        if os.path.exists(default):
+            diff_manifest = default
+    if not diff_manifest:
+        return
+
+    from core.diff_filter import apply_diff_filter, load_manifest
+
+    print(f"\n[Diff Filter] Loading manifest from {diff_manifest}", file=sys.stderr)
+    manifest = load_manifest(diff_manifest)
+
+    if not os.path.exists(result.dataset_path):
+        print(
+            f"  [Warning] dataset {result.dataset_path} not found; skipping diff filter",
+            file=sys.stderr,
+        )
+        return
+
+    with open(result.dataset_path, "r") as f:
+        dataset = json.load(f)
+
+    # Dataset may be a dict with "units" or a raw list.
+    if isinstance(dataset, dict):
+        units = dataset.get("units", [])
+    else:
+        units = dataset
+
+    stats = apply_diff_filter(units, manifest)
+
+    with open(result.dataset_path, "w") as f:
+        json.dump(dataset, f, indent=2)
+
+    # Expose stats on the ParseResult via a side-channel file; the parse
+    # step_context reads this when assembling parse.report.json.
+    diff_report_path = os.path.join(output_dir, "diff_filter.report.json")
+    with open(diff_report_path, "w") as f:
+        json.dump(stats.to_dict(), f, indent=2)
+
+    print(
+        f"  Diff filter ({stats.scope}): {stats.selected}/{stats.total} units selected"
+        + (f" ({stats.callers_added} added as callers)" if stats.callers_added else "")
+        + (f", {stats.fallback_file_match} fell back to file-level" if stats.fallback_file_match else ""),
+        file=sys.stderr,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -24,6 +24,43 @@ from core.schemas import ReportResult
 _CORE_ROOT = Path(__file__).parent.parent
 
 
+def _load_diff_metadata(scan_dir: str) -> dict | None:
+    """Return a summary dict if this scan dir contains a diff_manifest.json.
+
+    Combines fields from diff_manifest.json and diff_filter.report.json so the
+    HTML/report consumers have one place to read PR/incremental metadata.
+    """
+    manifest_path = os.path.join(scan_dir, "diff_manifest.json")
+    if not os.path.exists(manifest_path):
+        return None
+    try:
+        with open(manifest_path) as f:
+            manifest = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    out = {
+        "mode": "incremental",
+        "base_ref": manifest.get("base_ref"),
+        "base_sha": manifest.get("base_sha"),
+        "head_sha": manifest.get("head_sha"),
+        "scope": manifest.get("scope"),
+        "pr_number": manifest.get("pr_number") or None,
+        "changed_files": len(manifest.get("changed_files") or []),
+    }
+    filter_report = os.path.join(scan_dir, "diff_filter.report.json")
+    if os.path.exists(filter_report):
+        try:
+            with open(filter_report) as f:
+                stats = json.load(f)
+            out["units_in_diff"] = stats.get("selected")
+            out["units_total_parsed"] = stats.get("total")
+            out["callers_added"] = stats.get("callers_added") or 0
+            out["fallback_file_match"] = stats.get("fallback_file_match") or 0
+        except (json.JSONDecodeError, OSError):
+            pass
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -317,6 +354,21 @@ def build_pipeline_output(
         },
         "findings": findings_data,
     }
+
+    # If this scan ran in diff mode, attach the manifest + filter stats so the
+    # HTML report can show a PR / incremental scan header.
+    scan_dir = os.path.dirname(os.path.abspath(results_path))
+    diff_meta = _load_diff_metadata(scan_dir)
+    if diff_meta is not None:
+        pipeline_output["diff"] = diff_meta
+        _banner = (
+            f"[Report] Incremental scan: base={diff_meta.get('base_ref')}, "
+            f"scope={diff_meta.get('scope')}, "
+            f"{diff_meta.get('units_in_diff', '?')}/{diff_meta.get('units_total_parsed', '?')} units"
+        )
+        if diff_meta.get("pr_number"):
+            _banner += f", PR #{diff_meta['pr_number']}"
+        print(_banner, file=sys.stderr)
 
     os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
     with open(output_path, "w") as f:

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -58,6 +58,7 @@ def scan_repository(
     repo_name: str | None = None,
     repo_url: str | None = None,
     commit_sha: str | None = None,
+    diff_manifest: str | None = None,
 ) -> ScanResult:
     """Scan a repository for vulnerabilities.
 
@@ -136,6 +137,7 @@ def scan_repository(
             language=language,
             processing_level=processing_level,
             skip_tests=skip_tests,
+            diff_manifest=diff_manifest,
         )
 
         ctx.summary = {
@@ -143,6 +145,14 @@ def scan_repository(
             "language": parse_result.language,
             "processing_level": parse_result.processing_level,
         }
+        # If the parse step generated a diff_stats report, attach it.
+        _diff_report = os.path.join(output_dir, "diff_filter.report.json")
+        if os.path.exists(_diff_report):
+            try:
+                with open(_diff_report) as _f:
+                    ctx.summary["diff_stats"] = json.load(_f)
+            except (json.JSONDecodeError, OSError):
+                pass
         ctx.outputs = {
             "dataset_path": parse_result.dataset_path,
             "analyzer_output_path": parse_result.analyzer_output_path,

--- a/libs/openant-core/export_csv.py
+++ b/libs/openant-core/export_csv.py
@@ -27,7 +27,42 @@ Example:
 import argparse
 import csv
 import json
+import os
 import sys
+
+
+def _load_diff_block(experiment_path: str) -> dict | None:
+    """Look for the ``diff`` block in pipeline_output.json next to the
+    experiment file. Returns None for full scans / when not found.
+    Used to prepend an incremental-scan banner to CSV output.
+    """
+    exp_dir = os.path.dirname(os.path.abspath(experiment_path))
+    candidate = os.path.join(exp_dir, "pipeline_output.json")
+    if not os.path.exists(candidate):
+        return None
+    try:
+        with open(candidate) as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None
+    diff = data.get("diff")
+    if isinstance(diff, dict) and diff.get("mode") == "incremental":
+        return diff
+    return None
+
+
+def _format_diff_banner(diff: dict) -> str:
+    """Format the leading "# Incremental: ..." comment line for the CSV."""
+    base = (diff.get("base_sha") or "")[:8]
+    head = (diff.get("head_sha") or "")[:8]
+    units_in = diff.get("units_in_diff")
+    units_total = diff.get("units_total_parsed")
+    scope = diff.get("scope") or ""
+    units_str = ""
+    if units_in is not None and units_total is not None:
+        units_str = f", {units_in}/{units_total} units"
+    scope_str = f", scope={scope}" if scope else ""
+    return f"# Incremental: {base}..{head}{scope_str}{units_str}"
 
 
 def load_json(path: str) -> dict:
@@ -141,7 +176,14 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
         'agentic_classification'
     ]
 
+    diff = _load_diff_block(experiment_path)
+
     with open(output_path, 'w', newline='', encoding='utf-8') as f:
+        if diff is not None:
+            # Comment line preceding the header — most CSV consumers
+            # (Excel, Google Sheets, pandas with comment='#') ignore it,
+            # while still being human-readable when opened raw.
+            f.write(_format_diff_banner(diff) + "\n")
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)

--- a/libs/openant-core/generate_report.py
+++ b/libs/openant-core/generate_report.py
@@ -65,6 +65,66 @@ def get_verdict_priority(verdict: str) -> int:
     return priorities.get(verdict, 3)
 
 
+def _short_sha(sha: str | None) -> str:
+    """Return the first 8 characters of a SHA, or empty if input is None."""
+    if not sha:
+        return ""
+    return sha[:8]
+
+
+def _load_pipeline_metadata(experiment_path: str) -> tuple[dict | None, dict | None]:
+    """Auto-detect pipeline_output.json next to the experiment file.
+
+    Returns (repository, diff) blocks or (None, None) if not found / unreadable.
+    Used to render repo identity and incremental-scan range in the HTML header.
+    """
+    exp_dir = os.path.dirname(os.path.abspath(experiment_path))
+    candidate = os.path.join(exp_dir, "pipeline_output.json")
+    if not os.path.exists(candidate):
+        return None, None
+    try:
+        with open(candidate, 'r') as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return None, None
+    return data.get("repository"), data.get("diff")
+
+
+def _build_header_subtitle(
+    timestamp: str,
+    repository: dict | None,
+    diff: dict | None,
+) -> str:
+    """Build the HTML header subtitle.
+
+    Full scan: "<repo> @ <sha8> · Generated <ts>"
+    Incremental: "<repo> · Incremental: <base8>..<head8> · N/M units · Generated <ts>"
+    No metadata: "Generated <ts>" (preserves prior behavior)
+    """
+    if not repository:
+        return f"Generated on {html.escape(timestamp)}"
+
+    repo_name = html.escape(repository.get("name") or "unknown")
+
+    if diff and diff.get("mode") == "incremental":
+        base = _short_sha(diff.get("base_sha"))
+        head = _short_sha(diff.get("head_sha"))
+        units_in = diff.get("units_in_diff")
+        units_total = diff.get("units_total_parsed")
+        units_str = ""
+        if units_in is not None and units_total is not None:
+            units_str = f" · {units_in}/{units_total} units"
+        return (
+            f'<span class="incremental-badge">Incremental</span> '
+            f'{repo_name} · {html.escape(base)}..{html.escape(head)}{html.escape(units_str)} · '
+            f'Generated {html.escape(timestamp)}'
+        )
+
+    sha = _short_sha(repository.get("commit_sha"))
+    sha_str = f" @ {html.escape(sha)}" if sha else ""
+    return f"{repo_name}{sha_str} · Generated {html.escape(timestamp)}"
+
+
 def get_verdict_color(verdict: str) -> str:
     """Get color for verdict."""
     colors = {
@@ -222,8 +282,16 @@ def generate_html_report(
     remediation_html: str,
     output_path: str,
     step_reports: list[dict] | None = None,
+    repository: dict | None = None,
+    diff: dict | None = None,
 ):
-    """Generate the HTML report."""
+    """Generate the HTML report.
+
+    repository / diff are usually loaded from pipeline_output.json by the
+    caller (see ``_load_pipeline_metadata``). When present, the header
+    renders the repo identity and, for incremental scans, the
+    base..head range.
+    """
     # Prepare data
     units_by_id = {u['id']: u for u in dataset.get('units', [])}
 
@@ -352,6 +420,20 @@ def generate_html_report(
         .subtitle {{
             color: var(--text-secondary);
             font-size: 1rem;
+        }}
+
+        .incremental-badge {{
+            display: inline-block;
+            background: var(--accent);
+            color: #fff;
+            padding: 0.1rem 0.5rem;
+            border-radius: 4px;
+            font-size: 0.75rem;
+            font-weight: 600;
+            letter-spacing: 0.05em;
+            text-transform: uppercase;
+            margin-right: 0.5rem;
+            vertical-align: middle;
         }}
 
         .stats-grid {{
@@ -544,7 +626,7 @@ def generate_html_report(
     <div class="container">
         <header>
             <h1>Security Analysis Report</h1>
-            <p class="subtitle">Generated on {timestamp}</p>
+            <p class="subtitle">{_build_header_subtitle(timestamp, repository, diff)}</p>
         </header>
 
         <div class="stats-grid">
@@ -754,8 +836,18 @@ def main():
     print("Generating remediation guidance (calling LLM)...")
     remediation_html = generate_remediation_guidance(findings)
 
+    repository, diff = _load_pipeline_metadata(args.experiment)
+
     print("Building HTML report...")
-    generate_html_report(experiment, dataset, remediation_html, args.output, step_reports=step_reports)
+    generate_html_report(
+        experiment,
+        dataset,
+        remediation_html,
+        args.output,
+        step_reports=step_reports,
+        repository=repository,
+        diff=diff,
+    )
 
     # Print summary
     verdict_counts = {}

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -73,9 +73,23 @@ def cmd_scan(args):
             repo_name=getattr(args, "repo_name", None),
             repo_url=getattr(args, "repo_url", None),
             commit_sha=getattr(args, "commit_sha", None),
+            diff_manifest=getattr(args, "diff_manifest", None),
         )
 
-        _output_json(success(result.to_dict()))
+        scan_payload = result.to_dict()
+        # Surface the diff block on the envelope so the Go CLI banner can
+        # render an "Incremental: base..head" line on success. The block
+        # is the same one written into pipeline_output.json by reporter.py.
+        if result.pipeline_output_path and os.path.exists(result.pipeline_output_path):
+            try:
+                with open(result.pipeline_output_path) as f:
+                    po = json.load(f)
+                diff_block = po.get("diff")
+                if isinstance(diff_block, dict) and diff_block.get("mode") == "incremental":
+                    scan_payload["diff"] = diff_block
+            except (json.JSONDecodeError, OSError):
+                pass
+        _output_json(success(scan_payload))
 
         # Exit 1 if vulnerabilities found
         if result.metrics.vulnerable > 0 or result.metrics.bypassable > 0:
@@ -109,6 +123,7 @@ def cmd_parse(args):
                 processing_level=args.level,
                 skip_tests=not args.no_skip_tests,
                 name=getattr(args, "name", None),
+                diff_manifest=getattr(args, "diff_manifest", None),
             )
 
             ctx.summary = {
@@ -116,6 +131,14 @@ def cmd_parse(args):
                 "language": result.language,
                 "processing_level": result.processing_level,
             }
+            # Surface diff stats in the parse step report if present.
+            diff_report = os.path.join(output_dir, "diff_filter.report.json")
+            if os.path.exists(diff_report):
+                try:
+                    with open(diff_report) as f:
+                        ctx.summary["diff_stats"] = json.load(f)
+                except (json.JSONDecodeError, OSError):
+                    pass
             ctx.outputs = {
                 "dataset_path": result.dataset_path,
                 "analyzer_output_path": result.analyzer_output_path,
@@ -850,6 +873,7 @@ Format your response as HTML (use <h3>, <p>, <ul>, <li>, <strong> tags). Do not 
             commit_sha = ""
             language = ""
             repo_url = ""
+            diff_block = None
             if os.path.exists(po_path):
                 try:
                     with open(po_path) as f:
@@ -859,6 +883,21 @@ Format your response as HTML (use <h3>, <p>, <ul>, <li>, <strong> tags). Do not 
                     commit_sha = repo_info.get("commit_sha", "")
                     language = repo_info.get("language", "")
                     repo_url = repo_info.get("url", "")
+                    # Pass through the diff block when this scan ran in
+                    # incremental mode; the Go renderer surfaces base..head
+                    # in the report header.
+                    raw_diff = po.get("diff")
+                    if isinstance(raw_diff, dict) and raw_diff.get("mode") == "incremental":
+                        diff_block = {
+                            "mode": raw_diff.get("mode"),
+                            "base_sha": raw_diff.get("base_sha", ""),
+                            "head_sha": raw_diff.get("head_sha", ""),
+                            "scope": raw_diff.get("scope", ""),
+                            "units_in_diff": raw_diff.get("units_in_diff", 0) or 0,
+                            "units_total_parsed": raw_diff.get("units_total_parsed", 0) or 0,
+                            "changed_files": raw_diff.get("changed_files", 0) or 0,
+                            "pr_number": raw_diff.get("pr_number") or 0,
+                        }
                 except (json.JSONDecodeError, OSError):
                     pass
 
@@ -886,6 +925,7 @@ Format your response as HTML (use <h3>, <p>, <ul>, <li>, <strong> tags). Do not 
                 "findings_by_verdict": findings_by_verdict,
                 "step_reports": step_reports_data,
                 "categories": categories,
+                "diff": diff_block,
             }
 
             ctx.summary = {"findings": len(findings), "actionable": len(actionable)}
@@ -953,6 +993,7 @@ def main():
     scan_p.add_argument("--commit-sha", help="Commit SHA")
     scan_p.add_argument("--backoff", type=int, default=30,
                         help="Seconds to wait when rate-limited (default: 30)")
+    scan_p.add_argument("--diff-manifest", help="Path to diff_manifest.json for incremental scanning")
     scan_p.set_defaults(func=cmd_scan)
 
     # ---------------------------------------------------------------
@@ -975,6 +1016,7 @@ def main():
     )
     parse_p.add_argument("--no-skip-tests", action="store_true", help="Include test files in parsing (default: tests are skipped)")
     parse_p.add_argument("--name", help="Dataset name (default: derived from repo path)")
+    parse_p.add_argument("--diff-manifest", help="Path to diff_manifest.json; tags units with diff_selected")
     parse_p.set_defaults(func=cmd_parse)
 
     # ---------------------------------------------------------------

--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -35,6 +35,7 @@ import ast
 import json
 import re
 import sys
+import textwrap
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -176,7 +177,7 @@ class CallGraphBuilder:
         caller_class = caller_func.get('class_name')
 
         try:
-            tree = ast.parse(code)
+            tree = ast.parse(textwrap.dedent(code))
         except SyntaxError:
             # Fall back to regex-based extraction
             return self._extract_calls_regex(code, caller_id)

--- a/libs/openant-core/report/prompts/summary.txt
+++ b/libs/openant-core/report/prompts/summary.txt
@@ -10,6 +10,7 @@ OUTPUT FORMAT:
 **Repository:** {url}
 **Language:** {repository.language}
 **Commit:** {repository.commit_sha or "Not available"}
+**Scan Mode:** {scan_mode_line}
 **Analysis Date:** {date}
 **Application Type:** {app_type}
 **Processing Level:** {pipeline_stats.processing_level or "Not available"}
@@ -95,6 +96,12 @@ INSTRUCTIONS:
 - "Verified" column: "dynamic" if dynamic_testing exists for that finding, "verified" if stage2_verdict is "confirmed" or "agreed" (Stage 2 attacker simulation passed), else "static"
 - Language comes from repository.language
 - Commit SHA comes from repository.commit_sha; if null or missing, write "Not available"
+- Scan Mode is derived from the top-level `diff` field on the input data:
+  - If `diff` is missing or `diff.mode != "incremental"`, write: `Full`
+  - If `diff.mode == "incremental"`, write:
+    `Incremental ({diff.base_sha[:8]}..{diff.head_sha[:8]}, scope={diff.scope}, {diff.units_in_diff}/{diff.units_total_parsed} units)`
+  - When the scan was incremental, ALSO add a paragraph immediately after the metadata block:
+    `> This is an incremental scan. Only the {diff.units_in_diff}/{diff.units_total_parsed} unit(s) overlapping changes between {diff.base_sha[:8]} and {diff.head_sha[:8]} were analyzed. Findings on unchanged units inherit the most recent prior verdict and are not re-examined here.`
 - Processing Level comes from pipeline_stats.processing_level; if null or missing, write "Not available"
 - Reachable units comes from pipeline_stats.reachable_units; total units from pipeline_stats.total_units
 - Per-Step Costs: iterate pipeline_stats.costs; compute totals by summing estimated and actual

--- a/libs/openant-core/tests/parsers/python/test_call_graph_self_calls.py
+++ b/libs/openant-core/tests/parsers/python/test_call_graph_self_calls.py
@@ -1,0 +1,140 @@
+"""Regression tests for the Python call graph builder.
+
+Bug report (dbt-core scan, 2026-04-26):
+    `core/dbt/task/run.py:ModelRunner._execute_model` appears unreachable in
+    the parsed dataset, even though `ModelRunner.execute` calls
+    `self._execute_model(...)` on line 359.
+
+Root cause hypothesis:
+    The function code stored by `function_extractor` preserves the original
+    indentation (methods sit inside class blocks, so each line starts with
+    4 spaces). `call_graph_builder._extract_calls_from_code` calls
+    `ast.parse(code)` on that indented body, which raises `IndentationError`
+    (a subclass of `SyntaxError`). The except clause catches `SyntaxError`
+    and falls back to `_extract_calls_regex`, which has no `self.X()`
+    handling — every `self.method()` call silently disappears from the
+    call graph. The blast radius is "every method call inside every method
+    of every Python codebase," which matches the dbt-core scan stats:
+    72% of functions isolated, avg out-degree 0.31.
+
+These tests pin both the unit-level behavior (ast.parse on indented code)
+and the end-to-end behavior (self-method call appears in the graph).
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.python.call_graph_builder import CallGraphBuilder
+
+
+def test_ast_parse_fails_on_indented_method_body():
+    """Pin the underlying Python behavior: indented method bodies don't ast.parse.
+
+    This isn't testing our code — it's documenting the trap that the call
+    graph builder falls into. If this test ever starts failing (Python
+    changes the rule, or someone wraps the code in a `with textwrap.dedent`),
+    the call graph builder needs updating too.
+    """
+    indented = "    def execute(self):\n        return self._other()\n"
+    with pytest.raises((IndentationError, SyntaxError)):
+        ast.parse(indented)
+
+
+def _make_extractor_output() -> dict:
+    """Build a minimal extractor output that mirrors the dbt-core ModelRunner shape.
+
+    Two methods on the same class, where one calls the other via `self.`.
+    Critically, the `code` field preserves leading indentation — that's
+    what the function extractor actually stores.
+    """
+    file_path = "core/dbt/task/run.py"
+    return {
+        "repository": "/tmp/fake",
+        "imports": {file_path: {}},
+        "classes": {
+            f"{file_path}:ModelRunner": {
+                "name": "ModelRunner",
+                "file_path": file_path,
+            }
+        },
+        "functions": {
+            f"{file_path}:ModelRunner.execute": {
+                "name": "execute",
+                "qualified_name": "ModelRunner.execute",
+                "file_path": file_path,
+                "class_name": "ModelRunner",
+                "unit_type": "method",
+                "code": (
+                    "    def execute(self, model, manifest):\n"
+                    "        return self._execute_model(model, manifest)\n"
+                ),
+            },
+            f"{file_path}:ModelRunner._execute_model": {
+                "name": "_execute_model",
+                "qualified_name": "ModelRunner._execute_model",
+                "file_path": file_path,
+                "class_name": "ModelRunner",
+                "unit_type": "method",
+                "code": (
+                    "    def _execute_model(self, model, manifest):\n"
+                    "        return None\n"
+                ),
+            },
+        },
+    }
+
+
+def test_self_method_call_appears_in_forward_call_graph():
+    """ModelRunner.execute calls self._execute_model — the edge must exist."""
+    builder = CallGraphBuilder(_make_extractor_output())
+    builder.build_call_graph()
+
+    caller = "core/dbt/task/run.py:ModelRunner.execute"
+    callee = "core/dbt/task/run.py:ModelRunner._execute_model"
+
+    assert callee in builder.call_graph[caller], (
+        f"Forward call graph missing self-call edge.\n"
+        f"  Expected: {caller} -> {callee}\n"
+        f"  Got: {builder.call_graph[caller]}"
+    )
+
+
+def test_self_method_call_appears_in_reverse_call_graph():
+    """The callee must list its caller — otherwise reachability filtering drops it."""
+    builder = CallGraphBuilder(_make_extractor_output())
+    builder.build_call_graph()
+
+    caller = "core/dbt/task/run.py:ModelRunner.execute"
+    callee = "core/dbt/task/run.py:ModelRunner._execute_model"
+
+    callers = builder.reverse_call_graph.get(callee, [])
+    assert caller in callers, (
+        f"Reverse call graph missing caller for {callee}.\n"
+        f"  Expected to contain: {caller}\n"
+        f"  Got: {callers}"
+    )
+
+
+def test_callee_is_not_isolated_in_statistics():
+    """The dbt-core scan reported 72% isolated functions, driven by this bug.
+
+    A two-method class with one self-call should produce ZERO isolated
+    functions (one has an outgoing edge, the other has an incoming edge).
+    """
+    builder = CallGraphBuilder(_make_extractor_output())
+    builder.build_call_graph()
+
+    stats = builder.get_statistics()
+    assert stats["isolated_functions"] == 0, (
+        f"Expected 0 isolated functions in a two-method class with a "
+        f"self-call, got {stats['isolated_functions']}.\n"
+        f"  total_edges: {stats['total_edges']}\n"
+        f"  call_graph: {builder.call_graph}\n"
+        f"  reverse_call_graph: {builder.reverse_call_graph}"
+    )

--- a/libs/openant-core/tests/test_diff_filter.py
+++ b/libs/openant-core/tests/test_diff_filter.py
@@ -1,0 +1,198 @@
+"""Tests for core.diff_filter.apply_diff_filter."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import unittest
+
+# Make `core` importable when running this file directly.
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from core.diff_filter import (  # noqa: E402
+    SCOPE_CALLERS,
+    SCOPE_CHANGED_FILES,
+    SCOPE_CHANGED_FUNCTIONS,
+    apply_diff_filter,
+    load_manifest,
+)
+
+
+def _unit(uid: str, file: str, start: int, end: int, calls: list | None = None) -> dict:
+    return {
+        "id": uid,
+        "code": {
+            "primary_origin": {
+                "file_path": file,
+                "start_line": start,
+                "end_line": end,
+            },
+        },
+        "metadata": {"direct_calls": calls or []},
+    }
+
+
+class ChangedFilesScope(unittest.TestCase):
+    def test_selects_everything_in_changed_files(self):
+        units = [
+            _unit("a.py:f1", "a.py", 1, 10),
+            _unit("a.py:f2", "a.py", 20, 30),
+            _unit("b.py:f3", "b.py", 1, 5),  # b.py not in changed_files
+        ]
+        manifest = {
+            "scope": SCOPE_CHANGED_FILES,
+            "changed_files": ["a.py"],
+            "hunks": None,
+        }
+        stats = apply_diff_filter(units, manifest)
+        self.assertTrue(units[0]["diff_selected"])
+        self.assertTrue(units[1]["diff_selected"])
+        self.assertFalse(units[2]["diff_selected"])
+        self.assertEqual(stats.total, 3)
+        self.assertEqual(stats.selected, 2)
+
+
+class ChangedFunctionsScope(unittest.TestCase):
+    def test_selects_on_line_overlap(self):
+        units = [
+            _unit("a.py:touched", "a.py", 40, 80),    # overlaps 42..78
+            _unit("a.py:untouched", "a.py", 100, 120),
+            _unit("a.py:edge", "a.py", 78, 90),       # touches end of hunk at 78
+            _unit("b.py:other", "b.py", 1, 5),
+        ]
+        manifest = {
+            "scope": SCOPE_CHANGED_FUNCTIONS,
+            "changed_files": ["a.py"],
+            "hunks": {"a.py": [[42, 78]]},
+        }
+        apply_diff_filter(units, manifest)
+        self.assertTrue(units[0]["diff_selected"])
+        self.assertFalse(units[1]["diff_selected"])
+        self.assertTrue(units[2]["diff_selected"])
+        self.assertFalse(units[3]["diff_selected"])
+
+    def test_no_line_info_falls_back_to_file_match_and_counts_stat(self):
+        unit = {
+            "id": "a.py:no_lines",
+            "code": {"primary_origin": {"file_path": "a.py"}},
+            "metadata": {"direct_calls": []},
+        }
+        manifest = {
+            "scope": SCOPE_CHANGED_FUNCTIONS,
+            "changed_files": ["a.py"],
+            "hunks": {"a.py": [[1, 5]]},
+        }
+        stats = apply_diff_filter([unit], manifest)
+        self.assertTrue(unit["diff_selected"])
+        self.assertEqual(stats.fallback_file_match, 1)
+
+    def test_strips_leading_dotslash(self):
+        units = [_unit("./a.py:f", "./a.py", 1, 10)]
+        manifest = {
+            "scope": SCOPE_CHANGED_FUNCTIONS,
+            "changed_files": ["a.py"],
+            "hunks": {"a.py": [[1, 10]]},
+        }
+        apply_diff_filter(units, manifest)
+        self.assertTrue(units[0]["diff_selected"])
+
+
+class CallersScope(unittest.TestCase):
+    def test_one_hop_caller_is_selected_two_hop_is_not(self):
+        # Chain: A -> B -> C. Only C overlaps a hunk.
+        a = _unit("a.py:A", "a.py", 1, 5, calls=["a.py:B"])
+        b = _unit("a.py:B", "a.py", 10, 15, calls=["a.py:C"])
+        c = _unit("a.py:C", "a.py", 100, 110, calls=[])
+        units = [a, b, c]
+        manifest = {
+            "scope": SCOPE_CALLERS,
+            "changed_files": ["a.py"],
+            "hunks": {"a.py": [[100, 110]]},
+        }
+        stats = apply_diff_filter(units, manifest)
+        self.assertTrue(c["diff_selected"], "C is in the hunk")
+        self.assertTrue(b["diff_selected"], "B calls C directly (1 hop)")
+        self.assertFalse(a["diff_selected"], "A only reaches C via B (2 hops)")
+        self.assertEqual(stats.callers_added, 1)
+
+    def test_unit_without_direct_calls_is_not_selected(self):
+        a = _unit("a.py:A", "a.py", 1, 5)  # no calls metadata
+        c = _unit("a.py:C", "a.py", 100, 110)
+        units = [a, c]
+        manifest = {
+            "scope": SCOPE_CALLERS,
+            "changed_files": ["a.py"],
+            "hunks": {"a.py": [[100, 110]]},
+        }
+        apply_diff_filter(units, manifest)
+        self.assertFalse(a["diff_selected"])
+        self.assertTrue(c["diff_selected"])
+
+    def test_camelcase_directCalls_alias(self):
+        changed = _unit("a.py:C", "a.py", 100, 110)
+        caller = {
+            "id": "a.py:A",
+            "code": {"primary_origin": {"file_path": "a.py", "start_line": 1, "end_line": 5}},
+            "metadata": {"directCalls": ["a.py:C"]},  # camelCase
+        }
+        units = [caller, changed]
+        manifest = {
+            "scope": SCOPE_CALLERS,
+            "changed_files": ["a.py"],
+            "hunks": {"a.py": [[100, 110]]},
+        }
+        apply_diff_filter(units, manifest)
+        self.assertTrue(caller["diff_selected"])
+
+
+class FilePathResolution(unittest.TestCase):
+    def test_falls_back_to_unit_id_when_primary_origin_missing(self):
+        unit = {
+            "id": "handlers/auth.py:login",
+            "metadata": {"direct_calls": []},
+        }
+        manifest = {
+            "scope": SCOPE_CHANGED_FILES,
+            "changed_files": ["handlers/auth.py"],
+            "hunks": None,
+        }
+        apply_diff_filter([unit], manifest)
+        self.assertTrue(unit["diff_selected"])
+
+
+class ManifestLoader(unittest.TestCase):
+    def test_rejects_bad_scope(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump({"scope": "bogus", "changed_files": []}, f)
+            path = f.name
+        try:
+            with self.assertRaises(ValueError):
+                load_manifest(path)
+        finally:
+            os.unlink(path)
+
+    def test_round_trip(self):
+        m = {
+            "base_ref": "origin/main",
+            "base_sha": "abc",
+            "head_sha": "def",
+            "scope": SCOPE_CHANGED_FUNCTIONS,
+            "pr_number": 0,
+            "changed_files": ["a.py"],
+            "hunks": {"a.py": [[1, 10]]},
+        }
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+            json.dump(m, f)
+            path = f.name
+        try:
+            got = load_manifest(path)
+            self.assertEqual(got["scope"], SCOPE_CHANGED_FUNCTIONS)
+            self.assertEqual(got["changed_files"], ["a.py"])
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -342,6 +342,15 @@ class ContextEnhancer:
             Enhanced dataset
         """
         units = dataset.get("units", [])
+
+        # Diff filter: honor diff_selected when set by the parse step.
+        # Keep units_by_id scoped to the original so callers lookup still works
+        # for units outside the diff scope.
+        if any("diff_selected" in u for u in units):
+            _pre = len(units)
+            units = [u for u in units if u.get("diff_selected")]
+            self._log("info", f"Diff filter: {_pre} -> {len(units)} units")
+
         total = len(units)
 
         self._log("info", f"Enhancing {total} units with LLM context (single-shot mode)", units=total)
@@ -465,6 +474,13 @@ class ContextEnhancer:
             Enhanced dataset with agent_context field
         """
         units = dataset.get("units", [])
+
+        # Diff filter: honor diff_selected when set by the parse step.
+        if any("diff_selected" in u for u in units):
+            _pre = len(units)
+            units = [u for u in units if u.get("diff_selected")]
+            self._log("info", f"Diff filter: {_pre} -> {len(units)} units")
+
         total = len(units)
 
         # Checkpoint directory setup

--- a/scripts/check-public-release.sh
+++ b/scripts/check-public-release.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# Pre-push verification for public release branches.
+#
+# Run from anywhere inside the repo, while checked out on the release branch
+# you are about to push to `public`. Exits non-zero if any check fails so
+# callers (humans, hooks, CI) can gate on it.
+#
+# Encodes the checks from docs/internal/release-to-public.md step 6, plus:
+#   - race guard against public/master moving since the branch was cut
+#   - gitleaks secret scan (warns if not installed)
+#
+# Usage:
+#   scripts/check-public-release.sh              # fetch remotes, run all checks
+#   scripts/check-public-release.sh --no-fetch   # skip git fetch (offline / CI)
+#   scripts/check-public-release.sh --no-build   # skip Go build smoke test
+#   scripts/check-public-release.sh --post-merge # verify a fresh public clone
+#                                                # (skips branch + race guards;
+#                                                #  implies --no-fetch)
+#
+# Pattern files (read from repo root):
+#   .publish-exclude            — regexes for forbidden tracked paths
+#   .publish-forbidden-strings  — case-insensitive substrings forbidden in content
+
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null) || {
+  echo "fatal: not inside a git repository" >&2
+  exit 2
+}
+cd "$REPO_ROOT"
+
+NO_FETCH=0
+NO_BUILD=0
+POST_MERGE=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-fetch) NO_FETCH=1 ;;
+    --no-build) NO_BUILD=1 ;;
+    --post-merge) POST_MERGE=1; NO_FETCH=1 ;;
+    -h|--help)
+      sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      echo "use --help for usage" >&2
+      exit 2
+      ;;
+  esac
+done
+
+PASS_COUNT=0
+FAIL_COUNT=0
+WARN_COUNT=0
+
+pass() { printf '  PASS  %s\n' "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf '  FAIL  %s\n' "$1"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+warn() { printf '  WARN  %s\n' "$1"; WARN_COUNT=$((WARN_COUNT + 1)); }
+section() { printf '\n== %s ==\n' "$1"; }
+
+read_patterns() {
+  # Strip comments + blank lines from a pattern file. $1 = path.
+  sed -E 's/[[:space:]]*#.*$//; /^[[:space:]]*$/d' "$1"
+}
+
+# ---------- Setup ----------
+
+section "Setup"
+
+if [ "$NO_FETCH" = "0" ]; then
+  if git remote get-url public >/dev/null 2>&1; then
+    if git fetch --quiet origin && git fetch --quiet public; then
+      pass "fetched origin and public"
+    else
+      fail "git fetch failed — check network / remote auth"
+    fi
+  else
+    fail "remote 'public' missing — run: git remote add public git@github.com:knostic/OpenAnt.git"
+  fi
+else
+  pass "skipped fetch (--no-fetch)"
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$POST_MERGE" = "1" ]; then
+  pass "post-merge mode (branch + race guards skipped) — branch: $CURRENT_BRANCH"
+else
+  case "$CURRENT_BRANCH" in
+    master|main|HEAD)
+      fail "on '$CURRENT_BRANCH' — release checks must run on a release branch (e.g. release/<name>)"
+      ;;
+    *)
+      pass "on release branch: $CURRENT_BRANCH"
+      ;;
+  esac
+
+  section "Race guard vs public/master"
+
+  if git rev-parse --verify --quiet refs/remotes/public/master >/dev/null; then
+    AHEAD=$(git log --oneline public/master ^HEAD 2>/dev/null)
+    if [ -n "$AHEAD" ]; then
+      fail "public/master has commits not reachable from $CURRENT_BRANCH:"
+      printf '%s\n' "$AHEAD" | sed 's/^/        /'
+      echo "        rebase onto public/master before releasing"
+    else
+      pass "public/master fully reachable from $CURRENT_BRANCH"
+    fi
+  else
+    fail "public/master ref not found — fetch the public remote"
+  fi
+fi
+
+# ---------- Forbidden paths ----------
+
+section "Internal-only paths"
+
+EXCLUDE_FILE="$REPO_ROOT/.publish-exclude"
+if [ ! -f "$EXCLUDE_FILE" ]; then
+  fail ".publish-exclude not found at repo root"
+else
+  any_path_failure=0
+  ALL_TRACKED=$(git ls-files)
+  while IFS= read -r pattern; do
+    [ -z "$pattern" ] && continue
+    matches=$(printf '%s\n' "$ALL_TRACKED" | grep -E -- "$pattern" || true)
+    if [ -n "$matches" ]; then
+      fail "tracked files match forbidden pattern '$pattern':"
+      printf '%s\n' "$matches" | sed 's/^/        /'
+      any_path_failure=1
+    fi
+  done < <(read_patterns "$EXCLUDE_FILE")
+  if [ "$any_path_failure" = "0" ]; then
+    pass "no tracked files match .publish-exclude"
+  fi
+fi
+
+# ---------- Forbidden strings ----------
+
+section "Forbidden strings in content"
+
+FORBID_FILE="$REPO_ROOT/.publish-forbidden-strings"
+if [ ! -f "$FORBID_FILE" ]; then
+  fail ".publish-forbidden-strings not found at repo root"
+else
+  any_string_failure=0
+  # Exclude the pattern files themselves (they legitimately contain the patterns)
+  # plus anything already flagged by the path check.
+  GREP_PATHSPECS=(
+    ':(exclude).publish-exclude'
+    ':(exclude).publish-forbidden-strings'
+    ':(exclude)docs/internal'
+    ':(exclude)scripts/check-public-release.sh'
+  )
+  while IFS= read -r needle; do
+    [ -z "$needle" ] && continue
+    if matches=$(git grep -i -F -n -e "$needle" -- "${GREP_PATHSPECS[@]}" 2>/dev/null); then
+      fail "forbidden string '$needle' found:"
+      printf '%s\n' "$matches" | sed 's/^/        /'
+      any_string_failure=1
+    fi
+  done < <(read_patterns "$FORBID_FILE")
+  if [ "$any_string_failure" = "0" ]; then
+    pass "no forbidden strings found"
+  fi
+fi
+
+# ---------- Secret scan ----------
+
+section "Secret scan (gitleaks)"
+
+if command -v gitleaks >/dev/null 2>&1; then
+  # Scan ONLY the tracked content of HEAD — excludes untracked / gitignored
+  # files (notably node_modules) so the scan reflects what would land on public.
+  GL_DIR=$(mktemp -d)
+  GL_OUT=$(mktemp)
+  if git archive HEAD | tar -x -C "$GL_DIR"; then
+    if NO_COLOR=1 gitleaks detect --source "$GL_DIR" --no-banner --redact --no-git >"$GL_OUT" 2>&1; then
+      pass "gitleaks: no secrets detected in tracked content"
+    else
+      fail "gitleaks detected potential secrets:"
+      sed 's/^/        /' "$GL_OUT"
+    fi
+  else
+    fail "git archive HEAD failed — cannot run gitleaks scan"
+  fi
+  rm -rf "$GL_DIR" "$GL_OUT"
+else
+  warn "gitleaks not installed — install via 'brew install gitleaks' for secret scanning"
+fi
+
+# ---------- Build smoke test ----------
+
+section "Build smoke test"
+
+if [ "$NO_BUILD" = "1" ]; then
+  pass "skipped build (--no-build)"
+elif [ -d apps/openant-cli ]; then
+  BUILD_OUT=$(mktemp)
+  if (cd apps/openant-cli && go build ./... >"$BUILD_OUT" 2>&1); then
+    pass "apps/openant-cli builds cleanly"
+  else
+    fail "apps/openant-cli build failed:"
+    sed 's/^/        /' "$BUILD_OUT"
+  fi
+  rm -f "$BUILD_OUT"
+else
+  fail "apps/openant-cli not found — adjust check-public-release.sh"
+fi
+
+# ---------- Summary ----------
+
+section "Summary"
+printf '  %d passed, %d failed, %d warnings\n' "$PASS_COUNT" "$FAIL_COUNT" "$WARN_COUNT"
+
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  echo ""
+  echo "FAILED — fix issues above before pushing to public."
+  exit 1
+fi
+
+echo ""
+echo "OK — release branch is clean. Safe to push."
+exit 0


### PR DESCRIPTION
## Summary

- **Incremental scans** — `openant scan --diff` and `openant diff` flow:
  manifest computation in Go (`apps/openant-cli/internal/git`), pipeline
  filtering in Python (`core/diff_filter.py`), per-run scan metadata
  (`scan_meta.go`), HTML reports + summary surface diff range and changed
  files.
- **Mode selection** — `openant init`, `openant scan`, `openant parse` now
  prompt for `all` / `reachable` / `codeql` / `exploitable` mode; Docker
  preflight check before dynamic-test runs.
- **Python parser self-call fix** — dedent source before `ast.parse`
  in `parsers/python/call_graph_builder.py` so methods inside indented
  classes are parsed correctly.
- **Public-release tooling** — `.publish-exclude`,
  `.publish-forbidden-strings`, and `scripts/check-public-release.sh`
  encode the path / content / build / secret checks for outbound
  releases.

## Test plan

- [ ] `openant scan --diff <ref>` against a sample repo — incremental pipeline only processes changed units, HTML report shows diff range
- [ ] `openant init` selects mode interactively; `openant scan -m reachable` non-interactive
- [ ] `pytest libs/openant-core/tests/parsers/python/` — call-graph self-call regression suite passes
- [ ] `./scripts/check-public-release.sh --post-merge` on a fresh public clone — all 7 checks pass
