### PR TITLE
fix(cli): add zig to the --language choices for parse and scan

### DIFF
--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -959,7 +959,7 @@ def main():
     scan_p.add_argument("--output", "-o", help="Output directory (default: temp dir)")
     scan_p.add_argument(
         "--language", "-l",
-        choices=["auto", "python", "javascript", "go", "c", "ruby", "php"],
+        choices=["auto", "python", "javascript", "go", "c", "ruby", "php", "zig"],
         default="auto",
         help="Language (default: auto-detect)",
     )
@@ -1025,7 +1025,7 @@ def main():
     parse_p.add_argument("--output", "-o", help="Output directory (default: temp dir)")
     parse_p.add_argument(
         "--language", "-l",
-        choices=["auto", "python", "javascript", "go", "c", "ruby", "php"],
+        choices=["auto", "python", "javascript", "go", "c", "ruby", "php", "zig"],
         default="auto",
         help="Language (default: auto-detect)",
     )


### PR DESCRIPTION
## fix(cli): add zig to the `--language` choices for parse and scan

### Problem
`openant parse --language zig` (and `scan`) fails with `argument --language/-l: invalid choice: 'zig'`. The Zig parser is fully wired everywhere else: `core/parser_adapter.parse_repository` dispatches `language == "zig"`, `detect_language()` returns `"zig"` and lists it in its docstring + the "no source files" error, and `config/languages.json` maps `.zig` → `zig`. Only the explicit `--language` argparse `choices` list in `openant/cli.py` (for both `parse` and `scan`) was never updated — so Zig was reachable via `--language auto` but not by explicit selection.

### Fix
Add `"zig"` to the `choices` list at both `cli.py` sites (parse + scan). Purely additive; exposes nothing new — `auto` already routed `.zig` repos to the Zig parser.

### Verification
```
$ openant parse /tmp/zig-kf --language zig --level reachable
  Found 2 Zig files
  After reachable filter: 9 functions     # was: error: invalid choice: 'zig'
```

### Not a security fix
CLI usability fix.

### Tests
No test pins the `--language` choices list (verified: `grep -rn 'choices=\[.auto' tests/` = 0). The change is a 2-line argparse addition.

### Depends-on
None (standalone; the choices list is pre-existing on master).
