### PR TITLE
fix(llm): replace retired model IDs in default registry + pricing

### DIFF
--- a/libs/openant-core/tests/test_builtin_model_ids_current.py
+++ b/libs/openant-core/tests/test_builtin_model_ids_current.py
@@ -1,0 +1,38 @@
+"""Guard against shipping dead/retired Claude model IDs in the default registry.
+
+The scan path (analyzer/enhancer/verifier/reporter/scanner/llm_reachability) all
+resolve models through ``build_phase_registry`` whose config-less default is
+``OPENANT_DEFAULT`` in ``utilities/llm/builtins.py``. If that registry names a
+retired model, every LLM phase 404s on a fresh install. These dead IDs were
+shipped: ``claude-sonnet-4-20250514`` (retired) and ``claude-opus-4-6`` (stale).
+"""
+
+from __future__ import annotations
+
+from utilities.llm.builtins import OPENANT_DEFAULT
+
+# Models retired / not served by the Anthropic API.
+DEAD_MODEL_IDS = {
+    "claude-sonnet-4-20250514",
+    "claude-opus-4-20250514",
+    "claude-opus-4-5-20250514",
+    "claude-opus-4-6",
+}
+
+# Current Anthropic model IDs the pipeline should use.
+CURRENT_OPUS = "claude-opus-4-8"
+CURRENT_SONNET = "claude-sonnet-4-6"
+
+
+def test_no_dead_model_ids_in_default_registry():
+    for phase, ref in OPENANT_DEFAULT.phases.items():
+        assert ref.model not in DEAD_MODEL_IDS, (
+            f"phase {phase!r} points at retired model {ref.model!r}"
+        )
+
+
+def test_default_registry_uses_current_ids():
+    models = {ref.model for ref in OPENANT_DEFAULT.phases.values()}
+    assert models <= {CURRENT_OPUS, CURRENT_SONNET}, (
+        f"unexpected model ids in default registry: {models}"
+    )

--- a/libs/openant-core/tests/test_llm_builtins.py
+++ b/libs/openant-core/tests/test_llm_builtins.py
@@ -46,24 +46,24 @@ class TestOpenantDefault:
         # Pin today's behavior. If Anthropic deprecates one of these
         # IDs, this test breaks loudly and the change is recorded in
         # the CHANGELOG.
-        assert OPENANT_DEFAULT.phases["analyze"].model == "claude-opus-4-6"
-        assert OPENANT_DEFAULT.phases["verify"].model == "claude-opus-4-6"
-        assert OPENANT_DEFAULT.phases["llm_reach"].model == "claude-opus-4-6"
+        assert OPENANT_DEFAULT.phases["analyze"].model == "claude-opus-4-8"
+        assert OPENANT_DEFAULT.phases["verify"].model == "claude-opus-4-8"
+        assert OPENANT_DEFAULT.phases["llm_reach"].model == "claude-opus-4-8"
         # report restored to Opus (H1) — matches master's report generator.
-        assert OPENANT_DEFAULT.phases["report"].model == "claude-opus-4-6"
-        assert OPENANT_DEFAULT.phases["enhance"].model == "claude-sonnet-4-20250514"
-        assert OPENANT_DEFAULT.phases["dynamic_test"].model == "claude-sonnet-4-20250514"
-        assert OPENANT_DEFAULT.phases["app_context"].model == "claude-sonnet-4-20250514"
+        assert OPENANT_DEFAULT.phases["report"].model == "claude-opus-4-8"
+        assert OPENANT_DEFAULT.phases["enhance"].model == "claude-sonnet-4-6"
+        assert OPENANT_DEFAULT.phases["dynamic_test"].model == "claude-sonnet-4-6"
+        assert OPENANT_DEFAULT.phases["app_context"].model == "claude-sonnet-4-6"
 
     def test_report_phase_defaults_to_opus(self):
         # H1 drift-guard. Master's report/generator.py used
-        # MODEL="claude-opus-4-6"; the LLM-provider refactor silently
+        # MODEL="claude-opus-4-8"; the LLM-provider refactor silently
         # moved the builtin ``report`` default to Sonnet. Restore Opus so
         # the HTML-remediation / summary / disclosure sub-calls keep
         # producing Opus-quality output on a fresh, config-less install.
         # If you intend to change the report default, that is a
         # CHANGELOG-worthy event — update this assertion deliberately.
-        assert OPENANT_DEFAULT.phases["report"].model == "claude-opus-4-6"
+        assert OPENANT_DEFAULT.phases["report"].model == "claude-opus-4-8"
 
     def test_accessor_returns_same_object(self):
         # Frozen dataclass, but if a future refactor turns it into a
@@ -83,7 +83,7 @@ def _fake_binding() -> PhaseBinding:
     return PhaseBinding(
         phase="report",
         adapter=object(),
-        model="claude-opus-4-6",
+        model="claude-opus-4-8",
         provider_name="anthropic",
     )
 

--- a/libs/openant-core/utilities/llm/builtins.py
+++ b/libs/openant-core/utilities/llm/builtins.py
@@ -37,24 +37,24 @@ OPENANT_DEFAULT = LLMConfig(
     name="openant-default",
     phases={
         # Stage 1 detection. Opus by historical default.
-        "analyze": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-opus-4-6"),
+        "analyze": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-opus-4-8"),
         # Context enhancement (agentic + single-shot). Sonnet for cost.
-        "enhance": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-sonnet-4-20250514"),
+        "enhance": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-sonnet-4-6"),
         # Stage 2 attacker simulation. Opus, uses tool calling.
-        "verify": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-opus-4-6"),
+        "verify": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-opus-4-8"),
         # Disclosure + summary + remediation HTML generation. Opus —
-        # matches master's report/generator.py (MODEL="claude-opus-4-6").
+        # matches master's report/generator.py (MODEL="claude-opus-4-8").
         # The refactor briefly moved this to Sonnet; restored so the
         # report output (incl. the HTML-remediation sub-call) stays on
         # Opus on a fresh, config-less install.
-        "report": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-opus-4-6"),
+        "report": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-opus-4-8"),
         # Docker exploit-test generation. Sonnet.
-        "dynamic_test": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-sonnet-4-20250514"),
+        "dynamic_test": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-sonnet-4-6"),
         # LLM-driven reachability review (opt-in stage). Opus.
-        "llm_reach": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-opus-4-6"),
+        "llm_reach": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-opus-4-8"),
         # Application-context classification (web_app / cli_tool / etc).
         # Single-shot, runs once per scan during ``openant scan``. Sonnet.
-        "app_context": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-sonnet-4-20250514"),
+        "app_context": PhaseRef(provider=_ANTHROPIC_PROVIDER, model="claude-sonnet-4-6"),
     },
 )
 

--- a/libs/openant-core/utilities/llm/providers/anthropic.py
+++ b/libs/openant-core/utilities/llm/providers/anthropic.py
@@ -124,10 +124,14 @@ class AnthropicAdapter:
     # warning — the user can add to this dict locally if they need
     # accurate cost for a specific non-Claude model.
     pricing: dict[str, dict[str, float]] = {
+        # Current model IDs (must match utilities/llm/builtins.py OPENANT_DEFAULT).
+        "claude-opus-4-8": {"input": 15.00, "output": 75.00},
+        "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+        "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
+        # Retired IDs kept for historical reports / back-compat.
         "claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
         "claude-opus-4-6": {"input": 15.00, "output": 75.00},
         "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
-        "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
     }
 
     def __init__(

--- a/libs/openant-core/utilities/llm_client.py
+++ b/libs/openant-core/utilities/llm_client.py
@@ -32,10 +32,14 @@ import threading
 # fails if the two drift. Unknown models report $0 with a one-time warning
 # rather than silently estimating against Sonnet rates.
 MODEL_PRICING = {
+    # Current model IDs (must match utilities/llm/builtins.py OPENANT_DEFAULT).
+    "claude-opus-4-8": {"input": 15.00, "output": 75.00},
+    "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
+    "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
+    # Retired IDs kept for historical reports / back-compat.
     "claude-opus-4-20250514": {"input": 15.00, "output": 75.00},
     "claude-opus-4-6": {"input": 15.00, "output": 75.00},
     "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
-    "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
 }
 
 _unknown_pricing_warned: set[str] = set()


### PR DESCRIPTION
# fix(llm): replace retired model IDs in default registry + pricing

**Base:** `master` · **Type:** bug fix (HIGH) · **Finding:** F3 (re-opened)

## What
- `utilities/llm/builtins.py` — `OPENANT_DEFAULT` phase models: `claude-opus-4-6` → `claude-opus-4-8` (analyze/verify/report/llm_reach) and `claude-sonnet-4-20250514` → `claude-sonnet-4-6` (enhance/dynamic_test/app_context).
- `utilities/llm_client.py` `MODEL_PRICING` and `utilities/llm/providers/anthropic.py` `pricing` — add the current IDs (retired IDs kept for historical reports).
- `tests/test_builtin_model_ids_current.py` (new) — guard asserting the default registry names no retired ID; `tests/test_llm_builtins.py` updated to the current IDs.

## Why
Every scan stage (`analyzer`/`enhancer`/`verifier`/`reporter`/`scanner`/`llm_reachability`) resolves its model through `build_phase_registry(...)`, whose config-less default is `OPENANT_DEFAULT`. On `master` that registry named **retired** IDs: `claude-sonnet-4-20250514` returns `404 not_found_error`, and `claude-opus-4-6` is stale. On a fresh, config-less install every LLM phase fails. The pricing dicts only keyed the retired IDs, so once the registry is corrected, cost tracking would report `$0` + an "unknown model" warning for the current IDs.

## Tests
- RED: `test_no_dead_model_ids_in_default_registry` / `test_default_registry_uses_current_ids` failed on master (registry held retired IDs).
- GREEN: 35 passed (`test_builtin_model_ids_current` + `test_llm_builtins` + `test_token_tracker` + `test_llm_anthropic_adapter`).

## Scope / siblings (out of scope, noted)
Stale IDs also appear in `apps/openant-cli/cmd/setup.go` (Go CLI key-setup defaults), the unused `CONTEXT_ENHANCEMENT_MODEL_LEGACY` constant, and two JS-parser docs. None is on the Python scan path; tracked for a follow-up.

## Author notes
- **Fix line:** the eight `PhaseRef(... model=...)` entries in `OPENANT_DEFAULT` plus the two pricing-dict additions.
- **Input it now handles:** a config-less `openant scan` no longer 404s on the default models, and cost totals are non-zero.
- **Likely pushback:** "why keep the retired IDs in pricing?" — historical reports / saved configs may still reference them; removing would regress their cost readout.
