### PR TITLE
ci: add ruff lint with F821/F811 rules

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,25 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: Lint (Python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Lint Python (undefined names, syntax errors)
+        working-directory: libs/openant-core
+        run: ruff check .
+
   python-tests:
     name: Python tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -36,10 +55,6 @@ jobs:
       - name: Install Python dependencies
         working-directory: libs/openant-core
         run: pip install -r requirements.txt && pip install ".[dev]"
-
-      - name: Lint Python (undefined names, syntax errors)
-        working-directory: libs/openant-core
-        run: ruff check .
 
       - name: Cache JS parser node_modules
         id: cache-node-modules

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,10 @@ jobs:
         working-directory: libs/openant-core
         run: pip install -r requirements.txt && pip install ".[dev]"
 
+      - name: Lint Python (undefined names, syntax errors)
+        working-directory: libs/openant-core
+        run: ruff check .
+
       - name: Cache JS parser node_modules
         id: cache-node-modules
         uses: actions/cache@v4

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -390,7 +390,7 @@ def run_analysis(
 
     # Inject prior usage into tracker so step_report captures the total
     if _summary_input_tokens or _summary_output_tokens:
-        tracker.add_prior_usage(
+        get_global_tracker().add_prior_usage(
             _summary_input_tokens, _summary_output_tokens, _summary_cost_usd)
 
     # Write initial summary

--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.0.0",
+    "ruff>=0.8.0",
 ]
 
 [project.scripts]
@@ -29,6 +30,14 @@ openant = "openant.cli:main"
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+# Only rules that catch actual bugs (will break at runtime)
+# F821: undefined name, F811: redefined unused name
+select = ["F821", "F811"]
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -36,8 +36,8 @@ target-version = "py311"
 
 [tool.ruff.lint]
 # Only rules that catch actual bugs (will break at runtime)
-# F821: undefined name, F811: redefined unused name
-select = ["F821", "F811"]
+# F821: undefined name, F811: redefined unused name, F823: local var referenced before assignment
+select = ["F821", "F811", "F823"]
 
 [tool.hatch.build.targets.wheel]
 packages = [


### PR DESCRIPTION
## Summary

Adds a ruff lint step to the test workflow with two rules: `F821` (undefined name) and `F811` (redefined unused name). Python won't report an undefined name until that code path executes, so a missing import can ship undetected. F821 + F811 catch that statically with zero false positives and no style noise.

Configured to run before pytest so CI fails fast on missing imports.

Verified clean against `upstream/master` baseline after fixing one pre-existing violation:

- `libs/openant-core/core/analyzer.py:393` — `analyze()` called `tracker.add_prior_usage(...)` without defining `tracker` locally. Replaced with `get_global_tracker().add_prior_usage(...)` to match the pattern already used elsewhere in the same file (e.g. line 489). This is a real bug — the line would `NameError` at runtime whenever resuming with non-zero prior token usage.

Addresses item 2 from #16 (does not close the issue).

## Test plan

- [ ] `ruff check .` exits 0 on a clean checkout (verified locally).
- [ ] CI runs ruff before pytest; failure short-circuits.
- [ ] Existing pytest suite still passes (verified locally: 38 passed, 10 skipped).