### PR TITLE
fix(file_io): write_json atomically (temp + os.replace) to survive interrupted writes

### DIFF
--- a/libs/openant-core/tests/test_file_io_atomic_write.py
+++ b/libs/openant-core/tests/test_file_io_atomic_write.py
@@ -1,0 +1,42 @@
+"""Regression test — write_json is non-atomic (truncate-then-write).
+
+write_json opens the target in "w" (truncating it to 0 bytes) and then streams json.dump. If the process is
+killed mid-serialization (SIGKILL / OOM / power loss), the target is left partial/empty and the previous good
+content is lost → the next read_json raises JSONDecodeError. Fix: write to a temp file in the same directory and
+os.replace it onto the target (atomic rename), so an interrupted write never clobbers the prior version.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+import utilities.file_io as fio  # noqa: E402
+from utilities.file_io import read_json, write_json  # noqa: E402
+
+
+def test_write_json_atomic_preserves_original_on_crash(tmp_path, monkeypatch):
+    """An interrupted write must leave the prior good file intact (atomic replace)."""
+    p = tmp_path / "checkpoint.json"
+    write_json(p, {"v": 1})
+    assert read_json(p) == {"v": 1}
+
+    def boom(*a, **k):
+        raise RuntimeError("killed mid-write")
+
+    monkeypatch.setattr(fio.json, "dump", boom)
+    with pytest.raises(RuntimeError):
+        write_json(p, {"v": 2})
+
+    # Post-fix: the original is untouched. Pre-fix: p was truncated -> empty -> this raises/!= {"v":1}.
+    assert read_json(p) == {"v": 1}, "interrupted write clobbered the prior checkpoint"
+    leftovers = list(tmp_path.glob(".tmp*"))
+    assert not leftovers, f"temp file leaked after failed write: {leftovers}"
+
+
+def test_write_json_normal_roundtrip(tmp_path):
+    """Guard: the normal write path still round-trips correctly."""
+    p = tmp_path / "x.json"
+    write_json(p, {"a": [1, 2, 3], "b": "héllo"})
+    assert read_json(p) == {"a": [1, 2, 3], "b": "héllo"}

--- a/libs/openant-core/utilities/file_io.py
+++ b/libs/openant-core/utilities/file_io.py
@@ -9,6 +9,7 @@ explicitly, preventing ``'charmap' codec can't decode byte ...`` errors.
 import json
 import os
 import subprocess
+import tempfile
 from typing import Any, Union
 
 # Accept str, Path, or any os.PathLike
@@ -34,10 +35,31 @@ def read_json(path: PathLike) -> Any:
 
 
 def write_json(path: PathLike, data: Any, **kwargs) -> None:
-    """Write data as JSON to a file using UTF-8 encoding."""
+    """Write data as JSON to a file using UTF-8 encoding, atomically.
+
+    Serialize to a temp file in the same directory, fsync, then ``os.replace`` onto the
+    target. An interrupted write (SIGKILL / OOM / power loss) leaves the temp file behind
+    but never truncates or clobbers the existing target — the prior good copy survives.
+    """
     kwargs.setdefault("indent", 2)
-    with open_utf8(path, "w") as f:
-        json.dump(data, f, **kwargs)
+    target = os.fspath(path)
+    directory = os.path.dirname(target) or "."
+    # `.tmp` suffix (not `.json`): a leftover from a hard crash (where the except-cleanup
+    # below never runs) must not match directory scanners that do `endswith(".json")`
+    # (e.g. core/checkpoint.py's os.listdir loops, which also see dotfiles).
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".tmp-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, **kwargs)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, target)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def run_utf8(*args, **kwargs) -> subprocess.CompletedProcess:


### PR DESCRIPTION
write_json opened the target in "w" (truncating it to 0 bytes) and then streamed json.dump.
A crash mid-serialization (SIGKILL / OOM / power loss) left the target partial or empty and
destroyed the prior good copy, so the next read_json raised JSONDecodeError -- e.g. a
corrupted checkpoint.json that breaks resume.

Serialize to a temp file in the same directory, flush + fsync, then os.replace onto the
target (atomic rename). An interrupted write leaves only the temp file (unlinked on a caught
error); the existing target is never truncated. All write_json call sites inherit the fix.
The temp uses a `.tmp` suffix (not `.json`) so a hard-crash leftover can't be miscounted by
directory scanners that do os.listdir + endswith(".json") (e.g. core/checkpoint.py).

Tests: tests/test_file_io_atomic_write.py (2 cases: interrupted write preserves the prior
file + no temp leak; normal round-trip incl. non-ASCII). RED 1 failed (JSONDecodeError) ->
GREEN 2 passed (venv py3.11). ruff clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
