### PR TITLE
fix(parsers/go): correct call-graph receiver classification, package resolution, dispatch, os filtering

### DIFF
--- a/libs/openant-core/parsers/go/go_parser/callgraph.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph.go
@@ -47,7 +47,8 @@ func NewCallGraphBuilder(repoPath string) *CallGraphBuilder {
 		"sort":    true,
 		"math":    true,
 		"io":      true,
-		"os":      true,
+		// "os" is intentionally NOT skipped: it carries security-relevant sinks (os.StartProcess,
+		// etc.) that downstream analysis must be able to see; blanket-skipping dropped them.
 		"path":    true,
 		"regexp":  true,
 		"json":    true,
@@ -175,11 +176,11 @@ func (c *CallGraphBuilder) parseImports(fullPath, relPath string) {
 
 // CallInfo represents a function call found in code
 type CallInfo struct {
-	Name      string // Simple function name
-	Receiver  string // Receiver for method calls (e.g., "obj" in obj.Method())
-	Package   string // Package alias for package.Func() calls
-	IsMethod  bool   // True if this is a method call
-	IsSelf    bool   // True if receiver is "self" or matches current receiver
+	Name     string // Simple function name
+	Receiver string // Receiver for method calls (e.g., "obj" in obj.Method())
+	Package  string // Package alias for package.Func() calls
+	IsMethod bool   // True if this is a method call
+	IsSelf   bool   // True if receiver is "self" or matches current receiver
 }
 
 func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
@@ -194,6 +195,11 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 		return calls
 	}
 
+	// A selector receiver (pkg.Func vs obj.Method) is a package iff its name is one of THIS file's
+	// import aliases. Pass the file's import set down so analyzeCallExpr classifies using the real
+	// import table instead of a name-shape heuristic.
+	imports := c.importsByFile[funcInfo.FilePath]
+
 	// Walk the AST looking for call expressions
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
@@ -201,7 +207,7 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 			return true
 		}
 
-		callInfo := c.analyzeCallExpr(call)
+		callInfo := c.analyzeCallExpr(call, imports)
 		if callInfo.Name != "" && !c.builtins[callInfo.Name] && !c.builtins[callInfo.Package] {
 			calls = append(calls, callInfo)
 		}
@@ -211,7 +217,7 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 	return calls
 }
 
-func (c *CallGraphBuilder) analyzeCallExpr(call *ast.CallExpr) CallInfo {
+func (c *CallGraphBuilder) analyzeCallExpr(call *ast.CallExpr, imports map[string]string) CallInfo {
 	info := CallInfo{}
 
 	switch fun := call.Fun.(type) {
@@ -227,8 +233,9 @@ func (c *CallGraphBuilder) analyzeCallExpr(call *ast.CallExpr) CallInfo {
 		switch x := fun.X.(type) {
 		case *ast.Ident:
 			info.Receiver = x.Name
-			// Check if it looks like a package (lowercase) or object
-			if isLikelyPackage(x.Name) {
+			// It is a package call iff the receiver name is an import alias of this file.
+			// A short lowercase local (db, tx, ctx, w, r) is NOT a package.
+			if _, isImport := imports[x.Name]; isImport {
 				info.Package = x.Name
 				info.IsMethod = false
 			}
@@ -252,29 +259,6 @@ func (c *CallGraphBuilder) analyzeCallExpr(call *ast.CallExpr) CallInfo {
 	return info
 }
 
-func isLikelyPackage(name string) bool {
-	// Packages are typically lowercase
-	if len(name) == 0 {
-		return false
-	}
-
-	// Common patterns that are definitely packages
-	packagePatterns := []string{
-		"fmt", "log", "os", "io", "net", "http", "json", "xml",
-		"strings", "strconv", "bytes", "time", "context", "sync",
-		"errors", "filepath", "regexp", "math", "sort", "reflect",
-	}
-	for _, p := range packagePatterns {
-		if name == p {
-			return true
-		}
-	}
-
-	// If all lowercase and short, likely a package
-	first := rune(name[0])
-	return first >= 'a' && first <= 'z' && len(name) <= 10
-}
-
 func (c *CallGraphBuilder) resolveCalls(callerID string, callerInfo FunctionInfo, calls []CallInfo, analyzer *AnalyzerOutput) []string {
 	var resolved []string
 	seen := make(map[string]bool)
@@ -283,8 +267,10 @@ func (c *CallGraphBuilder) resolveCalls(callerID string, callerInfo FunctionInfo
 		var targetID string
 
 		// Try different resolution strategies
-		if call.IsSelf || call.Receiver == callerInfo.ClassName {
-			// Self/receiver call - look in same type's methods
+		if callerInfo.ClassName != "" && (call.IsSelf || call.Receiver == callerInfo.ClassName) {
+			// Self/receiver call - look in same type's methods. Guarded on ClassName != "" so a
+			// plain function (ClassName=="") making a simple call (Receiver=="") is NOT misrouted
+			// here via ""=="" and lost; it falls through to resolveSimpleCall below.
 			targetID = c.resolveMethodCall(call.Name, callerInfo.ClassName, callerInfo.FilePath)
 		} else if call.IsMethod && call.Receiver != "" {
 			// Method call on some object
@@ -341,12 +327,18 @@ func (c *CallGraphBuilder) resolvePackageCall(funcName, pkgAlias, currentFile st
 		return ""
 	}
 
-	// Try to find the function in files from that package
-	// This is a simplified approach - we look for functions by name
-	// that are in files whose directory matches the package
+	// Match by the package's directory (the last component of the resolved import path), NOT the
+	// user-chosen alias. funcID is "<relPath>:<Name>", so a function's package is the directory its
+	// file lives in. The old code tested strings.Contains(funcID, pkgAlias): it used the alias (so
+	// aliased imports failed to resolve) and matched any funcID merely CONTAINING the alias as a
+	// substring (so it emitted edges to unrelated packages).
+	pkgDir := filepath.Base(pkgPath)
 	for _, funcID := range c.functionsByName[funcName] {
-		// Check if the function is likely from the right package
-		if strings.Contains(funcID, pkgAlias) {
+		filePart := funcID
+		if ci := strings.LastIndex(funcID, ":"); ci >= 0 {
+			filePart = funcID[:ci]
+		}
+		if filepath.Base(filepath.Dir(filePart)) == pkgDir {
 			return funcID
 		}
 	}

--- a/libs/openant-core/parsers/go/go_parser/callgraph_test.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph_test.go
@@ -1,0 +1,96 @@
+package main
+
+// Regression tests for four coupled defects in the Go call-graph resolver (callgraph.go).
+//
+// Receiver classification: isLikelyPackage classified ANY short
+//   lowercase identifier (db, tx, ctx, w) as a package using a name-shape heuristic with no import
+//   context, so local-variable method calls were misrouted to package resolution. Fix: classify a
+//   selector receiver as a package iff its name is an import alias of the file.
+// Package-call resolution: resolvePackageCall
+//   resolved the import path correctly but matched candidates with strings.Contains(funcID, pkgAlias)
+//   -- the alias, not the package directory -- so aliased imports failed and edges were emitted to
+//   unrelated packages. Fix: match the package's directory (last path component of the import path).
+// Dispatch: resolveCalls routed a plain function's simple call to resolveMethodCall
+//   because `call.Receiver == callerInfo.ClassName` is ""=="" for a non-method caller. Fix: guard the
+//   self/method branch on callerInfo.ClassName != "".
+// os filtering: the entire "os" package was in the builtins skip-set, so os.StartProcess and
+//   other OS sinks were dropped by the call-extraction filter. Fix: do not blanket-skip "os".
+//
+// Tests exercise stable-signature boundaries (extractCalls / resolvePackageCall / resolveCalls) so they
+// compile against both the pre-fix and post-fix sources (RED demonstrated via `git stash` of the fix).
+
+import "testing"
+
+// receiver classification: local var must not be treated as a package
+func TestExtractCalls_LocalVarNotClassifiedAsPackage(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.importsByFile["a/a.go"] = map[string]string{"fmt": "fmt"} // fmt imported; db is a local var
+	fi := FunctionInfo{Name: "Run", FilePath: "a/a.go", Code: "func Run(){ db.Query() }"}
+
+	calls := c.extractCalls(fi)
+	if len(calls) != 1 || calls[0].Name != "Query" {
+		t.Fatalf("expected one db.Query call, got %+v", calls)
+	}
+	ci := calls[0]
+	if ci.Package != "" {
+		t.Errorf("local var 'db' misclassified as package (Package=%q)", ci.Package)
+	}
+	if !ci.IsMethod || ci.Receiver != "db" {
+		t.Errorf("db.Query() should be a method call on receiver 'db', got %+v", ci)
+	}
+}
+
+// package resolution must match the package directory, not the alias
+func TestResolvePackageCall_MatchesPackageDirNotAlias(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	// `import u "exp007/user"` -- alias 'u', package dir 'user'. The real target lives in user/.
+	c.importsByFile["main/main.go"] = map[string]string{"u": "exp007/user"}
+	// The unrelated candidate is FIRST and its path contains the alias 'u' as a substring (the old bug).
+	c.functionsByName["Helper"] = []string{"unrelated/stuff.go:Helper", "user/user.go:Helper"}
+
+	got := c.resolvePackageCall("Helper", "u", "main/main.go")
+	if got != "user/user.go:Helper" {
+		t.Errorf("expected resolution to the user/ package by directory, got %q "+
+			"(alias-substring match would wrongly pick 'unrelated/stuff.go:Helper')", got)
+	}
+}
+
+// a plain function's simple call must not be misrouted to method resolution
+func TestResolveCalls_PlainFuncSimpleCallNotMisroutedToMethod(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.functionsByFile["a/a.go"] = []string{"a/a.go:main", "a/a.go:greet"}
+	c.functionsByName["greet"] = []string{"a/a.go:greet"}
+
+	caller := FunctionInfo{Name: "main", ClassName: "", FilePath: "a/a.go"}
+	calls := []CallInfo{{Name: "greet", IsMethod: false, Receiver: "", IsSelf: false}}
+
+	resolved := c.resolveCalls("a/a.go:main", caller, calls, nil)
+	if len(resolved) != 1 || resolved[0] != "a/a.go:greet" {
+		t.Errorf("plain func calling greet() should resolve to a/a.go:greet via simple-call, got %v "+
+			"(\"\"==\"\" misroute to resolveMethodCall loses the edge)", resolved)
+	}
+}
+
+// an os sink must not be filtered out as a builtin
+func TestExtractCalls_OsSinkNotFilteredAsBuiltin(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.importsByFile["a/a.go"] = map[string]string{"os": "os", "fmt": "fmt"}
+	fi := FunctionInfo{Name: "F", FilePath: "a/a.go", Code: "func F(){ os.StartProcess(); fmt.Println() }"}
+
+	calls := c.extractCalls(fi)
+	var sawOs, sawFmt bool
+	for _, ci := range calls {
+		if ci.Name == "StartProcess" {
+			sawOs = true
+		}
+		if ci.Name == "Println" {
+			sawFmt = true
+		}
+	}
+	if !sawOs {
+		t.Error("os.StartProcess() was wrongly filtered out as a builtin (os is a security sink, not noise)")
+	}
+	if sawFmt {
+		t.Error("fmt.Println() should stay filtered as builtin noise")
+	}
+}


### PR DESCRIPTION
Four coupled defects in parsers/go/go_parser/callgraph.go, the Go call-graph resolver:

1. Receiver classification ignored the import table. isLikelyPackage classified a selector receiver `x`
   in `x.Sel()` as a package using a name-shape heuristic (lowercase first letter, len<=10) with no
   import context, so every short lowercase local (db, tx, ctx, w, r) was treated as a package and its
   method calls were misrouted to package resolution. Now a receiver is a package iff its name is one of
   the file's import aliases; the heuristic function is removed.

2. Package-call resolution matched the alias, not the package. resolvePackageCall resolved the import
   path (pkgPath := imports[pkgAlias]) but then matched candidates with strings.Contains(funcID,
   pkgAlias) -- the user-chosen alias. So `import u "example.com/user"` failed to resolve (the alias `u`
   is absent from the funcID), and any funcID merely containing the alias as a substring matched,
   emitting edges to unrelated packages. Now it matches the package directory (the last component of the
   resolved import path) against the directory the candidate's file lives in.

3. Dispatch misrouted a plain function's simple call. resolveCalls took the self/method branch when
   `call.Receiver == callerInfo.ClassName`, which is ""=="" for a plain function (ClassName=="") making
   a simple call (Receiver==""), so `greet()` from `main()` went to resolveMethodCall(name, "", file),
   found nothing, and the edge was lost. The branch is now guarded on callerInfo.ClassName != "", so
   non-method callers fall through to resolveSimpleCall.

4. The whole os package was skipped as a builtin. builtins included "os": true, so the call-extraction
   filter dropped os.StartProcess and other OS-level sinks before they could be seen. "os" is no longer
   blanket-skipped. (Such calls resolve to no in-repo target -- surfacing external sinks as graph nodes
   is a separate feature -- but they are no longer filtered out of the extracted call list.)

Scope: the Go AST import-resolution logic is unique to go_parser; the python/php/ruby/zig call-graph
builders are separate implementations and are not affected. extractor.go/types.go are unchanged.

Tests: parsers/go/go_parser/callgraph_test.go (new; the package had no tests). Four tests exercise the
stable extractCalls / resolvePackageCall / resolveCalls boundaries: local var not classified as a
package, package resolution by directory not alias, plain-func simple call not misrouted to method
resolution, and os sink not filtered as a builtin. RED 4 failed (pre-fix) -> GREEN 4 passed; go vet
clean; go test ./... ok.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
