### PR TITLE
fix(rate_limiter): re-check the backoff deadline after sleeping (close TOCTOU)

### DIFF
--- a/libs/openant-core/tests/test_rate_limiter_deadline_recheck.py
+++ b/libs/openant-core/tests/test_rate_limiter_deadline_recheck.py
@@ -1,0 +1,65 @@
+"""Regression test for the wait_if_needed TOCTOU on the backoff deadline.
+
+wait_if_needed reads _backoff_until under the lock, releases it, then sleeps for the *entry-time* duration.
+If another worker extends _backoff_until (via report_rate_limit on a fresh 429) while this worker sleeps, this
+worker wakes before the new deadline and issues a request into the still-active backoff window -> more 429s,
+thundering herd. Fix: after sleeping, re-check the deadline and keep waiting until it has actually passed.
+"""
+import sys
+import threading
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+import utilities.rate_limiter as rl  # noqa: E402
+
+
+def test_wait_if_needed_rechecks_extended_deadline(monkeypatch):
+    # Fresh, isolated instance (bypass the singleton) so the test doesn't touch global state.
+    limiter = object.__new__(rl.GlobalRateLimiter)
+    limiter._lock = threading.Lock()
+    limiter._total_waits = 0
+    limiter._total_wait_time = 0.0
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(rl.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(rl.random, "uniform", lambda a, b: 0.0)  # deterministic: no jitter
+    limiter._backoff_until = 1005.0  # 5s backoff from t=1000
+
+    sleeps = []
+    state = {"extended": False}
+
+    def fake_sleep(d):
+        clock["t"] += d
+        sleeps.append(d)
+        if not state["extended"]:
+            # Simulate another worker extending the backoff (a fresh 429) DURING this sleep.
+            limiter._backoff_until = clock["t"] + 3.0
+            state["extended"] = True
+
+    monkeypatch.setattr(rl.time, "sleep", fake_sleep)
+
+    limiter.wait_if_needed()
+
+    assert clock["t"] >= limiter._backoff_until, (
+        f"woke before the extended deadline: t={clock['t']} < backoff_until={limiter._backoff_until}"
+    )
+    assert len(sleeps) >= 2, f"did not re-check the deadline after it was extended (slept {len(sleeps)}x)"
+    # counters increment once per waiting call (not per loop iteration) and accumulate actual slept time
+    assert limiter._total_waits == 1, f"expected _total_waits == 1 (once per call), got {limiter._total_waits}"
+    assert limiter._total_wait_time == sum(sleeps), "should accumulate total slept time"
+
+
+def test_wait_if_needed_returns_zero_when_not_in_backoff(monkeypatch):
+    """Guard: when not in a backoff window, it returns immediately (0.0) and does not sleep."""
+    limiter = object.__new__(rl.GlobalRateLimiter)
+    limiter._lock = threading.Lock()
+    limiter._total_waits = 0
+    limiter._total_wait_time = 0.0
+    monkeypatch.setattr(rl.time, "monotonic", lambda: 2000.0)
+    limiter._backoff_until = 1000.0  # already past
+    slept = []
+    monkeypatch.setattr(rl.time, "sleep", lambda d: slept.append(d))
+    assert limiter.wait_if_needed() == 0.0
+    assert slept == []
+    assert limiter._total_waits == 0  # no-wait fast path must not increment the counter

--- a/libs/openant-core/utilities/rate_limiter.py
+++ b/libs/openant-core/utilities/rate_limiter.py
@@ -67,22 +67,29 @@ class GlobalRateLimiter:
 
         Call this before every API request. Returns the time waited (0 if none).
         """
-        with self._lock:
-            now = time.monotonic()
-            if now >= self._backoff_until:
-                return 0.0
+        total_wait = 0.0
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                if now >= self._backoff_until:
+                    break
 
-            wait_time = self._backoff_until - now
-            # Add jitter (0-2s) to prevent thundering herd when backoff expires
-            jitter = random.uniform(0, 2.0)
-            total_wait = wait_time + jitter
+                wait_time = self._backoff_until - now
+                # Add jitter (0-2s) to prevent thundering herd when backoff expires
+                jitter = random.uniform(0, 2.0)
+                this_wait = wait_time + jitter
 
-        # Sleep outside the lock so other threads can also read backoff_until
-        time.sleep(total_wait)
+            # Sleep outside the lock so other threads can also read backoff_until.
+            # Re-check after sleeping: another worker may have EXTENDED _backoff_until
+            # (a fresh 429 via report_rate_limit) while we slept. Without the re-check we
+            # would wake into the still-active backoff window and re-trigger the storm.
+            time.sleep(this_wait)
+            total_wait += this_wait
 
-        with self._lock:
-            self._total_waits += 1
-            self._total_wait_time += total_wait
+        if total_wait > 0.0:
+            with self._lock:
+                self._total_waits += 1
+                self._total_wait_time += total_wait
 
         return total_wait
 


### PR DESCRIPTION
wait_if_needed() read _backoff_until under the lock, released it, then slept for the entry-time
duration. If another worker extended _backoff_until (a fresh 429 via report_rate_limit) during that
sleep, this worker woke before the new deadline and issued a request into the still-active backoff
window -- re-triggering the 429 storm (thundering herd).

Wrap the read+sleep in a loop that re-checks _backoff_until after each sleep and keeps waiting until
the deadline has actually passed. Preserves the existing contract: returns 0.0 immediately when not
in backoff, and increments _total_waits once per waiting call. The loop waits as long as the backoff
is genuinely active (a persistently-overloaded API) -- the intended coordinated-backoff behavior, and
strictly safer than the old early-wake.

Tests: tests/test_rate_limiter_deadline_recheck.py (2 cases: a deadline extended mid-sleep is honored
via re-check; not-in-backoff returns 0.0 without sleeping). RED 1 failed -> GREEN 2 passed; full suite
178 passed / 63 skipped (py3.11).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
