### PR TITLE
fix(reachability): make get_all_reachable() overwrite the cache so a stale bounded False is corrected

### DIFF
--- a/libs/openant-core/tests/test_reachability_cache.py
+++ b/libs/openant-core/tests/test_reachability_cache.py
@@ -1,0 +1,36 @@
+"""Regression test -- ReachabilityAnalyzer stale-cache.
+
+is_reachable_from_entry_point() is a depth-BOUNDED reverse BFS: for a function farther than max_depth
+hops from an entry point it caches False (a false negative). get_all_reachable() is an UNBOUNDED forward
+BFS (the complete answer), but it used to update the cache only for keys NOT already present -- so the
+stale bounded False was frozen and never corrected. Fix: get_all_reachable() overwrites the cache.
+"""
+from utilities.agentic_enhancer.reachability_analyzer import ReachabilityAnalyzer
+
+
+def _analyzer(max_depth):
+    # E -> A -> B -> C  (forward).  reverse: A<-E, B<-A, C<-B.  Entry point: E.
+    functions = {"E": {}, "A": {}, "B": {}, "C": {}}
+    reverse_call_graph = {"A": ["E"], "B": ["A"], "C": ["B"]}
+    return ReachabilityAnalyzer(functions, reverse_call_graph, entry_points={"E"}, max_depth=max_depth)
+
+
+def test_get_all_reachable_overwrites_stale_bounded_false():
+    ra = _analyzer(max_depth=2)
+    # C is reachable (E->A->B->C) but 3 reverse hops away, so the depth-2 reverse BFS caches False:
+    assert ra.is_reachable_from_entry_point("C") is False
+    # the unbounded forward pass must CORRECT that stale cached False:
+    assert "C" in ra.get_all_reachable()
+    assert ra.is_reachable_from_entry_point("C") is True, \
+        "get_all_reachable() must overwrite the stale depth-bounded False, not freeze it"
+
+
+def test_get_all_reachable_does_not_break_true_or_unreachable():
+    # With ample depth, nothing is stale; reachable stays reachable, a disconnected node stays unreachable.
+    ra = ReachabilityAnalyzer(
+        {"E": {}, "A": {}, "X": {}}, {"A": ["E"]}, entry_points={"E"}, max_depth=15)
+    reachable = ra.get_all_reachable()
+    assert "A" in reachable and "E" in reachable
+    assert "X" not in reachable
+    assert ra.is_reachable_from_entry_point("A") is True
+    assert ra.is_reachable_from_entry_point("X") is False

--- a/libs/openant-core/utilities/agentic_enhancer/reachability_analyzer.py
+++ b/libs/openant-core/utilities/agentic_enhancer/reachability_analyzer.py
@@ -185,10 +185,14 @@ class ReachabilityAnalyzer:
                     reachable.add(callee)
                     queue.append(callee)
 
-        # Update cache
+        # Update cache. get_all_reachable() is the AUTHORITATIVE result -- an UNBOUNDED forward BFS over
+        # the full graph. is_reachable_from_entry_point() is a depth-BOUNDED reverse BFS that caches
+        # False for functions farther than max_depth from an entry point (a false negative). Overwrite
+        # unconditionally (the old "only if absent" froze whichever pass ran first) so this complete
+        # pass corrects any stale bounded result. The forward graph is built from the same reverse
+        # edges, so this can only flip stale False->True, never introduce a false positive.
         for func_id in self.functions:
-            if func_id not in self._reachability_cache:
-                self._reachability_cache[func_id] = func_id in reachable
+            self._reachability_cache[func_id] = func_id in reachable
 
         return reachable
 


### PR DESCRIPTION
ReachabilityAnalyzer has two cache-population paths that disagree:
- is_reachable_from_entry_point() is a depth-BOUNDED reverse BFS; for a function farther than max_depth
  hops from an entry point it caches False -- a false negative;
- get_all_reachable() is an UNBOUNDED forward BFS (the complete reachable set).

get_all_reachable() updated the shared _reachability_cache only for keys NOT already present, so a stale
False seeded by an earlier bounded per-query call was frozen and never corrected -- the complete pass
could not fix it (order-dependent wrong result). Overwrite the cache unconditionally: get_all_reachable()
is authoritative. Because its forward graph is built from the same reverse edges the bounded BFS walks,
this can only flip a stale False->True, never introduce a false positive.

Tests: tests/test_reachability_cache.py -- a function reachable only beyond max_depth is cached False
by the reverse BFS, then get_all_reachable() corrects it to True (and a disconnected node stays
unreachable, a within-depth node stays reachable). RED 1 failed (stale False frozen) -> GREEN 2 passed
(venv py3.11); ruff clean.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
