### PR TITLE
fix(c-parser): deterministic include resolution + call-graph precision/recall

### DIFF
--- a/libs/openant-core/parsers/c/call_graph_builder.py
+++ b/libs/openant-core/parsers/c/call_graph_builder.py
@@ -159,7 +159,10 @@ class CallGraphBuilder:
             for inc in inc_list:
                 # Match included header to files in repo
                 for other_file in self.functions_by_file:
-                    if other_file.endswith(inc) or other_file.endswith('/' + inc):
+                    # Require a path-component boundary. A bare `endswith(inc)`
+                    # matched any tail (include "x.h" -> "src/prefix-x.h"), so only
+                    # an exact match or a '/'-delimited basename match is valid.
+                    if other_file == inc or other_file.endswith('/' + inc):
                         self.include_map[file_path].add(other_file)
 
     def _is_stdlib(self, name: str) -> bool:
@@ -199,8 +202,35 @@ class CallGraphBuilder:
                         resolved = self._resolve_call(call_name, caller_file)
                         if resolved:
                             calls.add(resolved)
+                # A function passed by name as an argument (e.g.
+                # qsort(..., my_cmp), pthread_create(..., worker, ...)) is invoked
+                # indirectly by the callee. Resolve bare-identifier arguments that
+                # name a known function; non-function identifiers (variables) do not
+                # resolve and so do not create edges.
+                calls.update(self._extract_callback_args(node, code_bytes, caller_file))
             stack.extend(reversed(node.children))
         return calls
+
+    def _extract_callback_args(self, call_node, source: bytes, caller_file: str) -> Set[str]:
+        """Resolve function-name arguments passed to a call (higher-order/callback)."""
+        found: Set[str] = set()
+        arg_list = call_node.child_by_field_name('arguments')
+        if arg_list is None:
+            return found
+        for arg in arg_list.children:
+            name: Optional[str] = None
+            if arg.type == 'identifier':
+                name = source[arg.start_byte:arg.end_byte].decode('utf-8', errors='replace')
+            elif arg.type in ('pointer_expression', 'unary_expression'):
+                # &handler -> handler
+                operand = arg.child_by_field_name('argument')
+                if operand is not None and operand.type == 'identifier':
+                    name = source[operand.start_byte:operand.end_byte].decode('utf-8', errors='replace')
+            if name and not self._is_stdlib(name):
+                resolved = self._resolve_call(name, caller_file)
+                if resolved:
+                    found.add(resolved)
+        return found
 
     def _extract_call_name(self, node, source: bytes) -> Optional[str]:
         """Extract the function name from a call_expression's function child."""
@@ -210,10 +240,12 @@ class CallGraphBuilder:
             return text
 
         if node.type == 'field_expression':
-            # obj->method or obj.method - extract the field name
-            field = node.child_by_field_name('field')
-            if field:
-                return source[field.start_byte:field.end_byte].decode('utf-8', errors='replace')
+            # obj->method() / obj.method() is a member or function-pointer
+            # call, not a free-function call. The resolver only does name-only lookup
+            # (no struct-member / receiver-type model), so binding the bare field name
+            # wired the call to any unrelated free function of the same name. Decline
+            # here instead of emitting that false edge.
+            return None
 
         if node.type == 'qualified_identifier':
             return text
@@ -228,6 +260,19 @@ class CallGraphBuilder:
             return None
 
         return text if text.isidentifier() else None
+
+    def _is_visible_from(self, func_id: str, caller_file: str) -> bool:
+        """Whether a candidate definition is linkable from caller_file.
+
+        A `static` function has internal linkage and is only callable
+        within its own translation unit, so a static definition in another file
+        must not resolve a call made elsewhere. Same-file definitions are always
+        visible; cross-file resolution requires external (non-static) linkage.
+        """
+        func_data = self.functions.get(func_id, {})
+        if func_data.get('file_path', '') == caller_file:
+            return True
+        return not func_data.get('is_static', False)
 
     def _resolve_call(self, call_name: str, caller_file: str) -> Optional[str]:
         """Resolve a function call name to a function ID."""
@@ -253,18 +298,25 @@ class CallGraphBuilder:
 
         # 2. Functions in included headers
         included_files = self.include_map.get(caller_file, set())
-        for inc_file in included_files:
+        # Iterate in sorted order so resolution is deterministic regardless of
+        # set-iteration order (PYTHONHASHSEED); stable lexicographic tiebreak on file path
+        # when same-basename headers in different dirs define the same function name.
+        for inc_file in sorted(included_files):
             file_funcs = self.functions_by_file.get(inc_file, [])
             for func_id in file_funcs:
                 func_data = self.functions.get(func_id, {})
                 fname = func_data.get('name', '')
                 base_name = fname.split('::')[-1] if '::' in fname else fname
-                if base_name == call_name:
+                # A static function in an included header has internal linkage
+                # and is not callable from the including file.
+                if base_name == call_name and self._is_visible_from(func_id, caller_file):
                     return func_id
 
         # 3. Unique name match across entire repo
         candidates = self.functions_by_name.get(call_name, [])
-        if len(candidates) == 1:
+        # Do not resolve a call to a file-local (static) definition in a
+        # different translation unit; the repo-wide fallback previously ignored linkage.
+        if len(candidates) == 1 and self._is_visible_from(candidates[0], caller_file):
             return candidates[0]
 
         # 4. If prototype exists, try to find the definition
@@ -275,16 +327,64 @@ class CallGraphBuilder:
                 func_data = self.functions.get(func_id, {})
                 fp = func_data.get('file_path', '')
                 ext = Path(fp).suffix.lower()
-                if ext in {'.c', '.cpp', '.cc', '.cxx'}:
+                if ext in {'.c', '.cpp', '.cc', '.cxx'} and self._is_visible_from(func_id, caller_file):
                     return func_id
 
         return None
+
+    @staticmethod
+    def _strip_comments_and_literals(code: str) -> str:
+        """Blank out C comments and string/char literals, preserving length and
+        newlines.
+
+        The regex fallback scanned raw code, so a call-shaped token inside
+        a // or /* */ comment or a "..." / '...' literal produced a phantom edge.
+        Replacing those regions with spaces (newlines kept) removes the false matches
+        without disturbing offsets.
+        """
+        out = []
+        i, n = 0, len(code)
+        while i < n:
+            c = code[i]
+            nxt = code[i + 1] if i + 1 < n else ''
+            if c == '/' and nxt == '/':
+                while i < n and code[i] != '\n':
+                    out.append(' ')
+                    i += 1
+            elif c == '/' and nxt == '*':
+                out.append('  ')
+                i += 2
+                while i < n and not (code[i] == '*' and i + 1 < n and code[i + 1] == '/'):
+                    out.append('\n' if code[i] == '\n' else ' ')
+                    i += 1
+                if i < n:
+                    out.append('  ')
+                    i += 2
+            elif c in ('"', "'"):
+                quote = c
+                out.append(' ')
+                i += 1
+                while i < n and code[i] != quote:
+                    if code[i] == '\\' and i + 1 < n:
+                        out.append('  ')
+                        i += 2
+                        continue
+                    out.append('\n' if code[i] == '\n' else ' ')
+                    i += 1
+                if i < n:
+                    out.append(' ')
+                    i += 1
+            else:
+                out.append(c)
+                i += 1
+        return ''.join(out)
 
     def _extract_calls_regex(self, code: str, caller_id: str) -> Set[str]:
         """Fallback regex-based call extraction."""
         calls = set()
         caller_file = caller_id.split(':')[0]
 
+        code = self._strip_comments_and_literals(code)
         pattern = r'\b([a-zA-Z_][a-zA-Z0-9_]*)\s*\('
         for match in re.finditer(pattern, code):
             func_name = match.group(1)

--- a/libs/openant-core/tests/parsers/c/test_c_call_resolution_precision.py
+++ b/libs/openant-core/tests/parsers/c/test_c_call_resolution_precision.py
@@ -1,0 +1,180 @@
+"""Regression tests for the C call-graph resolver precision/recall defects.
+
+Defects covered:
+  - regex fallback scans raw code -> phantom edges from identifiers inside // and
+    /* */ comments and "..." string literals.
+  - obj->cb() (field_expression callee) was reduced to the bare field name and
+    name-resolved against the global free-function index, wiring a
+    member/function-pointer call to an unrelated free function.
+  - a function passed by name as a callback argument (qsort(..., my_cmp),
+    pthread_create(..., worker, ...)) produced no edge because only the call's
+    'function' child was inspected, never its args.
+  - the repo-wide unique-name fallback returned a `static` (file-local) function
+    defined in another translation unit, violating C file-scope (a static helper()
+    in b.c resolving a helper() call in a.c).
+
+CallGraphBuilder consumes a plain extractor_output dict, so these drive it directly
+(no repo fixture / extractor run). It builds a tree-sitter C Parser at init, so the
+module skips where tree_sitter_c is unavailable, matching the other C tests.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = Path(__file__).resolve().parents[3]  # libs/openant-core (test is at tests/parsers/c/)
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+pytest.importorskip("tree_sitter_c")  # CallGraphBuilder builds a tree-sitter C Parser at init
+
+from parsers.c.call_graph_builder import CallGraphBuilder  # noqa: E402
+
+
+# --- regex fallback must not match comment/string content ----------------
+
+def test_regex_fallback_ignores_comments_and_string_literals():
+    """A // line comment, a /* */ block comment, and a "..." string literal each
+    contain a call-shaped token (bar/baz/qux). The fallback must not emit edges for
+    them; only real code calls should resolve."""
+    eo = {
+        "functions": {
+            "m.c:f": {"name": "f", "file_path": "m.c", "code": "stub"},
+            "m.c:bar": {"name": "bar", "file_path": "m.c", "code": "void bar(void){}"},
+            "m.c:baz": {"name": "baz", "file_path": "m.c", "code": "void baz(void){}"},
+            "m.c:qux": {"name": "qux", "file_path": "m.c", "code": "void qux(void){}"},
+            "m.c:real": {"name": "real", "file_path": "m.c", "code": "void real(void){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    code = 'void f(void){ // bar()\n /* baz() */ const char *s = "qux()"; real(); }'
+    edges = b._extract_calls_regex(code, "m.c:f")
+    assert "m.c:bar" not in edges, f"phantom edge from // comment: {sorted(edges)}"
+    assert "m.c:baz" not in edges, f"phantom edge from /* */ comment: {sorted(edges)}"
+    assert "m.c:qux" not in edges, f"phantom edge from string literal: {sorted(edges)}"
+    assert "m.c:real" in edges, f"real call dropped after stripping: {sorted(edges)}"
+
+
+# --- field_expression callee must not bind to a free function ------------
+
+def test_field_call_does_not_bind_to_unrelated_free_function():
+    """obj->cb() is a member / function-pointer call. It must not be wired to a
+    repo-unique free function named cb."""
+    eo = {
+        "functions": {
+            "main.c:caller": {"name": "caller", "file_path": "main.c",
+                              "code": "void caller(struct S *obj){ obj->cb(); }"},
+            "util.c:cb": {"name": "cb", "file_path": "util.c", "code": "void cb(void){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code("void caller(struct S *obj){ obj->cb(); }", "main.c:caller")
+    assert "util.c:cb" not in edges, f"false edge obj->cb() -> unrelated free cb: {sorted(edges)}"
+
+
+def test_direct_free_call_still_resolves():
+    """Guard: the field-expression decline must not break ordinary direct calls."""
+    eo = {
+        "functions": {
+            "main.c:caller": {"name": "caller", "file_path": "main.c",
+                              "code": "void caller(void){ helper(); }"},
+            "main.c:helper": {"name": "helper", "file_path": "main.c", "code": "void helper(void){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code("void caller(void){ helper(); }", "main.c:caller")
+    assert "main.c:helper" in edges, f"direct call regressed: {sorted(edges)}"
+
+
+# --- callback function passed by name as an argument -------------------
+
+def test_callback_argument_to_qsort_creates_edge():
+    """qsort(arr, n, sz, my_cmp) invokes my_cmp indirectly; the by-name callback
+    argument must produce a caller -> my_cmp edge."""
+    eo = {
+        "functions": {
+            "m.c:caller": {"name": "caller", "file_path": "m.c",
+                           "code": "void caller(int *a, int n){ qsort(a, n, sizeof(int), my_cmp); }"},
+            "m.c:my_cmp": {"name": "my_cmp", "file_path": "m.c",
+                           "code": "int my_cmp(const void *a, const void *b){ return 0; }"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(
+        "void caller(int *a, int n){ qsort(a, n, sizeof(int), my_cmp); }", "m.c:caller"
+    )
+    assert "m.c:my_cmp" in edges, f"callback arg my_cmp not tracked: {sorted(edges)}"
+
+
+def test_callback_argument_to_pthread_create_creates_edge():
+    """pthread_create(&t, NULL, worker, NULL) launches worker; the by-name argument
+    must produce a caller -> worker edge."""
+    eo = {
+        "functions": {
+            "m.c:caller": {"name": "caller", "file_path": "m.c",
+                           "code": "void caller(void){ pthread_create(&t, NULL, worker, NULL); }"},
+            "m.c:worker": {"name": "worker", "file_path": "m.c",
+                           "code": "void *worker(void *arg){ return NULL; }"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(
+        "void caller(void){ pthread_create(&t, NULL, worker, NULL); }", "m.c:caller"
+    )
+    assert "m.c:worker" in edges, f"callback arg worker not tracked: {sorted(edges)}"
+
+
+def test_non_function_identifier_arguments_do_not_create_edges():
+    """Guard: plain data arguments (variables, not functions) must not produce edges."""
+    eo = {
+        "functions": {
+            "m.c:caller": {"name": "caller", "file_path": "m.c",
+                           "code": "void caller(int x){ helper(x, count); }"},
+            "m.c:helper": {"name": "helper", "file_path": "m.c", "code": "void helper(int a, int b){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code("void caller(int x){ helper(x, count); }", "m.c:caller")
+    assert edges == {"m.c:helper"}, f"data args x/count must not be edges: {sorted(edges)}"
+
+
+# --- static (file-local) over-resolution across translation units -----
+
+def test_unique_name_fallback_skips_static_in_other_file():
+    """A repo-unique helper() that is `static` in b.c must NOT resolve a helper()
+    call in a.c (C file-scope)."""
+    eo = {
+        "functions": {
+            "a.c:caller": {"name": "caller", "file_path": "a.c", "code": "void caller(void){ helper(); }"},
+            "b.c:helper": {"name": "helper", "file_path": "b.c",
+                           "code": "static void helper(void){}", "is_static": True},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    assert b._resolve_call("helper", "a.c") is None, "static helper() in b.c wrongly resolved cross-TU"
+
+
+def test_same_file_static_call_still_resolves():
+    """Guard: a static function is fully callable from its own file."""
+    eo = {
+        "functions": {
+            "a.c:caller": {"name": "caller", "file_path": "a.c", "code": "void caller(void){ helper(); }"},
+            "a.c:helper": {"name": "helper", "file_path": "a.c",
+                           "code": "static void helper(void){}", "is_static": True},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    assert b._resolve_call("helper", "a.c") == "a.c:helper", "same-file static call must resolve"
+
+
+def test_non_static_unique_name_still_resolves_cross_file():
+    """Guard: a non-static repo-unique function still resolves cross-file (extern linkage)."""
+    eo = {
+        "functions": {
+            "a.c:caller": {"name": "caller", "file_path": "a.c", "code": "void caller(void){ shared(); }"},
+            "b.c:shared": {"name": "shared", "file_path": "b.c",
+                           "code": "void shared(void){}", "is_static": False},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    assert b._resolve_call("shared", "a.c") == "b.c:shared", "extern unique-name resolution regressed"

--- a/libs/openant-core/tests/parsers/c/test_c_include_map_determinism.py
+++ b/libs/openant-core/tests/parsers/c/test_c_include_map_determinism.py
@@ -1,0 +1,83 @@
+"""Regression tests for the C parser include-map non-deterministic
+basename/suffix match.
+
+CallGraphBuilder consumes a plain extractor_output dict, so these drive it directly
+(no repo fixture or extractor run needed). It does build a tree-sitter C Parser at
+init, so the module skips where tree_sitter_c is unavailable, like the other C tests.
+Two compounding faults:
+
+  Fault 1 (construction over-match): include_map was filled by
+    `other_file.endswith(inc) or other_file.endswith('/' + inc)` — the bare
+    `endswith(inc)` disjunct matches any path whose tail is the token even across
+    a non-'/' boundary (include "x.h" wrongly matches "src/prefix-x.h").
+
+  Fault 2 (consumption non-determinism): _resolve_call iterated the *unordered*
+    include_map set and returned the first base_name==call_name match, so with two
+    same-basename headers in different dirs each defining f(), the winner depended
+    on set iteration order -> flipped across PYTHONHASHSEED.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = Path(__file__).resolve().parents[3]  # libs/openant-core (test is at tests/parsers/c/)
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+pytest.importorskip("tree_sitter_c")  # CallGraphBuilder builds a tree-sitter C Parser at init
+
+from parsers.c.call_graph_builder import CallGraphBuilder  # noqa: E402
+
+
+def _extractor_output():
+    # foo/x.h and bar/x.h both define f() (same basename header, different dirs).
+    # src/prefix-x.h ends with the token "x.h" but NOT with "/x.h" -> must NOT match.
+    return {
+        "functions": {
+            "F_foo": {"name": "f", "file_path": "foo/x.h", "code": "void f(void){}"},
+            "F_bar": {"name": "f", "file_path": "bar/x.h", "code": "void f(void){}"},
+            "F_prefix": {"name": "g", "file_path": "src/prefix-x.h", "code": "void g(void){}"},
+            "F_main": {"name": "main", "file_path": "main.c", "code": "int main(void){ f(); return 0; }"},
+        },
+        "includes": {"main.c": ["x.h"]},
+    }
+
+
+def test_include_map_no_basename_overmatch():
+    """Fault 1: include 'x.h' matches foo/x.h + bar/x.h (path-component boundary)
+    but must NOT match src/prefix-x.h (bare-suffix tail match = false positive)."""
+    b = CallGraphBuilder(_extractor_output())
+    b._build_indexes()
+    inc = b.include_map.get("main.c", set())
+    assert "foo/x.h" in inc and "bar/x.h" in inc, f"legit same-basename headers must match: {sorted(inc)}"
+    assert "src/prefix-x.h" not in inc, f"over-match: include 'x.h' wrongly matched 'src/prefix-x.h': {sorted(inc)}"
+
+
+_DRIVER = (
+    "import sys; sys.path.insert(0, %r);"
+    "from parsers.c.call_graph_builder import CallGraphBuilder;"
+    "b = CallGraphBuilder(%r); b._build_indexes();"
+    "print(b._resolve_call('f', 'main.c'))"
+)
+
+
+def test_include_resolution_deterministic_across_hashseeds():
+    """Fault 2: with two same-basename headers each defining f(), _resolve_call must be
+    deterministic across PYTHONHASHSEED (set-iteration order must not pick the winner)
+    and must select the lexicographically-first file's func (stable tiebreak)."""
+    eo = _extractor_output()
+    results = []
+    for seed in range(10):
+        env = dict(os.environ, PYTHONHASHSEED=str(seed))
+        out = subprocess.run(
+            [sys.executable, "-c", _DRIVER % (str(CORE), eo)],
+            capture_output=True, text=True, env=env, cwd=str(CORE),
+        )
+        assert out.returncode == 0, f"driver failed (seed={seed}): {out.stderr}"
+        results.append(out.stdout.strip())
+    assert len(set(results)) == 1, f"non-deterministic resolution across PYTHONHASHSEED: {sorted(set(results))}"
+    # stable tiebreak = lexicographically-first file: 'bar/x.h' < 'foo/x.h' -> F_bar
+    assert results[0] == "F_bar", f"expected stable lexicographic winner F_bar, got {results[0]!r}"


### PR DESCRIPTION
c/call_graph_builder built include_map by basename/suffix match into an unordered
set, then resolved calls by first-of-set, and the regex fallback / call-name
extraction emitted several classes of false or missing edges. This repairs both
the include-resolution determinism and the resolver precision/recall in one change
to the C call-graph builder.

Deterministic, path-anchored include resolution:
Two compounding faults:
(1) bare endswith(inc) over-matched any tail (include "x.h" -> "src/prefix-x.h")
    and every same-basename header repo-wide;
(2) first-match over the unordered set made the resolved callee depend on set
    iteration order -> flipped across PYTHONHASHSEED.
Fix: require a path-component boundary (other_file == inc or endswith('/'+inc))
and iterate sorted(included_files) for a stable lexicographic tiebreak.

Resolver precision/recall:

- _extract_calls_regex scanned raw code, so call-shaped tokens inside // or /* */
  comments or "..." / '...' literals became phantom edges. Blank out comments and
  string/char literals (length/newline preserving) before the regex scan.

- obj->cb() (field_expression callee) was reduced to the bare field name and
  resolved against the global free-function index, wiring the member/function-pointer
  call to an unrelated free function. _extract_call_name now declines (returns None)
  for field_expression -> no false edge. The resolver has no receiver-type model, so
  name-only binding of a member call is wrong.

- A function passed by name as a callback argument (qsort(..., my_cmp),
  pthread_create(..., worker, ...), signal(2, &handler)) produced no edge because
  only the call's 'function' child was inspected. Scan the 'arguments' child for
  bare-identifier / &name args that resolve to a known function and emit the
  caller->callback edge. Non-function identifiers do not resolve, so data args
  create no edge.

- The unique-name (and included-header and prototype) fallbacks returned a static
  (file-local) function in another translation unit, violating C internal linkage.
  New _is_visible_from guard requires a cross-file candidate to be non-static;
  same-file definitions stay visible. is_static and file_path are already in the
  extractor output.

Out of scope (no code change): recording unresolved/ambiguous direct-name calls,
field-pointer derefs, and tbl[i]() subscript-expression callees into an
indirect_calls store — that sink does not exist in any of the parsers (0 producers /
0 consumers); building it end-to-end is out of scope. Dropping these calls emits no
false edge (the safe outcome).

Tests (hermetic): tests/parsers/c/test_c_include_map_determinism.py (2; over-match
+ {F_bar,F_foo} flip across PYTHONHASHSEED 0..9) and
tests/parsers/c/test_c_call_resolution_precision.py (9). Full suite: 187 passed,
63 skipped (no regression). ruff check -> All checks passed.

Scope: C-only (grep -c 'include_map\[.*\] = set()': c=1, python/php/ruby/zig=0).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
