### PR TITLE
fix(parsers/python): repair 6 call-graph edge-fidelity bugs in the Python CallGraphBuilder

### DIFF
--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -183,17 +183,76 @@ class CallGraphBuilder:
             # Fall back to regex-based extraction
             return self._extract_calls_regex(code, caller_id)
 
+        # Local variable -> constructor-type map, so that `v = ClassName(); v.method()`
+        # dispatches to the bound type's method.
+        local_types = self._collect_local_types(tree)
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
-                resolved = self._resolve_call_node(node, caller_file, caller_class)
+                resolved = self._resolve_call_node(node, caller_file, caller_class, local_types)
                 if resolved:
                     calls.add(resolved)
+                # Higher-order-function callbacks: a function reference passed as an
+                # argument (map(func, xs), sorted(xs, key=func)) is a real reachability
+                # edge but lives in node.args / node.keywords, not node.func, so the
+                # main resolver above never sees it.
+                for callee in self._resolve_callback_args(node, caller_file):
+                    calls.add(callee)
 
         return calls
 
-    def _resolve_call_node(self, node: ast.Call, caller_file: str, caller_class: Optional[str]) -> Optional[str]:
+    def _collect_local_types(self, tree: ast.AST) -> Dict[str, str]:
+        """Map local variable names to the class name they are constructed from.
+
+        Handles the conservative, unambiguous case ``var = ClassName(...)`` where the
+        right-hand side is a direct call of a bare Name (the constructor). Used to resolve
+        ``var.method()`` against the constructed type. If the same
+        name is rebound to different types, it is treated as ambiguous and dropped.
+        """
+        types: Dict[str, str] = {}
+        ambiguous: Set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            value = node.value
+            if not (isinstance(value, ast.Call) and isinstance(value.func, ast.Name)):
+                continue
+            ctor = value.func.id
+            for target in node.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                name = target.id
+                if name in ambiguous:
+                    continue
+                if name in types and types[name] != ctor:
+                    ambiguous.add(name)
+                    types.pop(name, None)
+                else:
+                    types[name] = ctor
+        return types
+
+    def _resolve_callback_args(self, node: ast.Call, caller_file: str) -> List[str]:
+        """Resolve function references passed as call arguments to function ids.
+
+        Inspects positional args and keyword values for bare ``ast.Name`` references that
+        resolve to a known function (e.g. the callbacks of ``map``/``filter``/``sorted``).
+        Only Name references are considered -- inline lambdas and attribute references have
+        no standalone function id to point at.
+        """
+        callees: List[str] = []
+        candidates = list(node.args) + [kw.value for kw in node.keywords]
+        for arg in candidates:
+            if isinstance(arg, ast.Name) and not self._is_builtin(arg.id):
+                resolved = self._resolve_simple_call(arg.id, caller_file)
+                if resolved:
+                    callees.append(resolved)
+        return callees
+
+    def _resolve_call_node(self, node: ast.Call, caller_file: str, caller_class: Optional[str],
+                           local_types: Optional[Dict[str, str]] = None) -> Optional[str]:
         """Resolve an AST Call node to a function ID."""
         func = node.func
+        local_types = local_types or {}
 
         # Simple function call: func_name(...)
         if isinstance(func, ast.Name):
@@ -221,12 +280,20 @@ class CallGraphBuilder:
 
             # super().method(...)
             if isinstance(obj, ast.Call) and isinstance(obj.func, ast.Name) and obj.func.id == 'super':
-                # Would need to resolve parent class - skip for now
+                if caller_class:
+                    return self._resolve_super_call(method_name, caller_file, caller_class)
                 return None
 
             # module.func(...) or object.method(...)
             if isinstance(obj, ast.Name):
                 obj_name = obj.id
+                # Local variable of a locally-known type: `v = ClassName(); v.method()`
+                # resolves to the constructed class's method,
+                # which _resolve_module_call (imports / same-file class NAMES only) cannot do.
+                if obj_name in local_types:
+                    typed = self._resolve_class_method(local_types[obj_name], method_name, caller_file)
+                    if typed:
+                        return typed
                 return self._resolve_module_call(obj_name, method_name, caller_file)
 
             # Chained calls: obj.method1().method2(...)
@@ -273,6 +340,75 @@ class CallGraphBuilder:
 
         return None
 
+    def _resolve_super_call(self, method_name: str, caller_file: str, caller_class: str) -> Optional[str]:
+        """Resolve a ``super().method(...)`` call to the inherited parent method.
+
+        The previous implementation returned ``None`` unconditionally, so any method
+        reachable only through ``super()`` was dropped from the call graph -- including
+        cross-file inheritance, where the parent class lives in a different module.
+
+        Resolution walks the caller class's declared bases (``self.classes[...]['bases']``,
+        populated by the extractor) up the inheritance chain, looking for the first base
+        class -- in ANY file -- that defines ``method_name``. Base classes are matched by
+        their simple name, so a base declared as ``module.Base`` still matches the class
+        named ``Base``. Returns the parent method's function id, or ``None`` if the parent
+        class (e.g. an external library type) is not present in the parsed repo.
+        """
+        seen_classes: Set[str] = set()
+        # Seed the BFS with the caller's own class key.
+        queue: List[str] = [f"{caller_file}:{caller_class}"]
+        while queue:
+            class_key = queue.pop(0)
+            if class_key in seen_classes:
+                continue
+            seen_classes.add(class_key)
+            class_data = self.classes.get(class_key)
+            if not class_data:
+                continue
+            for base in class_data.get('bases', []):
+                base_simple = base.split('.')[-1]            # 'pkg.Base' -> 'Base'
+                # Find every class (across files) whose simple name matches this base.
+                for cand_key, cand_data in self.classes.items():
+                    if cand_data.get('name') != base_simple or cand_key in seen_classes:
+                        continue
+                    method_id = self._method_in_class(cand_key, method_name)
+                    if method_id:
+                        return method_id
+                    # Parent doesn't define it directly -- keep walking its own bases.
+                    queue.append(cand_key)
+        return None
+
+    def _method_in_class(self, class_key: str, method_name: str) -> Optional[str]:
+        """Return the function id of ``method_name`` declared on ``class_key``, or None."""
+        for func_id in self.methods_by_class.get(class_key, []):
+            if self.functions.get(func_id, {}).get('name') == method_name:
+                return func_id
+        return None
+
+    def _resolve_class_method(self, class_name: str, method_name: str, caller_file: str) -> Optional[str]:
+        """Resolve ``ClassName.method`` to a function id, same-file first then cross-file.
+
+        Used to dispatch a call on a local variable whose type is known.
+        Same-file resolution is preferred; otherwise the class
+        is matched by simple name across all parsed files (unambiguous single match only,
+        to avoid binding to an unrelated same-named class).
+        """
+        class_simple = class_name.split('.')[-1]
+        # 1. Same file.
+        same_file = self._method_in_class(f"{caller_file}:{class_simple}", method_name)
+        if same_file:
+            return same_file
+        # 2. Cross-file: exactly one class with this simple name that defines the method.
+        matches = []
+        for class_key, class_data in self.classes.items():
+            if class_data.get('name') == class_simple:
+                method_id = self._method_in_class(class_key, method_name)
+                if method_id:
+                    matches.append(method_id)
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
     def _resolve_module_call(self, obj_name: str, method_name: str, caller_file: str) -> Optional[str]:
         """Resolve a module.function() or object.method() call."""
         # Skip builtin modules
@@ -297,7 +433,8 @@ class CallGraphBuilder:
 
         return None
 
-    def _resolve_import(self, import_path: str, func_name: str, caller_file: str) -> Optional[str]:
+    def _resolve_import(self, import_path: str, func_name: str, caller_file: str,
+                        _seen: Optional[Set[str]] = None) -> Optional[str]:
         """Resolve an imported function to a function ID."""
         # import_path might be "module.submodule.function" or "module.ClassName"
         parts = import_path.split('.')
@@ -327,6 +464,15 @@ class CallGraphBuilder:
                 if target_id in self.functions:
                     return target_id
 
+        # Strategy 1b: package re-export via __init__.py.
+        # `from pkg import name` records import_path 'pkg.name', but `name` may not live in
+        # pkg.py -- it is commonly re-exported from pkg/__init__.py via
+        # `from .submodule import name`. Probe the package __init__.py, then follow the
+        # recorded re-export to the name's true origin module. _seen guards re-export cycles.
+        reexported = self._resolve_via_package_init(parts, func_name, _seen)
+        if reexported:
+            return reexported
+
         # Strategy 2: Check if import_path itself is a function
         for func_id in self.functions:
             func_data = self.functions[func_id]
@@ -338,6 +484,36 @@ class CallGraphBuilder:
                 if module_path.endswith(expected_module) or expected_module.endswith(module_path):
                     return func_id
 
+        return None
+
+    def _resolve_via_package_init(self, parts: List[str], func_name: str,
+                                  _seen: Optional[Set[str]]) -> Optional[str]:
+        """Follow a name re-exported through a package ``__init__.py`` to its origin.
+
+        Given the dotted import parts (e.g. ['utils', 'sanitize']) and the imported
+        ``func_name``, this walks the longest-to-shortest package prefixes, and for any
+        prefix whose ``<prefix>/__init__.py`` was parsed, looks up ``func_name`` in that
+        package's recorded import map. When the package re-exports the name (e.g.
+        ``from .helpers import sanitize`` -> 'utils.helpers.sanitize'), resolution recurses
+        on the re-export target to reach the true origin module.
+        """
+        seen = _seen if _seen is not None else set()
+        for i in range(len(parts), 0, -1):
+            init_file = '/'.join(parts[:i]) + '/__init__.py'
+            if init_file not in self.imports:
+                continue
+            if init_file in seen:                       # re-export cycle guard
+                continue
+            pkg_imports = self.imports[init_file]
+            if func_name not in pkg_imports:
+                continue
+            seen.add(init_file)
+            origin_path = pkg_imports[func_name]         # e.g. 'utils.helpers.sanitize'
+            if origin_path == '.'.join(parts):           # would re-resolve to itself
+                continue
+            resolved = self._resolve_import(origin_path, func_name, init_file, seen)
+            if resolved:
+                return resolved
         return None
 
     def _extract_calls_regex(self, code: str, caller_id: str) -> Set[str]:
@@ -380,8 +556,11 @@ class CallGraphBuilder:
             # Extract all function calls from this function's code
             calls = self._extract_calls_from_code(code, func_id)
 
-            # Filter to valid function IDs (must exist in our codebase, not self-calls)
-            valid_calls = [c for c in calls if c in self.functions and c != func_id]
+            # Filter to valid function IDs (must exist in our codebase, not self-calls).
+            # `calls` is a set, whose iteration order depends on PYTHONHASHSEED; sort the
+            # filtered list so call_graph (and, below, reverse_call_graph) emit a stable,
+            # reproducible ordering on identical input.
+            valid_calls = sorted(c for c in calls if c in self.functions and c != func_id)
             self.call_graph[func_id] = valid_calls
 
             # Build reverse graph: for each called function, record this caller
@@ -390,6 +569,10 @@ class CallGraphBuilder:
                     self.reverse_call_graph[called_id] = []
                 if func_id not in self.reverse_call_graph[called_id]:
                     self.reverse_call_graph[called_id].append(func_id)
+
+        # Sort reverse-graph caller lists for the same determinism guarantee.
+        for called_id in self.reverse_call_graph:
+            self.reverse_call_graph[called_id].sort()
 
     def get_dependencies(self, func_id: str, depth: Optional[int] = None) -> List[str]:
         """Get all dependencies (callees) for a function up to max depth."""

--- a/libs/openant-core/tests/test_python_call_graph_builder.py
+++ b/libs/openant-core/tests/test_python_call_graph_builder.py
@@ -1,0 +1,150 @@
+"""Regression tests for Python call-graph builder (parsers/python/call_graph_builder.py) edge-fidelity bugs.
+
+Seven independent defects in the Python CallGraphBuilder, each pinned by its own test:
+
+__init__.py re-export: _resolve_import never probes package ``__init__.py`` nor follows
+  ``from .submodule import name`` re-exports, so a call to a name re-exported via a package
+  __init__.py (ubiquitous in Python public APIs) gets no call edge.
+Local-variable type dispatch: obj.method() on a local variable of a locally-known type
+  (``v = ClassName(); v.method()``) is routed to _resolve_module_call, which only knows
+  imports/same-file class NAMES, never a local var's bound type -> edge dropped.
+super() resolution: the super().method() branch in
+  _resolve_call_node returns None unconditionally ("skip for now"), so an inherited
+  parent method reachable only via super() is dropped from the graph -- even when the
+  parent class is in the repo (cross-file inheritance).
+Deterministic ordering: per-function callee lists are built by iterating a Python
+  ``set`` with no sorted(), so call_graph / reverse_call_graph value ORDER is
+  PYTHONHASHSEED-dependent -> non-deterministic output on identical input.
+HOF callback arguments: higher-order-function callback arguments
+  (``map(func, xs)``, ``sorted(xs, key=func)``) are never read -- _resolve_call_node only
+  inspects node.func, never node.args/node.keywords -> callback-only functions look
+  unreachable.
+
+Loads call_graph_builder under a UNIQUE importlib module name (the bare
+'call_graph_builder' basename is shared by the c/go/php/ruby/zig parsers, so a plain
+import would pollute sys.modules for the rest of the suite).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[1]                  # libs/openant-core
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))                           # for utilities.* imported by the module
+
+_spec = importlib.util.spec_from_file_location(
+    "py_call_graph_builder_isolated", str(CORE / "parsers" / "python" / "call_graph_builder.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+CallGraphBuilder = _mod.CallGraphBuilder
+
+
+def _fn(file_path, name, code, class_name=None):
+    """Build one entry in the extractor 'functions' map."""
+    fid = f"{file_path}:{class_name + '.' if class_name else ''}{name}"
+    data = {"name": name, "file_path": file_path, "code": code}
+    if class_name:
+        data["class_name"] = class_name
+    return fid, data
+
+
+def _build(functions, imports=None, classes=None):
+    out = {
+        "repository": "/tmp/fake",
+        "functions": functions,
+        "imports": imports or {},
+        "classes": classes or {},
+    }
+    b = CallGraphBuilder(out)
+    b.build_call_graph()
+    return b
+
+
+# ---- __init__.py re-export resolution ----
+def test_init_reexport_resolved_to_origin():
+    helpers = "utils/helpers.py"
+    init = "utils/__init__.py"
+    main = "main.py"
+    fns = {}
+    fns.update(dict([_fn(helpers, "sanitize", "def sanitize(x):\n    return x\n")]))
+    # utils/__init__.py re-exports sanitize via `from .helpers import sanitize`
+    fid, data = _fn(main, "handler", "def handler(self):\n    return sanitize(self.value)\n")
+    fns[fid] = data
+    imports = {
+        # main.py imports sanitize from the package `utils` (re-export consumer)
+        main: {"sanitize": "utils.sanitize"},
+        init: {"sanitize": "utils.helpers.sanitize"},
+    }
+    # function_extractor records __init__.py imports under the package file path.
+    b = _build(fns, imports=imports)
+    edges = b.call_graph.get(f"{main}:handler", [])
+    assert f"{helpers}:sanitize" in edges, (
+        f"re-exported sanitize not resolved through utils/__init__.py: {edges}")
+
+
+# ---- local-variable type dispatch ----
+def test_local_var_type_dispatch_resolved():
+    f = "app.py"
+    fns = {}
+    fid_m, data_m = _fn(f, "run", "def run(self):\n    return self.x\n", class_name="Service")
+    fns[fid_m] = data_m
+    caller = ("def use():\n"
+              "    svc = Service()\n"
+              "    return svc.run()\n")
+    fid_c, data_c = _fn(f, "use", caller)
+    fns[fid_c] = data_c
+    classes = {f"{f}:Service": {"name": "Service", "file_path": f, "bases": []}}
+    b = _build(fns, classes=classes)
+    edges = b.call_graph.get(f"{f}:use", [])
+    assert f"{f}:Service.run" in edges, (
+        f"svc.run() on local var of known type Service not resolved: {edges}")
+
+
+# ---- super().method() resolution ----
+def test_super_call_resolved_cross_file():
+    base_f = "base.py"
+    child_f = "main.py"
+    fns = {}
+    fid_b, data_b = _fn(base_f, "process", "def process(self):\n    return 1\n", class_name="Base")
+    fns[fid_b] = data_b
+    child_code = "def process(self):\n    return super().process()\n"
+    fid_c, data_c = _fn(child_f, "process", child_code, class_name="Child")
+    fns[fid_c] = data_c
+    classes = {
+        f"{base_f}:Base": {"name": "Base", "file_path": base_f, "bases": []},
+        f"{child_f}:Child": {"name": "Child", "file_path": child_f, "bases": ["Base"]},
+    }
+    b = _build(fns, classes=classes)
+    edges = b.call_graph.get(f"{child_f}:Child.process", [])
+    assert f"{base_f}:Base.process" in edges, (
+        f"super().process() not resolved to cross-file parent Base.process: {edges}")
+
+
+# ---- deterministic ordering ----
+def test_call_lists_are_sorted_deterministic():
+    f = "m.py"
+    fns = {}
+    for name in ("zeta", "alpha", "mid"):
+        fid, data = _fn(f, name, f"def {name}():\n    return 1\n")
+        fns[fid] = data
+    caller = "def driver():\n    return zeta() + alpha() + mid()\n"
+    fid_d, data_d = _fn(f, "driver", caller)
+    fns[fid_d] = data_d
+    b = _build(fns)
+    edges = b.call_graph.get(f"{f}:driver", [])
+    assert edges == sorted(edges), f"call_graph edge list is not deterministically sorted: {edges}"
+
+
+# ---- HOF callback arguments tracked ----
+def test_hof_callback_arg_tracked():
+    f = "h.py"
+    fns = {}
+    fid_cb, data_cb = _fn(f, "scorer", "def scorer(x):\n    return x\n")
+    fns[fid_cb] = data_cb
+    caller = "def driver(items):\n    return sorted(items, key=scorer)\n"
+    fid_d, data_d = _fn(f, "driver", caller)
+    fns[fid_d] = data_d
+    b = _build(fns)
+    edges = b.call_graph.get(f"{f}:driver", [])
+    assert f"{f}:scorer" in edges, (
+        f"HOF callback 'scorer' passed to sorted(key=...) not tracked as an edge: {edges}")


### PR DESCRIPTION
Six independent defects in libs/openant-core/parsers/python/call_graph_builder.py, each
pinned by a RED->GREEN regression test. All fixes are Python-AST-native (ast.Call,
ast.Assign, ast.Name, the extractor's classes[...]['bases'] model); no code or tokens
copied from the sibling go/php/ruby/zig builders, which are untouched.

- Package __init__.py re-export resolution: _resolve_via_package_init follows names
  re-exported through a package __init__.py to their origin module (was: no __init__.py
  probing -> dropped edge).
- Local-variable type dispatch: _collect_local_types + _resolve_class_method dispatch
  `v = ClassName(); v.method()` to the constructed type's method (was: routed to
  _resolve_module_call, which knows only import/same-file class names -> dropped edge).
- super() resolution: _resolve_super_call walks the caller class's bases (cross-file) to
  resolve super().method() (was: stub returning None).
- Deterministic output: sort callee + reverse-caller lists on emit for reproducible output
  (was: set-iteration order, PYTHONHASHSEED-dependent).
- Higher-order callback args: _resolve_callback_args emits edges for function references
  passed as call arguments, e.g. sorted(xs, key=func) (was: only node.func inspected).

Deliberately not addressed here (documented scope boundaries, no code change):
- getattr(obj,'m')(args) is statically unresolvable string dispatch.
- A chained inner().method() outer method on a Call result is unresolvable; ast.walk
  already captures the resolvable inner call.

Tests: tests/test_python_call_graph_builder.py (unique importlib name; 5 tests covering
the 6 fixed bugs). RED 5 failed (pre-fix) -> GREEN 5 passed. Suite 181 passed / 63 skipped
/ 0 failed (base 176/63/0). Determinism verified across PYTHONHASHSEED 0/1/12345.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
