### PR TITLE
fix(parsers/python): resolve self/cls-aliased method calls in the call graph

### DIFF
--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -186,10 +186,13 @@ class CallGraphBuilder:
         # Local variable -> constructor-type map, so that `v = ClassName(); v.method()`
         # dispatches to the bound type's method.
         local_types = self._collect_local_types(tree)
+        # Receiver names that refer to the current instance/class: self/cls plus any
+        # local name single-bound to them (obj = self; obj.method()).
+        self_aliases = {'self', 'cls'} | self._collect_self_aliases(tree)
 
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
-                resolved = self._resolve_call_node(node, caller_file, caller_class, local_types)
+                resolved = self._resolve_call_node(node, caller_file, caller_class, local_types, self_aliases)
                 if resolved:
                     calls.add(resolved)
                 # Higher-order-function callbacks: a function reference passed as an
@@ -248,11 +251,38 @@ class CallGraphBuilder:
                     callees.append(resolved)
         return callees
 
+    def _collect_self_aliases(self, tree: ast.AST) -> Set[str]:
+        """Local names single-bound to ``self``/``cls`` (e.g. ``obj = self``).
+
+        Only single, unconditional bindings count: a name assigned more than
+        once — or ever rebound to something other than self/cls — is NOT an
+        alias, so no spurious self-method edge is created.
+        """
+        assign_count: dict = {}
+        self_bound: Set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name):
+                        assign_count[tgt.id] = assign_count.get(tgt.id, 0) + 1
+                        if isinstance(node.value, ast.Name) and node.value.id in ('self', 'cls'):
+                            self_bound.add(tgt.id)
+        return {name for name in self_bound if assign_count.get(name) == 1}
+
     def _resolve_call_node(self, node: ast.Call, caller_file: str, caller_class: Optional[str],
-                           local_types: Optional[Dict[str, str]] = None) -> Optional[str]:
-        """Resolve an AST Call node to a function ID."""
+                           local_types: Optional[Dict[str, str]] = None,
+                           self_aliases: Optional[Set[str]] = None) -> Optional[str]:
+        """Resolve an AST Call node to a function ID.
+
+        ``self_aliases`` is the set of receiver names that refer to the current
+        instance/class — always includes ``self``/``cls`` plus any local name
+        single-bound to them (``obj = self; obj.method()``). Defaults to the
+        bare ``{'self', 'cls'}`` so direct callers keep working.
+        """
         func = node.func
         local_types = local_types or {}
+        if self_aliases is None:
+            self_aliases = {'self', 'cls'}
 
         # Simple function call: func_name(...)
         if isinstance(func, ast.Name):
@@ -266,14 +296,9 @@ class CallGraphBuilder:
             method_name = func.attr
             obj = func.value
 
-            # self.method(...) - same class
-            if isinstance(obj, ast.Name) and obj.id == 'self':
-                if caller_class:
-                    return self._resolve_self_call(method_name, caller_file, caller_class)
-                return None
-
-            # cls.method(...) - classmethod
-            if isinstance(obj, ast.Name) and obj.id == 'cls':
+            # self.method(...) / cls.method(...) — same class, including a local
+            # alias single-bound to self/cls (obj = self; obj.method()).
+            if isinstance(obj, ast.Name) and obj.id in self_aliases:
                 if caller_class:
                     return self._resolve_self_call(method_name, caller_file, caller_class)
                 return None

--- a/libs/openant-core/tests/parsers/python/test_call_graph_self_calls.py
+++ b/libs/openant-core/tests/parsers/python/test_call_graph_self_calls.py
@@ -138,3 +138,65 @@ def test_callee_is_not_isolated_in_statistics():
         f"  call_graph: {builder.call_graph}\n"
         f"  reverse_call_graph: {builder.reverse_call_graph}"
     )
+
+
+# --- self / cls alias edges (byproduct-deepcheck 2026-06-12) ---
+# `obj = self; obj.method()` and `alias = cls; alias.method()` are real
+# self/class-method calls, but _resolve_call_node only matched a receiver
+# literally named `self`/`cls`, so the edge was DROPPED (under-resolution ->
+# the callee can look unreachable). Fixing ADDS the missing edge; it never
+# removes one (raises reachability, never lowers it).
+
+def _alias_extractor_output(body: str, decorator: str = "") -> dict:
+    """Two methods on one class; `caller` reaches `target` via a self/cls alias."""
+    file_path = "m.py"
+    dec = f"    {decorator}\n" if decorator else ""
+    return {
+        "repository": "/tmp/fake",
+        "imports": {file_path: {}},
+        "classes": {f"{file_path}:C": {"name": "C", "file_path": file_path}},
+        "functions": {
+            f"{file_path}:C.target": {
+                "name": "target", "qualified_name": "C.target", "file_path": file_path,
+                "class_name": "C", "unit_type": "method",
+                "code": f"{dec}    def target(self):\n        return 1\n",
+            },
+            f"{file_path}:C.caller": {
+                "name": "caller", "qualified_name": "C.caller", "file_path": file_path,
+                "class_name": "C", "unit_type": "method", "code": body,
+            },
+        },
+    }
+
+
+def test_self_alias_method_call_edge():
+    """`obj = self; obj.target()` must produce the C.caller -> C.target edge."""
+    body = "    def caller(self):\n        obj = self\n        return obj.target()\n"
+    builder = CallGraphBuilder(_alias_extractor_output(body))
+    builder.build_call_graph()
+    assert "m.py:C.target" in builder.call_graph["m.py:C.caller"], (
+        f"self-alias edge missing; got {builder.call_graph['m.py:C.caller']}"
+    )
+
+
+def test_cls_alias_method_call_edge():
+    """`alias = cls; alias.target()` in a classmethod must produce the edge."""
+    body = ("    @classmethod\n    def caller(cls):\n"
+            "        alias = cls\n        return alias.target()\n")
+    builder = CallGraphBuilder(_alias_extractor_output(body, decorator="@classmethod"))
+    builder.build_call_graph()
+    assert "m.py:C.target" in builder.call_graph["m.py:C.caller"], (
+        f"cls-alias edge missing; got {builder.call_graph['m.py:C.caller']}"
+    )
+
+
+def test_reassigned_alias_does_not_force_self_edge():
+    """Guard: a name reassigned away from self must NOT be treated as a self-alias
+    (single-unconditional binding only) — keeps the fix sound, no spurious edges."""
+    body = ("    def caller(self, other):\n        obj = self\n"
+            "        obj = other\n        return obj.target()\n")
+    builder = CallGraphBuilder(_alias_extractor_output(body))
+    builder.build_call_graph()
+    assert "m.py:C.target" not in builder.call_graph.get("m.py:C.caller", []), (
+        "reassigned alias wrongly resolved to a self-method edge"
+    )


### PR DESCRIPTION
## Root cause
`CallGraphBuilder._resolve_call_node` (`libs/openant-core/parsers/python/call_graph_builder.py`) matched a method-call receiver only when it was the literal name `self` or `cls`. A receiver that is a *local alias* of self/cls — `obj = self; obj.method()`, or `alias = cls; alias.method()` inside a classmethod — fell through to `_resolve_module_call`, which finds no import/class for a plain local variable and returns `None`. The self/class-method call produced **no call-graph edge**, so the callee can look unreachable (a false negative in the reachable set).

## Reproduction
```python
class C:
    def target(self):
        return 1
    def caller(self):
        obj = self
        return obj.target()
```
Before: `call_graph["m.py:C.caller"]` is `[]` (the `C.caller -> C.target` edge is missing).

## How
- New `_collect_self_aliases(tree)`: scans the function body for local names **single-bound** to `self`/`cls` (a name assigned more than once, or ever rebound to anything else, is not treated as an alias — so no spurious edge).
- `_extract_calls_from_code` builds `self_aliases = {'self','cls'} | _collect_self_aliases(tree)` and passes it to `_resolve_call_node`.
- `_resolve_call_node` takes `self_aliases` (defaulting to `{'self','cls'}` so existing callers are unchanged) and resolves any `<alias>.method()` through the existing `_resolve_self_call`. The two prior `self`/`cls` branches collapse into one `obj.id in self_aliases` check.

This only **adds** edges that were previously dropped; it never removes one — so it raises reachability, never lowers it. The change is confined to the receiver-resolution branch (no new subsystem / data model).

## Regression test
`libs/openant-core/tests/parsers/python/test_call_graph_self_calls.py` (+62 lines):
- `test_self_alias_method_call_edge` — `obj = self; obj.target()` edge present.
- `test_cls_alias_method_call_edge` — `alias = cls; alias.target()` edge present.
- `test_reassigned_alias_does_not_force_self_edge` — soundness guard: a name reassigned away from self is NOT aliased.

RED (before fix):
```
FAILED tests/parsers/python/test_call_graph_self_calls.py::test_self_alias_method_call_edge
FAILED tests/parsers/python/test_call_graph_self_calls.py::test_cls_alias_method_call_edge
2 failed, 5 passed in 157.48s
```
GREEN (after fix), full `tests/parsers/python/`:
```
7 passed in 50.40s
```

## Compatibility
None. `_resolve_call_node`'s new parameter is optional and defaults to the previous behavior. No public API change.

## Notes
The canonical per-parser `tests/parsers/python/test_callgraph_symmetry.py` / `test_python_schema_completeness.py` do not yet exist in this repo (a pre-existing gap across all parsers, not introduced here); this fix extends the existing `test_call_graph_self_calls.py`.

## Author notes
- **Implementing lines:** `_collect_self_aliases` (new), the `obj.id in self_aliases` receiver branch, and the `self_aliases` thread-through in `_extract_calls_from_code`.
- **Input fixed:** `obj = self; obj.target()` — previously no `C.caller -> C.target` edge; now resolved.
- **Likely pushback:** "wrong edge if the alias is reassigned?" — no; only single-unconditional `= self`/`= cls` bindings count, pinned by `test_reassigned_alias_does_not_force_self_edge`.


## Coordination with open PRs
**#112** adds a `_build_alias_map` to the same resolution path, but for **function-value** aliases (`fn = helper; fn()`) — its docstring notes class/method targets are out of scope. This PR handles the distinct **self/cls** alias case (`obj = self; obj.method()`), which #112 leaves unresolved. The two are complementary but touch the same code; they should be unified rather than stacked. Happy to rebase onto #112 and fold the self/cls aliasing into its alias map.
