### PR TITLE
ci(gitleaks): switch to pull_request_target so fork PRs get GITLEAKS_LICENSE

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -2,7 +2,7 @@ name: gitleaks
 on:
   push:
     branches: [master]
-  pull_request:
+  pull_request_target:
 jobs:
   scan:
     name: gitleaks
@@ -17,6 +17,7 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Set scan range
         id: range
         env:
@@ -26,7 +27,7 @@ jobs:
           FORCED: ${{ github.event.forced }}
         run: |
           NULL_SHA="0000000000000000000000000000000000000000"
-          if [ "$EVENT" = "pull_request" ]; then
+          if [ "$EVENT" = "pull_request_target" ]; then
             echo "log_opts=${BASE_SHA}..HEAD" >> $GITHUB_OUTPUT
           elif [ "$BEFORE_SHA" = "$NULL_SHA" ] || [ -z "$BEFORE_SHA" ] || [ "$FORCED" = "true" ]; then
             echo "log_opts=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- Fork PRs (e.g. #15 from `joshbouncesecurity/OpenAnt`) currently fail the `gitleaks` check with `missing gitleaks license`. GitHub strips secrets from `pull_request` runs whose head is in a fork, so `${{ secrets.GITLEAKS_LICENSE }}` resolves to an empty string and gitleaks-action rejects the org.
- Switch the trigger to `pull_request_target`, which runs in the base-repo context with org secrets available. Explicitly check out `pull_request.head.sha` so the scan still covers the contributor's commits, and update the scan-range branch to match the new event name.

## Why this is safe

`pull_request_target` is dangerous when a workflow executes PR-controlled code (build steps, `npm install`, `pip install`, etc.). This workflow does not — it only runs `gitleaks/gitleaks-action` pinned by full SHA against the checked-out tree. No installer, no script execution, no test runner. The action reads files; it does not evaluate them.

## Test plan

- [ ] Merge → re-run check on PR #15 (fork PR) → expect `gitleaks` SUCCESS with the license env populated.
- [ ] Open a same-repo branch PR → confirm scan still works (no regression on the non-fork path).
- [ ] Push to `master` → confirm push-event scan range falls through to the `BEFORE_SHA..HEAD` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)