### PR TITLE
fix(context): anchor entry-point path exclusions on components, not substrings

### DIFF
--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -270,6 +270,32 @@ def get_directory_structure(repo_path: Path, max_depth: int = 2) -> str:
     return "\n".join(lines[:100])  # Limit output
 
 
+# Directory names (exact path SEGMENTS, not substrings) to skip when scanning for entry points.
+_PY_EXCLUDE_DIRS = {'node_modules', '__pycache__', 'venv', '.venv', 'test', 'tests'}
+_JS_EXCLUDE_DIRS = {'node_modules', 'dist', 'build'}
+
+
+def _path_excluded(file_path: Path, repo_path: Path, exclude_dirs: set, anchored_test: bool = False) -> bool:
+    """Whether file_path should be skipped, matching on relative-path COMPONENTS.
+
+    Anchors on path *segments* relative to repo_path rather than a substring of the absolute
+    path, so a parent directory or a partial token ('protest_api.py', 'latest/', 'redistribute.js')
+    no longer wrongly excludes a real entry point — and a token in some ancestor of repo_path
+    (e.g. a CI checkout under '/build/' or '/latest/') can no longer suppress every file.
+    """
+    try:
+        parts = file_path.relative_to(repo_path).parts
+    except ValueError:
+        parts = file_path.parts
+    if exclude_dirs.intersection(parts):
+        return True
+    if anchored_test:
+        name = file_path.name
+        if name.startswith("test_") or name.endswith("_test.py"):
+            return True
+    return False
+
+
 def detect_entry_points(repo_path: Path) -> str:
     """Detect entry point patterns in the codebase.
 
@@ -287,7 +313,7 @@ def detect_entry_points(repo_path: Path) -> str:
     for py_file in repo_path.rglob("*.py"):
         if files_checked >= max_files:
             break
-        if any(p in str(py_file) for p in ['node_modules', '__pycache__', 'venv', '.venv', 'test', 'tests']):
+        if _path_excluded(py_file, repo_path, _PY_EXCLUDE_DIRS, anchored_test=True):
             continue
 
         try:
@@ -307,7 +333,7 @@ def detect_entry_points(repo_path: Path) -> str:
 
     # Check JavaScript/TypeScript files
     for js_file in list(repo_path.rglob("*.js"))[:20] + list(repo_path.rglob("*.ts"))[:20]:
-        if any(p in str(js_file) for p in ['node_modules', 'dist', 'build']):
+        if _path_excluded(js_file, repo_path, _JS_EXCLUDE_DIRS):
             continue
 
         try:

--- a/libs/openant-core/tests/test_application_context_entry_points_anchored.py
+++ b/libs/openant-core/tests/test_application_context_entry_points_anchored.py
@@ -1,0 +1,56 @@
+"""Regression tests for detect_entry_points unanchored-substring path-exclusion.
+
+Two sites exclude files via `token in str(absolute_path)` —
+  Python branch (application_context.py:290): tokens incl 'test','tests','venv'
+  JS branch     (application_context.py:310): tokens incl 'dist','build'
+So a path SEGMENT (or a PARENT dir) merely CONTAINING a token wrongly skips a real entry point.
+Vividly, pytest's own tmp_path contains 'test', so PRE-FIX every fixture below is excluded.
+Fix: match on relative-path COMPONENTS + anchored test-file detection.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+from context.application_context import detect_entry_points  # noqa: E402
+
+FASTAPI = "from fastapi import FastAPI\napp = FastAPI()\n"
+EXPRESS = "const express = require('express')\nconst app = express()\n"
+
+
+def _w(p: Path, text: str):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def test_substring_false_positive_python(tmp_path):
+    # 'protest_api.py' contains 'test' as a substring but is a real FastAPI entry point.
+    _w(tmp_path / "protest_api.py", FASTAPI)
+    out = detect_entry_points(tmp_path)
+    assert "protest_api.py" in out, f"real entry point wrongly excluded by 'test' substring: {out!r}"
+
+
+def test_parent_path_token_does_not_kill_all(tmp_path):
+    # repo under a parent dir named 'latest' (contains 'test') — pre-fix excludes EVERY file.
+    repo = tmp_path / "latest" / "app"
+    _w(repo / "server.py", FASTAPI)
+    out = detect_entry_points(repo)
+    assert "server.py" in out, f"parent-path token wrongly excluded all files: {out!r}"
+
+
+def test_js_substring_false_positive(tmp_path):
+    # 'redistribute.js' contains 'dist' as a substring but is a real express entry point.
+    _w(tmp_path / "redistribute.js", EXPRESS)
+    out = detect_entry_points(tmp_path)
+    assert "redistribute.js" in out, f"real JS entry point wrongly excluded by 'dist' substring: {out!r}"
+
+
+def test_genuine_exclusions_preserved(tmp_path):
+    # post-fix: a clean entry point IS detected; a real tests/ file and node_modules stay excluded.
+    _w(tmp_path / "real_app.py", FASTAPI)
+    _w(tmp_path / "tests" / "test_real.py", FASTAPI)
+    _w(tmp_path / "node_modules" / "pkg" / "mod.py", FASTAPI)
+    out = detect_entry_points(tmp_path)
+    assert "real_app.py" in out, f"clean entry point should be detected: {out!r}"
+    assert "test_real.py" not in out, f"genuine test file should stay excluded: {out!r}"
+    assert "mod.py" not in out, f"node_modules should stay excluded: {out!r}"


### PR DESCRIPTION
detect_entry_points() skipped candidate files via `any(token in str(path))`
against the full absolute path at two sites (Python branch + JS/TS branch).
Short tokens ('test','tests','venv','dist','build') matched as substrings, so:
  - real entry points whose name merely contains a token were skipped
    (protest_api.py, latest/main.py, redistribute.js, buildings/);
  - worse, a token in any ANCESTOR of repo_path (a CI checkout under
    /build/ or /latest/) suppressed EVERY file -> detect_entry_points
    returned '' -> downstream ApplicationType misclassification.

Fix: match on relative-path COMPONENTS via a shared _path_excluded() helper
(set-intersection on `relative_to(repo_path).parts`) plus anchored test-file
detection (test_*.py / *_test.py). Genuine node_modules/venv/dist/build dirs
and real test files stay excluded.

Tests: tests/test_application_context_entry_points_anchored.py (4 cases:
substring-FP python, parent-path-token, substring-FP js, genuine-exclusions
preserved). RED 4 failed -> GREEN 4 passed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
