### PR TITLE
fix(c-parser): anchor is_test_file patterns to path segments / filename boundaries

### DIFF
--- a/libs/openant-core/parsers/c/repository_scanner.py
+++ b/libs/openant-core/parsers/c/repository_scanner.py
@@ -102,11 +102,33 @@ class RepositoryScanner:
         return ext in self.source_extensions
 
     def is_test_file(self, relative_path: str) -> bool:
-        """Check if a file is a test file."""
+        """Check if a file is a test file.
+
+        Patterns are matched against path *segments* and filename boundaries,
+        not as bare substrings, so ordinary files whose name/path merely
+        contains a pattern (e.g. ``latest_value.c`` contains ``test_``;
+        ``contest/foo.c`` contains ``test/``) are not misclassified as tests.
+        """
         path_lower = relative_path.lower()
+        segments = path_lower.split('/')
+        basename = segments[-1]
+        dir_segments = segments[:-1]
         for pattern in self.test_patterns:
-            if pattern in path_lower:
-                return True
+            if pattern.endswith('/'):
+                # directory pattern: match a whole path segment (test/, tests/, fuzz/)
+                if pattern[:-1] in dir_segments:
+                    return True
+            elif '.' in pattern:
+                # filename-suffix pattern (e.g. _test.c, _test.cpp): compare the stem
+                # before the extension, so _test.cc / _test.cxx (common C/C++ test
+                # extensions the old substring check also matched) stay detected —
+                # without re-introducing substring over-match. Bounded by is_source_file.
+                if basename.rsplit('.', 1)[0].endswith(pattern.rsplit('.', 1)[0]):
+                    return True
+            else:
+                # filename-prefix token (test_)
+                if basename.startswith(pattern):
+                    return True
         return False
 
     def scan_directory(self, dir_path: Path, relative_path: str = '') -> None:

--- a/libs/openant-core/tests/parsers/c/test_repository_scanner_is_test_file.py
+++ b/libs/openant-core/tests/parsers/c/test_repository_scanner_is_test_file.py
@@ -1,0 +1,55 @@
+"""Regression tests for the C repository scanner's test-file detection.
+
+``RepositoryScanner.is_test_file`` matched its ``test_patterns`` as bare
+substrings (``if pattern in path_lower``). Because
+``test_patterns`` includes ``'test_'`` and ``'test/'``, ordinary source files
+whose *name or path merely contains* those characters were wrongly skipped as
+tests:
+
+    - ``latest_value.c``  contains ``'test_'`` (la**test_**value) -> skipped
+    - ``contest/foo.c``   contains ``'test/'`` (con**test/**)     -> skipped
+
+The fix anchors the patterns to path *segments* and filename boundaries, so a
+pattern only matches a whole directory segment (``test/``, ``tests/``, ``fuzz/``)
+or a filename prefix/suffix (``test_``, ``_test.c``).
+"""
+
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]  # libs/openant-core
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.c.repository_scanner import RepositoryScanner
+
+
+def _scanner() -> RepositoryScanner:
+    # is_test_file is pure string logic; repo_path is unused by it.
+    return RepositoryScanner(".")
+
+
+def test_is_test_file_true_for_real_tests():
+    """Genuine test files/dirs must still be detected (guards against over-correction)."""
+    s = _scanner()
+    assert s.is_test_file("test/foo.c") is True
+    assert s.is_test_file("src/tests/bar.c") is True
+    assert s.is_test_file("fuzz/baz.c") is True
+    assert s.is_test_file("foo_test.c") is True
+    assert s.is_test_file("test_foo.c") is True
+    assert s.is_test_file("src/util/widget_test.cpp") is True
+    # _test stem before any C/C++ source extension (the old substring check caught
+    # .cc/.cxx via the '.c' prefix; the stem match preserves that):
+    assert s.is_test_file("foo_test.cc") is True
+    assert s.is_test_file("foo_test.cxx") is True
+
+
+def test_is_test_file_false_for_substring_lookalikes():
+    """Non-test files whose name/path merely CONTAINS a pattern
+    must NOT be classified as tests."""
+    s = _scanner()
+    assert s.is_test_file("latest_value.c") is False   # contains 'test_'
+    assert s.is_test_file("contest/foo.c") is False    # contains 'test/'
+    assert s.is_test_file("src/greatest.c") is False   # contains 'test'
+    assert s.is_test_file("attestation.cpp") is False  # contains 'test'
+    assert s.is_test_file("mytest/foo.c") is False     # deceptive dir segment 'mytest'
+    assert s.is_test_file("testing/foo.c") is False    # deceptive dir segment 'testing'


### PR DESCRIPTION
RepositoryScanner.is_test_file matched test_patterns as bare substrings
(`pattern in path_lower`), so ordinary source files whose name/path merely
CONTAINED a pattern were wrongly skipped as tests when skip_tests=True:
  - latest_value.c  (contains 'test_')  -> skipped
  - contest/foo.c   (contains 'test/')  -> skipped

Match directory patterns (test/, tests/, fuzz/) against whole path *segments*,
and filename patterns against the basename: '_test' as a stem suffix and
'test_' as a prefix. The _test suffix is matched on the stem (before the
extension) so _test.cc / _test.cxx — which the old substring check also caught
— stay detected, bounded by is_source_file.

Adds tests/parsers/c/test_repository_scanner_is_test_file.py (RED->GREEN; both
true-positive and false-positive directions, incl. the _test.cc regression case).
GREEN: 2 passed (venv py3.11); ruff clean.

The same substring bug exists in the python/php/ruby repository_scanner.py —
handled in their own PRs (systemic family).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
