### PR TITLE
Fix JS DependencyResolver call-edge fidelity

### DIFF
--- a/libs/openant-core/parsers/javascript/dependency_resolver.js
+++ b/libs/openant-core/parsers/javascript/dependency_resolver.js
@@ -84,10 +84,15 @@ class DependencyResolver {
         }
       }
 
-      this.callGraph[funcId] = calls;
+      // Drop self-edges: the standalone-call regex matches a function's own
+      // name in its declaration/body, and recursion is not a dependency on a
+      // different unit. Mirrors the C sibling's `c != func_id` invariant.
+      const resolvedCalls = calls.filter((calledId) => calledId !== funcId);
+
+      this.callGraph[funcId] = resolvedCalls;
 
       // Build reverse graph
-      for (const calledId of calls) {
+      for (const calledId of resolvedCalls) {
         if (!this.reverseCallGraph[calledId]) {
           this.reverseCallGraph[calledId] = [];
         }
@@ -221,24 +226,32 @@ class DependencyResolver {
    * Resolve a simple function call to a function ID
    */
   _resolveCall(funcName, callerFile, callerFuncId) {
-    // 1. First check same file
+    // A bare call `foo()` is a free-function reference. It must not bind to a
+    // class method (`Class.foo`): a method is reached via `this.foo()`,
+    // `obj.foo()`, or `Class.foo()`, which are resolved by _resolveThisCall /
+    // _resolveMethodCall. Mirrors the Ruby/PHP siblings, which exclude
+    // class-owned candidates from bare-call resolution.
+
+    // 1. First check same file (free functions only)
     const sameFileFuncs = this.functionsByFile[callerFile];
     if (sameFileFuncs && Array.isArray(sameFileFuncs)) {
       for (const funcId of sameFileFuncs) {
         const funcData = this.functions[funcId];
-        if (funcData && (funcData.name === funcName || funcData.name.endsWith('.' + funcName))) {
+        if (funcData && !funcData.className && funcData.name === funcName) {
           return funcId;
         }
       }
     }
 
-    // 2. Check by simple name across all files
-    const candidates = this.functionsByName[funcName];
-    if (candidates && Array.isArray(candidates) && candidates.length === 1) {
+    // 2. Check by simple name across all files (free functions only)
+    const candidates = (this.functionsByName[funcName] || []).filter(
+      (funcId) => !(this.functions[funcId] && this.functions[funcId].className)
+    );
+    if (candidates.length === 1) {
       return candidates[0];
     }
 
-    // 3. Multiple candidates - return null (ambiguous)
+    // 3. Zero or multiple candidates - return null (ambiguous)
     // A more sophisticated implementation would parse imports to disambiguate
     return null;
   }
@@ -285,6 +298,25 @@ class DependencyResolver {
       }
     }
 
+    // 1b. Local-variable type dispatch: `const x = new C(); x.method()`.
+    //     Map the receiver var to the class it was constructed with, then
+    //     reuse the exact-class-name match. Built-in constructors (Map, Set,
+    //     Promise, ...) are skipped so e.g. `new Map().get()` does not bind to
+    //     a repo `get`.
+    if (callerFuncId) {
+      const callerFunc = this.functions[callerFuncId];
+      const localTypes = this._extractLocalTypes(callerFunc && callerFunc.code);
+      const localClass = localTypes[objectName];
+      if (localClass && !this._isBuiltIn(localClass)) {
+        for (const funcId of candidates) {
+          const funcData = this.functions[funcId];
+          if (funcData && funcData.className === localClass) {
+            return funcId;
+          }
+        }
+      }
+    }
+
     // 2. DI-aware resolution: look up objectName in caller's constructorDeps
     //    e.g., this.callService.getById() -> constructorDeps says callService: CallService
     //    -> resolve to CallService.getById
@@ -327,6 +359,26 @@ class DependencyResolver {
     }
 
     return null;
+  }
+
+  /**
+   * Scan a function body for `const/let/var x = new C()` declarations and
+   * return a { varName -> ClassName } map. Single-identifier constructors only;
+   * member/computed constructors (e.g. new ns.C(), new arr[i]()) are ignored.
+   */
+  _extractLocalTypes(code) {
+    const localTypes = Object.create(null);
+    if (!code) return localTypes;
+
+    const declPattern =
+      /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*new\s+([A-Za-z_$][\w$]*)\s*\(/g;
+    let match;
+    while ((match = declPattern.exec(code)) !== null) {
+      const [, varName, className] = match;
+      // Last write wins, matching JS reassignment order within a body.
+      localTypes[varName] = className;
+    }
+    return localTypes;
   }
 
   /**
@@ -493,7 +545,13 @@ if (require.main === module) {
     process.exit(1);
   }
 
-  const analyzerOutput = JSON.parse(fs.readFileSync(inputFile, 'utf-8'));
+  let analyzerOutput;
+  try {
+    analyzerOutput = JSON.parse(fs.readFileSync(inputFile, 'utf-8'));
+  } catch (err) {
+    console.error(`Failed to read/parse JSON from ${inputFile}: ${err.message}`);
+    process.exit(1);
+  }
 
   // Build call graph
   console.error(`Processing ${Object.keys(analyzerOutput.functions || {}).length} functions...`);

--- a/libs/openant-core/tests/parsers/javascript/test_dependency_resolver_edges.py
+++ b/libs/openant-core/tests/parsers/javascript/test_dependency_resolver_edges.py
@@ -1,0 +1,286 @@
+"""Resolver-level tests for dependency_resolver.js call-edge fidelity.
+
+These drive DependencyResolver directly (no analyzer pipeline) by requiring
+the module from a small Node harness, feeding it a synthetic analyzerOutput
+(functions / classes), building the call graph, and asserting on the resulting
+callGraph JSON. This isolates resolver behaviour from the upstream analyzer.
+
+Covers:
+  - bare call must not bind to a class method (over-resolution).
+  - `const x = new C(); x.m()` must resolve to C.m (local-type dispatch).
+  - a function's own name in its body must not create a self-edge.
+  - CLI on malformed JSON must emit a human-readable diagnostic, not a raw crash.
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+RESOLVER_JS = PARSERS_JS_DIR / "dependency_resolver.js"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _build_call_graph(analyzer_output: dict) -> dict:
+    """Run DependencyResolver on analyzer_output and return the resulting callGraph."""
+    harness = textwrap.dedent(
+        f"""
+        const {{ DependencyResolver }} = require({json.dumps(str(RESOLVER_JS))});
+        const out = JSON.parse(process.argv[1]);
+        const r = new DependencyResolver(out, {{}});
+        r.buildCallGraph();
+        process.stdout.write(JSON.stringify(r.callGraph));
+        """
+    )
+    result = subprocess.run(
+        ["node", "-e", harness, "--", json.dumps(analyzer_output)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"resolver harness failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# bare-call class-method leak
+# ---------------------------------------------------------------------------
+
+def test_bare_call_does_not_bind_same_file_class_method():
+    """`doWork()` must NOT resolve to same-file class method `Utils.doWork`."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:Utils.doWork": {
+                    "name": "Utils.doWork",
+                    "className": "Utils",
+                    "code": "doWork(){return 1;}",
+                },
+                "a.js:caller": {
+                    "name": "caller",
+                    "code": "function caller(){ doWork(); }",
+                },
+            },
+            "classes": {"a.js:Utils": {}},
+        }
+    )
+    assert "a.js:Utils.doWork" not in cg["a.js:caller"], (
+        f"bare doWork() leaked to class method; edges={cg['a.js:caller']}"
+    )
+
+
+def test_bare_call_does_not_bind_unique_cross_file_class_method():
+    """`format()` must NOT resolve to a unique cross-file class method `Utils.format`."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "u.js:Utils.format": {
+                    "name": "Utils.format",
+                    "className": "Utils",
+                    "code": "format(){return 1;}",
+                },
+                "a.js:caller": {
+                    "name": "caller",
+                    "code": "function caller(){ format(); }",
+                },
+            },
+            "classes": {"u.js:Utils": {}},
+        }
+    )
+    assert "u.js:Utils.format" not in cg["a.js:caller"], (
+        f"bare format() leaked to cross-file class method; edges={cg['a.js:caller']}"
+    )
+
+
+def test_bare_call_to_top_level_function_still_resolves():
+    """Control: a bare call to a genuine top-level function must still resolve."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:doWork": {
+                    "name": "doWork",
+                    "code": "function doWork(){return 1;}",
+                },
+                "a.js:caller": {
+                    "name": "caller",
+                    "code": "function caller(){ doWork(); }",
+                },
+            },
+            "classes": {},
+        }
+    )
+    assert "a.js:doWork" in cg["a.js:caller"], (
+        f"bare call to top-level function should resolve; edges={cg['a.js:caller']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# local-variable type dispatch
+# ---------------------------------------------------------------------------
+
+def test_local_var_constructor_method_resolves():
+    """`const x = new C(); x.m()` must resolve to `C.m`."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:C.m": {"name": "C.m", "className": "C", "code": "m(){return 1;}"},
+                "a.js:doWork": {
+                    "name": "doWork",
+                    "code": "function doWork(){ const x = new C(); x.m(); }",
+                },
+            },
+            "classes": {"a.js:C": {}},
+        }
+    )
+    assert "a.js:C.m" in cg["a.js:doWork"], (
+        f"local-var x.m() should resolve to C.m; edges={cg['a.js:doWork']}"
+    )
+
+
+def test_local_var_let_and_var_forms_resolve():
+    """`let`/`var` constructor declarations also resolve the method call."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:C.m": {"name": "C.m", "className": "C", "code": "m(){return 1;}"},
+                "a.js:withLet": {
+                    "name": "withLet",
+                    "code": "function withLet(){ let y = new C(); y.m(); }",
+                },
+                "a.js:withVar": {
+                    "name": "withVar",
+                    "code": "function withVar(){ var z = new C(); z.m(); }",
+                },
+            },
+            "classes": {"a.js:C": {}},
+        }
+    )
+    assert "a.js:C.m" in cg["a.js:withLet"], f"let form failed; edges={cg['a.js:withLet']}"
+    assert "a.js:C.m" in cg["a.js:withVar"], f"var form failed; edges={cg['a.js:withVar']}"
+
+
+def test_local_var_builtin_constructor_not_resolved():
+    """`const m = new Map(); m.get()` must not spuriously resolve to a repo method."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:Cache.get": {
+                    "name": "Cache.get",
+                    "className": "Cache",
+                    "code": "get(){return 1;}",
+                },
+                "a.js:doWork": {
+                    "name": "doWork",
+                    "code": "function doWork(){ const m = new Map(); m.get('k'); }",
+                },
+            },
+            "classes": {"a.js:Cache": {}},
+        }
+    )
+    assert "a.js:Cache.get" not in cg["a.js:doWork"], (
+        f"built-in Map receiver must not bind to Cache.get; edges={cg['a.js:doWork']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# self-edge from own name in body
+# ---------------------------------------------------------------------------
+
+def test_function_own_name_does_not_create_self_edge():
+    """A function's own name appearing in its body must not produce a self-edge."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "auth.js:login": {
+                    "name": "login",
+                    "code": "function login(){ return doStuff(); }",
+                },
+                "auth.js:doStuff": {
+                    "name": "doStuff",
+                    "code": "function doStuff(){ return 1; }",
+                },
+            },
+            "classes": {},
+        }
+    )
+    assert "auth.js:login" not in cg["auth.js:login"], (
+        f"function must not have a self-edge; edges={cg['auth.js:login']}"
+    )
+    # The genuine cross-function edge must survive.
+    assert "auth.js:doStuff" in cg["auth.js:login"], (
+        f"genuine edge to doStuff lost; edges={cg['auth.js:login']}"
+    )
+
+
+def test_genuine_recursion_self_edge_absent():
+    """Even a truly self-recursive function should not list itself as a dependency.
+
+    Self-edges inflate out-degree and create self-dependencies in bundles; the
+    C-sibling call_graph_builder enforces `c != func_id`.
+    """
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:fact": {
+                    "name": "fact",
+                    "code": "function fact(n){ return n <= 1 ? 1 : n * fact(n - 1); }",
+                },
+            },
+            "classes": {},
+        }
+    )
+    assert "a.js:fact" not in cg["a.js:fact"], (
+        f"recursive function must not self-edge; edges={cg['a.js:fact']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI JSON.parse must fail gracefully
+# ---------------------------------------------------------------------------
+
+def test_cli_malformed_json_emits_diagnostic(tmp_path):
+    """`node dependency_resolver.js <malformed.json>` must print a readable error."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{bad json")
+    result = subprocess.run(
+        ["node", str(RESOLVER_JS), str(bad)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 1, f"expected exit 1, got {result.returncode}"
+    combined = result.stdout + result.stderr
+    assert str(bad) in combined, f"diagnostic should name the input file; got: {combined}"
+    assert "SyntaxError" not in result.stderr.split("\n")[0], (
+        f"first stderr line should be a diagnostic, not a raw V8 SyntaxError; got: {result.stderr}"
+    )
+    # No raw V8 stack trace pointing into the resolver source.
+    assert "dependency_resolver.js:" not in result.stderr, (
+        f"raw stack trace leaked to stderr: {result.stderr}"
+    )
+
+
+def test_cli_missing_file_still_guarded(tmp_path):
+    """Control: the existing missing-file guard must remain intact."""
+    missing = tmp_path / "nope.json"
+    result = subprocess.run(
+        ["node", str(RESOLVER_JS), str(missing)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 1
+    assert "not found" in (result.stdout + result.stderr).lower()


### PR DESCRIPTION
dependency_resolver.js only. Four independent call-graph defects:

- Bare call `foo()` no longer binds to a class method `Class.foo`. _resolveCall
  now resolves only free functions (!className) at both the same-file and
  unique-simple-name sites; methods stay reachable via this./obj./Class. paths.
  Mirrors the Ruby/PHP siblings.
- `const x = new C(); x.m()` now resolves to C.m via a per-function
  _extractLocalTypes pre-pass + a local-var-type branch in _resolveMethodCall;
  built-in constructors (Map/Set/...) skipped.
- buildCallGraph drops self-edges (calledId === funcId) from the standalone-call
  regex matching a function's own name; matches the C sibling's `c != func_id`
  invariant.
- CLI JSON.parse is wrapped in try/catch emitting a readable diagnostic + exit 1
  instead of an uncaught V8 SyntaxError.

Deferred / not-a-defect (not fixed here):
- Import-based resolution needs typescript_analyzer.js to emit imports
  (cross-cutting); repoRoot is a dead field.
- eval/Function are in a call-graph noise filter, not a security sink;
  indirect_calls is a phantom field. Correct-by-design over-claim, no resolver
  defect.
- The silent-drop / dead this.imports path: no consumer for an unresolvedCalls
  channel; import disambiguation is cross-cutting.

The five funcId parse sites all use split(':')[0] (first colon), consistent with
the unit_generator.js id-parse fix; no resolver change was needed there.

Tests: tests/parsers/javascript/test_dependency_resolver_edges.py (Node harness on
the resolver + CLI subprocess). 7 failed pre-fix (3 control/guard tests green at
base) -> 10 passed after the fix. Full suite 227 passed / 22 skipped
(Go-binary, unrelated) / 0 failed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
