### PR TITLE
fix(reachability): anchor user-input entry-point patterns with word boundary

### DIFF
--- a/libs/openant-core/tests/test_entry_point_input_pattern_boundary.py
+++ b/libs/openant-core/tests/test_entry_point_input_pattern_boundary.py
@@ -1,0 +1,52 @@
+"""Regression test for F9: USER_INPUT_PATTERNS FastAPI alternation needs a word boundary.
+
+The pattern ``(Query|Body|Form|File|Header|Cookie)\\s*\\(`` (no leading ``\\b``)
+matches any identifier *ending* in one of those words, so ordinary library
+calls like ``setCookie(``, ``PQsendQuery(`` or ``getHeader(`` were flagged as
+user-input sources and seeded as false remote-web entry points across C/Go/
+PHP/Python repos. The fix anchors the alternation with ``\\b`` so only the
+standalone FastAPI dependency symbols match.
+"""
+
+from __future__ import annotations
+
+import re
+
+from utilities.agentic_enhancer.entry_point_detector import USER_INPUT_PATTERNS
+
+
+def _fastapi_pattern():
+    """The FastAPI Query/Body/.../Cookie alternation from USER_INPUT_PATTERNS."""
+    for p in USER_INPUT_PATTERNS:
+        if "Cookie" in p and "Query" in p:
+            return re.compile(p)
+    raise AssertionError("FastAPI input pattern not found in USER_INPUT_PATTERNS")
+
+
+FALSE_POSITIVES = [
+    "res.setCookie(token)",
+    "PQsendQuery(conn, sql)",
+    "req.getHeader('X')",
+    "parseMultipartFile(x)",
+    "renderBody(html)",
+    "buildForm(fields)",
+]
+
+TRUE_POSITIVES = [
+    "def handler(c: str = Cookie(None)): ...",
+    "def handler(q: str = Query(...)): ...",
+    "def handler(b: Item = Body(...)): ...",
+    "def handler(h: str = Header(None)): ...",
+]
+
+
+def test_input_pattern_rejects_substring_false_positives():
+    pat = _fastapi_pattern()
+    for code in FALSE_POSITIVES:
+        assert pat.search(code) is None, f"false positive: {code!r} matched {pat.pattern!r}"
+
+
+def test_input_pattern_still_matches_standalone_symbols():
+    pat = _fastapi_pattern()
+    for code in TRUE_POSITIVES:
+        assert pat.search(code) is not None, f"regressed: {code!r} no longer matches"

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -62,7 +62,7 @@ USER_INPUT_PATTERNS = [
     r'request\.environ',
     # FastAPI
     r'request\.(query_params|body|json)',
-    r'(Query|Body|Form|File|Header|Cookie)\s*\(',
+    r'\b(Query|Body|Form|File|Header|Cookie)\s*\(',
     # Django
     r'request\.(GET|POST|data|FILES|body)',
     r'self\.request\.(GET|POST|data)',
@@ -72,7 +72,7 @@ USER_INPUT_PATTERNS = [
     # CLI arguments
     r'sys\.argv',
     r'argparse\.',
-    r'ArgumentParser\s*\(',
+    r'\bArgumentParser\s*\(',
     r'click\.(argument|option)',
     # Standard input
     r'\binput\s*\(',


### PR DESCRIPTION
# fix(reachability): anchor user-input entry-point patterns with word boundary

**Base:** `master` · **Type:** bug fix · **Finding:** F9 (MED-HIGH)

## What
`utilities/agentic_enhancer/entry_point_detector.py` — add a leading `\b` to two
`USER_INPUT_PATTERNS` entries:
- the FastAPI alternation `(Query|Body|Form|File|Header|Cookie)\s*\(` → `\b(...)\s*\(`
- `ArgumentParser\s*\(` → `\bArgumentParser\s*\(`

## Why
The unanchored alternation matched any identifier *ending* in one of those words,
so ordinary library calls — `res.setCookie(`, `PQsendQuery(`, `req.getHeader(`,
`MyArgumentParser(` — matched as user-input sources and were seeded as **false
remote-web entry points**. Measured across the eval corpus: ~1,800 false seeds
(postgres 431, kubernetes 717, symfony 600, laravel 377). False entry points
inflate the reachable set and mis-label attack surface.

Qualified forms still match after the fix: `fastapi.Query(`, `models.Header(`,
`argparse.ArgumentParser(` — the `.` supplies the word boundary.

## Tests
`tests/test_entry_point_input_pattern_boundary.py` (new): rejects
`setCookie(`/`PQsendQuery(`/`getHeader(`/`parseMultipartFile(`; still matches
standalone `Cookie(`/`Query(`/`Body(`/`Header(`.
- RED (pre-fix): `setCookie(token)` matched `Cookie(`.
- GREEN (post-fix): 2 passed; `test_entry_point_detector.py` + bindings 18 passed.

## Reachability impact (verified)
Empirically, this only removes FALSE input entry points — genuine FastAPI
dependency seeds are retained. No legitimate reachability lost. (Library-collapse
behaviour F6 is untouched — this change is two regex lines.)

## Upstream coordination
No open PR modifies this regex. PR #120/#75/#76 reference `USER_INPUT_PATTERNS`
only in added comments / new helpers; the regex line is unchanged on all of them.
Non-overlapping.

## Author notes
- **Fix line:** the two `\b`-anchored patterns at the FastAPI and ArgumentParser
  entries.
- **Input it now handles:** calls like `setCookie(`/`PQsendQuery(` that previously
  produced false entry points.
- **Likely pushback:** "does `\b` drop `fastapi.Query(`?" — no; the `.` is a
  non-word char so the boundary holds (covered by a test assertion).
