### PR TITLE
fix(reachability): seed native/cross-language entry points, fix Zig reachability crash, stop silent zero-seed blackout

### DIFF
--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -262,6 +262,34 @@ def apply_reachability_filter(
     if extra_entry_points:
         entry_points = entry_points | extra_entry_points
 
+    units = dataset.get("units", [])
+    original_count = len(units)
+
+    # Empty-seed safety-net: a zero entry-point seed would prune EVERY unit
+    # (the BFS frontier starts empty), silently emptying the dataset and
+    # reporting a 100% reduction as success. That is the dominant failure mode
+    # for non-web library / stdlib targets, whose ordinary functions are not a
+    # seedable entry type. Rather than a silent total blackout, degrade to
+    # pass-through (keep all units, unfiltered) and record a loud warning so the
+    # degraded result is never silent. Higher-level callers may still seed
+    # ``extra_entry_points`` to get real filtering.
+    if not entry_points and original_count > 0:
+        warning = (
+            "No entry points detected — reachability cannot seed a frontier. "
+            "Returning all units unfiltered to avoid a silent blackout; "
+            f"'{processing_level}' filtering was NOT applied."
+        )
+        print(f"  [Warning] {warning}", file=sys.stderr)
+        dataset.setdefault("metadata", {})["reachability_filter"] = {
+            "original_units": original_count,
+            "entry_points": 0,
+            "reachable_units": original_count,
+            "filtered_out": 0,
+            "reduction_percentage": 0,
+            "warning": warning,
+        }
+        return dataset
+
     # Compute reachable set (BFS forward from entry points)
     reachability = ReachabilityAnalyzer(
         functions=functions,
@@ -271,8 +299,6 @@ def apply_reachability_filter(
     reachable_ids = reachability.get_all_reachable()
 
     # Filter dataset units and stamp reachability tags
-    units = dataset.get("units", [])
-    original_count = len(units)
     filtered_units = []
     for u in units:
         unit_id = u.get("id", "")

--- a/libs/openant-core/parsers/zig/function_extractor.py
+++ b/libs/openant-core/parsers/zig/function_extractor.py
@@ -269,9 +269,12 @@ class FunctionExtractor:
         if name in ("init", "create", "new"):
             return "constructor"
 
-        # Main entry point
+        # Main entry point. Classify as 'main' (matching the C and Go parsers)
+        # so the reachability seeder recognises a Zig binary's program entry —
+        # 'main' is an ENTRY_POINT_TYPE. Returning the generic 'function' here
+        # left every Zig binary with zero seeded entry points.
         if name == "main":
-            return "function"
+            return "main"
 
         return "function"
 

--- a/libs/openant-core/parsers/zig/test_pipeline.py
+++ b/libs/openant-core/parsers/zig/test_pipeline.py
@@ -188,51 +188,66 @@ def apply_processing_filter(
 
 
 def apply_reachability_filter(call_graph_output: dict, repo_path: str) -> dict:
-    """Filter to functions reachable from entry points."""
+    """Filter to functions reachable from entry points.
+
+    Uses the real EntryPointDetector / ReachabilityAnalyzer contract, matching
+    the central core/parser_adapter.apply_reachability_filter and the C/Go/PHP/
+    Ruby/JS sibling pipelines. The previous implementation called an API that
+    never existed (``EntryPointDetector(repo_path)``, ``detector.detect()``,
+    ``ReachabilityAnalyzer(call_graph_output, entry_points)``,
+    ``analyzer.get_reachable_functions()``); because libs/openant-core is on
+    sys.path the imports succeeded, so the ``except ImportError`` guard never
+    fired and the resulting wrong-arity TypeError crashed every Zig parse at
+    --processing-level reachable.
+    """
     try:
-        # Try to import the reachability analyzer
         from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector
         from utilities.agentic_enhancer.reachability_analyzer import ReachabilityAnalyzer
-
-        # Detect entry points
-        detector = EntryPointDetector(repo_path)
-        entry_points = detector.detect()
-
-        # Analyze reachability
-        analyzer = ReachabilityAnalyzer(call_graph_output, entry_points)
-        reachable = analyzer.get_reachable_functions()
-
-        # Filter functions to only reachable ones
-        filtered_functions = {
-            fid: finfo
-            for fid, finfo in call_graph_output["functions"].items()
-            if fid in reachable
-        }
-
-        # Update the output with filtered functions
-        result = call_graph_output.copy()
-        result["functions"] = filtered_functions
-
-        # Filter call graphs too
-        result["call_graph"] = {
-            k: [v for v in vs if v in reachable]
-            for k, vs in call_graph_output.get("call_graph", {}).items()
-            if k in reachable
-        }
-        result["reverse_call_graph"] = {
-            k: [v for v in vs if v in reachable]
-            for k, vs in call_graph_output.get("reverse_call_graph", {}).items()
-            if k in reachable
-        }
-
-        return result
-
     except ImportError:
         print(
             "  Warning: Reachability analyzer not available, skipping filter",
             file=sys.stderr,
         )
         return call_graph_output
+
+    functions = call_graph_output.get("functions", {})
+    call_graph = call_graph_output.get("call_graph", {})
+    reverse_call_graph = call_graph_output.get("reverse_call_graph", {})
+
+    # Detect entry points structurally (functions carry the snake_case
+    # 'unit_type' the Zig extractor emits, which the detector reads directly).
+    detector = EntryPointDetector(functions, call_graph)
+    entry_points = detector.detect_entry_points()
+
+    # Compute the reachable set via reverse-BFS from the entry points.
+    analyzer = ReachabilityAnalyzer(
+        functions=functions,
+        reverse_call_graph=reverse_call_graph,
+        entry_points=entry_points,
+    )
+    reachable = analyzer.get_all_reachable()
+
+    # Filter functions to only reachable ones.
+    filtered_functions = {
+        fid: finfo for fid, finfo in functions.items() if fid in reachable
+    }
+
+    result = call_graph_output.copy()
+    result["functions"] = filtered_functions
+
+    # Filter the call graphs to the reachable subgraph too.
+    result["call_graph"] = {
+        k: [v for v in vs if v in reachable]
+        for k, vs in call_graph.items()
+        if k in reachable
+    }
+    result["reverse_call_graph"] = {
+        k: [v for v in vs if v in reachable]
+        for k, vs in reverse_call_graph.items()
+        if k in reachable
+    }
+
+    return result
 
 
 if __name__ == "__main__":

--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "tree-sitter-cpp>=0.21.0",
     "tree-sitter-ruby>=0.21.0",
     "tree-sitter-php>=0.22.0",
+    "tree-sitter-zig==1.1.2",
 ]
 
 [project.optional-dependencies]

--- a/libs/openant-core/requirements.txt
+++ b/libs/openant-core/requirements.txt
@@ -22,3 +22,4 @@ tree-sitter-c>=0.21.0
 tree-sitter-cpp>=0.21.0
 tree-sitter-ruby>=0.21.0
 tree-sitter-php>=0.22.0
+tree-sitter-zig==1.1.2

--- a/libs/openant-core/tests/parsers/zig/test_zig_main_classification.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_main_classification.py
@@ -1,0 +1,59 @@
+"""Zig `main` classification.
+
+The Zig FunctionExtractor has a dedicated branch for `main` that returned the
+generic 'function' unit_type instead of an entry-point type:
+
+    # Main entry point
+    if name == "main":
+        return "function"
+
+C and Go classify a top-level main as unit_type='main'; Zig folded it into
+'function'. With 'main' an ENTRY_POINT_TYPE in the central detector, Zig must emit
+'main' so a Zig binary's entry point seeds reachability — otherwise the Zig
+classifier is the lone divergent parser and Zig binaries stay blacked out.
+
+function_extractor.py recurs across parser packages, so this module is loaded
+under a unique name via importlib to avoid sys.modules collisions with the
+C/Python sibling extractors.
+"""
+
+import importlib.util
+import pathlib
+
+_CORE = pathlib.Path(__file__).resolve().parents[3]
+_ZIG_FE = _CORE / "parsers" / "zig" / "function_extractor.py"
+
+
+def _load_zig_extractor():
+    spec = importlib.util.spec_from_file_location("isolated_zig_function_extractor", _ZIG_FE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _classify(name: str) -> str:
+    mod = _load_zig_extractor()
+    # _classify_function only uses (name, file_path); construct a minimal
+    # extractor (scan_results unused by the classifier).
+    extractor = mod.FunctionExtractor.__new__(mod.FunctionExtractor)
+    return extractor._classify_function(name, "src/main.zig")
+
+
+def test_zig_main_classified_as_main():
+    assert _classify("main") == "main", (
+        "Zig must classify a top-level `main` as unit_type='main' (matching C/Go) "
+        "so it is recognised as a program entry point"
+    )
+
+
+def test_zig_main_is_distinct_from_plain_function():
+    # A regular function still classifies as 'function'; only `main` is special.
+    assert _classify("handleRequest") == "function"
+    assert _classify("main") != _classify("handleRequest")
+
+
+def test_zig_other_classifications_unchanged():
+    # Guard against over-broadening the fix.
+    assert _classify("init") == "constructor"
+    assert _classify("create") == "constructor"
+    assert _classify("testThing") == "test"

--- a/libs/openant-core/tests/parsers/zig/test_zig_reachability_api.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_reachability_api.py
@@ -1,0 +1,102 @@
+"""Zig reachability-filter API crash.
+
+parsers/zig/test_pipeline.py apply_reachability_filter was written against an
+EntryPointDetector / ReachabilityAnalyzer API that never existed:
+
+    detector = EntryPointDetector(repo_path)        # ctor needs (functions, call_graph)
+    entry_points = detector.detect()                # real: detect_entry_points()
+    analyzer = ReachabilityAnalyzer(call_graph_output, entry_points)
+                                                    # real: (functions, reverse_call_graph, entry_points)
+    reachable = analyzer.get_reachable_functions()  # real: get_all_reachable()
+
+Because test_pipeline.py puts libs/openant-core on sys.path, the two imports
+SUCCEED, so the `except ImportError` guard never fires — the wrong-arity call
+raises a TypeError that escapes the helper and crashes the whole Zig parse
+(exit 1, zero output) at the default --processing-level reachable.
+
+This test calls apply_reachability_filter directly with a tiny call graph whose
+`main` is an entry point and which calls a helper; the fixed function must (a)
+not raise, and (b) keep the reachable functions (main + helper) while dropping an
+unreachable orphan.
+
+test_pipeline.py shares its basename across all six parsers, so it is loaded
+under a unique module name via importlib.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+_CORE = pathlib.Path(__file__).resolve().parents[3]
+_ZIG_TP = _CORE / "parsers" / "zig" / "test_pipeline.py"
+
+
+def _load_zig_pipeline():
+    # The Zig pipeline does bare local imports (`from repository_scanner import`)
+    # relative to its own dir, mirroring how it is invoked as a script.
+    zig_dir = str(_ZIG_TP.parent)
+    core_dir = str(_CORE)
+    added = []
+    for p in (zig_dir, core_dir):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+            added.append(p)
+    spec = importlib.util.spec_from_file_location("isolated_zig_test_pipeline", _ZIG_TP)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _call_graph_output():
+    # main (entry) -> helper ; orphan is unreachable.
+    return {
+        "functions": {
+            "src/main.zig:main": {
+                "name": "main",
+                "unit_type": "main",
+                "code": "pub fn main() void { helper(); }",
+            },
+            "src/main.zig:helper": {
+                "name": "helper",
+                "unit_type": "function",
+                "code": "fn helper() void {}",
+            },
+            "src/main.zig:orphan": {
+                "name": "orphan",
+                "unit_type": "function",
+                "code": "fn orphan() void {}",
+            },
+        },
+        "call_graph": {
+            "src/main.zig:main": ["src/main.zig:helper"],
+        },
+        "reverse_call_graph": {
+            "src/main.zig:helper": ["src/main.zig:main"],
+        },
+        "statistics": {"total_edges": 1},
+    }
+
+
+def test_apply_reachability_filter_does_not_crash_and_seeds_main():
+    mod = _load_zig_pipeline()
+    out = mod.apply_reachability_filter(_call_graph_output(), repo_path="/tmp/repo")
+
+    fids = set(out["functions"].keys())
+    assert "src/main.zig:main" in fids, (
+        "main is an entry point and must survive the reachability filter"
+    )
+    assert "src/main.zig:helper" in fids, (
+        "helper is reachable from main and must survive"
+    )
+    assert "src/main.zig:orphan" not in fids, (
+        "orphan is unreachable and must be filtered out — proving the filter "
+        "actually ran rather than passing everything through"
+    )
+
+
+def test_apply_reachability_filter_filters_call_graph_too():
+    mod = _load_zig_pipeline()
+    out = mod.apply_reachability_filter(_call_graph_output(), repo_path="/tmp/repo")
+    # orphan must not linger in the (reverse) call graphs either.
+    assert "src/main.zig:orphan" not in out.get("call_graph", {})
+    assert "src/main.zig:orphan" not in out.get("reverse_call_graph", {})

--- a/libs/openant-core/tests/test_entry_point_detector_native_seeds.py
+++ b/libs/openant-core/tests/test_entry_point_detector_native_seeds.py
@@ -1,0 +1,97 @@
+"""EntryPointDetector cross-language entry-point gaps.
+
+Covers two central-detector faults:
+
+* Program-entry unit_types the parsers actually emit ('main' from C/Go/Zig,
+  'http_handler' / 'middleware' from Go) are absent from ENTRY_POINT_TYPES, so a
+  native program entry seeds ZERO entry points -> total reachability blackout for
+  C/Go/Zig binaries.
+
+* The per-parser reachable path normalizes func metadata under the camelCase key
+  'unitType' (c/php/ruby test_pipeline.py:257), but _get_entry_point_reasons reads
+  the snake_case 'unit_type' only -> Check-1 (and the module_level Check-4) are
+  dead on the real subprocess path even for an entry type that IS in the set.
+
+These assertions are written against the central detector contract, so they hold
+regardless of which parser produced the data.
+"""
+
+from utilities.agentic_enhancer.entry_point_detector import (
+    ENTRY_POINT_TYPES,
+    EntryPointDetector,
+)
+
+
+def _detect(func_data: dict, func_id: str = "src/main.c:main"):
+    detector = EntryPointDetector({func_id: func_data}, call_graph={})
+    return detector.detect_entry_points(), detector
+
+
+# --- Cluster A: program-entry types missing from the central set ----------
+
+def test_main_unit_type_is_an_entry_point_type():
+    """C/Go emit unit_type='main'; Zig (after its classifier fix) does too.
+    Without 'main' in ENTRY_POINT_TYPES a native program entry seeds nothing."""
+    assert "main" in ENTRY_POINT_TYPES, (
+        "'main' must be in ENTRY_POINT_TYPES so a native program entry "
+        "(C/Go/Zig main) seeds reachability"
+    )
+
+
+def test_native_main_seeds_an_entry_point():
+    eps, _ = _detect(
+        {"name": "main", "unit_type": "main", "code": "int main(void){return 0;}"}
+    )
+    assert "src/main.c:main" in eps, (
+        "a function with unit_type='main' must be detected as an entry point"
+    )
+
+
+def test_go_http_handler_and_middleware_are_entry_point_types():
+    """The Go parser emits 'http_handler' and 'middleware' (go_parser/types.go
+    UnitTypeHTTPHandler / UnitTypeMiddleware) but the detector only knew the
+    Python/Express vocabulary -> Go web servers seeded no entry points."""
+    assert "http_handler" in ENTRY_POINT_TYPES
+    assert "middleware" in ENTRY_POINT_TYPES
+
+
+# --- Cluster B: camelCase 'unitType' key must also be honoured ------------
+
+def test_unit_type_read_handles_camelcase_unitType_key():
+    """The C/PHP/Ruby reachable path writes the camelCase 'unitType' key; the
+    detector previously read snake-case 'unit_type' only, so Check-1 was dead on
+    that path even for a valid entry type."""
+    eps, _ = _detect(
+        {"name": "handler", "unitType": "route_handler", "code": ""},
+        func_id="app.py:handler",
+    )
+    assert "app.py:handler" in eps, (
+        "an entry unit normalized under the camelCase 'unitType' key must still "
+        "be recognised as an entry point"
+    )
+
+
+def test_camelcase_main_is_an_entry_point():
+    """End-to-end of Cluster A + B together: a C 'main' normalized to the
+    camelCase key must seed reachability."""
+    eps, _ = _detect(
+        {"name": "main", "unitType": "main", "code": "int main(void){return 0;}"}
+    )
+    assert "src/main.c:main" in eps
+
+
+def test_module_level_check4_handles_camelcase_key():
+    """Check-4 keys off unit_type=='module_level'; it must also see the
+    camelCase 'unitType' so module-level scripts on the camel path still seed."""
+    # Use a code pattern that ONLY Check-4 (module_level) matches — the
+    # __name__ guard is in MODULE_LEVEL_INPUT_PATTERNS but NOT in
+    # USER_INPUT_PATTERNS, so Check-3 cannot mask the result.
+    eps, _ = _detect(
+        {
+            "name": "__module__",
+            "unitType": "module_level",
+            "code": 'if __name__ == "__main__":\n    run()',
+        },
+        func_id="script.py:__module__",
+    )
+    assert "script.py:__module__" in eps

--- a/libs/openant-core/tests/test_reachability_empty_seed.py
+++ b/libs/openant-core/tests/test_reachability_empty_seed.py
@@ -1,0 +1,109 @@
+"""Empty-seed reachability blackout safety-net.
+
+When EntryPointDetector finds ZERO entry points (the dominant case for a non-web
+library/stdlib target — ordinary Python functions are unit_type='function', which
+is not seedable), core.parser_adapter.apply_reachability_filter ran the BFS over
+an empty seed, kept nothing, and emptied dataset['units'] entirely — reporting
+100% reduction as SUCCESS with no error or warning. `--level reachable` thus
+produced a silent total blackout.
+
+A zero-entry-point seed must NOT silently drop every unit. The filter degrades to
+pass-through (units preserved) and records a loud warning in the filter metadata
+so the blackout can never be silent.
+
+(The broader generic-library / public-API seeding heuristic is an architectural
+change with an undetermined approach and is deliberately out of scope; this test
+pins only the no-silent-blackout invariant.)
+"""
+
+import importlib.util
+import pathlib
+
+_CORE = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_parser_adapter():
+    spec = importlib.util.spec_from_file_location(
+        "isolated_parser_adapter", _CORE / "core" / "parser_adapter.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_json(path, obj):
+    import json
+
+    path.write_text(json.dumps(obj))
+
+
+def test_zero_entry_points_does_not_silently_empty_dataset(tmp_path):
+    pa = _load_parser_adapter()
+
+    # A library: two ordinary functions, neither a seedable entry point.
+    call_graph = {
+        "functions": {
+            "lib.py:add": {"name": "add", "unit_type": "function", "code": "return a + b"},
+            "lib.py:sub": {"name": "sub", "unit_type": "function", "code": "return a - b"},
+        },
+        "call_graph": {"lib.py:add": ["lib.py:sub"]},
+        "reverse_call_graph": {"lib.py:sub": ["lib.py:add"]},
+    }
+    _write_json(tmp_path / "call_graph.json", call_graph)
+
+    dataset = {
+        "units": [
+            {"id": "lib.py:add"},
+            {"id": "lib.py:sub"},
+        ],
+        "metadata": {},
+    }
+
+    out = pa.apply_reachability_filter(dataset, str(tmp_path), "reachable")
+
+    # The dataset must NOT be silently emptied.
+    assert len(out["units"]) == 2, (
+        "zero entry points must not drop every unit (silent blackout) — the "
+        "filter should degrade to pass-through"
+    )
+
+    # The blackout-avoidance must be recorded loudly, not silently.
+    meta = out.get("metadata", {}).get("reachability_filter", {})
+    assert meta.get("entry_points") == 0
+    assert meta.get("warning"), (
+        "a zero-entry-point pass-through must record a warning so the degraded "
+        "result is never silent"
+    )
+
+
+def test_normal_seed_still_filters(tmp_path):
+    """Guard: when there IS an entry point, the filter still prunes unreachable
+    units (the safety-net must not disable real filtering)."""
+    pa = _load_parser_adapter()
+
+    call_graph = {
+        "functions": {
+            "app.py:main": {"name": "main", "unit_type": "main", "code": "handler()"},
+            "app.py:handler": {"name": "handler", "unit_type": "function", "code": ""},
+            "app.py:dead": {"name": "dead", "unit_type": "function", "code": ""},
+        },
+        "call_graph": {"app.py:main": ["app.py:handler"]},
+        "reverse_call_graph": {"app.py:handler": ["app.py:main"]},
+    }
+    _write_json(tmp_path / "call_graph.json", call_graph)
+
+    dataset = {
+        "units": [
+            {"id": "app.py:main"},
+            {"id": "app.py:handler"},
+            {"id": "app.py:dead"},
+        ],
+        "metadata": {},
+    }
+
+    out = pa.apply_reachability_filter(dataset, str(tmp_path), "reachable")
+    ids = {u["id"] for u in out["units"]}
+    assert ids == {"app.py:main", "app.py:handler"}, (
+        "with a real entry point the unreachable 'dead' unit must still be pruned"
+    )
+    assert not out["metadata"]["reachability_filter"].get("warning")

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -22,6 +22,19 @@ import re
 from typing import Dict, List, Set
 
 
+def _unit_type(func_data: Dict) -> str:
+    """Read a unit's type tolerating both key casings.
+
+    The per-parser reachable path normalizes function metadata under the
+    camelCase key ``unitType`` (parsers/{c,php,ruby}/test_pipeline.py), while the
+    central Python path and this detector historically used the snake_case
+    ``unit_type``. Reading only one casing left Check-1 (and the module_level
+    Check-4) dead on the camelCase path — a valid entry type was silently
+    ignored. Prefer snake_case, fall back to camelCase.
+    """
+    return func_data.get('unit_type') or func_data.get('unitType') or ''
+
+
 # Entry point patterns by unit_type (from function extractor classification)
 ENTRY_POINT_TYPES = {
     'route_handler',      # Flask/FastAPI/Express routes
@@ -29,6 +42,15 @@ ENTRY_POINT_TYPES = {
     'view_function',      # Django views
     'websocket_handler',  # WebSocket endpoints
     'cli_handler',        # CLI commands
+    # Native program entry points emitted by the systems-language parsers.
+    # The C and Go extractors classify a top-level `main` as unit_type='main'
+    # (parsers/c/function_extractor.py, go_parser/types.go UnitTypeMain); the
+    # Zig extractor does too once its `main` classifier branch is fixed. Without
+    # these the only seed for a compiled binary is absent, so reachability seeds
+    # zero entry points and silently empties the dataset for every C/Go/Zig repo.
+    'main',               # C/Go/Zig program entry
+    'http_handler',       # Go net/http handlers (go_parser/types.go UnitTypeHTTPHandler)
+    'middleware',         # Go HTTP middleware (go_parser/types.go UnitTypeMiddleware)
 }
 
 # Decorator patterns indicating entry points (case-insensitive matching)
@@ -154,7 +176,7 @@ class EntryPointDetector:
                 self.entry_points.add(func_id)
                 self.entry_point_details[func_id] = {
                     'reasons': reasons,
-                    'unit_type': func_data.get('unit_type'),
+                    'unit_type': _unit_type(func_data),
                     'name': func_data.get('name'),
                 }
 
@@ -173,7 +195,7 @@ class EntryPointDetector:
         reasons = []
 
         # Check 1: Unit type indicates entry point
-        unit_type = func_data.get('unit_type', '')
+        unit_type = _unit_type(func_data)
         if unit_type in ENTRY_POINT_TYPES:
             reasons.append(f'unit_type:{unit_type}')
 
@@ -194,7 +216,7 @@ class EntryPointDetector:
                 break  # One input pattern is enough
 
         # Check 4: Module-level code with input patterns
-        if func_data.get('unit_type') == 'module_level':
+        if unit_type == 'module_level':
             for pattern in self._module_input_patterns:
                 if pattern.search(code):
                     reasons.append('module_level_with_input')


### PR DESCRIPTION
Six filed defects converge on the shared EntryPointDetector + reachability seeding
path; one is a Zig-local crash.

Central detector (utilities/agentic_enhancer/entry_point_detector.py):
- Add 'main' / 'http_handler' / 'middleware' to ENTRY_POINT_TYPES. The C/Go/Zig
  parsers emit these program/web entry unit_types, but the set only knew the
  Python/Express web vocabulary, so a compiled binary seeded zero entry points
  (total reachability blackout).
- Add _unit_type() dual-key read (snake 'unit_type' + camel 'unitType') for
  Check-1, Check-4, details and statistics. The per-parser reachable path
  normalizes under camelCase 'unitType' (parsers/{c,php,ruby}/test_pipeline.py:257)
  while the detector read snake-only, so Check-1/Check-4 were dead on that path
  even for valid entry types. (The earlier-filed file_path/filePath locus is
  phantom; the operative residual is exactly this dual-read gap.)

Zig classifier (parsers/zig/function_extractor.py):
- _classify_function: main -> 'main' (was generic 'function'), matching C/Go so a
  Zig binary's entry point is now seedable.

Zig reachability filter (parsers/zig/test_pipeline.py):
- Rewrite apply_reachability_filter to the real EntryPointDetector(functions,
  call_graph).detect_entry_points() / ReachabilityAnalyzer(functions,
  reverse_call_graph, entry_points).get_all_reachable() contract. The old code
  called a non-existent API; imports succeed (sys.path), so except ImportError
  never fired and the wrong-arity TypeError crashed every Zig parse at
  --processing-level reachable. Derived against Zig's own snake-case data shape
  (no token-copy of the C normalizer).

Empty-seed safety-net (core/parser_adapter.py):
- A zero entry-point seed previously emptied the dataset silently (100% reduction
  reported as SUCCESS) — the dominant failure for non-web library/stdlib targets.
  Degrade to pass-through (units preserved, filtering NOT applied) + record a loud
  warning in the filter metadata so the blackout can never be silent. The broader
  generic-library seeding heuristic is architectural and out of scope.

Tests (RED->GREEN): tests/test_entry_point_detector_native_seeds.py (6),
tests/parsers/zig/test_zig_main_classification.py (3),
tests/parsers/zig/test_zig_reachability_api.py (2, reproduced the exact
TypeError), tests/test_reachability_empty_seed.py (2). 12 failed pre-fix (1
guard green at base by design) -> 13 passed after the fix. Full suite 189 passed /
63 skipped / 0 failed. go test/vet/build clean in parsers/go/go_parser (types.go
unchanged, gofmt-clean). ruff clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
