### PR TITLE
fix(parsers/javascript): extract Express anonymous route handler callbacks (#21)

### DIFF
--- a/libs/openant-core/parsers/javascript/typescript_analyzer.js
+++ b/libs/openant-core/parsers/javascript/typescript_analyzer.js
@@ -240,6 +240,149 @@ class TypeScriptAnalyzer {
     // Extract functions from module.exports.propertyName = function() {...}
     // Pattern used by DVNA and similar CommonJS codebases
     this._extractModuleExportsPropertyFunctions(sourceFile, relativePath);
+
+    // Extract anonymous arrow / function-expression callbacks passed to
+    // Express.js style route registrations. Without this pass the parser
+    // misses the actual handler bodies whenever a codebase uses the
+    // idiomatic `router.post('/x', handler, async (req, res) => {...})`
+    // pattern, which is the bug reported in
+    // https://github.com/knostic/OpenAnt/issues/21.
+    this._extractRouteHandlerCallbacks(sourceFile, relativePath);
+  }
+
+  /**
+   * Express verbs that take a path-string and one or more handler
+   * callbacks. `use` is included because `app.use('/api', (req, res, next) => …)`
+   * is a common middleware mounting pattern. `all` is the Express
+   * "match every method" wildcard.
+   *
+   * Hapi / Koa / Fastify use a different shape (object literal with a
+   * `handler` property rather than a positional callback) and would need
+   * separate detection — out of scope for the #21 fix.
+   */
+  static _expressRouteVerbs() {
+    return new Set([
+      "get",
+      "post",
+      "put",
+      "patch",
+      "delete",
+      "options",
+      "head",
+      "all",
+      "use",
+    ]);
+  }
+
+  /**
+   * Walk every call expression in the file and, when it looks like
+   * `<receiver>.<verb>(<path>, ...callbacks)` for an Express verb, treat
+   * each arrow / function-expression argument as a route handler unit.
+   *
+   * Each extracted unit gets:
+   *   - a synthetic name in the shape `<VERB> <path>` (e.g.
+   *     `POST /orders`) when the path is a string literal — matches the
+   *     "method and path as metadata" expectation in the issue.
+   *   - `isEntryPoint: true` since these directly receive HTTP request
+   *     data, which is what the reachability_filter looks for.
+   *   - `unitType: "route_handler"` so the existing classifier logic
+   *     downstream doesn't have to re-derive it.
+   *
+   * If multiple callbacks are passed (middleware chain plus the final
+   * handler), each one becomes its own unit suffixed with its 0-based
+   * argument index, so they don't collide.
+   */
+  _extractRouteHandlerCallbacks(sourceFile, relativePath) {
+    const verbs = TypeScriptAnalyzer._expressRouteVerbs();
+
+    // SyntaxKind.CallExpression — its numeric value drifts between
+    // typescript releases (213 in older versions, 214 in 5.x), so we
+    // resolve it dynamically off the typescript dep rather than
+    // hard-coding it.
+    const ts = require("typescript");
+    const callExprKind = ts.SyntaxKind.CallExpression;
+
+    for (const callExpr of sourceFile.getDescendantsOfKind(callExprKind)) {
+      const expression = callExpr.getExpression();
+      if (!expression || expression.getKindName() !== "PropertyAccessExpression") {
+        continue;
+      }
+
+      const verb = expression.getName ? expression.getName() : null;
+      if (!verb || !verbs.has(verb.toLowerCase())) {
+        continue;
+      }
+
+      const args = callExpr.getArguments();
+      if (args.length === 0) {
+        continue;
+      }
+
+      // Path is the first arg if it's a string literal. Some patterns
+      // pass a regex or omit the path entirely (e.g. `app.use(middleware)`),
+      // in which case we fall back to a `<verb>` label.
+      let pathLiteral = null;
+      const first = args[0];
+      const firstKind = first.getKindName();
+      if (
+        firstKind === "StringLiteral" ||
+        firstKind === "NoSubstitutionTemplateLiteral"
+      ) {
+        // .getLiteralText() returns the unquoted value
+        pathLiteral = first.getLiteralText ? first.getLiteralText() : null;
+      }
+
+      // Iterate the *callback* arguments — skip the path arg if present.
+      const startIdx =
+        firstKind === "StringLiteral" ||
+        firstKind === "NoSubstitutionTemplateLiteral" ||
+        firstKind === "RegularExpressionLiteral"
+          ? 1
+          : 0;
+
+      for (let i = startIdx; i < args.length; i++) {
+        const arg = args[i];
+        const argKind = arg.getKindName();
+        if (argKind !== "ArrowFunction" && argKind !== "FunctionExpression") {
+          continue;
+        }
+
+        const argIdx = i - startIdx;
+        const verbUpper = verb.toUpperCase();
+        let baseName;
+        if (pathLiteral) {
+          baseName = `${verbUpper} ${pathLiteral}`;
+        } else {
+          baseName = verbUpper;
+        }
+
+        // Suffix duplicate base names with the argument index so the
+        // function map doesn't collide. The first callback gets no
+        // suffix to keep the common "single handler" case readable.
+        const name = argIdx === 0 ? baseName : `${baseName} [${argIdx}]`;
+        const functionId = `${relativePath}:${name}`;
+
+        // Skip if a previous pass already extracted this exact id, e.g.
+        // when the route handler was named via a separate variable
+        // declaration earlier in the file.
+        if (this.functions[functionId]) {
+          continue;
+        }
+
+        const code = arg.getFullText();
+        this.functions[functionId] = {
+          name: name,
+          code: code,
+          isExported: false,
+          unitType: "route_handler",
+          startLine: arg.getStartLineNumber(),
+          endLine: arg.getEndLineNumber(),
+          isEntryPoint: true,
+          httpMethod: verbUpper,
+          httpPath: pathLiteral || null,
+        };
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #21.

The analyzer never walked into call-expression argument lists, so when a route was defined idiomatically as

\`\`\`js
router.post('/orders', authenticateToken, async (req, res) => { ... });
\`\`\`

the only thing it picked up was the named middleware reference. The actual handler body — where most of the application's business logic and vulnerabilities live — was invisible to every downstream stage, which is why \`reachability_filter\` was dropping ~75% of the units in the example codebase.

## Approach

New \`_extractRouteHandlerCallbacks\` pass on every source file that walks every \`CallExpression\`, detects the Express verb shape (\`<receiver>.{get,post,put,patch,delete,options,head,all,use}(...)\`), and extracts each \`ArrowFunction\` / \`FunctionExpression\` argument as its own unit with:

- synthetic name \`<METHOD> <path>\` (e.g. \`POST /orders\`) when the path is a string literal — matches the "method and path as metadata" bullet under "Expected behavior" in the issue.
- \`unitType: "route_handler"\` so the existing classifier downstream doesn't have to re-derive it from the body.
- \`isEntryPoint: true\` so \`reachability_filter\` treats it as a request-data entry the way it already treats named \`(req, res)\` middleware.
- \`httpMethod\` / \`httpPath\` carried through for any follow-up step that wants to render route info.

Multi-callback registrations (chained middleware + final handler) get suffixed with their post-path arg index — \`POST /orders\` for the first callback, \`POST /orders [1]\` for the second, etc — so they don't collide.

\`SyntaxKind.CallExpression\` is resolved off the typescript dep at call time (its numeric value drifts between releases — 213 in older versions, 214 in 5.x) rather than hard-coded.

## Smoke test

Ran the analyzer against the issue's example file plus three additional shapes:

\`\`\`
$ node -e "const { TypeScriptAnalyzer } = require('./typescript_analyzer.js');
const a = new TypeScriptAnalyzer('/tmp/express_test_repo');
const result = a.analyzeFiles(['routes.js']);
for (const [id, f] of Object.entries(result.functions)) {
  console.log(id, '| type=' + f.unitType, '| entry=' + (f.isEntryPoint||false),
              '| method=' + (f.httpMethod||''), '| path=' + (f.httpPath||''));
}
"
routes.js:POST /orders [1]    | type=route_handler | entry=true | method=POST   | path=/orders
routes.js:GET /users/:id      | type=route_handler | entry=true | method=GET    | path=/users/:id
routes.js:USE /api            | type=route_handler | entry=true | method=USE    | path=/api
routes.js:DELETE /items/:id [2] | type=route_handler | entry=true | method=DELETE | path=/items/:id
\`\`\`

Named middleware references (\`authenticateToken\`, \`authorizeAdmin\`) correctly stay out of the unit list since they parse as \`Identifier\`, not \`ArrowFunction\` / \`FunctionExpression\`. The existing variable-decl and module.exports passes still pick those up where they're defined.

## What's not in scope

- **Hapi / Koa / Fastify** use a different shape — \`server.route({ method, path, handler: () => {...} })\` — and would need separate detection. Left out so this PR is focused on the Express case the issue described.
- **Method names spelled different from \`router\` / \`app\`** — the detector looks at the verb suffix only, not the receiver. So \`myCustomRouter.post('/x', handler)\` works the same way \`app.post\` does. If you'd prefer a tighter receiver allowlist, easy to swap in.
- **Route handlers passed indirectly** (\`const h = (req, res) => {...}; router.post('/x', h)\`) — the variable-declaration pass already extracts \`h\`, so reachability_filter sees it via that name. Worth flagging for review in case you'd rather de-dup or tag it as a route handler too.

## Test plan

- [x] Manual smoke test against the issue's example file (4 routes → 4 units, all flagged \`isEntryPoint\`)
- [x] Verified named-middleware references stay out of the unit list (no double-extraction)
- [x] No JS-side test harness exists in the repo for the parser, so I'm relying on the smoke test above plus your CI for downstream regressions. Happy to bolt on a small node-based test suite for the analyzer in a follow-up if you want one.