### PR TITLE
fix(parsers/go): give CodeQL DB-create the same timeout budget as analyze

### DIFF
--- a/libs/openant-core/parsers/go/test_pipeline.py
+++ b/libs/openant-core/parsers/go/test_pipeline.py
@@ -93,6 +93,13 @@ class ProcessingLevel(Enum):
     EXPLOITABLE = "exploitable"    # Level 4: Filter to reachable + CodeQL-flagged + exploitable
 
 
+# CodeQL stage subprocess timeouts (seconds). DB `create` compiles the source -- the slower stage for
+# compiled languages -- so it must not get a smaller budget than `analyze`: a too-short create times out,
+# the stage degrades to reachable-only, and CodeQL security findings are silently lost.
+CODEQL_DB_CREATE_TIMEOUT_SECS = 1800
+CODEQL_ANALYZE_TIMEOUT_SECS = 1800
+
+
 class GoPipelineTest:
     def __init__(
         self,
@@ -517,7 +524,7 @@ class GoPipelineTest:
                 create_db_cmd,
                 capture_output=True,
                 text=True,
-                timeout=600  # 10 minute timeout
+                timeout=CODEQL_DB_CREATE_TIMEOUT_SECS
             )
 
             if result.returncode != 0:
@@ -548,7 +555,7 @@ class GoPipelineTest:
                 analyze_cmd,
                 capture_output=True,
                 text=True,
-                timeout=1800  # 30 minute timeout
+                timeout=CODEQL_ANALYZE_TIMEOUT_SECS
             )
 
             if result.returncode != 0:

--- a/libs/openant-core/tests/test_go_test_pipeline_codeql_timeout.py
+++ b/libs/openant-core/tests/test_go_test_pipeline_codeql_timeout.py
@@ -1,0 +1,51 @@
+"""Regression: go test_pipeline CodeQL stage timeouts must not be inverted.
+
+The CodeQL `database create` step (which COMPILES the source — the slower stage for compiled languages)
+was given timeout=600s while `database analyze` got 1800s. The slower stage with the smaller budget times
+out first; on timeout run_codeql_analysis records the codeql stage success=False and returns, the pipeline
+prints "continuing with reachable units only" and proceeds, and apply_codeql_filter is skipped — so the
+written dataset is reachable-only with CodeQL findings dropped. (The run reports success=False / exit 1, so
+an exit-code CI gate still catches it; the harm is the silently-degraded artifact for any consumer that
+reads the results rather than the exit code.) The create budget must be at least the analyze budget.
+
+This reads the source (the timeout values are module constants) rather than importing test_pipeline, which
+does module-level sys.path manipulation and shares its module name with the other parsers' test_pipeline.py.
+"""
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "parsers" / "go" / "test_pipeline.py"
+
+
+def _const(name: str) -> int:
+    m = re.search(rf"^{name}\s*=\s*(\d+)", SRC.read_text(), re.M)
+    assert m, f"{name} constant not found in {SRC}"
+    return int(m.group(1))
+
+
+def test_codeql_db_create_timeout_not_less_than_analyze():
+    create = _const("CODEQL_DB_CREATE_TIMEOUT_SECS")
+    analyze = _const("CODEQL_ANALYZE_TIMEOUT_SECS")
+    assert create >= analyze, (
+        f"codeql DB-create timeout ({create}s) < analyze timeout ({analyze}s): the slower "
+        f"compile-the-DB stage gets the smaller budget, so it times out first, the stage is "
+        f"recorded failed, and the pipeline writes a reachable-only dataset with CodeQL findings "
+        f"dropped"
+    )
+
+
+def test_codeql_timeouts_are_wired_to_the_constants():
+    """The create/analyze subprocess calls must USE the constants, not inline literals — otherwise a
+    future edit could revert a call site to timeout=600 while the constant stays 1800 and the value
+    check above would still pass green. Pre-fix the call sites passed literal timeouts (no constants
+    existed), so these assertions are RED before the fix and GREEN after — they lock the wiring, not
+    just the values."""
+    src = SRC.read_text()
+    assert "timeout=CODEQL_DB_CREATE_TIMEOUT_SECS" in src, (
+        "codeql `database create` must pass timeout=CODEQL_DB_CREATE_TIMEOUT_SECS, not an inline "
+        "literal — otherwise the create budget can silently drift below analyze again"
+    )
+    assert "timeout=CODEQL_ANALYZE_TIMEOUT_SECS" in src, (
+        "codeql `database analyze` must pass timeout=CODEQL_ANALYZE_TIMEOUT_SECS, not an inline "
+        "literal"
+    )


### PR DESCRIPTION
go/test_pipeline.py ran `codeql database create` with timeout=600s and `codeql database analyze` with
timeout=1800s. DB creation compiles the source -- the slower stage for compiled languages -- so the slower
stage had the smaller budget and times out first. On a create timeout run_codeql_analysis records the codeql
stage success=False and returns; run_full_pipeline prints "continuing with reachable units only" and proceeds,
and apply_codeql_filter (test_pipeline.py:1009, success-gated) is skipped -- so the written dataset is
reachable-only with CodeQL findings dropped. The run does report success=False / exit 1 (all_success ANDs the
failed stage, :1040-1045, :1199), so an exit-code CI gate still catches it; the harm is the silently-degraded
artifact for any consumer that reads the results rather than the exit code.

Extract both stage timeouts to named module constants and set the create budget equal to analyze (1800s), so
the create stage is no longer shortchanged.

Scope: the c/php/js/ruby test_pipeline.py orchestrators carry the same inverted timeouts and are separate
units -- not widened here.

Tests: tests/test_go_test_pipeline_codeql_timeout.py -- two checks that read the source rather than importing
the module (which does module-level sys.path manipulation and shares its name with sibling parser
test_pipeline.py): the create timeout >= analyze timeout, and that both call sites pass the named constants
(not inline literals, which could silently drift the budget back). RED -> GREEN; full suite 178 passed,
63 skipped, 0 failed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
