### PR TITLE
docs(validate_dataset_schema): cite experiment.py analyze_unit() instead of drifting line numbers

### DIFF
--- a/libs/openant-core/validate_dataset_schema.py
+++ b/libs/openant-core/validate_dataset_schema.py
@@ -18,7 +18,7 @@ def validate_unit(unit, index):
     if not unit.get("id"):
         errors.append(f"Unit {index}: missing 'id'")
 
-    # 2. Check unit.code structure (experiment.py lines 186-196)
+    # 2. Check unit.code structure (built by experiment.py analyze_unit())
     code_field = unit.get("code", {})
     if not isinstance(code_field, dict):
         errors.append(f"Unit {index}: 'code' must be dict, got {type(code_field)}")
@@ -43,7 +43,7 @@ def validate_unit(unit, index):
     elif not isinstance(primary_origin.get(deps_inlined_key), bool):
         errors.append(f"Unit {index}: 'code.primary_origin.deps_inlined' must be bool")
 
-    # 6. CRITICAL: Check files_included (experiment.py line 192)
+    # 6. CRITICAL: Check files_included (set by experiment.py analyze_unit())
     if "files_included" not in primary_origin:
         errors.append(f"Unit {index}: MISSING 'code.primary_origin.files_included'")
     elif not isinstance(primary_origin.get("files_included"), list):


### PR DESCRIPTION
Two comments in validate_unit() cited hardcoded experiment.py line numbers ("lines 186-196",
"line 192") that had drifted: experiment.py:186-196 is now load_application_context(), unrelated
to unit.code/files_included. The actual code/files_included handling lives in experiment.py
analyze_unit(). Replace the brittle line-number citations with the stable function-name anchor so
they cannot re-drift.

Doc/comment-only: no behavioral change, no regression test. Verified: 0 residual
"experiment.py lines N" citations remain; experiment.py analyze_unit() handles code_field
+ files_included; ruff clean (venv py3.11).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
