### PR TITLE
fix(parsers/go): classify entry points by signature, not return type or bare next(

### DIFF
--- a/libs/openant-core/parsers/go/go_parser/extractor.go
+++ b/libs/openant-core/parsers/go/go_parser/extractor.go
@@ -273,11 +273,13 @@ var httpHandlerPatterns = []*regexp.Regexp{
 
 func (e *Extractor) isHTTPHandler(params, returns []string, code string) bool {
 	paramsStr := strings.Join(params, " ")
-	returnsStr := strings.Join(returns, " ")
 
-	// Check parameters for HTTP patterns
+	// Check parameters for HTTP patterns. A handler is identified by what it
+	// RECEIVES (request/context types in params), not by what it returns —
+	// matching these patterns against the return type mis-tagged factories
+	// such as `func Logger() gin.HandlerFunc` as http_handler entry points (F10).
 	for _, pattern := range httpHandlerPatterns {
-		if pattern.MatchString(paramsStr) || pattern.MatchString(returnsStr) {
+		if pattern.MatchString(paramsStr) {
 			return true
 		}
 	}
@@ -325,11 +327,20 @@ func (e *Extractor) isCLIHandler(params, returns []string, code string) bool {
 func (e *Extractor) isMiddleware(params, returns []string, code string) bool {
 	// Middleware often takes and returns http.Handler or similar
 	returnsStr := strings.Join(returns, " ")
+	paramsStr := strings.Join(params, " ")
+
+	// A bare `next(` substring previously matched any body with a next() call
+	// (Go 1.23 iterators, lexers, cursors), mislabelling them middleware (F7).
+	// Only treat a `next(` call as middleware when the function has an HTTP
+	// request signature, i.e. it is actually wrapping a handler.
+	hasHTTPSignature := strings.Contains(paramsStr, "http.ResponseWriter") ||
+		strings.Contains(paramsStr, "http.Request") ||
+		strings.Contains(paramsStr, "http.Handler")
 
 	if strings.Contains(returnsStr, "http.Handler") ||
 		strings.Contains(returnsStr, "http.HandlerFunc") ||
 		strings.Contains(code, "next.ServeHTTP") ||
-		strings.Contains(code, "next(") {
+		(hasHTTPSignature && strings.Contains(code, "next(")) {
 		return true
 	}
 

--- a/libs/openant-core/parsers/go/go_parser/extractor_classify_test.go
+++ b/libs/openant-core/parsers/go/go_parser/extractor_classify_test.go
@@ -1,0 +1,70 @@
+package main
+
+import "testing"
+
+// Regression tests for F7 and F10 — over-broad unit-type classification in
+// classifyUnitType, which seeds false remote-web entry points downstream.
+
+// F10: a factory that *returns* http.HandlerFunc (no request-shaped params,
+// no handler body) must NOT be classified http_handler — only a function that
+// RECEIVES a request is a handler.
+func TestFactoryReturningHandlerFuncIsNotHTTPHandler(t *testing.T) {
+	e := NewExtractor(".")
+	got := e.classifyUnitType(
+		"NewLoggingHandler", "",
+		[]string{"prefix string"},    // params: no request types
+		[]string{"http.HandlerFunc"}, // returns a handler (factory)
+		"{ return func(w http.ResponseWriter, r *http.Request) {} }",
+		"x.go",
+	)
+	if got == UnitTypeHTTPHandler {
+		t.Fatalf("factory returning http.HandlerFunc classified as %q, want != http_handler", got)
+	}
+}
+
+// F7: an iterator/lexer whose body merely contains a "next(" call must NOT be
+// classified middleware. Real middleware returns http.Handler/HandlerFunc or
+// calls next.ServeHTTP / next(w, r) with an http signature.
+func TestIteratorWithNextCallIsNotMiddleware(t *testing.T) {
+	e := NewExtractor(".")
+	got := e.classifyUnitType(
+		"CutPrefix", "",
+		[]string{"s string", "prefix string"}, // no http params
+		[]string{"string", "bool"},            // no http returns
+		"{ for next, hasNext := iter(); hasNext; { _ = next(); } ; return s, true }",
+		"seq.go",
+	)
+	if got == UnitTypeMiddleware {
+		t.Fatalf("iterator using next() classified as %q, want != middleware", got)
+	}
+}
+
+// Guard against over-correction: a genuine net/http handler and genuine
+// middleware must still be detected.
+func TestGenuineHTTPHandlerStillDetected(t *testing.T) {
+	e := NewExtractor(".")
+	got := e.classifyUnitType(
+		"ServeIndex", "",
+		[]string{"w http.ResponseWriter", "r *http.Request"},
+		[]string{},
+		"{ w.Write([]byte(\"ok\")) }",
+		"h.go",
+	)
+	if got != UnitTypeHTTPHandler {
+		t.Fatalf("genuine handler classified as %q, want http_handler", got)
+	}
+}
+
+func TestGenuineMiddlewareStillDetected(t *testing.T) {
+	e := NewExtractor(".")
+	got := e.classifyUnitType(
+		"Logging", "",
+		[]string{"next http.Handler"},
+		[]string{"http.Handler"},
+		"{ return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){ next.ServeHTTP(w, r) }) }",
+		"mw.go",
+	)
+	if got != UnitTypeMiddleware {
+		t.Fatalf("genuine middleware classified as %q, want middleware", got)
+	}
+}


### PR DESCRIPTION
# fix(parsers/go): classify entry points by signature, not return type or bare next(

**Base:** `master` · **Type:** bug fix · **Findings:** F10 + F7 (MED)

## What
`parsers/go/go_parser/extractor.go`:
- **F10** — `isHTTPHandler` no longer matches `httpHandlerPatterns` against the
  return type (dropped `|| pattern.MatchString(returnsStr)`); it matches
  parameters only.
- **F7** — `isMiddleware` no longer treats a bare `next(` substring as middleware;
  the `next(` heuristic is now gated on the function having an HTTP request
  signature (`hasHTTPSignature && strings.Contains(code, "next(")`). The
  `http.Handler`/`http.HandlerFunc` return and `next.ServeHTTP` signals are kept.

## Why
Both heuristics over-matched, seeding **false remote-web entry points**:
- A factory `func Logger() gin.HandlerFunc` has no request param but matched the
  bare `HandlerFunc` pattern against its *return* type → tagged `http_handler`. A
  handler is defined by what it *receives*, not what it returns.
- Any function whose body contains `next(` — Go 1.23 range-over-func iterators
  (`iter.Pull` → `next()`), lexers, cursors — was tagged `middleware`.

## Tests
`parsers/go/go_parser/extractor_classify_test.go` (new): factory returning
`http.HandlerFunc` is not `http_handler`; iterator using `next()` is not
`middleware`; a genuine `(w, r)` handler and genuine `next.ServeHTTP` middleware
are still detected.
- RED (pre-fix): both negative tests failed.
- GREEN (post-fix): 4 passed; `go test ./...` passes.

## Reachability impact (verified empirically, base vs patched binary)
Function-id sets identical (no extraction loss). Reclassified units sampled and
confirmed all fake:
- **samber/lo:** `middleware` 1 → 0 (`CutPrefix`, a pull-iterator).
- **gin-gonic/gin:** `http_handler` 108 → 89; all 19 removed are factories
  returning `HandlerFunc` (`Logger`, `Recovery`, `BasicAuth`, …) with no request
  param. All 89 retained handlers carry a genuine request/context param.

Zero genuine handlers or middleware lost.

## Scope / siblings (deferred, documented)
Same defect class but **out of scope** here (tightening risks false negatives,
needs its own corpus): `isHTTPHandler` body heuristics `w.Write(` / `Handler =`
(`:289-290`) over-match any local `w` with `.Write(`; `isCLIHandler` `os.Args`
body match (`:318`). Tracked for a follow-up.

## Upstream coordination
Only PR #126 also edits `extractor.go` (different functions: `typeToString`
generics + `duplicateIDWarning`). No hunk overlap with `isHTTPHandler`/
`isMiddleware`; rebase trivially if #126 lands first. Binary `go_parser` not
included — reviewers/CI rebuild from source.

## Author notes
- **Fix lines:** `isHTTPHandler` param-only loop; `isMiddleware` `hasHTTPSignature`
  gate on `next(`.
- **Input it now handles:** middleware factories and `next()`-using iterators that
  previously became false entry points.
- **Likely pushback:** "could a real handler be return-only?" — net/http and
  gin/echo/fiber handlers always take the request/context as a param; a return-only
  match is a factory. Body heuristics still catch param-less real handlers.
