### PR TITLE
fix(parsers/js): discover and resolve .mjs/.cjs modules in context_assembler

### DIFF
--- a/libs/openant-core/parsers/javascript/context_assembler.js
+++ b/libs/openant-core/parsers/javascript/context_assembler.js
@@ -84,7 +84,7 @@ class ContextAssembler {
 
             if (entry.isDirectory()) {
                 this.findSourceFiles(fullPath, files);
-            } else if (/\.(js|ts|jsx|tsx)$/.test(entry.name) && !entry.name.endsWith('.d.ts')) {
+            } else if (/\.(js|ts|jsx|tsx|mjs|cjs)$/.test(entry.name) && !entry.name.endsWith('.d.ts')) {
                 files.push(fullPath);
             }
         }
@@ -319,7 +319,7 @@ class ContextAssembler {
         let resolvedPath = path.resolve(fromDir, importPath);
 
         // Try to find the actual file
-        const extensions = ['', '.js', '.ts', '.jsx', '.tsx', '/index.js', '/index.ts'];
+        const extensions = ['', '.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs', '/index.js', '/index.ts', '/index.mjs', '/index.cjs'];
         let found = false;
 
         for (const ext of extensions) {
@@ -462,7 +462,7 @@ class ContextAssembler {
         const fromDir = path.dirname(fromSourceFile.fileName);
         let resolvedPath = path.resolve(fromDir, importPath);
 
-        const extensions = ['', '.js', '.ts'];
+        const extensions = ['', '.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'];
 
         for (const ext of extensions) {
             const tryPath = resolvedPath + ext;

--- a/libs/openant-core/tests/test_context_assembler_mjs.py
+++ b/libs/openant-core/tests/test_context_assembler_mjs.py
@@ -1,0 +1,49 @@
+"""Regression: context_assembler must not omit .mjs/.cjs (silent edge drop).
+
+context_assembler.js's source-discovery glob (findSourceFiles, ~:87) and its import-resolution extension
+lists (~:322, ~:465) only cover .js/.ts/.jsx/.tsx — never .mjs/.cjs. So ESM (.mjs) / CommonJS (.cjs) modules are
+never loaded into the TypeScript program (getSourceFile -> undefined) and imports targeting them are silently
+unresolved. The sibling repository_scanner.js already includes .mjs/.cjs in its sourceExtensions. Fix: add
+.mjs/.cjs to the discovery glob and the resolution extension lists.
+
+This drives the discovery root via the exported ContextAssembler.findSourceFiles (a .mjs/.cjs file must be
+discovered). Skips portably where the JS parser's node deps aren't installed.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PARSERS_JS_DIR = Path(__file__).parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def test_findsourcefiles_discovers_mjs_and_cjs(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.js").write_text("export {};\n")
+    (repo / "esm.mjs").write_text("export const x = 1;\n")
+    (repo / "cjs.cjs").write_text("module.exports = {};\n")
+
+    ca_path = str(PARSERS_JS_DIR / "context_assembler.js")
+    script = (
+        "const {ContextAssembler}=require(%r);"
+        "const path=require('path');"
+        "const ca=new ContextAssembler(%r);"
+        "const f=ca.findSourceFiles(%r);"
+        "console.log(JSON.stringify(f.map(p=>path.basename(p))));"
+    ) % (ca_path, str(repo), str(repo))
+
+    r = subprocess.run(["node", "-e", script], capture_output=True, text=True, timeout=30)
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    found = json.loads(r.stdout.strip().splitlines()[-1])
+    assert "esm.mjs" in found, f".mjs not discovered (discovery glob omits it): {found}"
+    assert "cjs.cjs" in found, f".cjs not discovered (discovery glob omits it): {found}"
+    assert "main.js" in found  # control: .js still discovered


### PR DESCRIPTION
context_assembler.js omitted .mjs (ESM) and .cjs (CommonJS) from both its source-discovery glob
(findSourceFiles) and its import-resolution extension lists. So .mjs/.cjs files were never loaded into
the TypeScript program (getSourceFile -> undefined) and imports targeting them were silently unresolved --
dropped call-graph edges. The sibling repository_scanner.js already includes .mjs/.cjs in its
sourceExtensions; this brings context_assembler to the same canonical set (.js/.ts/.jsx/.tsx/.mjs/.cjs).

Three sites updated:
- findSourceFiles discovery glob: add mjs|cjs.
- import-resolution extensions: add .mjs/.cjs + /index.mjs / /index.cjs.
- resolveModuleFunctionDefinition extensions (the sibling site -- it omitted even .jsx/.tsx): bring to
  the canonical set.

Tests: tests/test_context_assembler_mjs.py (ContextAssembler.findSourceFiles discovers .mjs/.cjs; skips
portably where the JS parser's node deps aren't installed). RED 1 failed (['main.js']) -> GREEN 1 passed;
JS parser suite 10 passed; full venv suite 218 passed, 22 skipped, 0 failed (with node deps installed,
which unlocks the otherwise-skipped JS tests). node --check clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
