### PR TITLE
fix(export_csv): neutralize CSV/formula injection in exported cells (CWE-1236)

### DIFF
--- a/libs/openant-core/export_csv.py
+++ b/libs/openant-core/export_csv.py
@@ -31,6 +31,20 @@ import os
 import sys
 from utilities.file_io import read_json
 
+# Characters that make a spreadsheet treat a cell as a formula on open (CSV / formula
+# injection, CWE-1236 / OWASP). Cells written from scanned source or LLM text must be
+# neutralized so opening the export in Excel / Google Sheets can't execute a payload.
+_CSV_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _csv_safe(value):
+    """Prefix a leading formula-trigger character with a single quote, neutralizing CSV
+    formula injection. Non-string/None values become '' / their str form first."""
+    s = "" if value is None else str(value)
+    if s and s[0] in _CSV_FORMULA_TRIGGERS:
+        return "'" + s
+    return s
+
 
 def _load_diff_block(experiment_path: str) -> dict | None:
     """Look for the ``diff`` block in pipeline_output.json next to the
@@ -159,7 +173,8 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
             'stage1_confidence': result.get('confidence', ''),
             'agentic_classification': llm_context.get('security_classification', '')
         }
-        rows.append(row)
+        # Neutralize CSV / formula injection on every cell before writing.
+        rows.append({k: _csv_safe(v) for k, v in row.items()})
 
     # Write CSV
     fieldnames = [

--- a/libs/openant-core/tests/test_export_csv_formula_injection.py
+++ b/libs/openant-core/tests/test_export_csv_formula_injection.py
@@ -1,0 +1,48 @@
+"""Regression tests for CSV / formula injection in export_csv (CWE-1236).
+
+export_csv() writes the verbatim scanned source (unit_code = primary_code) and LLM text columns into the CSV
+with no neutralization. A scanned snippet beginning with =, +, -, @ (or a leading tab / CR) is interpreted as a
+formula by Excel / Google Sheets when the analyst opens the file, enabling formula execution / data exfiltration
+on the analyst's machine. Fix: prefix any cell whose first character is a formula trigger with a single quote
+(the OWASP CSV-Injection defense), applied to every cell.
+"""
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+import export_csv as ec  # noqa: E402
+
+PAYLOAD = "=cmd|'/c calc'!A1"
+
+
+def test__csv_safe_neutralizes_formula_triggers():
+    """Unit: cells starting with a formula trigger get a leading quote; safe cells are unchanged."""
+    for trigger in ("=", "+", "-", "@", "\t", "\r"):
+        assert ec._csv_safe(trigger + "x") == "'" + trigger + "x", f"{trigger!r} not neutralized"
+    assert ec._csv_safe("safe value") == "safe value"
+    assert ec._csv_safe("") == ""
+    assert ec._csv_safe(None) == ""
+
+
+def test_export_csv_neutralizes_formula_in_unit_code(tmp_path):
+    """Integration: a scanned snippet that is a spreadsheet formula is neutralized in the exported CSV."""
+    ds = tmp_path / "dataset.json"
+    exp = tmp_path / "experiment.json"
+    out = tmp_path / "out.csv"
+    ds.write_text(
+        '{"units": [{"id": "f.py:foo", "code": {"primary_code": "' + PAYLOAD + '"},'
+        ' "llm_context": {"reasoning": "r", "security_classification": "c"}}]}'
+    )
+    exp.write_text(
+        '{"results": [{"route_key": "f.py:foo", "verification": {"explanation": "e"},'
+        ' "finding": "vulnerable", "reasoning": "r1", "confidence": "high"}]}'
+    )
+    ec.export_csv(str(exp), str(ds), str(out))
+    with open(out, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows, "no rows exported"
+    cell = rows[0]["unit_code"]
+    assert not cell.startswith(("=", "+", "-", "@")), f"formula cell not neutralized: {cell!r}"
+    assert cell == "'" + PAYLOAD, f"expected leading-quote neutralization, got {cell!r}"


### PR DESCRIPTION
export_csv() wrote the verbatim scanned source (unit_code) and LLM-derived text
columns into the CSV with no neutralization. A scanned snippet beginning with =,
+, -, @ (or a leading tab/CR) is treated as a formula by Excel / Google Sheets
when the analyst opens the export, enabling formula execution / data
exfiltration on the analyst's machine (OWASP CSV Injection / CWE-1236).

Add a _csv_safe() helper that prefixes any cell whose first character is a
formula trigger with a single quote, applied to every cell before writing.

The payload originates in the scanned (untrusted) source and only fires in a
downstream spreadsheet app -- it is not reachable from OpenAnt's own callers --
so this is output hardening / defense-in-depth, not an exploitable-now
vulnerability. It is a real producer-side output-sanitization gap (CWE-1236),
distinct from the "OpenAnt processing hostile input" class.

Tests: tests/test_export_csv_formula_injection.py (2 cases: _csv_safe
neutralizes =/+/-/@/tab/CR and leaves safe cells unchanged; export_csv
neutralizes a formula unit_code end-to-end). RED 2 failed -> GREEN 2 passed
(py3.11).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
