### PR TITLE
feat(Release): 2026-06-24

### DIFF
--- a/apps/openant-cli/cmd/analyze.go
+++ b/apps/openant-cli/cmd/analyze.go
@@ -30,6 +30,7 @@ var (
 	analyzeAppContext     string
 	analyzeRepoPath       string
 	analyzeExploitOnly    bool
+	analyzeExploitAll     bool
 	analyzeLimit          int
 	analyzeModel          string
 	analyzeWorkers        int
@@ -43,12 +44,66 @@ func init() {
 	analyzeCmd.Flags().StringVar(&analyzeAnalyzerOutput, "analyzer-output", "", "Path to analyzer_output.json (for Stage 2)")
 	analyzeCmd.Flags().StringVar(&analyzeAppContext, "app-context", "", "Path to application_context.json")
 	analyzeCmd.Flags().StringVar(&analyzeRepoPath, "repo-path", "", "Path to the repository (for context correction)")
-	analyzeCmd.Flags().BoolVar(&analyzeExploitOnly, "exploitable-only", false, "Only analyze units classified as exploitable by enhancer")
+	analyzeCmd.Flags().BoolVar(&analyzeExploitAll, "exploitable-all", false, "Analyze units classified as exploitable or vulnerable_internal (safer, compensates for parser gaps)")
+	analyzeCmd.Flags().BoolVar(&analyzeExploitOnly, "exploitable-only", false, "Analyze only units classified as exploitable (strict, use after parser entry point fixes)")
+	analyzeCmd.MarkFlagsMutuallyExclusive("exploitable-all", "exploitable-only")
 	analyzeCmd.Flags().IntVar(&analyzeLimit, "limit", 0, "Max units to analyze (0 = no limit)")
 	analyzeCmd.Flags().StringVar(&analyzeModel, "model", "opus", "Model: opus or sonnet")
 	analyzeCmd.Flags().IntVar(&analyzeWorkers, "workers", 8, "Number of parallel workers for LLM steps (default: 8)")
 	analyzeCmd.Flags().StringVar(&analyzeCheckpoint, "checkpoint", "", "Path to checkpoint directory for save/resume")
 	analyzeCmd.Flags().IntVar(&analyzeBackoff, "backoff", 30, "Seconds to wait when rate-limited (default: 30)")
+}
+
+// buildAnalyzePyArgs assembles the argv passed to the Python `openant analyze`
+// subprocess. Extracted as a pure function (mirrors buildParsePyArgs) so the
+// flag-forwarding contract — including the exploitable filter parity with the
+// Python backend — is unit-testable without spawning Python.
+func buildAnalyzePyArgs(
+	datasetPath, output string,
+	verify bool,
+	analyzerOutput, appContext, repoPath string,
+	exploitOnly, exploitAll bool,
+	limit int,
+	model string,
+	workers int,
+	checkpoint string,
+	backoff int,
+) []string {
+	pyArgs := []string{"analyze", datasetPath, "--output", output}
+	if verify {
+		pyArgs = append(pyArgs, "--verify")
+	}
+	if analyzerOutput != "" {
+		pyArgs = append(pyArgs, "--analyzer-output", analyzerOutput)
+	}
+	if appContext != "" {
+		pyArgs = append(pyArgs, "--app-context", appContext)
+	}
+	if repoPath != "" {
+		pyArgs = append(pyArgs, "--repo-path", repoPath)
+	}
+	if exploitAll {
+		pyArgs = append(pyArgs, "--exploitable-all")
+	}
+	if exploitOnly {
+		pyArgs = append(pyArgs, "--exploitable-only")
+	}
+	if limit > 0 {
+		pyArgs = append(pyArgs, "--limit", fmt.Sprintf("%d", limit))
+	}
+	if model != "opus" {
+		pyArgs = append(pyArgs, "--model", model)
+	}
+	if workers != 8 {
+		pyArgs = append(pyArgs, "--workers", fmt.Sprintf("%d", workers))
+	}
+	if checkpoint != "" {
+		pyArgs = append(pyArgs, "--checkpoint", checkpoint)
+	}
+	if backoff != 30 {
+		pyArgs = append(pyArgs, "--backoff", fmt.Sprintf("%d", backoff))
+	}
+	return pyArgs
 }
 
 func runAnalyze(cmd *cobra.Command, args []string) {
@@ -92,37 +147,12 @@ func runAnalyze(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	pyArgs := []string{"analyze", datasetPath, "--output", analyzeOutput}
-	if analyzeVerify {
-		pyArgs = append(pyArgs, "--verify")
-	}
-	if analyzeAnalyzerOutput != "" {
-		pyArgs = append(pyArgs, "--analyzer-output", analyzeAnalyzerOutput)
-	}
-	if analyzeAppContext != "" {
-		pyArgs = append(pyArgs, "--app-context", analyzeAppContext)
-	}
-	if analyzeRepoPath != "" {
-		pyArgs = append(pyArgs, "--repo-path", analyzeRepoPath)
-	}
-	if analyzeExploitOnly {
-		pyArgs = append(pyArgs, "--exploitable-only")
-	}
-	if analyzeLimit > 0 {
-		pyArgs = append(pyArgs, "--limit", fmt.Sprintf("%d", analyzeLimit))
-	}
-	if analyzeModel != "opus" {
-		pyArgs = append(pyArgs, "--model", analyzeModel)
-	}
-	if analyzeWorkers != 8 {
-		pyArgs = append(pyArgs, "--workers", fmt.Sprintf("%d", analyzeWorkers))
-	}
-	if analyzeCheckpoint != "" {
-		pyArgs = append(pyArgs, "--checkpoint", analyzeCheckpoint)
-	}
-	if analyzeBackoff != 30 {
-		pyArgs = append(pyArgs, "--backoff", fmt.Sprintf("%d", analyzeBackoff))
-	}
+	pyArgs := buildAnalyzePyArgs(
+		datasetPath, analyzeOutput, analyzeVerify,
+		analyzeAnalyzerOutput, analyzeAppContext, analyzeRepoPath,
+		analyzeExploitOnly, analyzeExploitAll, analyzeLimit,
+		analyzeModel, analyzeWorkers, analyzeCheckpoint, analyzeBackoff,
+	)
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())
 	if err != nil {

--- a/apps/openant-cli/cmd/analyze_flags_test.go
+++ b/apps/openant-cli/cmd/analyze_flags_test.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestAnalyzeExploitableAllFlagDefined locks the flag-parity fix:
+// the Go `analyze` command must expose
+// `--exploitable-all`, mirroring the Python backend (cli.py analyze_p
+// defines both --exploitable-all and --exploitable-only). Before the fix the
+// Go CLI defined only --exploitable-only, so `analyze --exploitable-all`
+// failed with "unknown flag".
+func TestAnalyzeExploitableAllFlagDefined(t *testing.T) {
+	flag := analyzeCmd.Flag("exploitable-all")
+	if flag == nil {
+		t.Fatal("analyzeCmd has no --exploitable-all flag (parity gap with Python backend)")
+	}
+	if got, want := flag.DefValue, "false"; got != want {
+		t.Errorf("--exploitable-all default = %q, want %q", got, want)
+	}
+	// The control flag must still exist.
+	if analyzeCmd.Flag("exploitable-only") == nil {
+		t.Fatal("analyzeCmd lost its --exploitable-only flag")
+	}
+}
+
+// TestAnalyzeExploitableAllForwardedToPython locks that the new flag is
+// actually forwarded to the Python subprocess argv (not just defined). It
+// exercises buildAnalyzePyArgs, the pure argv-builder helper (mirrors the
+// buildParsePyArgs pattern), so a future refactor that drops the forwarding
+// fails here.
+func TestAnalyzeExploitableAllForwardedToPython(t *testing.T) {
+	tests := []struct {
+		name          string
+		exploitAll    bool
+		exploitOnly   bool
+		wantAllInArgv bool
+	}{
+		{"exploitable-all forwarded", true, false, true},
+		{"neither flag -> not forwarded", false, false, false},
+		{"exploitable-only does not emit --exploitable-all", false, true, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			argv := buildAnalyzePyArgs(
+				"ds.json", "out", false, "", "", "",
+				tc.exploitOnly, tc.exploitAll, 0, "opus", 8, "", 30,
+			)
+			joined := strings.Join(argv, " ")
+			got := false
+			for _, a := range argv {
+				if a == "--exploitable-all" {
+					got = true
+					break
+				}
+			}
+			if got != tc.wantAllInArgv {
+				t.Errorf("buildAnalyzePyArgs --exploitable-all present=%v, want %v; argv=%q", got, tc.wantAllInArgv, joined)
+			}
+		})
+	}
+}

--- a/apps/openant-cli/cmd/enhance.go
+++ b/apps/openant-cli/cmd/enhance.go
@@ -32,6 +32,7 @@ var (
 	enhanceCheckpoint     string
 	enhanceWorkers        int
 	enhanceBackoff        int
+	enhanceLimit          int
 )
 
 func init() {
@@ -42,6 +43,7 @@ func init() {
 	enhanceCmd.Flags().StringVar(&enhanceCheckpoint, "checkpoint", "", "Path to save/resume checkpoint (agentic mode)")
 	enhanceCmd.Flags().IntVar(&enhanceWorkers, "workers", 8, "Number of parallel workers for LLM steps (default: 8)")
 	enhanceCmd.Flags().IntVar(&enhanceBackoff, "backoff", 30, "Seconds to wait when rate-limited (default: 30)")
+	enhanceCmd.Flags().IntVar(&enhanceLimit, "limit", 0, "Max units to enhance (0 = no limit)")
 }
 
 func runEnhance(cmd *cobra.Command, args []string) {
@@ -103,6 +105,9 @@ func runEnhance(cmd *cobra.Command, args []string) {
 	}
 	if enhanceBackoff != 30 {
 		pyArgs = append(pyArgs, "--backoff", fmt.Sprintf("%d", enhanceBackoff))
+	}
+	if enhanceLimit > 0 {
+		pyArgs = append(pyArgs, "--limit", fmt.Sprintf("%d", enhanceLimit))
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/enhance_limit_test.go
+++ b/apps/openant-cli/cmd/enhance_limit_test.go
@@ -1,0 +1,15 @@
+package cmd
+
+import "testing"
+
+// The `enhance` command must expose a `--limit` flag for
+// parity with `analyze`/`scan`, so a user can cost-limit / test-run enhancement on N units.
+func TestEnhanceCommandHasLimitFlag(t *testing.T) {
+	f := enhanceCmd.Flags().Lookup("limit")
+	if f == nil {
+		t.Fatal("enhance command is missing the --limit flag (parity with analyze/scan)")
+	}
+	if f.DefValue != "0" {
+		t.Errorf("--limit default = %q, want \"0\" (0 = no limit)", f.DefValue)
+	}
+}

--- a/apps/openant-cli/internal/config/config.go
+++ b/apps/openant-cli/internal/config/config.go
@@ -107,6 +107,12 @@ func Save(cfg *Config) error {
 		return fmt.Errorf("failed to write config: %w", err)
 	}
 
+	// os.WriteFile only applies the mode when it CREATES the file; a pre-existing config
+	// may hold an API key under looser permissions, so enforce 0600 explicitly (CWE-732).
+	if err := os.Chmod(path, 0600); err != nil {
+		return fmt.Errorf("failed to restrict config permissions: %w", err)
+	}
+
 	return nil
 }
 

--- a/apps/openant-cli/internal/config/config_perms_test.go
+++ b/apps/openant-cli/internal/config/config_perms_test.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// CWE-732: Save() does not enforce restrictive
+// permissions on a PRE-EXISTING config file. os.WriteFile only applies the mode argument
+// when it creates the file; if the config (which may hold an API key) already exists with
+// looser perms (e.g. 0644), the secret stays world-readable after Save().
+func TestSaveEnforcesRestrictivePermsOnPreexistingFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+
+	dir := filepath.Join(tmp, "openant")
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "config.json")
+
+	// Pre-existing config file with loose (world/group-readable) permissions.
+	if err := os.WriteFile(path, []byte(`{"api_key":"old"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0644); err != nil { // defeat umask so the file is genuinely 0644
+		t.Fatal(err)
+	}
+
+	if err := Save(&Config{APIKey: "sk-secret-value"}); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("secret config perms = %#o, want 0600 (CWE-732: pre-existing loose perms not enforced)", perm)
+	}
+}

--- a/apps/openant-cli/internal/config/config_perms_test.go
+++ b/apps/openant-cli/internal/config/config_perms_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -11,6 +12,9 @@ import (
 // when it creates the file; if the config (which may hold an API key) already exists with
 // looser perms (e.g. 0644), the secret stays world-readable after Save().
 func TestSaveEnforcesRestrictivePermsOnPreexistingFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file-mode bits not enforced on Windows")
+	}
 	tmp := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 

--- a/apps/openant-cli/internal/python/invoke.go
+++ b/apps/openant-cli/internal/python/invoke.go
@@ -3,6 +3,7 @@ package python
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -15,6 +16,14 @@ import (
 
 	"github.com/knostic/open-ant-cli/internal/types"
 )
+
+// defaultInvokeTimeout bounds how long Invoke will wait on the Python
+// subprocess before the process is killed and Invoke returns. It guards
+// against a hung parser (infinite loop, I/O deadlock, pathological repo)
+// wedging the CLI forever, which matters most for headless/automated
+// callers that cannot deliver a manual Ctrl+C. It is a package var so
+// tests can shrink it.
+var defaultInvokeTimeout = 30 * time.Minute
 
 // InvokeResult holds the result of a Python CLI invocation.
 type InvokeResult struct {
@@ -30,7 +39,23 @@ type InvokeResult struct {
 // - If apiKey is non-empty, it is injected as ANTHROPIC_API_KEY in the subprocess
 func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey string) (*InvokeResult, error) {
 	cmdArgs := append([]string{"-m", "openant"}, args...)
-	cmd := exec.Command(pythonPath, cmdArgs...)
+
+	// Bound the subprocess with an automatic deadline so a hung parser
+	// cannot wedge the CLI forever on cmd.Wait(). When the context expires
+	// CommandContext kills the process. This is the only recovery path for
+	// headless/automated callers, which never deliver the manual SIGINT the
+	// signal goroutine below relies on. Mirrors the pattern at cmd/docker.go.
+	ctx, cancel := context.WithTimeout(context.Background(), defaultInvokeTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, pythonPath, cmdArgs...)
+
+	// Killing the process is not sufficient on its own: a descendant the
+	// parser spawned can keep the stdout/stderr pipe write-ends open, leaving
+	// the io.Copy below blocked forever even after the parent is dead.
+	// WaitDelay tells os/exec to force-close those inherited pipe FDs shortly
+	// after the context is done, and the explicit read-end close in the
+	// watchdog goroutine (below) unblocks the in-flight reads.
+	cmd.WaitDelay = 5 * time.Second
 
 	if workDir != "" {
 		cmd.Dir = workDir
@@ -59,6 +84,23 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start Python process: %w", err)
 	}
+
+	// Watchdog: when the timeout (or any context cancellation) fires, close
+	// the pipe read-ends so io.Copy(stdout) and streamStderr(stderr) return
+	// promptly instead of blocking on a descendant that still holds the
+	// write-ends open. Without this, the deadline would kill the parser but
+	// the CLI would still hang in io.Copy. watchdogDone stops the goroutine
+	// on the normal (non-timeout) exit path.
+	watchdogDone := make(chan struct{})
+	defer close(watchdogDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = stdout.Close()
+			_ = stderr.Close()
+		case <-watchdogDone:
+		}
+	}()
 
 	// Forward SIGINT/SIGTERM to the Python subprocess so Ctrl+C kills it.
 	sigChan := make(chan os.Signal, 1)

--- a/apps/openant-cli/internal/python/invoke_test.go
+++ b/apps/openant-cli/internal/python/invoke_test.go
@@ -1,0 +1,64 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// writeHangScript creates an executable script that ignores its arguments,
+// prints nothing on stdout, and sleeps far longer than any test deadline.
+// It stands in for a hung Python parser (infinite loop / I/O deadlock).
+func writeHangScript(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("hang-subprocess test uses a POSIX shell script")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hang.sh")
+	// Sleep well past the test's deadline; never produces stdout.
+	script := "#!/bin/sh\nsleep 600\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("failed to write hang script: %v", err)
+	}
+	return path
+}
+
+// TestInvoke_HangingSubprocessIsBoundedByTimeout asserts that a hung Python
+// subprocess must be bounded by an automatic timeout so Invoke returns
+// instead of blocking forever on cmd.Wait().
+//
+// Pre-fix invoke.go:33 uses exec.Command (no context, no deadline), so
+// Invoke blocks on io.Copy/cmd.Wait for the full 600s sleep and this test
+// hangs until `go test` kills it — i.e. it does NOT return within the
+// bounded window. Post-fix (exec.CommandContext + a default timeout) the
+// command is killed at the deadline and Invoke returns promptly.
+func TestInvoke_HangingSubprocessIsBoundedByTimeout(t *testing.T) {
+	hang := writeHangScript(t)
+
+	// Shrink the automatic deadline so the test is fast. The default is
+	// far larger; this knob is the wiring the fix must expose.
+	prev := defaultInvokeTimeout
+	defaultInvokeTimeout = 500 * time.Millisecond
+	t.Cleanup(func() { defaultInvokeTimeout = prev })
+
+	// Generous wall-clock budget: comfortably larger than the deadline but
+	// far smaller than the 600s the subprocess would otherwise sleep.
+	const budget = 10 * time.Second
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = Invoke(hang, []string{"parse", "."}, "", true, "")
+	}()
+
+	select {
+	case <-done:
+		// Invoke returned within budget — the timeout bounded the hang.
+	case <-time.After(budget):
+		t.Fatalf("Invoke did not return within %v on a hung subprocess; "+
+			"expected the automatic timeout (%v) to bound it", budget, defaultInvokeTimeout)
+	}
+}

--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -201,8 +201,7 @@ func CheckOpenantInstalled(pythonPath string) error {
 	}
 
 	// Save dependency hash so CheckDepsStale knows this is the baseline.
-	pyprojectPath := filepath.Join(corePath, "pyproject.toml")
-	if h, err := hashFile(pyprojectPath); err == nil {
+	if h, err := depsHash(corePath); err == nil {
 		if err := writeStoredHash(h); err != nil {
 			fmt.Fprintf(os.Stderr,
 				"warning: could not save dependency hash at %s: %v (next run may reinstall)\n",
@@ -285,13 +284,26 @@ func readStoredHash() string { return readHashAt(depsHashPath()) }
 // writeStoredHash saves the dependency hash to the venv marker file.
 func writeStoredHash(hash string) error { return writeHashAt(depsHashPath(), hash) }
 
+// depsHash keys the dependency stamp on BOTH pyproject.toml contents AND corePath (the
+// editable-install source). The managed venv is a single global path shared across worktrees;
+// without corePath in the key, two worktrees with identical pyproject.toml share one editable
+// install and a binary built in one silently imports the other's source. Including corePath forces
+// a reinstall (re-pointing the editable install) when the active source changes.
+func depsHash(corePath string) (string, error) {
+	pyproject, err := os.ReadFile(filepath.Join(corePath, "pyproject.toml"))
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(append([]byte(corePath+"\x00"), pyproject...))
+	return hex.EncodeToString(sum[:]), nil
+}
+
 // depsStalenessAt inspects pyproject.toml at corePath and the hash stored at
 // hashPath, and reports whether a reinstall is needed. The boolean is true
 // when deps are stale (i.e. the hash differs and a reinstall is warranted).
 // The caller is expected to skip the check on any error.
 func depsStalenessAt(corePath, hashPath string) (stale bool, currentHash string, err error) {
-	pyprojectPath := filepath.Join(corePath, "pyproject.toml")
-	currentHash, err = hashFile(pyprojectPath)
+	currentHash, err = depsHash(corePath)
 	if err != nil {
 		return false, "", err
 	}

--- a/apps/openant-cli/internal/python/runtime_corepath_test.go
+++ b/apps/openant-cli/internal/python/runtime_corepath_test.go
@@ -1,0 +1,53 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Regression test: the dependency-staleness check keyed only on
+// pyproject.toml content, blind to corePath. The managed venv is a single global path shared across
+// all worktrees; with two worktrees whose pyproject.toml is identical, the staleness check reports
+// "not stale" even though the venv's editable install (`pip install -e <corePath>`) points at the
+// OTHER worktree's source — so a binary built in worktree B silently imports worktree A's Python.
+// Fix: key staleness on corePath as well, so switching the editable-install source is detected.
+func TestDepsStalenessDetectsCorePathChange(t *testing.T) {
+	const pyproject = "[project]\nname = \"openant\"\nversion = \"1.0.0\"\n"
+
+	coreA := t.TempDir()
+	coreB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(coreA, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// coreB has BYTE-IDENTICAL pyproject.toml — only the corePath differs.
+	if err := os.WriteFile(filepath.Join(coreB, "pyproject.toml"), []byte(pyproject), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hashPath := filepath.Join(t.TempDir(), ".deps-hash")
+
+	// Baseline: install was done from coreA -> stamp coreA's hash.
+	_, hashA, err := depsStalenessAt(coreA, hashPath)
+	if err != nil {
+		t.Fatalf("depsStalenessAt(coreA): %v", err)
+	}
+	if err := writeHashAt(hashPath, hashA); err != nil {
+		t.Fatalf("writeHashAt: %v", err)
+	}
+
+	// Same corePath -> not stale.
+	if staleA, _, _ := depsStalenessAt(coreA, hashPath); staleA {
+		t.Fatalf("same corePath reported stale (should be up-to-date)")
+	}
+
+	// Different corePath, identical pyproject -> MUST be stale: otherwise the two worktrees share
+	// one editable install and the binary imports the wrong source.
+	staleB, _, err := depsStalenessAt(coreB, hashPath)
+	if err != nil {
+		t.Fatalf("depsStalenessAt(coreB): %v", err)
+	}
+	if !staleB {
+		t.Fatalf("corePath change (identical pyproject) not detected as stale -> worktrees share the editable install")
+	}
+}

--- a/libs/openant-core/conftest.py
+++ b/libs/openant-core/conftest.py
@@ -1,0 +1,4 @@
+# The parsers/<lang>/test_pipeline.py files are CLI pipeline orchestrators (run as scripts), not
+# pytest tests. Their shared basename + script-only bare imports make pytest mis-collection fail
+# with import-file-mismatch under `pytest parsers/`. Exclude them from collection.
+collect_ignore_glob = ["parsers/*/test_pipeline.py"]

--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -270,6 +270,32 @@ def get_directory_structure(repo_path: Path, max_depth: int = 2) -> str:
     return "\n".join(lines[:100])  # Limit output
 
 
+# Directory names (exact path SEGMENTS, not substrings) to skip when scanning for entry points.
+_PY_EXCLUDE_DIRS = {'node_modules', '__pycache__', 'venv', '.venv', 'test', 'tests'}
+_JS_EXCLUDE_DIRS = {'node_modules', 'dist', 'build'}
+
+
+def _path_excluded(file_path: Path, repo_path: Path, exclude_dirs: set, anchored_test: bool = False) -> bool:
+    """Whether file_path should be skipped, matching on relative-path COMPONENTS.
+
+    Anchors on path *segments* relative to repo_path rather than a substring of the absolute
+    path, so a parent directory or a partial token ('protest_api.py', 'latest/', 'redistribute.js')
+    no longer wrongly excludes a real entry point — and a token in some ancestor of repo_path
+    (e.g. a CI checkout under '/build/' or '/latest/') can no longer suppress every file.
+    """
+    try:
+        parts = file_path.relative_to(repo_path).parts
+    except ValueError:
+        parts = file_path.parts
+    if exclude_dirs.intersection(parts):
+        return True
+    if anchored_test:
+        name = file_path.name
+        if name.startswith("test_") or name.endswith("_test.py"):
+            return True
+    return False
+
+
 def detect_entry_points(repo_path: Path) -> str:
     """Detect entry point patterns in the codebase.
 
@@ -287,7 +313,7 @@ def detect_entry_points(repo_path: Path) -> str:
     for py_file in repo_path.rglob("*.py"):
         if files_checked >= max_files:
             break
-        if any(p in str(py_file) for p in ['node_modules', '__pycache__', 'venv', '.venv', 'test', 'tests']):
+        if _path_excluded(py_file, repo_path, _PY_EXCLUDE_DIRS, anchored_test=True):
             continue
 
         try:
@@ -307,7 +333,7 @@ def detect_entry_points(repo_path: Path) -> str:
 
     # Check JavaScript/TypeScript files
     for js_file in list(repo_path.rglob("*.js"))[:20] + list(repo_path.rglob("*.ts"))[:20]:
-        if any(p in str(js_file) for p in ['node_modules', 'dist', 'build']):
+        if _path_excluded(js_file, repo_path, _JS_EXCLUDE_DIRS):
             continue
 
         try:

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -47,6 +47,24 @@ except ImportError:
     load_context = None
 
 
+def _unit_security_classification(unit):
+    """Return a unit's security_classification, regardless of enhance mode.
+
+    Agentic enhance writes ``unit['agent_context']['security_classification']``;
+    single-shot enhance writes ``unit['llm_context']`` and historically had no
+    classification at all. Reading only ``agent_context`` silently dropped every
+    single-shot unit from ``--exploitable-only/all``. Prefer
+    agent_context, fall back to llm_context, else None.
+    """
+    agent_ctx = unit.get("agent_context")
+    if isinstance(agent_ctx, dict) and agent_ctx.get("security_classification") is not None:
+        return agent_ctx.get("security_classification")
+    llm_ctx = unit.get("llm_context")
+    if isinstance(llm_ctx, dict) and llm_ctx.get("security_classification") is not None:
+        return llm_ctx.get("security_classification")
+    return None
+
+
 def _process_unit(client, unit, index, json_corrector, app_context):
     """Process a single unit for Stage 1 detection.
 
@@ -349,10 +367,23 @@ def run_analysis(
             keep = ("exploitable",)
         else:  # "all" — default when filtering is enabled
             keep = ("exploitable", "vulnerable_internal")
-        units = [
-            u for u in units
-            if u.get("agent_context", {}).get("security_classification") in keep
-        ]
+        # Read classification mode-agnostically (agent_context OR llm_context)
+        # so single-shot-enhanced datasets are not silently dropped.
+        classified = sum(1 for u in units if _unit_security_classification(u) is not None)
+        units = [u for u in units if _unit_security_classification(u) in keep]
+        # Loud guard: a filter that matches nothing because the dataset carries
+        # NO classifications at all is almost always an un-enhanced / wrong-mode
+        # input, not a genuine "0 exploitable units" result. Warn instead of
+        # silently returning an empty analysis.
+        if original_count and classified == 0:
+            print(
+                f"[Analyze] WARNING: --exploitable filter ({exploitable_filter}) "
+                f"requested but NONE of the {original_count} units carry a "
+                "security_classification (run `enhance` first; single-shot mode "
+                "must populate llm_context.security_classification). "
+                "Filter matched 0 units.",
+                file=sys.stderr,
+            )
         print(f"[Analyze] Exploitable filter ({exploitable_filter}): {original_count} -> {len(units)} units", file=sys.stderr)
 
     if limit:

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -47,6 +47,51 @@ except ImportError:
     load_context = None
 
 
+# Truncation priority: higher score = kept first when --limit drops units.
+# Units the enhancer flagged as exploitable/vulnerable_internal must outrank
+# unclassified/neutral code so a limited run does not silently drop the most
+# security-relevant units.
+_LIMIT_PRIORITY = {"exploitable": 2, "vulnerable_internal": 1}
+
+
+def _limit_classification(unit):
+    """Return a unit's security_classification regardless of enhance mode.
+
+    Agentic enhance writes ``unit['agent_context']['security_classification']``;
+    single-shot enhance writes ``unit['llm_context']``. Reading only one mode
+    would treat the other's classified units as un-prioritized.
+    """
+    for ctx_key in ("agent_context", "llm_context"):
+        ctx = unit.get(ctx_key)
+        if isinstance(ctx, dict) and ctx.get("security_classification") is not None:
+            return ctx.get("security_classification")
+    return None
+
+
+def _apply_limit(units, limit):
+    """Truncate ``units`` to ``limit``, keeping the highest-priority units.
+
+    Units arrive from the parser in alphabetical-by-path order
+    (repository_scanner.py sorts ``self.files`` by path). A raw head-slice
+    therefore kept the first N alphabetical units (``Doc/`` before ``Lib/``)
+    with no relevance weighting, silently dropping high-value code on a
+    ``--limit`` run.
+
+    Sort by enhancement security_classification (exploitable >
+    vulnerable_internal > other) before slicing. The sort is stable, so units
+    in the same classification tier keep their original (alphabetical) order;
+    a no-limit call returns the list unchanged.
+    """
+    if not limit:
+        return units
+    prioritized = sorted(
+        units,
+        key=lambda u: _LIMIT_PRIORITY.get(_limit_classification(u), 0),
+        reverse=True,
+    )
+    return prioritized[:limit]
+
+
 def _process_unit(client, unit, index, json_corrector, app_context):
     """Process a single unit for Stage 1 detection.
 
@@ -356,7 +401,9 @@ def run_analysis(
         print(f"[Analyze] Exploitable filter ({exploitable_filter}): {original_count} -> {len(units)} units", file=sys.stderr)
 
     if limit:
-        units = units[:limit]
+        # Priority-sort before truncating so a --limit run keeps the most
+        # security-relevant units rather than the alphabetically-first ones.
+        units = _apply_limit(units, limit)
 
     total = len(units)
     print(f"[Analyze] Analyzing {total} units...", file=sys.stderr)

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -30,6 +30,7 @@ def enhance_dataset(
     model: str = "sonnet",
     workers: int = 8,
     backoff_seconds: int = 30,
+    limit: int | None = None,
 ) -> EnhanceResult:
     """Enhance a parsed dataset with security context.
 
@@ -44,6 +45,7 @@ def enhance_dataset(
         model: "sonnet" (default, cost-effective).
         workers: Number of parallel workers (default: 8).
         backoff_seconds: Seconds to wait on rate limit before retry (default: 30).
+        limit: Max number of units to enhance (None = all). Mirrors `analyze --limit`.
 
     Returns:
         EnhanceResult with output path, stats, and usage.
@@ -72,6 +74,9 @@ def enhance_dataset(
     print(f"[Enhance] Loading dataset: {dataset_path}", file=sys.stderr)
     dataset = read_json(dataset_path)
     units = dataset.get("units", [])
+    if limit:
+        units = units[:limit]
+        dataset["units"] = units  # so the agentic/single-shot paths enhance only these
     print(f"[Enhance] Units to enhance: {len(units)}", file=sys.stderr)
 
     # Set up progress reporter

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -39,7 +39,7 @@ def enhance_dataset(
         analyzer_output_path: Path to analyzer_output.json (required for agentic mode).
         repo_path: Path to the repository (required for agentic mode).
         mode: "agentic" (thorough, tool-use) or "single-shot" (fast, cheaper).
-        checkpoint_path: Path to save/resume checkpoint (agentic mode only).
+        checkpoint_path: Path to save/resume checkpoint (both modes).
             If None, auto-derived from output_path.
         model: "sonnet" (default, cost-effective).
         workers: Number of parallel workers (default: 8).
@@ -55,8 +55,11 @@ def enhance_dataset(
     print(f"[Enhance] Mode: {mode}", file=sys.stderr)
     print(f"[Enhance] Model: {model_id}", file=sys.stderr)
 
-    # Auto-derive checkpoint path for agentic mode
-    if mode == "agentic" and checkpoint_path is None:
+    # Auto-derive checkpoint path for BOTH modes so single-shot also resumes
+    # after an interrupt / cost-cap instead of reprocessing every unit
+    # Single-shot is the cheap, high-volume mode, so wasted
+    # re-enhancement there is the most costly to lose.
+    if checkpoint_path is None:
         output_dir = os.path.dirname(os.path.abspath(output_path))
         checkpoint_path = os.path.join(output_dir, "enhance_checkpoints")
 
@@ -106,6 +109,7 @@ def enhance_dataset(
             dataset,
             progress_callback=_on_unit_done,
             workers=workers,
+            checkpoint_path=checkpoint_path,
         )
     else:
         raise ValueError(f"Unknown enhancement mode: {mode}. Use 'agentic' or 'single-shot'.")

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -262,6 +262,34 @@ def apply_reachability_filter(
     if extra_entry_points:
         entry_points = entry_points | extra_entry_points
 
+    units = dataset.get("units", [])
+    original_count = len(units)
+
+    # Empty-seed safety-net: a zero entry-point seed would prune EVERY unit
+    # (the BFS frontier starts empty), silently emptying the dataset and
+    # reporting a 100% reduction as success. That is the dominant failure mode
+    # for non-web library / stdlib targets, whose ordinary functions are not a
+    # seedable entry type. Rather than a silent total blackout, degrade to
+    # pass-through (keep all units, unfiltered) and record a loud warning so the
+    # degraded result is never silent. Higher-level callers may still seed
+    # ``extra_entry_points`` to get real filtering.
+    if not entry_points and original_count > 0:
+        warning = (
+            "No entry points detected — reachability cannot seed a frontier. "
+            "Returning all units unfiltered to avoid a silent blackout; "
+            f"'{processing_level}' filtering was NOT applied."
+        )
+        print(f"  [Warning] {warning}", file=sys.stderr)
+        dataset.setdefault("metadata", {})["reachability_filter"] = {
+            "original_units": original_count,
+            "entry_points": 0,
+            "reachable_units": original_count,
+            "filtered_out": 0,
+            "reduction_percentage": 0,
+            "warning": warning,
+        }
+        return dataset
+
     # Compute reachable set (BFS forward from entry points)
     reachability = ReachabilityAnalyzer(
         functions=functions,
@@ -271,8 +299,6 @@ def apply_reachability_filter(
     reachable_ids = reachability.get_all_reachable()
 
     # Filter dataset units and stamp reachability tags
-    units = dataset.get("units", [])
-    original_count = len(units)
     filtered_units = []
     for u in units:
         unit_id = u.get("id", "")

--- a/libs/openant-core/core/progress.py
+++ b/libs/openant-core/core/progress.py
@@ -85,7 +85,9 @@ class ProgressReporter:
         if self.completed == 0:
             return "~?"
         avg = elapsed / self.completed
-        remaining_units = self.total - self.completed
+        # Floor at 0: retries can double-count `completed` past `total`, which would otherwise
+        # make remaining_units negative and render the ETA as a negative duration.
+        remaining_units = max(0, self.total - self.completed)
         remaining_secs = avg * remaining_units
         return f"~{_fmt_duration(remaining_secs)}"
 

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -187,7 +187,7 @@ def build_pipeline_output(
     application_type: str = "web_app",
     processing_level: str | None = None,
     step_reports: list[dict] | None = None,
-) -> str:
+) -> tuple[str, int]:
     """Build ``pipeline_output.json`` from analysis results.
 
     Reads ``results.json`` or ``results_verified.json`` and transforms
@@ -206,7 +206,8 @@ def build_pipeline_output(
         step_reports: Optional list of step report dicts for duration/cost info.
 
     Returns:
-        The *output_path* written to.
+        A ``(output_path, findings_count)`` tuple: the *output_path* written
+        to and the number of findings emitted into ``pipeline_output.json``.
     """
     print(f"[Report] Building pipeline_output.json...", file=sys.stderr)
 

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -213,11 +213,11 @@ def scan_repository(
     elif generate_context:
         print(_step_label("Skipping application context (module not available)."),
               file=sys.stderr)
-        result.skipped_steps.append("app-context")
+        _record_skip(result, "app-context", "module_unavailable")
     else:
         print(_step_label("Skipping application context (--no-context)."),
               file=sys.stderr)
-        result.skipped_steps.append("app-context")
+        _record_skip(result, "app-context", "not_requested")
     print(file=sys.stderr)
 
     # ---------------------------------------------------------------
@@ -344,7 +344,7 @@ def scan_repository(
             _load_step_report(output_dir, "llm-reachability")
         )
     else:
-        result.skipped_steps.append("llm-reachability")
+        _record_skip(result, "llm-reachability", "not_requested")
     print(file=sys.stderr)
 
     # ---------------------------------------------------------------
@@ -363,40 +363,50 @@ def scan_repository(
             "repo_path": repo_path,
             "mode": enhance_mode,
         }) as ctx:
-            enhance_result = enhance_dataset(
-                dataset_path=active_dataset_path,
-                output_path=enhanced_path,
-                analyzer_output_path=parse_result.analyzer_output_path,
-                repo_path=repo_path,
-                mode=enhance_mode,
-                workers=workers,
-                backoff_seconds=backoff_seconds,
-                # checkpoint_path auto-derived from output_path
-            )
+            # Enhance is OPTIONAL: a failure here must not discard the completed
+            # parse work. Catch-and-continue (matching app-context /
+            # llm-reachability), since step_context re-raises otherwise.
+            try:
+                enhance_result = enhance_dataset(
+                    dataset_path=active_dataset_path,
+                    output_path=enhanced_path,
+                    analyzer_output_path=parse_result.analyzer_output_path,
+                    repo_path=repo_path,
+                    mode=enhance_mode,
+                    workers=workers,
+                    backoff_seconds=backoff_seconds,
+                    # checkpoint_path auto-derived from output_path
+                )
 
-            ctx.summary = {
-                "units_enhanced": enhance_result.units_enhanced,
-                "error_count": enhance_result.error_count,
-                "classifications": enhance_result.classifications,
-                "mode": enhance_mode,
-            }
-            if enhance_result.error_summary:
-                ctx.summary["error_summary"] = enhance_result.error_summary
-            ctx.outputs = {
-                "enhanced_dataset_path": enhance_result.enhanced_dataset_path,
-            }
+                ctx.summary = {
+                    "units_enhanced": enhance_result.units_enhanced,
+                    "error_count": enhance_result.error_count,
+                    "classifications": enhance_result.classifications,
+                    "mode": enhance_mode,
+                }
+                if enhance_result.error_summary:
+                    ctx.summary["error_summary"] = enhance_result.error_summary
+                ctx.outputs = {
+                    "enhanced_dataset_path": enhance_result.enhanced_dataset_path,
+                }
 
-        result.enhanced_dataset_path = enhance_result.enhanced_dataset_path
-        active_dataset_path = enhance_result.enhanced_dataset_path
+                result.enhanced_dataset_path = enhance_result.enhanced_dataset_path
+                active_dataset_path = enhance_result.enhanced_dataset_path
+
+                print(f"  Enhanced: {enhance_result.units_enhanced} units", file=sys.stderr)
+                print(f"  Classifications: {enhance_result.classifications}", file=sys.stderr)
+                if enhance_result.error_summary:
+                    print(f"  Errors: {enhance_result.error_count} ({enhance_result.error_summary})", file=sys.stderr)
+            except Exception as e:
+                print(f"  WARNING: Enhancement failed: {e}", file=sys.stderr)
+                print("  Continuing with the un-enhanced dataset.", file=sys.stderr)
+                ctx.summary = {"skipped": True, "reason": str(e)}
+                _record_skip(result, "enhance", "failed")
+
         collected_step_reports.append(_load_step_report(output_dir, "enhance"))
-
-        print(f"  Enhanced: {enhance_result.units_enhanced} units", file=sys.stderr)
-        print(f"  Classifications: {enhance_result.classifications}", file=sys.stderr)
-        if enhance_result.error_summary:
-            print(f"  Errors: {enhance_result.error_count} ({enhance_result.error_summary})", file=sys.stderr)
     else:
         print(_step_label("Skipping enhancement (--no-enhance)."), file=sys.stderr)
-        result.skipped_steps.append("enhance")
+        _record_skip(result, "enhance", "not_requested")
     print(file=sys.stderr)
 
     # ---------------------------------------------------------------
@@ -462,55 +472,64 @@ def scan_repository(
             "results_path": analyze_result.results_path,
             "analyzer_output_path": parse_result.analyzer_output_path,
         }) as ctx:
-            verify_result = run_verification(
-                results_path=analyze_result.results_path,
-                output_dir=output_dir,
-                analyzer_output_path=parse_result.analyzer_output_path,
-                app_context_path=app_context_path,
-                repo_path=repo_path,
-                workers=workers,
-                backoff_seconds=backoff_seconds,
-            )
+            # Verify is OPTIONAL: a failure here must not discard completed
+            # parse/analyze work (step_context re-raises otherwise).
+            try:
+                verify_result = run_verification(
+                    results_path=analyze_result.results_path,
+                    output_dir=output_dir,
+                    analyzer_output_path=parse_result.analyzer_output_path,
+                    app_context_path=app_context_path,
+                    repo_path=repo_path,
+                    workers=workers,
+                    backoff_seconds=backoff_seconds,
+                )
 
-            ctx.summary = {
-                "findings_input": verify_result.findings_input,
-                "findings_verified": verify_result.findings_verified,
-                "agreed": verify_result.agreed,
-                "disagreed": verify_result.disagreed,
-                "confirmed_vulnerabilities": verify_result.confirmed_vulnerabilities,
-            }
-            ctx.outputs = {
-                "verified_results_path": verify_result.verified_results_path,
-            }
+                ctx.summary = {
+                    "findings_input": verify_result.findings_input,
+                    "findings_verified": verify_result.findings_verified,
+                    "agreed": verify_result.agreed,
+                    "disagreed": verify_result.disagreed,
+                    "confirmed_vulnerabilities": verify_result.confirmed_vulnerabilities,
+                }
+                ctx.outputs = {
+                    "verified_results_path": verify_result.verified_results_path,
+                }
 
-        result.verified_results_path = verify_result.verified_results_path
-        active_results_path = verify_result.verified_results_path
+                result.verified_results_path = verify_result.verified_results_path
+                active_results_path = verify_result.verified_results_path
+
+                print(f"  Confirmed: {verify_result.confirmed_vulnerabilities} vulnerabilities",
+                      file=sys.stderr)
+
+                # Update metrics from verified results
+                result.metrics = AnalysisMetrics(
+                    total=analyze_result.metrics.total,
+                    vulnerable=verify_result.confirmed_vulnerabilities,
+                    bypassable=0,
+                    inconclusive=analyze_result.metrics.inconclusive,
+                    protected=analyze_result.metrics.protected,
+                    safe=analyze_result.metrics.safe + verify_result.disagreed,
+                    errors=analyze_result.metrics.errors,
+                    verified=verify_result.findings_verified,
+                    stage2_agreed=verify_result.agreed,
+                    stage2_disagreed=verify_result.disagreed,
+                )
+            except Exception as e:
+                print(f"  WARNING: Verification failed: {e}", file=sys.stderr)
+                print("  Continuing with unverified Stage 1 results.", file=sys.stderr)
+                ctx.summary = {"skipped": True, "reason": str(e)}
+                _record_skip(result, "verify", "failed")
+
         collected_step_reports.append(_load_step_report(output_dir, "verify"))
-
-        print(f"  Confirmed: {verify_result.confirmed_vulnerabilities} vulnerabilities",
-              file=sys.stderr)
-
-        # Update metrics from verified results
-        result.metrics = AnalysisMetrics(
-            total=analyze_result.metrics.total,
-            vulnerable=verify_result.confirmed_vulnerabilities,
-            bypassable=0,
-            inconclusive=analyze_result.metrics.inconclusive,
-            protected=analyze_result.metrics.protected,
-            safe=analyze_result.metrics.safe + verify_result.disagreed,
-            errors=analyze_result.metrics.errors,
-            verified=verify_result.findings_verified,
-            stage2_agreed=verify_result.agreed,
-            stage2_disagreed=verify_result.disagreed,
-        )
     elif verify and not has_findings:
         print(_step_label("Skipping verification (no vulnerable findings)."),
               file=sys.stderr)
-        result.skipped_steps.append("verify")
+        _record_skip(result, "verify", "no_candidates")
     else:
         print(_step_label("Skipping verification (--no-verify or not requested)."),
               file=sys.stderr)
-        result.skipped_steps.append("verify")
+        _record_skip(result, "verify", "not_requested")
     print(file=sys.stderr)
 
     # ---------------------------------------------------------------
@@ -552,7 +571,7 @@ def scan_repository(
         if not shutil.which("docker"):
             print(_step_label("Skipping dynamic test (Docker not found)."),
                   file=sys.stderr)
-            result.skipped_steps.append("dynamic-test")
+            _record_skip(result, "dynamic-test", "docker_unavailable")
         else:
             from core.dynamic_tester import run_tests
 
@@ -561,38 +580,47 @@ def scan_repository(
             with step_context("dynamic-test", output_dir, inputs={
                 "pipeline_output_path": pipeline_output_path,
             }) as ctx:
-                dt_result = run_tests(
-                    pipeline_output_path=pipeline_output_path,
-                    output_dir=output_dir,
-                )
+                # Dynamic test is OPTIONAL: a failure here must not discard
+                # completed work (step_context re-raises otherwise).
+                try:
+                    dt_result = run_tests(
+                        pipeline_output_path=pipeline_output_path,
+                        output_dir=output_dir,
+                    )
 
-                ctx.summary = {
-                    "findings_tested": dt_result.findings_tested,
-                    "confirmed": dt_result.confirmed,
-                    "not_reproduced": dt_result.not_reproduced,
-                    "blocked": dt_result.blocked,
-                    "inconclusive": dt_result.inconclusive,
-                    "errors": dt_result.errors,
-                }
-                ctx.outputs = {
-                    "results_json_path": dt_result.results_json_path,
-                    "results_md_path": dt_result.results_md_path,
-                }
+                    ctx.summary = {
+                        "findings_tested": dt_result.findings_tested,
+                        "confirmed": dt_result.confirmed,
+                        "not_reproduced": dt_result.not_reproduced,
+                        "blocked": dt_result.blocked,
+                        "inconclusive": dt_result.inconclusive,
+                        "errors": dt_result.errors,
+                    }
+                    ctx.outputs = {
+                        "results_json_path": dt_result.results_json_path,
+                        "results_md_path": dt_result.results_md_path,
+                    }
 
-            result.dynamic_test_path = dt_result.results_json_path
+                    result.dynamic_test_path = dt_result.results_json_path
+
+                    print(f"  Dynamic test: {dt_result.confirmed} confirmed, "
+                          f"{dt_result.not_reproduced} not reproduced", file=sys.stderr)
+                except Exception as e:
+                    print(f"  WARNING: Dynamic test failed: {e}", file=sys.stderr)
+                    print("  Continuing without dynamic-test results.", file=sys.stderr)
+                    ctx.summary = {"skipped": True, "reason": str(e)}
+                    _record_skip(result, "dynamic-test", "failed")
+
             collected_step_reports.append(
                 _load_step_report(output_dir, "dynamic-test"),
             )
-
-            print(f"  Dynamic test: {dt_result.confirmed} confirmed, "
-                  f"{dt_result.not_reproduced} not reproduced", file=sys.stderr)
     elif dynamic_test and not has_findings:
         print(_step_label("Skipping dynamic test (no findings to test)."),
               file=sys.stderr)
-        result.skipped_steps.append("dynamic-test")
+        _record_skip(result, "dynamic-test", "no_candidates")
     else:
         print(_step_label("Skipping dynamic test (not enabled)."), file=sys.stderr)
-        result.skipped_steps.append("dynamic-test")
+        _record_skip(result, "dynamic-test", "not_requested")
     print(file=sys.stderr)
 
     # ---------------------------------------------------------------
@@ -639,7 +667,7 @@ def scan_repository(
         collected_step_reports.append(_load_step_report(output_dir, "report"))
     else:
         print(_step_label("Skipping report generation (--no-report)."), file=sys.stderr)
-        result.skipped_steps.append("report")
+        _record_skip(result, "report", "not_requested")
     print(file=sys.stderr)
 
     # ---------------------------------------------------------------
@@ -683,6 +711,19 @@ def _count_steps(
     return count
 
 
+def _record_skip(result: ScanResult, step: str, reason: str) -> None:
+    """Record that ``step`` was skipped.
+
+    Appends the bare step name to ``result.skipped_steps`` (UNCHANGED behaviour
+    — telemetry consumers read this flat list) and ADDITIVELY records the
+    disambiguated cause in ``result.skipped_step_reasons`` so distinct causes
+    (e.g. verify auto-skip 'no_candidates' vs opt-out 'not_requested') are no
+    longer conflated to one bare string.
+    """
+    result.skipped_steps.append(step)
+    result.skipped_step_reasons[step] = reason
+
+
 def _load_step_report(output_dir: str, step: str) -> dict:
     """Load a step report JSON from disk. Returns empty dict on failure."""
     path = os.path.join(output_dir, f"{step}.report.json")
@@ -724,6 +765,9 @@ def _write_scan_report(
             "metrics": result.metrics.to_dict(),
             "steps_completed": [sr.get("step") for sr in step_reports],
             "steps_skipped": result.skipped_steps,
+            # ADDITIVE / non-breaking: disambiguated skip cause per step.
+            # `steps_skipped` above stays a flat bare list (consumers read it).
+            "steps_skipped_reasons": result.skipped_step_reasons,
         },
         inputs={"repo_path": result.output_dir.replace(os.path.abspath("."), ".")},
         outputs={

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -135,6 +135,11 @@ class ScanResult:
     usage: UsageInfo = field(default_factory=UsageInfo)
     step_reports: list = field(default_factory=list)
     skipped_steps: list = field(default_factory=list)
+    # Disambiguated skip cause per skipped step. ADDITIVE / non-breaking:
+    # `skipped_steps` stays a flat bare list of step names (telemetry consumers
+    # read it). This map records WHY each step was skipped (e.g. 'verify' ->
+    # 'no_candidates' for an auto-skip vs 'not_requested' for an opt-out).
+    skipped_step_reasons: dict = field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
@@ -155,6 +160,7 @@ class ScanResult:
             "usage": self.usage.to_dict(),
             "step_reports": self.step_reports,
             "skipped_steps": self.skipped_steps,
+            "skipped_step_reasons": self.skipped_step_reasons,
         }
 
 

--- a/libs/openant-core/export_csv.py
+++ b/libs/openant-core/export_csv.py
@@ -31,6 +31,20 @@ import os
 import sys
 from utilities.file_io import read_json
 
+# Characters that make a spreadsheet treat a cell as a formula on open (CSV / formula
+# injection, CWE-1236 / OWASP). Cells written from scanned source or LLM text must be
+# neutralized so opening the export in Excel / Google Sheets can't execute a payload.
+_CSV_FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
+
+
+def _csv_safe(value):
+    """Prefix a leading formula-trigger character with a single quote, neutralizing CSV
+    formula injection. Non-string/None values become '' / their str form first."""
+    s = "" if value is None else str(value)
+    if s and s[0] in _CSV_FORMULA_TRIGGERS:
+        return "'" + s
+    return s
+
 
 def _load_diff_block(experiment_path: str) -> dict | None:
     """Look for the ``diff`` block in pipeline_output.json next to the
@@ -159,7 +173,8 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
             'stage1_confidence': result.get('confidence', ''),
             'agentic_classification': llm_context.get('security_classification', '')
         }
-        rows.append(row)
+        # Neutralize CSV / formula injection on every cell before writing.
+        rows.append({k: _csv_safe(v) for k, v in row.items()})
 
     # Write CSV
     fieldnames = [

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -189,6 +189,7 @@ def cmd_enhance(args):
                 checkpoint_path=args.checkpoint,
                 workers=args.workers,
                 backoff_seconds=args.backoff,
+                limit=args.limit,
             )
 
             ctx.summary = {
@@ -1049,6 +1050,7 @@ def main():
     enhance_p.add_argument("--repo-path", help="Path to the repository (required for agentic mode)")
     enhance_p.add_argument("--output", "-o", help="Output path for enhanced dataset (default: {input}_enhanced.json)")
     enhance_p.add_argument("--checkpoint", help="Path to save/resume checkpoint (agentic mode)")
+    enhance_p.add_argument("--limit", type=int, help="Max units to enhance")
     enhance_p.add_argument(
         "--mode",
         choices=["agentic", "single-shot"],

--- a/libs/openant-core/parsers/c/call_graph_builder.py
+++ b/libs/openant-core/parsers/c/call_graph_builder.py
@@ -159,7 +159,10 @@ class CallGraphBuilder:
             for inc in inc_list:
                 # Match included header to files in repo
                 for other_file in self.functions_by_file:
-                    if other_file.endswith(inc) or other_file.endswith('/' + inc):
+                    # Require a path-component boundary. A bare `endswith(inc)`
+                    # matched any tail (include "x.h" -> "src/prefix-x.h"), so only
+                    # an exact match or a '/'-delimited basename match is valid.
+                    if other_file == inc or other_file.endswith('/' + inc):
                         self.include_map[file_path].add(other_file)
 
     def _is_stdlib(self, name: str) -> bool:
@@ -199,8 +202,35 @@ class CallGraphBuilder:
                         resolved = self._resolve_call(call_name, caller_file)
                         if resolved:
                             calls.add(resolved)
+                # A function passed by name as an argument (e.g.
+                # qsort(..., my_cmp), pthread_create(..., worker, ...)) is invoked
+                # indirectly by the callee. Resolve bare-identifier arguments that
+                # name a known function; non-function identifiers (variables) do not
+                # resolve and so do not create edges.
+                calls.update(self._extract_callback_args(node, code_bytes, caller_file))
             stack.extend(reversed(node.children))
         return calls
+
+    def _extract_callback_args(self, call_node, source: bytes, caller_file: str) -> Set[str]:
+        """Resolve function-name arguments passed to a call (higher-order/callback)."""
+        found: Set[str] = set()
+        arg_list = call_node.child_by_field_name('arguments')
+        if arg_list is None:
+            return found
+        for arg in arg_list.children:
+            name: Optional[str] = None
+            if arg.type == 'identifier':
+                name = source[arg.start_byte:arg.end_byte].decode('utf-8', errors='replace')
+            elif arg.type in ('pointer_expression', 'unary_expression'):
+                # &handler -> handler
+                operand = arg.child_by_field_name('argument')
+                if operand is not None and operand.type == 'identifier':
+                    name = source[operand.start_byte:operand.end_byte].decode('utf-8', errors='replace')
+            if name and not self._is_stdlib(name):
+                resolved = self._resolve_call(name, caller_file)
+                if resolved:
+                    found.add(resolved)
+        return found
 
     def _extract_call_name(self, node, source: bytes) -> Optional[str]:
         """Extract the function name from a call_expression's function child."""
@@ -210,10 +240,12 @@ class CallGraphBuilder:
             return text
 
         if node.type == 'field_expression':
-            # obj->method or obj.method - extract the field name
-            field = node.child_by_field_name('field')
-            if field:
-                return source[field.start_byte:field.end_byte].decode('utf-8', errors='replace')
+            # obj->method() / obj.method() is a member or function-pointer
+            # call, not a free-function call. The resolver only does name-only lookup
+            # (no struct-member / receiver-type model), so binding the bare field name
+            # wired the call to any unrelated free function of the same name. Decline
+            # here instead of emitting that false edge.
+            return None
 
         if node.type == 'qualified_identifier':
             return text
@@ -228,6 +260,19 @@ class CallGraphBuilder:
             return None
 
         return text if text.isidentifier() else None
+
+    def _is_visible_from(self, func_id: str, caller_file: str) -> bool:
+        """Whether a candidate definition is linkable from caller_file.
+
+        A `static` function has internal linkage and is only callable
+        within its own translation unit, so a static definition in another file
+        must not resolve a call made elsewhere. Same-file definitions are always
+        visible; cross-file resolution requires external (non-static) linkage.
+        """
+        func_data = self.functions.get(func_id, {})
+        if func_data.get('file_path', '') == caller_file:
+            return True
+        return not func_data.get('is_static', False)
 
     def _resolve_call(self, call_name: str, caller_file: str) -> Optional[str]:
         """Resolve a function call name to a function ID."""
@@ -253,18 +298,25 @@ class CallGraphBuilder:
 
         # 2. Functions in included headers
         included_files = self.include_map.get(caller_file, set())
-        for inc_file in included_files:
+        # Iterate in sorted order so resolution is deterministic regardless of
+        # set-iteration order (PYTHONHASHSEED); stable lexicographic tiebreak on file path
+        # when same-basename headers in different dirs define the same function name.
+        for inc_file in sorted(included_files):
             file_funcs = self.functions_by_file.get(inc_file, [])
             for func_id in file_funcs:
                 func_data = self.functions.get(func_id, {})
                 fname = func_data.get('name', '')
                 base_name = fname.split('::')[-1] if '::' in fname else fname
-                if base_name == call_name:
+                # A static function in an included header has internal linkage
+                # and is not callable from the including file.
+                if base_name == call_name and self._is_visible_from(func_id, caller_file):
                     return func_id
 
         # 3. Unique name match across entire repo
         candidates = self.functions_by_name.get(call_name, [])
-        if len(candidates) == 1:
+        # Do not resolve a call to a file-local (static) definition in a
+        # different translation unit; the repo-wide fallback previously ignored linkage.
+        if len(candidates) == 1 and self._is_visible_from(candidates[0], caller_file):
             return candidates[0]
 
         # 4. If prototype exists, try to find the definition
@@ -275,16 +327,64 @@ class CallGraphBuilder:
                 func_data = self.functions.get(func_id, {})
                 fp = func_data.get('file_path', '')
                 ext = Path(fp).suffix.lower()
-                if ext in {'.c', '.cpp', '.cc', '.cxx'}:
+                if ext in {'.c', '.cpp', '.cc', '.cxx'} and self._is_visible_from(func_id, caller_file):
                     return func_id
 
         return None
+
+    @staticmethod
+    def _strip_comments_and_literals(code: str) -> str:
+        """Blank out C comments and string/char literals, preserving length and
+        newlines.
+
+        The regex fallback scanned raw code, so a call-shaped token inside
+        a // or /* */ comment or a "..." / '...' literal produced a phantom edge.
+        Replacing those regions with spaces (newlines kept) removes the false matches
+        without disturbing offsets.
+        """
+        out = []
+        i, n = 0, len(code)
+        while i < n:
+            c = code[i]
+            nxt = code[i + 1] if i + 1 < n else ''
+            if c == '/' and nxt == '/':
+                while i < n and code[i] != '\n':
+                    out.append(' ')
+                    i += 1
+            elif c == '/' and nxt == '*':
+                out.append('  ')
+                i += 2
+                while i < n and not (code[i] == '*' and i + 1 < n and code[i + 1] == '/'):
+                    out.append('\n' if code[i] == '\n' else ' ')
+                    i += 1
+                if i < n:
+                    out.append('  ')
+                    i += 2
+            elif c in ('"', "'"):
+                quote = c
+                out.append(' ')
+                i += 1
+                while i < n and code[i] != quote:
+                    if code[i] == '\\' and i + 1 < n:
+                        out.append('  ')
+                        i += 2
+                        continue
+                    out.append('\n' if code[i] == '\n' else ' ')
+                    i += 1
+                if i < n:
+                    out.append(' ')
+                    i += 1
+            else:
+                out.append(c)
+                i += 1
+        return ''.join(out)
 
     def _extract_calls_regex(self, code: str, caller_id: str) -> Set[str]:
         """Fallback regex-based call extraction."""
         calls = set()
         caller_file = caller_id.split(':')[0]
 
+        code = self._strip_comments_and_literals(code)
         pattern = r'\b([a-zA-Z_][a-zA-Z0-9_]*)\s*\('
         for match in re.finditer(pattern, code):
             func_name = match.group(1)

--- a/libs/openant-core/parsers/c/function_extractor.py
+++ b/libs/openant-core/parsers/c/function_extractor.py
@@ -530,8 +530,11 @@ class FunctionExtractor:
             all_extensions = C_EXTENSIONS | CPP_EXTENSIONS
             for ext in all_extensions:
                 for file_path in self.repo_path.rglob(f'*{ext}'):
-                    path_str = str(file_path)
-                    if any(excl in path_str for excl in ['.git', 'build', 'test', 'node_modules']):
+                    # Exclude on path COMPONENTS relative to repo_path, not a substring of the absolute
+                    # path. A substring test wrongly skips files whose path merely contains a token
+                    # ('src/latest/main.c', 'contest/sol.c' contain 'test') and is poisoned when an
+                    # ancestor of repo_path contains one (a checkout under '/home/tester/' excludes all).
+                    if {'.git', 'build', 'test', 'node_modules'} & set(file_path.relative_to(self.repo_path).parts):
                         continue
                     self.process_file(file_path)
 

--- a/libs/openant-core/parsers/c/repository_scanner.py
+++ b/libs/openant-core/parsers/c/repository_scanner.py
@@ -102,11 +102,33 @@ class RepositoryScanner:
         return ext in self.source_extensions
 
     def is_test_file(self, relative_path: str) -> bool:
-        """Check if a file is a test file."""
+        """Check if a file is a test file.
+
+        Patterns are matched against path *segments* and filename boundaries,
+        not as bare substrings, so ordinary files whose name/path merely
+        contains a pattern (e.g. ``latest_value.c`` contains ``test_``;
+        ``contest/foo.c`` contains ``test/``) are not misclassified as tests.
+        """
         path_lower = relative_path.lower()
+        segments = path_lower.split('/')
+        basename = segments[-1]
+        dir_segments = segments[:-1]
         for pattern in self.test_patterns:
-            if pattern in path_lower:
-                return True
+            if pattern.endswith('/'):
+                # directory pattern: match a whole path segment (test/, tests/, fuzz/)
+                if pattern[:-1] in dir_segments:
+                    return True
+            elif '.' in pattern:
+                # filename-suffix pattern (e.g. _test.c, _test.cpp): compare the stem
+                # before the extension, so _test.cc / _test.cxx (common C/C++ test
+                # extensions the old substring check also matched) stay detected —
+                # without re-introducing substring over-match. Bounded by is_source_file.
+                if basename.rsplit('.', 1)[0].endswith(pattern.rsplit('.', 1)[0]):
+                    return True
+            else:
+                # filename-prefix token (test_)
+                if basename.startswith(pattern):
+                    return True
         return False
 
     def scan_directory(self, dir_path: Path, relative_path: str = '') -> None:

--- a/libs/openant-core/parsers/c/test_pipeline.py
+++ b/libs/openant-core/parsers/c/test_pipeline.py
@@ -68,6 +68,15 @@ class ProcessingLevel(Enum):
     EXPLOITABLE = "exploitable"
 
 
+# Pipeline stages that are OPTIONAL: they may fail or be skipped (e.g. CodeQL not installed, no entry
+# points) without the run being a failure. They record success=False on failure, so they must be
+# excluded from the overall-success conjunction -- otherwise an optional-stage failure forces exit 1.
+OPTIONAL_STAGES = frozenset({
+    'reachability_filter', 'codeql_analysis', 'codeql_filter',
+    'context_enhancer', 'exploitable_filter',
+})
+
+
 class CPipelineTest:
     def __init__(
         self,
@@ -376,6 +385,11 @@ class CPipelineTest:
                 codeql_db_path,
                 f'--language={language}',
                 f'--source-root={self.repo_path}',
+                # These repos carry extracted source with no build system to run, so use the
+                # build-mode-none extractor: a compiled language (cpp) is indexed without autobuild,
+                # which would otherwise fail/degrade on no-build/autotools repos and silently drop
+                # CodeQL findings.
+                '--build-mode=none',
                 '--overwrite'
             ]
 
@@ -803,6 +817,19 @@ class CPipelineTest:
             self.results['stages']['exploitable_filter'] = result
             return False
 
+    def _compute_success(self) -> bool:
+        """Overall success = all REQUIRED stages succeeded.
+
+        Optional stages (CodeQL, reachability filter, context enhancer, exploitable filter) write
+        success=False on failure/skip; ANDing them into overall success made an optional-stage
+        failure a spurious pipeline failure (exit 1). Exclude them from the conjunction.
+        """
+        return all(
+            stage.get('success', False)
+            for name, stage in self.results['stages'].items()
+            if name not in OPTIONAL_STAGES
+        )
+
     def run_full_pipeline(self):
         """Run the complete pipeline."""
         print("=" * 60)
@@ -861,10 +888,7 @@ class CPipelineTest:
         print("PIPELINE SUMMARY")
         print("=" * 60)
 
-        all_success = all(
-            stage.get('success', False)
-            for stage in self.results['stages'].values()
-        )
+        all_success = self._compute_success()
 
         self.results['success'] = all_success
 

--- a/libs/openant-core/parsers/go/go_parser/callgraph.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph.go
@@ -47,7 +47,8 @@ func NewCallGraphBuilder(repoPath string) *CallGraphBuilder {
 		"sort":    true,
 		"math":    true,
 		"io":      true,
-		"os":      true,
+		// "os" is intentionally NOT skipped: it carries security-relevant sinks (os.StartProcess,
+		// etc.) that downstream analysis must be able to see; blanket-skipping dropped them.
 		"path":    true,
 		"regexp":  true,
 		"json":    true,
@@ -175,11 +176,11 @@ func (c *CallGraphBuilder) parseImports(fullPath, relPath string) {
 
 // CallInfo represents a function call found in code
 type CallInfo struct {
-	Name      string // Simple function name
-	Receiver  string // Receiver for method calls (e.g., "obj" in obj.Method())
-	Package   string // Package alias for package.Func() calls
-	IsMethod  bool   // True if this is a method call
-	IsSelf    bool   // True if receiver is "self" or matches current receiver
+	Name     string // Simple function name
+	Receiver string // Receiver for method calls (e.g., "obj" in obj.Method())
+	Package  string // Package alias for package.Func() calls
+	IsMethod bool   // True if this is a method call
+	IsSelf   bool   // True if receiver is "self" or matches current receiver
 }
 
 func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
@@ -194,6 +195,11 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 		return calls
 	}
 
+	// A selector receiver (pkg.Func vs obj.Method) is a package iff its name is one of THIS file's
+	// import aliases. Pass the file's import set down so analyzeCallExpr classifies using the real
+	// import table instead of a name-shape heuristic.
+	imports := c.importsByFile[funcInfo.FilePath]
+
 	// Walk the AST looking for call expressions
 	ast.Inspect(file, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
@@ -201,7 +207,7 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 			return true
 		}
 
-		callInfo := c.analyzeCallExpr(call)
+		callInfo := c.analyzeCallExpr(call, imports)
 		if callInfo.Name != "" && !c.builtins[callInfo.Name] && !c.builtins[callInfo.Package] {
 			calls = append(calls, callInfo)
 		}
@@ -211,7 +217,7 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 	return calls
 }
 
-func (c *CallGraphBuilder) analyzeCallExpr(call *ast.CallExpr) CallInfo {
+func (c *CallGraphBuilder) analyzeCallExpr(call *ast.CallExpr, imports map[string]string) CallInfo {
 	info := CallInfo{}
 
 	switch fun := call.Fun.(type) {
@@ -227,8 +233,9 @@ func (c *CallGraphBuilder) analyzeCallExpr(call *ast.CallExpr) CallInfo {
 		switch x := fun.X.(type) {
 		case *ast.Ident:
 			info.Receiver = x.Name
-			// Check if it looks like a package (lowercase) or object
-			if isLikelyPackage(x.Name) {
+			// It is a package call iff the receiver name is an import alias of this file.
+			// A short lowercase local (db, tx, ctx, w, r) is NOT a package.
+			if _, isImport := imports[x.Name]; isImport {
 				info.Package = x.Name
 				info.IsMethod = false
 			}
@@ -252,29 +259,6 @@ func (c *CallGraphBuilder) analyzeCallExpr(call *ast.CallExpr) CallInfo {
 	return info
 }
 
-func isLikelyPackage(name string) bool {
-	// Packages are typically lowercase
-	if len(name) == 0 {
-		return false
-	}
-
-	// Common patterns that are definitely packages
-	packagePatterns := []string{
-		"fmt", "log", "os", "io", "net", "http", "json", "xml",
-		"strings", "strconv", "bytes", "time", "context", "sync",
-		"errors", "filepath", "regexp", "math", "sort", "reflect",
-	}
-	for _, p := range packagePatterns {
-		if name == p {
-			return true
-		}
-	}
-
-	// If all lowercase and short, likely a package
-	first := rune(name[0])
-	return first >= 'a' && first <= 'z' && len(name) <= 10
-}
-
 func (c *CallGraphBuilder) resolveCalls(callerID string, callerInfo FunctionInfo, calls []CallInfo, analyzer *AnalyzerOutput) []string {
 	var resolved []string
 	seen := make(map[string]bool)
@@ -283,8 +267,10 @@ func (c *CallGraphBuilder) resolveCalls(callerID string, callerInfo FunctionInfo
 		var targetID string
 
 		// Try different resolution strategies
-		if call.IsSelf || call.Receiver == callerInfo.ClassName {
-			// Self/receiver call - look in same type's methods
+		if callerInfo.ClassName != "" && (call.IsSelf || call.Receiver == callerInfo.ClassName) {
+			// Self/receiver call - look in same type's methods. Guarded on ClassName != "" so a
+			// plain function (ClassName=="") making a simple call (Receiver=="") is NOT misrouted
+			// here via ""=="" and lost; it falls through to resolveSimpleCall below.
 			targetID = c.resolveMethodCall(call.Name, callerInfo.ClassName, callerInfo.FilePath)
 		} else if call.IsMethod && call.Receiver != "" {
 			// Method call on some object
@@ -341,12 +327,18 @@ func (c *CallGraphBuilder) resolvePackageCall(funcName, pkgAlias, currentFile st
 		return ""
 	}
 
-	// Try to find the function in files from that package
-	// This is a simplified approach - we look for functions by name
-	// that are in files whose directory matches the package
+	// Match by the package's directory (the last component of the resolved import path), NOT the
+	// user-chosen alias. funcID is "<relPath>:<Name>", so a function's package is the directory its
+	// file lives in. The old code tested strings.Contains(funcID, pkgAlias): it used the alias (so
+	// aliased imports failed to resolve) and matched any funcID merely CONTAINING the alias as a
+	// substring (so it emitted edges to unrelated packages).
+	pkgDir := filepath.Base(pkgPath)
 	for _, funcID := range c.functionsByName[funcName] {
-		// Check if the function is likely from the right package
-		if strings.Contains(funcID, pkgAlias) {
+		filePart := funcID
+		if ci := strings.LastIndex(funcID, ":"); ci >= 0 {
+			filePart = funcID[:ci]
+		}
+		if filepath.Base(filepath.Dir(filePart)) == pkgDir {
 			return funcID
 		}
 	}

--- a/libs/openant-core/parsers/go/go_parser/callgraph_test.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph_test.go
@@ -1,0 +1,96 @@
+package main
+
+// Regression tests for four coupled defects in the Go call-graph resolver (callgraph.go).
+//
+// Receiver classification: isLikelyPackage classified ANY short
+//   lowercase identifier (db, tx, ctx, w) as a package using a name-shape heuristic with no import
+//   context, so local-variable method calls were misrouted to package resolution. Fix: classify a
+//   selector receiver as a package iff its name is an import alias of the file.
+// Package-call resolution: resolvePackageCall
+//   resolved the import path correctly but matched candidates with strings.Contains(funcID, pkgAlias)
+//   -- the alias, not the package directory -- so aliased imports failed and edges were emitted to
+//   unrelated packages. Fix: match the package's directory (last path component of the import path).
+// Dispatch: resolveCalls routed a plain function's simple call to resolveMethodCall
+//   because `call.Receiver == callerInfo.ClassName` is ""=="" for a non-method caller. Fix: guard the
+//   self/method branch on callerInfo.ClassName != "".
+// os filtering: the entire "os" package was in the builtins skip-set, so os.StartProcess and
+//   other OS sinks were dropped by the call-extraction filter. Fix: do not blanket-skip "os".
+//
+// Tests exercise stable-signature boundaries (extractCalls / resolvePackageCall / resolveCalls) so they
+// compile against both the pre-fix and post-fix sources (RED demonstrated via `git stash` of the fix).
+
+import "testing"
+
+// receiver classification: local var must not be treated as a package
+func TestExtractCalls_LocalVarNotClassifiedAsPackage(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.importsByFile["a/a.go"] = map[string]string{"fmt": "fmt"} // fmt imported; db is a local var
+	fi := FunctionInfo{Name: "Run", FilePath: "a/a.go", Code: "func Run(){ db.Query() }"}
+
+	calls := c.extractCalls(fi)
+	if len(calls) != 1 || calls[0].Name != "Query" {
+		t.Fatalf("expected one db.Query call, got %+v", calls)
+	}
+	ci := calls[0]
+	if ci.Package != "" {
+		t.Errorf("local var 'db' misclassified as package (Package=%q)", ci.Package)
+	}
+	if !ci.IsMethod || ci.Receiver != "db" {
+		t.Errorf("db.Query() should be a method call on receiver 'db', got %+v", ci)
+	}
+}
+
+// package resolution must match the package directory, not the alias
+func TestResolvePackageCall_MatchesPackageDirNotAlias(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	// `import u "exp007/user"` -- alias 'u', package dir 'user'. The real target lives in user/.
+	c.importsByFile["main/main.go"] = map[string]string{"u": "exp007/user"}
+	// The unrelated candidate is FIRST and its path contains the alias 'u' as a substring (the old bug).
+	c.functionsByName["Helper"] = []string{"unrelated/stuff.go:Helper", "user/user.go:Helper"}
+
+	got := c.resolvePackageCall("Helper", "u", "main/main.go")
+	if got != "user/user.go:Helper" {
+		t.Errorf("expected resolution to the user/ package by directory, got %q "+
+			"(alias-substring match would wrongly pick 'unrelated/stuff.go:Helper')", got)
+	}
+}
+
+// a plain function's simple call must not be misrouted to method resolution
+func TestResolveCalls_PlainFuncSimpleCallNotMisroutedToMethod(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.functionsByFile["a/a.go"] = []string{"a/a.go:main", "a/a.go:greet"}
+	c.functionsByName["greet"] = []string{"a/a.go:greet"}
+
+	caller := FunctionInfo{Name: "main", ClassName: "", FilePath: "a/a.go"}
+	calls := []CallInfo{{Name: "greet", IsMethod: false, Receiver: "", IsSelf: false}}
+
+	resolved := c.resolveCalls("a/a.go:main", caller, calls, nil)
+	if len(resolved) != 1 || resolved[0] != "a/a.go:greet" {
+		t.Errorf("plain func calling greet() should resolve to a/a.go:greet via simple-call, got %v "+
+			"(\"\"==\"\" misroute to resolveMethodCall loses the edge)", resolved)
+	}
+}
+
+// an os sink must not be filtered out as a builtin
+func TestExtractCalls_OsSinkNotFilteredAsBuiltin(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.importsByFile["a/a.go"] = map[string]string{"os": "os", "fmt": "fmt"}
+	fi := FunctionInfo{Name: "F", FilePath: "a/a.go", Code: "func F(){ os.StartProcess(); fmt.Println() }"}
+
+	calls := c.extractCalls(fi)
+	var sawOs, sawFmt bool
+	for _, ci := range calls {
+		if ci.Name == "StartProcess" {
+			sawOs = true
+		}
+		if ci.Name == "Println" {
+			sawFmt = true
+		}
+	}
+	if !sawOs {
+		t.Error("os.StartProcess() was wrongly filtered out as a builtin (os is a security sink, not noise)")
+	}
+	if sawFmt {
+		t.Error("fmt.Println() should stay filtered as builtin noise")
+	}
+}

--- a/libs/openant-core/parsers/go/test_pipeline.py
+++ b/libs/openant-core/parsers/go/test_pipeline.py
@@ -93,6 +93,13 @@ class ProcessingLevel(Enum):
     EXPLOITABLE = "exploitable"    # Level 4: Filter to reachable + CodeQL-flagged + exploitable
 
 
+# CodeQL stage subprocess timeouts (seconds). DB `create` compiles the source -- the slower stage for
+# compiled languages -- so it must not get a smaller budget than `analyze`: a too-short create times out,
+# the stage degrades to reachable-only, and CodeQL security findings are silently lost.
+CODEQL_DB_CREATE_TIMEOUT_SECS = 1800
+CODEQL_ANALYZE_TIMEOUT_SECS = 1800
+
+
 class GoPipelineTest:
     def __init__(
         self,
@@ -517,7 +524,7 @@ class GoPipelineTest:
                 create_db_cmd,
                 capture_output=True,
                 text=True,
-                timeout=600  # 10 minute timeout
+                timeout=CODEQL_DB_CREATE_TIMEOUT_SECS
             )
 
             if result.returncode != 0:
@@ -548,7 +555,7 @@ class GoPipelineTest:
                 analyze_cmd,
                 capture_output=True,
                 text=True,
-                timeout=1800  # 30 minute timeout
+                timeout=CODEQL_ANALYZE_TIMEOUT_SECS
             )
 
             if result.returncode != 0:

--- a/libs/openant-core/parsers/javascript/context_assembler.js
+++ b/libs/openant-core/parsers/javascript/context_assembler.js
@@ -84,7 +84,7 @@ class ContextAssembler {
 
             if (entry.isDirectory()) {
                 this.findSourceFiles(fullPath, files);
-            } else if (/\.(js|ts|jsx|tsx)$/.test(entry.name) && !entry.name.endsWith('.d.ts')) {
+            } else if (/\.(js|ts|jsx|tsx|mjs|cjs)$/.test(entry.name) && !entry.name.endsWith('.d.ts')) {
                 files.push(fullPath);
             }
         }
@@ -319,7 +319,7 @@ class ContextAssembler {
         let resolvedPath = path.resolve(fromDir, importPath);
 
         // Try to find the actual file
-        const extensions = ['', '.js', '.ts', '.jsx', '.tsx', '/index.js', '/index.ts'];
+        const extensions = ['', '.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs', '/index.js', '/index.ts', '/index.mjs', '/index.cjs'];
         let found = false;
 
         for (const ext of extensions) {
@@ -462,7 +462,7 @@ class ContextAssembler {
         const fromDir = path.dirname(fromSourceFile.fileName);
         let resolvedPath = path.resolve(fromDir, importPath);
 
-        const extensions = ['', '.js', '.ts'];
+        const extensions = ['', '.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs'];
 
         for (const ext of extensions) {
             const tryPath = resolvedPath + ext;

--- a/libs/openant-core/parsers/javascript/dependency_resolver.js
+++ b/libs/openant-core/parsers/javascript/dependency_resolver.js
@@ -84,10 +84,15 @@ class DependencyResolver {
         }
       }
 
-      this.callGraph[funcId] = calls;
+      // Drop self-edges: the standalone-call regex matches a function's own
+      // name in its declaration/body, and recursion is not a dependency on a
+      // different unit. Mirrors the C sibling's `c != func_id` invariant.
+      const resolvedCalls = calls.filter((calledId) => calledId !== funcId);
+
+      this.callGraph[funcId] = resolvedCalls;
 
       // Build reverse graph
-      for (const calledId of calls) {
+      for (const calledId of resolvedCalls) {
         if (!this.reverseCallGraph[calledId]) {
           this.reverseCallGraph[calledId] = [];
         }
@@ -221,24 +226,32 @@ class DependencyResolver {
    * Resolve a simple function call to a function ID
    */
   _resolveCall(funcName, callerFile, callerFuncId) {
-    // 1. First check same file
+    // A bare call `foo()` is a free-function reference. It must not bind to a
+    // class method (`Class.foo`): a method is reached via `this.foo()`,
+    // `obj.foo()`, or `Class.foo()`, which are resolved by _resolveThisCall /
+    // _resolveMethodCall. Mirrors the Ruby/PHP siblings, which exclude
+    // class-owned candidates from bare-call resolution.
+
+    // 1. First check same file (free functions only)
     const sameFileFuncs = this.functionsByFile[callerFile];
     if (sameFileFuncs && Array.isArray(sameFileFuncs)) {
       for (const funcId of sameFileFuncs) {
         const funcData = this.functions[funcId];
-        if (funcData && (funcData.name === funcName || funcData.name.endsWith('.' + funcName))) {
+        if (funcData && !funcData.className && funcData.name === funcName) {
           return funcId;
         }
       }
     }
 
-    // 2. Check by simple name across all files
-    const candidates = this.functionsByName[funcName];
-    if (candidates && Array.isArray(candidates) && candidates.length === 1) {
+    // 2. Check by simple name across all files (free functions only)
+    const candidates = (this.functionsByName[funcName] || []).filter(
+      (funcId) => !(this.functions[funcId] && this.functions[funcId].className)
+    );
+    if (candidates.length === 1) {
       return candidates[0];
     }
 
-    // 3. Multiple candidates - return null (ambiguous)
+    // 3. Zero or multiple candidates - return null (ambiguous)
     // A more sophisticated implementation would parse imports to disambiguate
     return null;
   }
@@ -285,6 +298,25 @@ class DependencyResolver {
       }
     }
 
+    // 1b. Local-variable type dispatch: `const x = new C(); x.method()`.
+    //     Map the receiver var to the class it was constructed with, then
+    //     reuse the exact-class-name match. Built-in constructors (Map, Set,
+    //     Promise, ...) are skipped so e.g. `new Map().get()` does not bind to
+    //     a repo `get`.
+    if (callerFuncId) {
+      const callerFunc = this.functions[callerFuncId];
+      const localTypes = this._extractLocalTypes(callerFunc && callerFunc.code);
+      const localClass = localTypes[objectName];
+      if (localClass && !this._isBuiltIn(localClass)) {
+        for (const funcId of candidates) {
+          const funcData = this.functions[funcId];
+          if (funcData && funcData.className === localClass) {
+            return funcId;
+          }
+        }
+      }
+    }
+
     // 2. DI-aware resolution: look up objectName in caller's constructorDeps
     //    e.g., this.callService.getById() -> constructorDeps says callService: CallService
     //    -> resolve to CallService.getById
@@ -327,6 +359,26 @@ class DependencyResolver {
     }
 
     return null;
+  }
+
+  /**
+   * Scan a function body for `const/let/var x = new C()` declarations and
+   * return a { varName -> ClassName } map. Single-identifier constructors only;
+   * member/computed constructors (e.g. new ns.C(), new arr[i]()) are ignored.
+   */
+  _extractLocalTypes(code) {
+    const localTypes = Object.create(null);
+    if (!code) return localTypes;
+
+    const declPattern =
+      /(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*new\s+([A-Za-z_$][\w$]*)\s*\(/g;
+    let match;
+    while ((match = declPattern.exec(code)) !== null) {
+      const [, varName, className] = match;
+      // Last write wins, matching JS reassignment order within a body.
+      localTypes[varName] = className;
+    }
+    return localTypes;
   }
 
   /**
@@ -493,7 +545,13 @@ if (require.main === module) {
     process.exit(1);
   }
 
-  const analyzerOutput = JSON.parse(fs.readFileSync(inputFile, 'utf-8'));
+  let analyzerOutput;
+  try {
+    analyzerOutput = JSON.parse(fs.readFileSync(inputFile, 'utf-8'));
+  } catch (err) {
+    console.error(`Failed to read/parse JSON from ${inputFile}: ${err.message}`);
+    process.exit(1);
+  }
 
   // Build call graph
   console.error(`Processing ${Object.keys(analyzerOutput.functions || {}).length} functions...`);

--- a/libs/openant-core/parsers/javascript/test_pipeline.py
+++ b/libs/openant-core/parsers/javascript/test_pipeline.py
@@ -877,8 +877,11 @@ class PipelineTest:
             # Build mapping of file -> [(start_line, end_line, func_id)]
             file_functions = {}
             for func_id, func_data in functions.items():
-                # Extract file path from func_id (format: "file/path.ts:functionName")
-                colon_idx = func_id.rfind(":")
+                # Extract file path from func_id (format: "file/path.ts:functionName").
+                # The separator is the FIRST colon: functionName may itself contain
+                # colons (e.g. "src/r.ts:express(GET:/items/:id)"). This matches the
+                # dependency_resolver contract (`funcId.split(':')[0]`).
+                colon_idx = func_id.find(":")
                 if colon_idx > 0:
                     file_path = func_id[:colon_idx]
                     start_line = func_data.get('startLine', 0)

--- a/libs/openant-core/parsers/javascript/test_pipeline.py
+++ b/libs/openant-core/parsers/javascript/test_pipeline.py
@@ -126,6 +126,11 @@ class PipelineTest:
         self.analyzer_output_file = None
         self.dataset_file = None
 
+        # Set when the repository contains zero JS-family source files. An empty
+        # repo is a valid 0-unit result (mirroring the Python/Ruby/Zig parsers),
+        # not a failure, so the downstream unit-generator stage is skipped.
+        self.empty_repo = False
+
         # Reachability data (populated if processing_level >= REACHABLE)
         self.entry_points: Set[str] = set()
         self.reachable_units: Set[str] = set()
@@ -278,8 +283,18 @@ class PipelineTest:
             files = [f['path'] for f in scan_data.get('files', [])]
 
         if not files:
-            print("No files to analyze")
-            return False
+            # A repository with zero JS-family source files is a valid 0-unit
+            # result, not a failure. The Python, Ruby and Zig parsers all handle
+            # an empty repo gracefully; previously the JS pipeline returned False
+            # here, which made run_full_pipeline early-return without
+            # results['success'], so main() did sys.exit(1) and the adapter's
+            # _parse_javascript raised RuntimeError, aborting the entire scan.
+            # Mirror the zig graceful-empty pattern: write empty analyzer and
+            # dataset outputs and report success so the adapter reads
+            # units_count=0.
+            print("No files to analyze; treating as empty repository (0 units)")
+            self._write_empty_outputs()
+            return True
 
         # Write file list to a temporary file to avoid command-line length limits
         file_list_path = os.path.join(self.output_dir, 'file_list.txt')
@@ -325,6 +340,56 @@ class PipelineTest:
                 print(f"Warning: could not write call_graph.json: {e}")
 
         return result.get('success', False)
+
+    def _write_empty_outputs(self) -> None:
+        """Write valid empty analyzer + dataset outputs for a zero-file repo.
+
+        Mirrors the zig parser's graceful-empty pattern so a repository with no
+        JS-family source files yields a valid 0-unit result instead of a fatal
+        non-zero exit. Records synthetic successful stage entries and sets
+        ``self.empty_repo`` so run_full_pipeline skips the unit-generator stage.
+        """
+        self.empty_repo = True
+
+        analyzer_output = {
+            "repository": self.repo_path,
+            "functions": {},
+            "callGraph": {},
+        }
+        write_json(self.analyzer_output_file, analyzer_output)
+
+        self.dataset_file = os.path.join(self.output_dir, 'dataset.json')
+        empty_dataset = {
+            "name": self.dataset_name or os.path.basename(self.repo_path),
+            "repository": self.repo_path,
+            "units": [],
+            "statistics": {"totalUnits": 0, "byType": {}},
+            "metadata": {"generator": "test_pipeline.py", "empty_repository": True},
+        }
+        write_json(self.dataset_file, empty_dataset)
+
+        call_graph_file = os.path.join(self.output_dir, 'call_graph.json')
+        write_json(call_graph_file, {"functions": {}, "call_graph": {}, "reverse_call_graph": {}})
+
+        empty_stage = {
+            'success': True,
+            'elapsed_seconds': 0.0,
+            'output_file': self.analyzer_output_file,
+            'summary': {'total_functions': 0, 'by_unit_type': {}, 'call_graph_entries': 0},
+        }
+        self.results['stages']['typescript_analyzer'] = empty_stage
+        self.results['stages']['unit_generator'] = {
+            'success': True,
+            'elapsed_seconds': 0.0,
+            'output_file': self.dataset_file,
+            'summary': {
+                'total_units': 0,
+                'by_type': {},
+                'units_with_dependencies': 0,
+                'call_graph_edges': 0,
+                'avg_out_degree': 0,
+            },
+        }
 
     def run_stage_with_stdout_capture(self, name: str, command: list, output_file: str) -> dict:
         """Run a stage that outputs JSON to stdout, capturing to a file."""
@@ -1083,6 +1148,18 @@ class PipelineTest:
         # Stage 2: TypeScript Analyzer
         if not self.run_typescript_analyzer():
             print("Pipeline stopped: TypeScript analyzer failed")
+            return self.results
+
+        # Empty repository (zero JS-family files): the analyzer already wrote
+        # valid empty outputs and recorded synthetic successful stages. There is
+        # nothing for the unit generator or optional downstream stages to do, so
+        # report success directly instead of crashing.
+        if self.empty_repo:
+            self.results['success'] = True
+            print("=" * 60)
+            print("PIPELINE SUMMARY")
+            print("=" * 60)
+            print(f"{SYM_OK} Empty repository: 0 units (graceful)")
             return self.results
 
         # Stage 3: Unit Generator

--- a/libs/openant-core/parsers/javascript/typescript_analyzer.js
+++ b/libs/openant-core/parsers/javascript/typescript_analyzer.js
@@ -59,7 +59,12 @@ class TypeScriptAnalyzer {
     });
     this.functions = {}; // functionId -> function metadata
     this.classes = {};   // "filePath:className" -> { constructorDeps, fieldDeps, baseTypes }
-    this.callGraph = {}; // callerId -> array of call info
+    this.callGraph = {}; // callerId -> array of call info { resolved, name }
+    // Resolved bidirectional graph (snake_case, list-of-resolved-ids) matching
+    // the C/Python/Ruby sibling contract consumed by the Python pipeline.
+    this.resolvedCallGraph = {};  // callerId -> [resolvedCalleeId]
+    this.reverseCallGraph = {};   // calleeId -> [callerId]
+    this.indirectCalls = {};      // callerId -> [unresolved/dynamic call names]
   }
 
   /**
@@ -100,16 +105,24 @@ class TypeScriptAnalyzer {
   }
 
   /**
-   * Check if function has route handler signature (req, res) or (request, response)
+   * Check if a function's parameter shape matches a known web-framework route
+   * handler (Express / Koa / Fastify).
+   *
+   * The bare `(request, response)` pattern was removed: it is ambiguous and
+   * misfires on React components (`function MyComponent(request, response)`)
+   * which share those parameter names. Fastify's distinctive
+   * `(request, reply)` shape is added. The
+   * remaining patterns (`(req, res)`, Koa `(ctx)`, TS `: Request`/`: Response`
+   * type annotations) are framework-specific enough to be reliable.
    */
   _hasRouteHandlerSignature(code) {
-    // Match common Express handler patterns
     const handlerPatterns = [
-      /\(\s*req\s*,\s*res\s*[,\)]/, // (req, res) or (req, res, next)
-      /\(\s*request\s*,\s*response\s*[,\)]/, // (request, response)
+      /\(\s*req\s*,\s*res\s*[,\)]/, // Express (req, res) / (req, res, next)
+      /\(\s*request\s*,\s*reply\s*[,\)]/, // Fastify (request, reply)
       /\(\s*ctx\s*[,\)]/, // Koa style (ctx)
       /:\s*Request\s*,/, // TypeScript: Request type
       /:\s*Response\s*[,\)]/, // TypeScript: Response type
+      /:\s*FastifyRequest\b/, // TypeScript Fastify: FastifyRequest type
     ];
     return handlerPatterns.some((pattern) => pattern.test(code));
   }
@@ -162,10 +175,44 @@ class TypeScriptAnalyzer {
       this.buildCallGraphForFile(sourceFile);
     }
 
+    // Step 4: Backstop the Pattern-A companion invariant — every function in
+    // the inventory must have a callGraph key.
+    // The emit-time companions above cover the AST-walked paths; this fills any
+    // remaining function (e.g. re-export references) with an empty edge list so
+    // `len(callGraph) === len(functions)` always holds.
+    for (const functionId of Object.keys(this.functions)) {
+      if (!(functionId in this.callGraph)) {
+        this.callGraph[functionId] = [];
+      }
+    }
+
+    // Step 4.5: Stamp the snake_case schema-contract fields downstream Python
+    // consumers expect. EntryPointDetector keys off `unit_type`;
+    // without it no Express route is ever seen as an entry point and every
+    // reachable callee is filtered out. We keep the camelCase `unitType` too so
+    // the JS unit_generator continues to work.
+    for (const funcData of Object.values(this.functions)) {
+      if (funcData.unit_type === undefined) {
+        funcData.unit_type = funcData.unitType || "function";
+      }
+      if (funcData.parameters === undefined) {
+        funcData.parameters = [];
+      }
+    }
+
+    // Step 5: Build the resolved bidirectional graph + per-function metadata
+    // expected by downstream Python consumers (snake_case call_graph /
+    // reverse_call_graph of resolved ids, repository, per-fn parameters).
+    this._buildResolvedGraphs();
+
     return {
+      repository: this.repoPath,
       functions: this.functions,
       classes: this.classes,
       callGraph: this.callGraph,
+      call_graph: this.resolvedCallGraph,
+      reverse_call_graph: this.reverseCallGraph,
+      indirect_calls: this.indirectCalls,
     };
   }
 
@@ -194,18 +241,24 @@ class TypeScriptAnalyzer {
         unitType: this.classifyFunction(name, code, false, null),
         startLine: func.getStartLineNumber(),
         endLine: func.getEndLineNumber(),
+        parameters: this._extractParameters(func),
       };
     }
 
-    // Extract arrow functions assigned to variables/constants
+    // Extract arrow functions assigned to variables/constants.
+    // Also covers Higher-Order-Component wrappers whose initializer is a call
+    // expression containing an inline function — `const X = memo(() => {})`,
+    // `forwardRef((p, r) => {})`, `styled.div\`...\``.
     for (const statement of sourceFile.getVariableStatements()) {
       for (const declaration of statement.getDeclarations()) {
         const initializer = declaration.getInitializer();
-        if (
-          initializer &&
-          (initializer.getKindName() === "ArrowFunction" ||
-            initializer.getKindName() === "FunctionExpression")
-        ) {
+        if (!initializer) continue;
+        const initKind = initializer.getKindName();
+        const isDirectFunction =
+          initKind === "ArrowFunction" || initKind === "FunctionExpression";
+        const isHocWrapper =
+          !isDirectFunction && this._isFunctionProducingInitializer(initializer);
+        if (isDirectFunction || isHocWrapper) {
           const name = declaration.getName();
           const code = statement.getFullText();
           const functionId = `${relativePath}:${name}`;
@@ -218,6 +271,9 @@ class TypeScriptAnalyzer {
             unitType: this.classifyFunction(name, code, false, null),
             startLine: statement.getStartLineNumber(),
             endLine: statement.getEndLineNumber(),
+            parameters: isDirectFunction
+              ? this._extractParameters(initializer)
+              : [],
           };
         }
       }
@@ -227,7 +283,14 @@ class TypeScriptAnalyzer {
     for (const classDecl of sourceFile.getClasses()) {
       const className = classDecl.getName() || "AnonymousClass";
 
-      for (const method of classDecl.getMethods()) {
+      // getMethods() excludes get/set accessors, so iterate the
+      // accessor lists too. They share the member-naming contract (Class.name).
+      const classMembers = [
+        ...classDecl.getMethods(),
+        ...classDecl.getGetAccessors(),
+        ...classDecl.getSetAccessors(),
+      ];
+      for (const method of classMembers) {
         const methodName = method.getName();
         const code = method.getFullText();
         const functionId = `${relativePath}:${className}.${methodName}`;
@@ -240,6 +303,7 @@ class TypeScriptAnalyzer {
           startLine: method.getStartLineNumber(),
           endLine: method.getEndLineNumber(),
           className: className,
+          parameters: this._extractParameters(method),
         };
       }
 
@@ -340,11 +404,427 @@ class TypeScriptAnalyzer {
     // Extract anonymous callbacks used as Express route handlers / middleware
     // Pattern: app.get('/x', auth, async (req, res) => {...})
     this._extractExpressRouteCallbacks(sourceFile, relativePath);
+
+    // Extract methods from class *expressions* (module.exports = class {...},
+    // const X = class {...}) which getClasses() does not return.
+    this._extractClassExpressionMethods(sourceFile, relativePath);
+
+    // Extract anonymous `export default function(){...}`.
+    this._extractAnonymousDefaultExport(sourceFile, relativePath);
+
+    // Extract prototype / this-assignment / Object.assign / defineProperty
+    // method shapes that aren't class members or top-level functions.
+    this._extractAssignedMethods(sourceFile, relativePath);
+
+    // Extract a synthetic unit for files whose only meaningful content is a
+    // bare top-level side-effect call, e.g. preload scripts calling
+    // contextBridge.exposeInMainWorld({...}).
+    this._extractTopLevelSideEffects(sourceFile, relativePath);
   }
 
   /**
-   * Express HTTP verbs we recognise on a router/app object.
-   * `use` is included to pick up middleware-mount callbacks.
+   * True if `node` is a call/tagged-template whose argument list contains an
+   * inline function — the Higher-Order-Component pattern. Examples:
+   *   memo(() => {})            forwardRef((p, r) => {})
+   *   React.memo(function(){})  styled.div`...`
+   */
+  _isFunctionProducingInitializer(node) {
+    if (!node) return false;
+    const kind = node.getKindName();
+    if (kind === "CallExpression") {
+      const args = node.getArguments ? node.getArguments() : [];
+      return args.some((a) => {
+        const k = a.getKindName();
+        return k === "ArrowFunction" || k === "FunctionExpression";
+      });
+    }
+    if (kind === "TaggedTemplateExpression") {
+      // styled.div`...` / css`...` — component-producing template tags.
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * True if `node` is a re-export reference value, e.g. `require('./x').foo`
+   * or a bare identifier/property-access that names an exported symbol.
+   */
+  _isReexportInitializer(node) {
+    if (!node) return false;
+    const kind = node.getKindName();
+    if (kind === "PropertyAccessExpression") {
+      // require('./x').foo  or  mod.foo
+      return /require\s*\(|\./.test(node.getText());
+    }
+    return false;
+  }
+
+  /**
+   * Extract methods declared inside class *expressions* (not ClassDeclarations,
+   * which getClasses() already covers). Names the class from the binding it is
+   * assigned to where possible, else "AnonymousClass".
+   */
+  _extractClassExpressionMethods(sourceFile, relativePath) {
+    const classExprs = sourceFile.getDescendantsOfKind(
+      ts.SyntaxKind.ClassExpression,
+    );
+    for (const classExpr of classExprs) {
+      const className =
+        (classExpr.getName && classExpr.getName()) ||
+        this._inferAssignedName(classExpr) ||
+        "AnonymousClass";
+
+      const methods = classExpr.getMethods ? classExpr.getMethods() : [];
+      for (const method of methods) {
+        const methodName = method.getName();
+        const functionId = `${relativePath}:${className}.${methodName}`;
+        if (this.functions[functionId]) continue;
+        const code = method.getFullText();
+        this.functions[functionId] = {
+          name: `${className}.${methodName}`,
+          code: code,
+          isExported: false,
+          unitType: this.classifyFunction(methodName, code, true, className),
+          startLine: method.getStartLineNumber(),
+          endLine: method.getEndLineNumber(),
+          className: className,
+        };
+        this.callGraph[functionId] = this.extractCallsFromFunction(
+          method,
+          relativePath,
+        );
+      }
+    }
+  }
+
+  /**
+   * Infer the binding name a node is assigned to:
+   *   const X = <node>            -> "X"
+   *   module.exports = <node>     -> "exports"
+   */
+  _inferAssignedName(node) {
+    const parent = node.getParent && node.getParent();
+    if (!parent) return null;
+    const pk = parent.getKindName();
+    if (pk === "VariableDeclaration" && parent.getName) {
+      return parent.getName();
+    }
+    if (pk === "BinaryExpression" && parent.getLeft) {
+      const leftText = parent.getLeft().getText();
+      if (leftText === "module.exports" || leftText === "exports") {
+        return "exports";
+      }
+      return leftText;
+    }
+    return null;
+  }
+
+  /**
+   * Extract anonymous `export default function(){...}`.
+   *
+   * ts-morph parses `export default function(){}` as a *nameless* exported
+   * FunctionDeclaration (the named-declaration loop skips it via
+   * `if (!name) continue`), and parses `export default () => {}` as an
+   * ExportAssignment. Handle both.
+   */
+  _extractAnonymousDefaultExport(sourceFile, relativePath) {
+    const emit = (node, code, bodyNode) => {
+      const functionId = `${relativePath}:default`;
+      if (this.functions[functionId]) return;
+      this.functions[functionId] = {
+        name: "default",
+        code: code,
+        isExported: true,
+        unitType: this.classifyFunction("default", code, false, null),
+        startLine: node.getStartLineNumber(),
+        endLine: node.getEndLineNumber(),
+        exportType: "default",
+      };
+      this.callGraph[functionId] = this.extractCallsFromFunction(
+        bodyNode,
+        relativePath,
+      );
+    };
+
+    // Nameless default-exported function declaration.
+    for (const func of sourceFile.getFunctions()) {
+      if (func.getName()) continue;
+      if (func.isDefaultExport && func.isDefaultExport()) {
+        emit(func, func.getFullText(), func);
+      }
+    }
+
+    // `export default () => {}` / `export default function(){}` expressions.
+    for (const exportDecl of sourceFile.getExportAssignments()) {
+      if (exportDecl.isExportEquals && exportDecl.isExportEquals()) continue;
+      const expr = exportDecl.getExpression();
+      if (!expr) continue;
+      const k = expr.getKindName();
+      if (k === "ArrowFunction" || k === "FunctionExpression") {
+        emit(exportDecl, exportDecl.getFullText(), expr);
+      }
+    }
+  }
+
+  /**
+   * Extract function-valued assignments that aren't class members or named
+   * declarations:
+   *   Foo.prototype.bar = function(){}
+   *   function Ctor(){ this.method = fn; }
+   *   Object.assign(Foo.prototype, { m(){}, n: fn })
+   *   Object.defineProperty(X.prototype, "n", { value: fn })
+   *
+   * We walk every CallExpression / BinaryExpression descendant so the shape is
+   * found regardless of whether it lives at top level or inside a constructor
+   * function body.
+   */
+  _extractAssignedMethods(sourceFile, relativePath) {
+    // 1. Assignment expressions: X.prototype.m = fn  /  this.m = fn
+    for (const bin of sourceFile.getDescendantsOfKind(
+      ts.SyntaxKind.BinaryExpression,
+    )) {
+      if (bin.getOperatorToken().getText() !== "=") continue;
+      const left = bin.getLeft();
+      const right = bin.getRight();
+      if (!left || left.getKindName() !== "PropertyAccessExpression") continue;
+      const rk = right && right.getKindName();
+      if (rk !== "ArrowFunction" && rk !== "FunctionExpression") continue;
+
+      const qualified = this._qualifiedNameForAssignmentTarget(
+        left,
+        bin,
+        relativePath,
+      );
+      if (!qualified) continue;
+      this._emitAssignedFunction(qualified, right, relativePath);
+    }
+
+    // 2. Object.assign(<ClassOrProto>, { ... })  and
+    //    Object.defineProperty(<ClassOrProto>, "name", { value: fn })
+    for (const call of sourceFile.getDescendantsOfKind(
+      ts.SyntaxKind.CallExpression,
+    )) {
+      const callee = call.getExpression();
+      if (!callee || callee.getKindName() !== "PropertyAccessExpression") {
+        continue;
+      }
+      const objText =
+        callee.getExpression && callee.getExpression()
+          ? callee.getExpression().getText()
+          : null;
+      const member = callee.getName ? callee.getName() : null;
+      if (objText !== "Object") continue;
+      const args = call.getArguments();
+
+      if (member === "assign" && args.length >= 2) {
+        const target = this._receiverClassName(args[0]);
+        if (!target) continue;
+        const objLit = args[1];
+        if (objLit.getKindName() !== "ObjectLiteralExpression") continue;
+        for (const prop of objLit.getProperties()) {
+          const pk = prop.getKindName();
+          let propName = null;
+          let fnNode = null;
+          if (pk === "MethodDeclaration") {
+            propName = prop.getName();
+            fnNode = prop;
+          } else if (pk === "PropertyAssignment") {
+            propName = prop.getName();
+            const init = prop.getInitializer();
+            const ik = init && init.getKindName();
+            if (ik === "ArrowFunction" || ik === "FunctionExpression") {
+              fnNode = init;
+            }
+          }
+          if (propName && fnNode) {
+            this._emitAssignedFunction(
+              `${target}.${propName}`,
+              fnNode,
+              relativePath,
+            );
+          }
+        }
+      } else if (member === "defineProperty" && args.length >= 3) {
+        const target = this._receiverClassName(args[0]);
+        const nameArg = args[1];
+        const descriptor = args[2];
+        if (!target) continue;
+        if (
+          nameArg.getKindName() !== "StringLiteral" ||
+          descriptor.getKindName() !== "ObjectLiteralExpression"
+        ) {
+          continue;
+        }
+        const propName = nameArg.getLiteralValue
+          ? nameArg.getLiteralValue()
+          : nameArg.getText().slice(1, -1);
+        for (const prop of descriptor.getProperties()) {
+          if (prop.getKindName() !== "PropertyAssignment") continue;
+          const dName = prop.getName();
+          if (dName !== "value" && dName !== "get" && dName !== "set") continue;
+          const init = prop.getInitializer();
+          const ik = init && init.getKindName();
+          if (ik === "ArrowFunction" || ik === "FunctionExpression") {
+            this._emitAssignedFunction(
+              `${target}.${propName}`,
+              init,
+              relativePath,
+            );
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Map an assignment target PropertyAccessExpression to a qualified
+   * "Class.member" name.
+   *   Foo.prototype.bar  -> "Foo.bar"
+   *   this.bar (in fn F)  -> "F.bar"
+   */
+  _qualifiedNameForAssignmentTarget(left, binExpr, relativePath) {
+    const member = left.getName ? left.getName() : null;
+    if (!member) return null;
+    const obj = left.getExpression ? left.getExpression() : null;
+    if (!obj) return null;
+    const objKind = obj.getKindName();
+
+    if (objKind === "PropertyAccessExpression") {
+      // Foo.prototype.bar  ->  obj is `Foo.prototype`
+      if (obj.getName && obj.getName() === "prototype") {
+        const cls = obj.getExpression ? obj.getExpression().getText() : null;
+        if (cls) return `${cls}.${member}`;
+      }
+      return null;
+    }
+
+    if (objKind === "ThisKeyword") {
+      // this.bar — name the enclosing function as the class.
+      const cls = this._enclosingFunctionName(binExpr);
+      if (cls) return `${cls}.${member}`;
+    }
+    return null;
+  }
+
+  /**
+   * The name of the nearest enclosing named function declaration (used to
+   * label `this.method = fn` assignments inside constructor functions).
+   */
+  _enclosingFunctionName(node) {
+    let cur = node.getParent && node.getParent();
+    while (cur) {
+      const k = cur.getKindName();
+      if (k === "FunctionDeclaration" && cur.getName && cur.getName()) {
+        return cur.getName();
+      }
+      cur = cur.getParent && cur.getParent();
+    }
+    return null;
+  }
+
+  /**
+   * Resolve a `Object.assign`/`Object.defineProperty` first argument to a class
+   * name. Accepts `Foo.prototype` -> "Foo" and bare `Foo` -> "Foo".
+   */
+  _receiverClassName(arg) {
+    if (!arg) return null;
+    const k = arg.getKindName();
+    if (k === "PropertyAccessExpression") {
+      if (arg.getName && arg.getName() === "prototype") {
+        return arg.getExpression ? arg.getExpression().getText() : null;
+      }
+      return null;
+    }
+    if (k === "Identifier") {
+      return arg.getText();
+    }
+    return null;
+  }
+
+  /**
+   * Emit a function entry for an assigned method shape, keyed
+   * "<relativePath>:<qualifiedName>".
+   */
+  _emitAssignedFunction(qualifiedName, fnNode, relativePath) {
+    const functionId = `${relativePath}:${qualifiedName}`;
+    if (this.functions[functionId]) return;
+    const code = fnNode.getFullText();
+    const methodName = qualifiedName.includes(".")
+      ? qualifiedName.split(".").pop()
+      : qualifiedName;
+    const className = qualifiedName.includes(".")
+      ? qualifiedName.slice(0, qualifiedName.lastIndexOf("."))
+      : null;
+    this.functions[functionId] = {
+      name: qualifiedName,
+      code: code,
+      isExported: false,
+      unitType: this.classifyFunction(methodName, code, className !== null, className),
+      startLine: fnNode.getStartLineNumber(),
+      endLine: fnNode.getEndLineNumber(),
+      className: className,
+    };
+    // Pattern-A companion: emit the callGraph entry alongside the function so
+    // `len(callGraph) === len(functions)` holds.
+    this.callGraph[functionId] = this.extractCallsFromFunction(
+      fnNode,
+      relativePath,
+    );
+  }
+
+  /**
+   * Emit a synthetic unit when a file's top-level statements are dominated by
+   * a bare side-effect call (e.g. an Electron preload script that only calls
+   * contextBridge.exposeInMainWorld({...})). Without this, such files yield
+   * zero units even though they carry analysable behaviour.
+   */
+  _extractTopLevelSideEffects(sourceFile, relativePath) {
+    // Only synthesise when the regular extractors produced nothing for this
+    // file — otherwise we'd duplicate real functions/methods.
+    const filePrefix = `${relativePath}:`;
+    const hasAny = Object.keys(this.functions).some((id) =>
+      id.startsWith(filePrefix),
+    );
+    if (hasAny) return;
+
+    for (const statement of sourceFile.getStatements()) {
+      if (statement.getKindName() !== "ExpressionStatement") continue;
+      const expr = statement.getExpression();
+      if (!expr || expr.getKindName() !== "CallExpression") continue;
+
+      const callee = expr.getExpression();
+      let label = "module";
+      if (callee && callee.getKindName() === "PropertyAccessExpression") {
+        const obj = callee.getExpression
+          ? callee.getExpression().getText()
+          : "";
+        const member = callee.getName ? callee.getName() : "";
+        label = member ? `${obj}.${member}` : obj || "module";
+      } else if (callee && callee.getKindName() === "Identifier") {
+        label = callee.getText();
+      }
+
+      const functionId = `${relativePath}:${label}`;
+      if (this.functions[functionId]) continue;
+      const code = statement.getFullText();
+      this.functions[functionId] = {
+        name: label,
+        code: code,
+        isExported: false,
+        unitType: "module_level",
+        startLine: statement.getStartLineNumber(),
+        endLine: statement.getEndLineNumber(),
+      };
+      // One synthetic unit per file is enough to make the file analysable.
+      return;
+    }
+  }
+
+  /**
+   * HTTP verbs we recognise on a router/app/server object. Shared by Express,
+   * Fastify and Koa router DSLs. `use` is included to pick
+   * up middleware-mount callbacks; `route` covers `app.route('/x', handler)`
+   * style registrations.
    */
   static EXPRESS_VERBS = new Set([
     "get",
@@ -355,6 +835,7 @@ class TypeScriptAnalyzer {
     "options",
     "head",
     "all",
+    "route",
     "use",
   ]);
 
@@ -386,13 +867,15 @@ class TypeScriptAnalyzer {
    * receivers so generic `.get(...)` calls on caches / clients / query-builders
    * aren't misread as routes.
    *
-   * Accepted stems: app, router, routes, server, web, api, endpoints, controller.
-   * Codebases using single-word identifiers outside this list (e.g. `http`) will
-   * not be extracted; add the stem here if needed.
+   * Accepted stems: app, router, routes, server, web, api, endpoints,
+   * controller, plus framework names fastify and koa so
+   * `fastify.get(...)` / `koa.get(...)` registrations are recognised alongside
+   * Express. Codebases using single-word identifiers outside this list (e.g.
+   * `http`) will not be extracted; add the stem here if needed.
    */
-  // Stems that strongly suggest an Express app/router object.
+  // Stems that strongly suggest an Express/Fastify/Koa app/router/server object.
   static EXPRESS_RECEIVER_STEMS =
-    "app|router|routes|server|web|api|endpoints|controller";
+    "app|router|routes|server|web|api|endpoints|controller|fastify|koa";
 
   _isPlausibleExpressReceiver(receiver) {
     if (!receiver) return false;
@@ -667,6 +1150,11 @@ class TypeScriptAnalyzer {
                   endLine: statement.getEndLineNumber(),
                   exportType: "commonjs",
                 };
+                // Pattern-A companion.
+                this.callGraph[functionId] = this.extractCallsFromFunction(
+                  right,
+                  relativePath,
+                );
               }
             }
           }
@@ -688,11 +1176,15 @@ class TypeScriptAnalyzer {
         kindName === "PropertyAssignment"
       ) {
         let name, code;
+        // The AST node whose body holds the function's call expressions, used
+        // to emit the Pattern-A callGraph companion. null for re-exports.
+        let bodyNode = null;
 
         if (kindName === "MethodDeclaration") {
           // Pattern: { methodName() { ... } }
           name = property.getName();
           code = property.getFullText();
+          bodyNode = property;
         } else if (kindName === "ShorthandPropertyAssignment") {
           // Pattern: { methodName } - references a variable defined elsewhere
           name = property.getName();
@@ -701,6 +1193,9 @@ class TypeScriptAnalyzer {
           continue;
         } else if (kindName === "PropertyAssignment") {
           // Pattern: { methodName: () => { ... } } or { methodName: function() { ... } }
+          // Also re-export barrels: { foo: require('./x').foo } — the value is
+          // a function reference, not an inline function. We surface
+          // the property so the re-exported symbol is visible downstream.
           name = property.getName();
           const initializer = property.getInitializer();
           if (
@@ -709,8 +1204,11 @@ class TypeScriptAnalyzer {
               initializer.getKindName() === "FunctionExpression")
           ) {
             code = property.getFullText();
+            bodyNode = initializer;
+          } else if (initializer && this._isReexportInitializer(initializer)) {
+            code = property.getFullText();
           } else {
-            continue; // Not a function
+            continue; // Not a function or re-export
           }
         }
 
@@ -727,6 +1225,14 @@ class TypeScriptAnalyzer {
               endLine: property.getEndLineNumber(),
               exportType: exportType,
             };
+            // Pattern-A companion. Re-export references have no
+            // inline body; the Step-4 backstop fills them with [].
+            if (bodyNode) {
+              this.callGraph[functionId] = this.extractCallsFromFunction(
+                bodyNode,
+                relativePath,
+              );
+            }
           }
         }
       }
@@ -778,7 +1284,14 @@ class TypeScriptAnalyzer {
     for (const classDecl of sourceFile.getClasses()) {
       const className = classDecl.getName() || "AnonymousClass";
 
-      for (const method of classDecl.getMethods()) {
+      // Mirror the inventory builder: include get/set accessors so
+      // every emitted function gets a callGraph companion (Pattern-A).
+      const classMembers = [
+        ...classDecl.getMethods(),
+        ...classDecl.getGetAccessors(),
+        ...classDecl.getSetAccessors(),
+      ];
+      for (const method of classMembers) {
         const methodName = method.getName();
         const callerId = `${relativePath}:${className}.${methodName}`;
         this.callGraph[callerId] = this.extractCallsFromFunction(
@@ -790,29 +1303,164 @@ class TypeScriptAnalyzer {
   }
 
   /**
-   * Extract function calls from within a function body
+   * Parameter names for a function-like node, used to populate the per-function
+   * `parameters` schema field. Returns [] when the node has no
+   * getParameters() accessor.
+   */
+  _extractParameters(node) {
+    if (!node || !node.getParameters) return [];
+    try {
+      return node.getParameters().map((p) => p.getName());
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Normalise a call-expression callee to a simple identifier name, matching
+   * the C parser's `_extract_call_name` contract:
+   *   plain(...)                 -> "plain"
+   *   obj.method(...)            -> "method"   (trailing member)
+   *   foo.bar().baz(...)         -> "baz"      (trailing member of the chain)
+   *   obj['m'](...)              -> null       (dynamic / element access)
+   *   (expr)(...)                -> null
+   * Returns null when no stable identifier name can be derived (the call is
+   * then treated as dynamic/indirect).
+   */
+  _normalizeCallName(calleeExpr) {
+    if (!calleeExpr) return null;
+    const kind = calleeExpr.getKindName();
+    if (kind === "Identifier") {
+      return calleeExpr.getText();
+    }
+    if (kind === "PropertyAccessExpression") {
+      // Trailing member name (e.g. `baz` from `foo.bar().baz`).
+      return calleeExpr.getName ? calleeExpr.getName() : null;
+    }
+    // ElementAccessExpression (obj['m']), ParenthesizedExpression, etc. have no
+    // stable identifier name — treat as dynamic.
+    return null;
+  }
+
+  /**
+   * Extract function calls from within a function body.
+   *
+   * Each entry is { resolved, name, dynamic }:
+   *  - `name` is the normalised callee identifier or null.
+   *  - `dynamic` is true when the callee has no stable identifier name
+   *    (element access, IIFE, etc.) — bucketed into indirect_calls.
+   * Identifier arguments passed to a call (callback arguments) are also
+   * recorded as edges so `addEventListener('click', handler)` / `setTimeout(cb)`
+   * / `arr.forEach(cb)` relationships are visible.
    */
   extractCallsFromFunction(funcNode, currentFile) {
     const calls = [];
-    const callExpressions = funcNode
-      .getDescendantsOfKind(funcNode.getKind())
-      .filter((n) => n.getKindName() === "CallExpression");
+    const seen = new Set();
+    const pushName = (name, dynamic) => {
+      const key = `${name} ${dynamic ? 1 : 0}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      calls.push({ resolved: false, name: name, dynamic: dynamic });
+    };
 
-    // This is simplified - a full implementation would:
-    // 1. Resolve import/require statements
-    // 2. Track variable assignments
-    // 3. Resolve member expressions (obj.method())
-    // 4. Handle dynamic calls
+    const callExpressions = funcNode.getDescendantsOfKind(
+      ts.SyntaxKind.CallExpression,
+    );
 
-    // For now, just track that calls exist without full resolution
     for (const callExpr of callExpressions) {
-      calls.push({
-        resolved: false,
-        name: callExpr.getExpression().getText(),
-      });
+      const callee = callExpr.getExpression();
+      const normalized = this._normalizeCallName(callee);
+      if (normalized) {
+        pushName(normalized, false);
+      } else {
+        // Dynamic / element-access callee — record the raw span trimmed to a
+        // single line so node names never become multiline blobs.
+        const raw = callee ? callee.getText().replace(/\s+/g, " ").trim() : "";
+        pushName(raw, true);
+      }
+
+      // Callback arguments: bare identifiers handed to the call become edges.
+      for (const arg of callExpr.getArguments()) {
+        if (arg.getKindName() === "Identifier") {
+          pushName(arg.getText(), false);
+        }
+      }
     }
 
     return calls;
+  }
+
+  /**
+   * Build the resolved bidirectional call graph and indirect-call buckets in
+   * the snake_case shape the Python pipeline consumes. Resolution is JS-native
+   * and conservative:
+   * same-file name match, else unique-name match across the repo — mirroring
+   * the contract the C/Ruby siblings satisfy, without lifting their code.
+   *
+   * Also stamps per-function `parameters` metadata so the schema contract is
+   * complete.
+   */
+  _buildResolvedGraphs() {
+    // Index functions by file and by simple name for resolution.
+    const byFile = Object.create(null);
+    const byName = Object.create(null);
+    for (const funcId of Object.keys(this.functions)) {
+      const file = funcId.slice(0, funcId.lastIndexOf(":"));
+      (byFile[file] = byFile[file] || []).push(funcId);
+      const simple = (this.functions[funcId].name || "").split(".").pop();
+      (byName[simple] = byName[simple] || []).push(funcId);
+    }
+
+    const resolveName = (name, callerFile) => {
+      // 1. Same-file simple-name match.
+      for (const funcId of byFile[callerFile] || []) {
+        const fname = this.functions[funcId].name || "";
+        if (fname === name || fname.endsWith("." + name)) return funcId;
+      }
+      // 2. Unique-name match across the repo.
+      const candidates = byName[name];
+      if (candidates && candidates.length === 1) return candidates[0];
+      return null;
+    };
+
+    for (const [callerId, edges] of Object.entries(this.callGraph)) {
+      const callerFile = callerId.slice(0, callerId.lastIndexOf(":"));
+      const resolvedTargets = [];
+      const indirect = [];
+
+      for (const edge of edges) {
+        const name = edge && edge.name;
+        if (!name) continue;
+        if (edge.dynamic) {
+          if (!indirect.includes(name)) indirect.push(name);
+          continue;
+        }
+        const target = resolveName(name, callerFile);
+        if (target && target !== callerId) {
+          if (!resolvedTargets.includes(target)) resolvedTargets.push(target);
+        } else if (!target) {
+          // Unresolvable static name — bucket as indirect so it isn't lost.
+          if (!indirect.includes(name)) indirect.push(name);
+        }
+      }
+
+      this.resolvedCallGraph[callerId] = resolvedTargets;
+      if (indirect.length > 0) this.indirectCalls[callerId] = indirect;
+
+      for (const target of resolvedTargets) {
+        (this.reverseCallGraph[target] = this.reverseCallGraph[target] || []);
+        if (!this.reverseCallGraph[target].includes(callerId)) {
+          this.reverseCallGraph[target].push(callerId);
+        }
+      }
+    }
+
+    // Ensure every function has a (possibly empty) resolved entry.
+    for (const funcId of Object.keys(this.functions)) {
+      if (!(funcId in this.resolvedCallGraph)) {
+        this.resolvedCallGraph[funcId] = [];
+      }
+    }
   }
 }
 
@@ -857,7 +1505,14 @@ function extractSingleFunction(filePath, functionRef) {
       for (const classDecl of sourceFile.getClasses()) {
         const classNameMatch = classDecl.getName();
         if (classNameMatch === className) {
-          for (const method of classDecl.getMethods()) {
+          // getMethods() excludes get/set accessors, so search the
+          // accessor lists too when resolving a single member by name.
+          const classMembers = [
+            ...classDecl.getMethods(),
+            ...classDecl.getGetAccessors(),
+            ...classDecl.getSetAccessors(),
+          ];
+          for (const method of classMembers) {
             if (method.getName() === functionName) {
               foundFunction = {
                 node: method,

--- a/libs/openant-core/parsers/javascript/unit_generator.js
+++ b/libs/openant-core/parsers/javascript/unit_generator.js
@@ -196,9 +196,11 @@ class UnitGenerator {
         const files = new Set();
         files.add(primaryFilePath);
 
+        // Separator is the FIRST colon (matches the dependency_resolver
+        // contract); functionName may itself contain colons.
         for (const dep of upstreamDependencies) {
             if (dep.id) {
-                const colonIndex = dep.id.lastIndexOf(':');
+                const colonIndex = dep.id.indexOf(':');
                 if (colonIndex > 0) {
                     files.add(dep.id.substring(0, colonIndex));
                 }
@@ -207,7 +209,7 @@ class UnitGenerator {
 
         for (const caller of downstreamCallers) {
             if (caller.id) {
-                const colonIndex = caller.id.lastIndexOf(':');
+                const colonIndex = caller.id.indexOf(':');
                 if (colonIndex > 0) {
                     files.add(caller.id.substring(0, colonIndex));
                 }
@@ -221,8 +223,12 @@ class UnitGenerator {
      * Create a single analysis unit
      */
     _createUnit(functionId, funcData, routeHandlerMap) {
-        // Parse function ID: "relative/path/file.ts:functionName"
-        const colonIndex = functionId.lastIndexOf(':');
+        // Parse function ID: "relative/path/file.ts:functionName".
+        // The separator is the FIRST colon: the functionName may itself contain
+        // colons (e.g. an Express route id "src/r.ts:express(GET:/items/:id)").
+        // This matches the dependency_resolver contract (`funcId.split(':')[0]`)
+        // and recovers filePath/functionName correctly for multi-colon ids.
+        const colonIndex = functionId.indexOf(':');
         const filePath = functionId.substring(0, colonIndex);
         const functionName = functionId.substring(colonIndex + 1);
 

--- a/libs/openant-core/parsers/javascript/unit_generator.js
+++ b/libs/openant-core/parsers/javascript/unit_generator.js
@@ -49,6 +49,11 @@ const fs = require('fs');
 const path = require('path');
 const { DependencyResolver } = require('./dependency_resolver');
 
+// File boundary marker for enhanced code (module-level for parity with the
+// python/php/c/ruby parsers, so external consumers can import the canonical
+// marker instead of re-defining it and risking silent drift).
+const FILE_BOUNDARY = '\n\n// ========== File Boundary ==========\n\n';
+
 class UnitGenerator {
     constructor(repoPath, datasetName = null, options = {}) {
         this.repoPath = repoPath;
@@ -162,7 +167,6 @@ class UnitGenerator {
      * Matches DVNA enhanced dataset format expected by experiment.py
      */
     _assembleEnhancedCode(funcData, upstreamDependencies, downstreamCallers) {
-        const FILE_BOUNDARY = '\n\n// ========== File Boundary ==========\n\n';
         const parts = [];
         const includedCode = new Set();
 
@@ -479,4 +483,4 @@ if (require.main === module) {
     }
 }
 
-module.exports = { UnitGenerator };
+module.exports = { UnitGenerator, FILE_BOUNDARY };

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -42,7 +42,9 @@ from tree_sitter import Language, Parser
 from utilities.file_io import read_json, write_json, open_utf8
 
 
-PHP_LANGUAGE = Language(ts_php.language_php())
+# Use the tagless grammar variant: function bodies are re-parsed WITHOUT their <?php tag (func_data
+# ['code'] is tag-stripped), and language_php() treats tagless input as inert 'text' (0 call nodes).
+PHP_LANGUAGE = Language(ts_php.language_php_only())
 
 # PHP builtins and common functions to filter out
 PHP_BUILTINS = {
@@ -85,6 +87,15 @@ PHP_BUILTINS = {
     'array_chunk', 'array_column', 'array_pad',
     'array_intersect', 'array_diff', 'range',
     'call_user_func', 'call_user_func_array',
+}
+
+# Higher-order builtins whose callback argument is a real call edge. Maps builtin name -> the 0-based
+# position of the callback argument. The outer builtin call is still filtered (it is in PHP_BUILTINS);
+# we additionally resolve the callback it dispatches to.
+CALLBACK_BUILTINS = {
+    'call_user_func': 0, 'call_user_func_array': 0,
+    'array_map': 0, 'array_filter': 1, 'array_walk': 1, 'array_reduce': 1,
+    'usort': 1, 'uasort': 1, 'uksort': 1, 'preg_replace_callback': 1,
 }
 
 # PHP keywords to skip in regex fallback
@@ -153,7 +164,7 @@ class CallGraphBuilder:
 
     def _is_builtin(self, name: str) -> bool:
         """Check if name is a PHP builtin or common function."""
-        return name in PHP_BUILTINS
+        return name.lower() in PHP_BUILTINS  # PHP function names are case-insensitive
 
     def _extract_calls_from_code(self, code: str, caller_id: str) -> Set[str]:
         """Extract function call references from code using tree-sitter."""
@@ -172,7 +183,7 @@ class CallGraphBuilder:
         while stack:
             node = stack.pop()
             if node.type in ('function_call_expression', 'member_call_expression',
-                             'scoped_call_expression'):
+                             'scoped_call_expression', 'object_creation_expression'):
                 resolved = self._resolve_call_node(node, code_bytes, caller_file, caller_class)
                 if resolved:
                     calls.add(resolved)
@@ -189,6 +200,8 @@ class CallGraphBuilder:
             return self._resolve_member_call(node, source, caller_file, caller_class)
         elif node.type == 'scoped_call_expression':
             return self._resolve_scoped_call(node, source, caller_file, caller_class)
+        elif node.type == 'object_creation_expression':
+            return self._resolve_new(node, source, caller_file, caller_class)
         return None
 
     def _resolve_function_call(self, node, source: bytes, caller_file: str,
@@ -211,9 +224,68 @@ class CallGraphBuilder:
             return None
 
         if self._is_builtin(func_name):
+            # Higher-order builtins (call_user_func, array_map, ...) drop the OUTER call, but the
+            # callback they dispatch to is a real edge -- resolve it instead of returning None.
+            cb_idx = CALLBACK_BUILTINS.get(func_name.lower())
+            if cb_idx is not None:
+                return self._resolve_callback_arg(node, source, caller_file, caller_class, cb_idx)
             return None
 
         return self._resolve_simple_call(func_name, caller_file, caller_class)
+
+    def _resolve_callback_arg(self, node, source: bytes, caller_file: str,
+                              caller_class: Optional[str], idx: int) -> Optional[str]:
+        """Resolve the callback argument at position `idx` of a higher-order builtin call.
+
+        Only string-literal callbacks have a static target: 'fn', 'Class::method', or the array form
+        ['Class', 'method']. Variable/closure callbacks ($cb, fn() => ...) have no resolvable target.
+        """
+        args_node = next((c for c in node.children if c.type == 'arguments'), None)
+        if args_node is None:
+            return None
+        arg_nodes = [c for c in args_node.children if c.type == 'argument']
+        if idx >= len(arg_nodes) or not arg_nodes[idx].children:
+            return None
+        value = arg_nodes[idx].children[0]
+        if value.type == 'string':
+            name = source[value.start_byte:value.end_byte].decode('utf-8', errors='replace').strip('\'"')
+            return self._resolve_callback_name(name, caller_file, caller_class)
+        if value.type == 'array_creation_expression':
+            # ['ClassName', 'method'] static callback (instance [$obj,'m'] needs a type we don't track).
+            strings = []
+            stack = [value]
+            while stack:
+                n = stack.pop()
+                if n.type == 'string':
+                    strings.append(source[n.start_byte:n.end_byte].decode('utf-8', errors='replace').strip('\'"'))
+                stack.extend(reversed(n.children))
+            if len(strings) >= 2:
+                return self._resolve_class_call(strings[0], strings[1], caller_file)
+        return None
+
+    def _resolve_callback_name(self, name: str, caller_file: str,
+                               caller_class: Optional[str]) -> Optional[str]:
+        """Resolve a string callback: 'Class::method' (static) or a plain function name."""
+        if '::' in name:
+            cls, _, method = name.partition('::')
+            return self._resolve_class_call(cls, method, caller_file)
+        if self._is_builtin(name):
+            return None
+        return self._resolve_simple_call(name, caller_file, caller_class)
+
+    def _resolve_new(self, node, source: bytes, caller_file: str,
+                     caller_class: Optional[str]) -> Optional[str]:
+        """Resolve `new ClassName(...)` to the class's __construct method, if one is defined."""
+        class_name = None
+        for child in node.children:
+            if child.type in ('name', 'qualified_name'):
+                class_name = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
+                if '\\' in class_name:
+                    class_name = class_name.rsplit('\\', 1)[-1]
+                break
+        if not class_name:
+            return None
+        return self._resolve_class_call(class_name, '__construct', caller_file)
 
     def _resolve_member_call(self, node, source: bytes, caller_file: str,
                               caller_class: Optional[str]) -> Optional[str]:
@@ -250,6 +322,10 @@ class CallGraphBuilder:
         for child in node.children:
             if child.type == 'name' and scope is not None:
                 method_name = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
+            elif child.type == 'relative_scope' and scope is None:
+                # self / static / parent are `relative_scope` nodes, not `name` -- without this branch
+                # the scope was never captured and self::/static::/parent:: calls were silently dropped.
+                scope = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
             elif child.type in ('name', 'qualified_name') and scope is None:
                 scope = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
                 if '\\' in scope:
@@ -264,11 +340,29 @@ class CallGraphBuilder:
             return None
 
         # self::method() or static::method() - same class
-        if scope in ('self', 'static', 'parent') and caller_class:
+        if scope in ('self', 'static') and caller_class:
             return self._resolve_self_call(method_name, caller_file, caller_class)
+
+        # parent::method() - resolve in the superclass (extends), not the caller's own class.
+        if scope == 'parent' and caller_class:
+            superclass = self._superclass_of(caller_file, caller_class)
+            if not superclass:
+                return None
+            if '\\' in superclass:
+                superclass = superclass.rsplit('\\', 1)[-1]  # `extends App\Base` -> match `Base`
+            # Resolve in the superclass only; do NOT fall back to the caller's own class, which would
+            # mis-link an overriding child's parent:: call to the child's own method.
+            return self._resolve_class_call(superclass, method_name, caller_file)
 
         # ClassName::method()
         return self._resolve_class_call(scope, method_name, caller_file)
+
+    def _superclass_of(self, caller_file: str, caller_class: str) -> Optional[str]:
+        """Return the superclass (extends) name of caller_class defined in caller_file, or None."""
+        for class_data in self.classes.values():
+            if class_data.get('name') == caller_class and class_data.get('file_path') == caller_file:
+                return class_data.get('superclass')
+        return None
 
     def _resolve_simple_call(self, func_name: str, caller_file: str,
                              caller_class: Optional[str]) -> Optional[str]:
@@ -290,9 +384,13 @@ class CallGraphBuilder:
         file_imports = self.imports.get(caller_file, {})
         for import_name, import_type in file_imports.items():
             if import_type in ('require', 'require_once', 'include', 'include_once', 'use'):
-                # Try matching import path to file
+                # Match the import by file name (anchored), not an unanchored `in` substring which
+                # over-matched any path merely containing the import string.
+                imp_base = import_name.replace('\\', '/').rsplit('/', 1)[-1]
                 for file_path in self.functions_by_file:
-                    if file_path.endswith(f"{import_name}.php") or import_name in file_path:
+                    if (file_path.endswith(f"{import_name}.php")
+                            or file_path.endswith(f"/{imp_base}.php")
+                            or file_path == f"{imp_base}.php"):
                         file_funcs = self.functions_by_file[file_path]
                         for func_id in file_funcs:
                             func_data = self.functions.get(func_id, {})

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -161,6 +161,7 @@ class CallGraphBuilder:
         caller_file = caller_id.split(':')[0]
         caller_func = self.functions.get(caller_id, {})
         caller_class = caller_func.get('class_name')
+        caller_namespace = caller_func.get('namespace_name')
 
         code_bytes = code.encode('utf-8', errors='replace')
         try:
@@ -173,7 +174,8 @@ class CallGraphBuilder:
             node = stack.pop()
             if node.type in ('function_call_expression', 'member_call_expression',
                              'scoped_call_expression'):
-                resolved = self._resolve_call_node(node, code_bytes, caller_file, caller_class)
+                resolved = self._resolve_call_node(node, code_bytes, caller_file,
+                                                   caller_class, caller_namespace)
                 if resolved:
                     calls.add(resolved)
             stack.extend(reversed(node.children))
@@ -181,10 +183,12 @@ class CallGraphBuilder:
         return calls
 
     def _resolve_call_node(self, node, source: bytes, caller_file: str,
-                           caller_class: Optional[str]) -> Optional[str]:
+                           caller_class: Optional[str],
+                           caller_namespace: Optional[str] = None) -> Optional[str]:
         """Resolve a tree-sitter call node to a function ID."""
         if node.type == 'function_call_expression':
-            return self._resolve_function_call(node, source, caller_file, caller_class)
+            return self._resolve_function_call(node, source, caller_file, caller_class,
+                                               caller_namespace)
         elif node.type == 'member_call_expression':
             return self._resolve_member_call(node, source, caller_file, caller_class)
         elif node.type == 'scoped_call_expression':
@@ -192,7 +196,8 @@ class CallGraphBuilder:
         return None
 
     def _resolve_function_call(self, node, source: bytes, caller_file: str,
-                                caller_class: Optional[str]) -> Optional[str]:
+                                caller_class: Optional[str],
+                                caller_namespace: Optional[str] = None) -> Optional[str]:
         """Resolve a simple function call like func()."""
         func_name = None
 
@@ -213,7 +218,7 @@ class CallGraphBuilder:
         if self._is_builtin(func_name):
             return None
 
-        return self._resolve_simple_call(func_name, caller_file, caller_class)
+        return self._resolve_simple_call(func_name, caller_file, caller_class, caller_namespace)
 
     def _resolve_member_call(self, node, source: bytes, caller_file: str,
                               caller_class: Optional[str]) -> Optional[str]:
@@ -271,8 +276,9 @@ class CallGraphBuilder:
         return self._resolve_class_call(scope, method_name, caller_file)
 
     def _resolve_simple_call(self, func_name: str, caller_file: str,
-                             caller_class: Optional[str]) -> Optional[str]:
-        """Resolve a simple function call to a function ID."""
+                             caller_class: Optional[str],
+                             caller_namespace: Optional[str] = None) -> Optional[str]:
+        """Resolve a simple (unqualified) function call to a function ID."""
         # 1. Check same class first (implicit $this)
         if caller_class:
             result = self._resolve_self_call(func_name, caller_file, caller_class)
@@ -299,13 +305,29 @@ class CallGraphBuilder:
                             if func_data.get('name') == func_name:
                                 return func_id
 
-        # 4. Unique name match across files
+        # 4. Unique name match across files. An unqualified call resolves within
+        #    the caller's own namespace; a function in a different namespace is not
+        #    reachable this way, so a same-named function elsewhere must not leak an
+        #    edge across the namespace boundary.
         candidates = self.functions_by_name.get(func_name, [])
-        candidates = [c for c in candidates if not self.functions.get(c, {}).get('class_name')]
+        candidates = [c for c in candidates
+                      if not self.functions.get(c, {}).get('class_name')
+                      and self._namespace_compatible(
+                          self.functions.get(c, {}).get('namespace_name'), caller_namespace)]
         if len(candidates) == 1:
             return candidates[0]
 
         return None
+
+    @staticmethod
+    def _namespace_compatible(candidate_ns: Optional[str],
+                              caller_ns: Optional[str]) -> bool:
+        """Whether an unqualified call from caller_ns may bind a function in
+        candidate_ns. They must be the same namespace (treating None / '' / '\\'
+        as the global namespace)."""
+        def norm(ns):
+            return (ns or '').strip('\\')
+        return norm(candidate_ns) == norm(caller_ns)
 
     def _resolve_self_call(self, method_name: str, caller_file: str,
                            caller_class: str) -> Optional[str]:

--- a/libs/openant-core/parsers/php/function_extractor.py
+++ b/libs/openant-core/parsers/php/function_extractor.py
@@ -655,8 +655,11 @@ class FunctionExtractor:
         else:
             for ext in ('.php', '.phtml'):
                 for file_path in self.repo_path.rglob(f'*{ext}'):
-                    path_str = str(file_path)
-                    if any(excl in path_str for excl in ['.git', 'vendor', 'node_modules', 'tmp', '.cache']):
+                    # Exclude vendored/transient dirs by path COMPONENT relative to the repo, not by
+                    # absolute-path substring -- an ancestor dir (e.g. a /tmp working dir, as on Linux CI)
+                    # or a name like 'template' must not exclude the repo's own files.
+                    rel_parts = file_path.relative_to(self.repo_path).parts
+                    if any(excl in rel_parts for excl in ('.git', 'vendor', 'node_modules', 'tmp', '.cache')):
                         continue
                     self.process_file(file_path)
 

--- a/libs/openant-core/parsers/php/function_extractor.py
+++ b/libs/openant-core/parsers/php/function_extractor.py
@@ -195,15 +195,23 @@ class FunctionExtractor:
         while stack:
             node = stack.pop()
 
-            if node.type == 'use_declaration':
-                # Extract the full use statement value
+            if node.type in ('namespace_use_declaration', 'use_declaration'):
+                # tree-sitter-php emits `namespace_use_declaration` (not `use_declaration`) for
+                # `use App\Service\Foo;`, so the old node-type check matched nothing and use-imports
+                # were never recorded.
                 import_text = self._node_text(node, source)
-                # Clean up: remove 'use ' prefix and trailing ';'
                 cleaned = import_text.strip()
                 if cleaned.startswith('use '):
                     cleaned = cleaned[4:]
                 cleaned = cleaned.rstrip(';').strip()
-                imports[cleaned] = 'use'
+                # Handle grouped `use A\B, C\D;` and drop trailing `as Alias` so the stored import is
+                # the namespace path (matched by file name downstream).
+                for part in cleaned.split(','):
+                    entry = part.strip()
+                    if not entry:
+                        continue
+                    path = entry.split(' as ')[0].strip() if ' as ' in entry else entry
+                    imports[path] = 'use'
 
             elif node.type == 'namespace_definition':
                 # Extract namespace name

--- a/libs/openant-core/parsers/php/function_extractor.py
+++ b/libs/openant-core/parsers/php/function_extractor.py
@@ -238,6 +238,13 @@ class FunctionExtractor:
                     node, source, relative_path, class_name, namespace_name,
                     is_static=False
                 )
+                # Recurse into the body so nested closures/arrow functions are
+                # reached; named definitions cannot lexically nest other named
+                # functions/classes in PHP, so this only surfaces
+                # anonymous_function / arrow_function units.
+                for child in reversed(node.children):
+                    stack.append((child, class_name, namespace_name))
+                continue
 
             elif node.type == 'method_declaration':
                 is_static = self._is_static_method(node, source)
@@ -245,6 +252,24 @@ class FunctionExtractor:
                     node, source, relative_path, class_name, namespace_name,
                     is_static=is_static
                 )
+                for child in reversed(node.children):
+                    stack.append((child, class_name, namespace_name))
+                continue
+
+            elif node.type in ('anonymous_function', 'arrow_function'):
+                # Anonymous closures (`function ($x) {...}`) and arrow functions
+                # (`fn($z) => ...`) are unnamed; tree-sitter emits them as
+                # `anonymous_function` / `arrow_function`. Without this branch
+                # they fell through the catch-all else and were never modeled as
+                # units, so callback-heavy PHP was invisible.
+                self._process_closure_node(
+                    node, source, relative_path, class_name, namespace_name
+                )
+                # Still recurse so a closure declared inside another closure
+                # (or anything else nested in its body) is reached.
+                for child in reversed(node.children):
+                    stack.append((child, class_name, namespace_name))
+                continue
 
             elif node.type == 'class_declaration':
                 # Extract class name
@@ -462,6 +487,129 @@ class FunctionExtractor:
 
         self.stats['by_type'][unit_type] = self.stats['by_type'].get(unit_type, 0) + 1
 
+    def _process_closure_node(self, node, source: bytes, relative_path: str,
+                               class_name: Optional[str],
+                               namespace_name: Optional[str]) -> None:
+        """Process an anonymous_function or arrow_function node as a closure unit.
+
+        Closures are unnamed, so a synthetic name keyed on the source position
+        keeps the func_id unique within a file.
+        """
+        start_line = node.start_point[0] + 1  # tree-sitter is 0-indexed
+        end_line = node.end_point[0] + 1
+        start_col = node.start_point[1]
+
+        kind = 'arrow' if node.type == 'arrow_function' else 'closure'
+        name = f'{{{kind}@{start_line}:{start_col}}}'
+
+        code = self._node_text(node, source)
+        parameters = self._get_parameters(node, source)
+
+        # Qualify the synthetic name with the lexical owner so distinct closures
+        # in the same file do not collide.
+        if class_name:
+            qualified_name = f"{class_name}.{name}"
+        elif namespace_name:
+            qualified_name = f"{namespace_name}\\{name}"
+        else:
+            qualified_name = name
+
+        func_id = f"{relative_path}:{qualified_name}"
+
+        self.functions[func_id] = {
+            'name': name,
+            'qualified_name': qualified_name,
+            'file_path': relative_path,
+            'start_line': start_line,
+            'end_line': end_line,
+            'code': code,
+            'class_name': class_name,
+            'namespace_name': namespace_name,
+            'parameters': parameters,
+            'is_static': False,
+            'unit_type': 'closure',
+        }
+        self.stats['total_functions'] += 1
+        self.stats['standalone_functions'] += 1
+        self.stats['by_type']['closure'] = self.stats['by_type'].get('closure', 0) + 1
+
+    def _extract_module_level_unit(self, tree, source: bytes,
+                                    relative_path: str) -> None:
+        """Synthesise a `module_level` unit for top-level procedural statements.
+
+        PHP scripts (WordPress plugins, legacy procedural files) run top-to-bottom
+        and register hooks / read superglobals at file scope. The named-definition
+        walk in `_extract_functions_from_tree` never emits a unit for that
+        file-scope code, so it was invisible to reachability seeding. This
+        mirrors the Python parser's `extract_module_level_code`,
+        emitting a single synthetic `<file>:__module__` unit whose code is the
+        concatenation of the program-level statements that are not themselves
+        function/class/interface/trait/namespace declarations.
+        """
+        root = tree.root_node
+
+        # Named definitions (each already emitted as its own unit) and pure
+        # structural/import tokens are NOT executable top-level code.
+        skip_types = {
+            'function_definition', 'class_declaration', 'interface_declaration',
+            'trait_declaration', 'enum_declaration', 'namespace_use_declaration',
+            'use_declaration', 'php_tag', 'text_interpolation', 'text', ';',
+            'comment', 'declare_statement', '{', '}',
+        }
+
+        def program_statements(node):
+            """Yield file-scope statement nodes.
+
+            A braceless `namespace App;` is a self-contained node whose following
+            statements are program-level SIBLINGS (tree-sitter-php does not nest
+            them), so we simply skip the namespace token-node. A braced
+            `namespace App { ... }` wraps its statements in a body, so we descend
+            into that body.
+            """
+            for child in node.children:
+                if child.type == 'namespace_definition':
+                    body = child.child_by_field_name('body')
+                    if body is not None:
+                        yield from program_statements(body)
+                    # braceless: its real statements are program-level siblings,
+                    # reached later in this same loop; the namespace node itself
+                    # contributes no executable code.
+                    continue
+                if child.type in skip_types:
+                    continue
+                yield child
+
+        statements = list(program_statements(root))
+        if not statements:
+            return
+
+        code = '\n'.join(self._node_text(s, source) for s in statements).strip()
+        if not code:
+            return
+
+        start_line = statements[0].start_point[0] + 1
+        end_line = statements[-1].end_point[0] + 1
+
+        func_id = f"{relative_path}:__module__"
+        self.functions[func_id] = {
+            'name': '__module__',
+            'qualified_name': '__module__',
+            'file_path': relative_path,
+            'start_line': start_line,
+            'end_line': end_line,
+            'code': code,
+            'class_name': None,
+            'namespace_name': None,
+            'parameters': [],
+            'is_static': False,
+            'unit_type': 'module_level',
+            'is_module_level': True,
+        }
+        self.stats['total_functions'] += 1
+        self.stats['standalone_functions'] += 1
+        self.stats['by_type']['module_level'] = \
+            self.stats['by_type'].get('module_level', 0) + 1
+
     def process_file(self, file_path: Path) -> None:
         """Process a single PHP file."""
         source = self.read_file(file_path)
@@ -485,6 +633,9 @@ class FunctionExtractor:
 
         # Extract functions
         self._extract_functions_from_tree(tree, source, file_path, relative_path)
+
+        # Synthesise a module_level unit for any top-level procedural statements
+        self._extract_module_level_unit(tree, source, relative_path)
 
     def extract_from_scan(self, scan_result: Dict) -> Dict:
         """Extract functions from files listed in a scan result."""

--- a/libs/openant-core/parsers/php/repository_scanner.py
+++ b/libs/openant-core/parsers/php/repository_scanner.py
@@ -82,7 +82,17 @@ class RepositoryScanner:
 
         # Skip test files by default (can be overridden)
         self.skip_tests = options.get('skip_tests', False)
-        self.test_patterns = {'test_', '_test.php', 'Test.php', 'test/', 'tests/', 'spec/', 'phpunit'}
+        # Native PHP test conventions (PHPUnit). Directory names match whole
+        # path segments; filename rules are anchored to the basename so that
+        # ordinary sources like ``Contest.php``/``latest_helper.php`` are NOT
+        # misclassified as tests (an unanchored substring scan would).
+        self.test_dir_names = {'test', 'tests', 'spec'}
+        # Case-insensitive basename rules.
+        self.test_file_prefixes = ('test_', 'phpunit')
+        self.test_file_suffixes = ('_test.php',)
+        # PSR PascalCase suffix matched on the original-case basename so that
+        # ``FooTest.php`` is a test while ``Contest.php`` is not.
+        self.test_file_pascal_suffix = 'Test.php'
 
         # Statistics
         self.stats = {
@@ -112,11 +122,23 @@ class RepositoryScanner:
         return ext in self.source_extensions
 
     def is_test_file(self, relative_path: str) -> bool:
-        """Check if a file is a test file."""
-        path_lower = relative_path.lower()
-        for pattern in self.test_patterns:
-            if pattern.lower() in path_lower:
-                return True
+        """Check if a file is a test file.
+
+        Matches on path *components* and *anchored* filename rules rather than
+        unanchored substrings, so non-test files whose name merely contains a
+        token (``Contest.php``, ``latest_helper.php``) are not skipped.
+        """
+        p = Path(relative_path)
+        if any(part.lower() in self.test_dir_names for part in p.parts[:-1]):
+            return True
+        name = p.name
+        if name.endswith(self.test_file_pascal_suffix):
+            return True
+        name_lower = name.lower()
+        if name_lower.startswith(self.test_file_prefixes):
+            return True
+        if name_lower.endswith(self.test_file_suffixes):
+            return True
         return False
 
     def scan_directory(self, dir_path: Path, relative_path: str = '') -> None:

--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -183,17 +183,76 @@ class CallGraphBuilder:
             # Fall back to regex-based extraction
             return self._extract_calls_regex(code, caller_id)
 
+        # Local variable -> constructor-type map, so that `v = ClassName(); v.method()`
+        # dispatches to the bound type's method.
+        local_types = self._collect_local_types(tree)
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
-                resolved = self._resolve_call_node(node, caller_file, caller_class)
+                resolved = self._resolve_call_node(node, caller_file, caller_class, local_types)
                 if resolved:
                     calls.add(resolved)
+                # Higher-order-function callbacks: a function reference passed as an
+                # argument (map(func, xs), sorted(xs, key=func)) is a real reachability
+                # edge but lives in node.args / node.keywords, not node.func, so the
+                # main resolver above never sees it.
+                for callee in self._resolve_callback_args(node, caller_file):
+                    calls.add(callee)
 
         return calls
 
-    def _resolve_call_node(self, node: ast.Call, caller_file: str, caller_class: Optional[str]) -> Optional[str]:
+    def _collect_local_types(self, tree: ast.AST) -> Dict[str, str]:
+        """Map local variable names to the class name they are constructed from.
+
+        Handles the conservative, unambiguous case ``var = ClassName(...)`` where the
+        right-hand side is a direct call of a bare Name (the constructor). Used to resolve
+        ``var.method()`` against the constructed type. If the same
+        name is rebound to different types, it is treated as ambiguous and dropped.
+        """
+        types: Dict[str, str] = {}
+        ambiguous: Set[str] = set()
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            value = node.value
+            if not (isinstance(value, ast.Call) and isinstance(value.func, ast.Name)):
+                continue
+            ctor = value.func.id
+            for target in node.targets:
+                if not isinstance(target, ast.Name):
+                    continue
+                name = target.id
+                if name in ambiguous:
+                    continue
+                if name in types and types[name] != ctor:
+                    ambiguous.add(name)
+                    types.pop(name, None)
+                else:
+                    types[name] = ctor
+        return types
+
+    def _resolve_callback_args(self, node: ast.Call, caller_file: str) -> List[str]:
+        """Resolve function references passed as call arguments to function ids.
+
+        Inspects positional args and keyword values for bare ``ast.Name`` references that
+        resolve to a known function (e.g. the callbacks of ``map``/``filter``/``sorted``).
+        Only Name references are considered -- inline lambdas and attribute references have
+        no standalone function id to point at.
+        """
+        callees: List[str] = []
+        candidates = list(node.args) + [kw.value for kw in node.keywords]
+        for arg in candidates:
+            if isinstance(arg, ast.Name) and not self._is_builtin(arg.id):
+                resolved = self._resolve_simple_call(arg.id, caller_file)
+                if resolved:
+                    callees.append(resolved)
+        return callees
+
+    def _resolve_call_node(self, node: ast.Call, caller_file: str, caller_class: Optional[str],
+                           local_types: Optional[Dict[str, str]] = None) -> Optional[str]:
         """Resolve an AST Call node to a function ID."""
         func = node.func
+        local_types = local_types or {}
 
         # Simple function call: func_name(...)
         if isinstance(func, ast.Name):
@@ -221,12 +280,20 @@ class CallGraphBuilder:
 
             # super().method(...)
             if isinstance(obj, ast.Call) and isinstance(obj.func, ast.Name) and obj.func.id == 'super':
-                # Would need to resolve parent class - skip for now
+                if caller_class:
+                    return self._resolve_super_call(method_name, caller_file, caller_class)
                 return None
 
             # module.func(...) or object.method(...)
             if isinstance(obj, ast.Name):
                 obj_name = obj.id
+                # Local variable of a locally-known type: `v = ClassName(); v.method()`
+                # resolves to the constructed class's method,
+                # which _resolve_module_call (imports / same-file class NAMES only) cannot do.
+                if obj_name in local_types:
+                    typed = self._resolve_class_method(local_types[obj_name], method_name, caller_file)
+                    if typed:
+                        return typed
                 return self._resolve_module_call(obj_name, method_name, caller_file)
 
             # Chained calls: obj.method1().method2(...)
@@ -273,6 +340,75 @@ class CallGraphBuilder:
 
         return None
 
+    def _resolve_super_call(self, method_name: str, caller_file: str, caller_class: str) -> Optional[str]:
+        """Resolve a ``super().method(...)`` call to the inherited parent method.
+
+        The previous implementation returned ``None`` unconditionally, so any method
+        reachable only through ``super()`` was dropped from the call graph -- including
+        cross-file inheritance, where the parent class lives in a different module.
+
+        Resolution walks the caller class's declared bases (``self.classes[...]['bases']``,
+        populated by the extractor) up the inheritance chain, looking for the first base
+        class -- in ANY file -- that defines ``method_name``. Base classes are matched by
+        their simple name, so a base declared as ``module.Base`` still matches the class
+        named ``Base``. Returns the parent method's function id, or ``None`` if the parent
+        class (e.g. an external library type) is not present in the parsed repo.
+        """
+        seen_classes: Set[str] = set()
+        # Seed the BFS with the caller's own class key.
+        queue: List[str] = [f"{caller_file}:{caller_class}"]
+        while queue:
+            class_key = queue.pop(0)
+            if class_key in seen_classes:
+                continue
+            seen_classes.add(class_key)
+            class_data = self.classes.get(class_key)
+            if not class_data:
+                continue
+            for base in class_data.get('bases', []):
+                base_simple = base.split('.')[-1]            # 'pkg.Base' -> 'Base'
+                # Find every class (across files) whose simple name matches this base.
+                for cand_key, cand_data in self.classes.items():
+                    if cand_data.get('name') != base_simple or cand_key in seen_classes:
+                        continue
+                    method_id = self._method_in_class(cand_key, method_name)
+                    if method_id:
+                        return method_id
+                    # Parent doesn't define it directly -- keep walking its own bases.
+                    queue.append(cand_key)
+        return None
+
+    def _method_in_class(self, class_key: str, method_name: str) -> Optional[str]:
+        """Return the function id of ``method_name`` declared on ``class_key``, or None."""
+        for func_id in self.methods_by_class.get(class_key, []):
+            if self.functions.get(func_id, {}).get('name') == method_name:
+                return func_id
+        return None
+
+    def _resolve_class_method(self, class_name: str, method_name: str, caller_file: str) -> Optional[str]:
+        """Resolve ``ClassName.method`` to a function id, same-file first then cross-file.
+
+        Used to dispatch a call on a local variable whose type is known.
+        Same-file resolution is preferred; otherwise the class
+        is matched by simple name across all parsed files (unambiguous single match only,
+        to avoid binding to an unrelated same-named class).
+        """
+        class_simple = class_name.split('.')[-1]
+        # 1. Same file.
+        same_file = self._method_in_class(f"{caller_file}:{class_simple}", method_name)
+        if same_file:
+            return same_file
+        # 2. Cross-file: exactly one class with this simple name that defines the method.
+        matches = []
+        for class_key, class_data in self.classes.items():
+            if class_data.get('name') == class_simple:
+                method_id = self._method_in_class(class_key, method_name)
+                if method_id:
+                    matches.append(method_id)
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
     def _resolve_module_call(self, obj_name: str, method_name: str, caller_file: str) -> Optional[str]:
         """Resolve a module.function() or object.method() call."""
         # Skip builtin modules
@@ -297,7 +433,8 @@ class CallGraphBuilder:
 
         return None
 
-    def _resolve_import(self, import_path: str, func_name: str, caller_file: str) -> Optional[str]:
+    def _resolve_import(self, import_path: str, func_name: str, caller_file: str,
+                        _seen: Optional[Set[str]] = None) -> Optional[str]:
         """Resolve an imported function to a function ID."""
         # import_path might be "module.submodule.function" or "module.ClassName"
         parts = import_path.split('.')
@@ -327,6 +464,15 @@ class CallGraphBuilder:
                 if target_id in self.functions:
                     return target_id
 
+        # Strategy 1b: package re-export via __init__.py.
+        # `from pkg import name` records import_path 'pkg.name', but `name` may not live in
+        # pkg.py -- it is commonly re-exported from pkg/__init__.py via
+        # `from .submodule import name`. Probe the package __init__.py, then follow the
+        # recorded re-export to the name's true origin module. _seen guards re-export cycles.
+        reexported = self._resolve_via_package_init(parts, func_name, _seen)
+        if reexported:
+            return reexported
+
         # Strategy 2: Check if import_path itself is a function
         for func_id in self.functions:
             func_data = self.functions[func_id]
@@ -338,6 +484,36 @@ class CallGraphBuilder:
                 if module_path.endswith(expected_module) or expected_module.endswith(module_path):
                     return func_id
 
+        return None
+
+    def _resolve_via_package_init(self, parts: List[str], func_name: str,
+                                  _seen: Optional[Set[str]]) -> Optional[str]:
+        """Follow a name re-exported through a package ``__init__.py`` to its origin.
+
+        Given the dotted import parts (e.g. ['utils', 'sanitize']) and the imported
+        ``func_name``, this walks the longest-to-shortest package prefixes, and for any
+        prefix whose ``<prefix>/__init__.py`` was parsed, looks up ``func_name`` in that
+        package's recorded import map. When the package re-exports the name (e.g.
+        ``from .helpers import sanitize`` -> 'utils.helpers.sanitize'), resolution recurses
+        on the re-export target to reach the true origin module.
+        """
+        seen = _seen if _seen is not None else set()
+        for i in range(len(parts), 0, -1):
+            init_file = '/'.join(parts[:i]) + '/__init__.py'
+            if init_file not in self.imports:
+                continue
+            if init_file in seen:                       # re-export cycle guard
+                continue
+            pkg_imports = self.imports[init_file]
+            if func_name not in pkg_imports:
+                continue
+            seen.add(init_file)
+            origin_path = pkg_imports[func_name]         # e.g. 'utils.helpers.sanitize'
+            if origin_path == '.'.join(parts):           # would re-resolve to itself
+                continue
+            resolved = self._resolve_import(origin_path, func_name, init_file, seen)
+            if resolved:
+                return resolved
         return None
 
     def _extract_calls_regex(self, code: str, caller_id: str) -> Set[str]:
@@ -380,8 +556,11 @@ class CallGraphBuilder:
             # Extract all function calls from this function's code
             calls = self._extract_calls_from_code(code, func_id)
 
-            # Filter to valid function IDs (must exist in our codebase, not self-calls)
-            valid_calls = [c for c in calls if c in self.functions and c != func_id]
+            # Filter to valid function IDs (must exist in our codebase, not self-calls).
+            # `calls` is a set, whose iteration order depends on PYTHONHASHSEED; sort the
+            # filtered list so call_graph (and, below, reverse_call_graph) emit a stable,
+            # reproducible ordering on identical input.
+            valid_calls = sorted(c for c in calls if c in self.functions and c != func_id)
             self.call_graph[func_id] = valid_calls
 
             # Build reverse graph: for each called function, record this caller
@@ -390,6 +569,10 @@ class CallGraphBuilder:
                     self.reverse_call_graph[called_id] = []
                 if func_id not in self.reverse_call_graph[called_id]:
                     self.reverse_call_graph[called_id].append(func_id)
+
+        # Sort reverse-graph caller lists for the same determinism guarantee.
+        for called_id in self.reverse_call_graph:
+            self.reverse_call_graph[called_id].sort()
 
     def get_dependencies(self, func_id: str, depth: Optional[int] = None) -> List[str]:
         """Get all dependencies (callees) for a function up to max depth."""

--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -194,6 +194,19 @@ class FunctionExtractor:
         """Extract docstring from a function or class."""
         return ast.get_docstring(node)
 
+    def _path_has_segment(self, file_path: str, token: str) -> bool:
+        """True if `token` equals a whole path segment (a directory name or the filename stem),
+        case-insensitively -- used instead of a bare ``token in path`` substring test so that, for
+        example, 'views' classifies ``app/views.py`` and ``app/views/x.py`` but NOT ``interviews/a.py``
+        or ``app/previews/b.py``."""
+        p = Path(file_path)
+        try:
+            p = p.relative_to(self.repo_path)
+        except ValueError:
+            pass
+        segments = {s.lower() for s in p.with_suffix('').parts}
+        return token.lower() in segments
+
     def classify_function(self, func_name: str, decorators: List[str],
                           class_name: Optional[str], file_path: str) -> str:
         """Classify a function by its type/purpose."""
@@ -207,7 +220,7 @@ class FunctionExtractor:
             return 'route_handler'
 
         # Django views
-        if 'views' in path_lower and class_name is None:
+        if self._path_has_segment(file_path, 'views') and class_name is None:
             return 'view_function'
 
         # Class methods
@@ -225,10 +238,15 @@ class FunctionExtractor:
             return 'method'
 
         # Middleware/decorators
-        if 'middleware' in func_name.lower() or 'middleware' in path_lower:
+        if 'middleware' in func_name.lower() or self._path_has_segment(file_path, 'middleware'):
             return 'middleware'
 
-        # Test functions
+        # Test functions.
+        # 'test' is matched as a substring here on purpose: test-file conventions use plural/affixed
+        # forms ('tests/' dir, 'test_*'/'*_test' files) that a whole-segment match would miss. The
+        # substring over-match (e.g. 'latest'/'contest') is the is_test_file family handled in its own
+        # scheduled units -- 'test' is NOT an entry-point type, so unlike 'views' it seeds no false
+        # reachability and is intentionally left as a substring test in this fix.
         if func_name.startswith('test_') or 'test' in path_lower:
             return 'test'
 
@@ -261,9 +279,21 @@ class FunctionExtractor:
                     imports[name] = alias.name
             elif isinstance(node, ast.ImportFrom):
                 module = node.module or ''
+                level = node.level or 0
+                if level > 0:
+                    # Relative import: reconstruct the absolute package anchor from the importing
+                    # file's location so the dotted path resolves to a real module. file_path is
+                    # repo-relative (e.g. 'pkg/sub/mod.py'); its package is the directory parts.
+                    # level=1 -> the file's own package, level=2 -> the parent package, etc.
+                    pkg_parts = list(Path(file_path).parts[:-1])
+                    keep = max(0, len(pkg_parts) - (level - 1))
+                    anchor = pkg_parts[:keep]
+                    base_parts = anchor + ([module] if module else [])
+                else:
+                    base_parts = [module] if module else []
                 for alias in node.names:
                     name = alias.asname or alias.name
-                    full_path = f"{module}.{alias.name}" if module else alias.name
+                    full_path = '.'.join(base_parts + [alias.name]) if base_parts else alias.name
                     imports[name] = full_path
 
         return imports
@@ -552,9 +582,12 @@ class FunctionExtractor:
         else:
             # Scan all .py files
             for file_path in self.repo_path.rglob('*.py'):
-                # Skip common exclude patterns
-                path_str = str(file_path)
-                if any(excl in path_str for excl in ['__pycache__', '.git', 'venv', '.venv', 'node_modules']):
+                # Skip common excluded directories. Match whole path SEGMENTS (not a substring of the
+                # full path) so e.g. 'venv' excludes a real venv/ dir but not 'myvenv/keep.py', and an
+                # ancestor dir whose name contains a token cannot poison the whole scan. rglob yields
+                # paths under repo_path, so relative_to never raises.
+                excluded = {'__pycache__', '.git', 'venv', '.venv', 'node_modules'}
+                if excluded & set(file_path.relative_to(self.repo_path).parts):
                     continue
                 self.process_file(file_path)
 

--- a/libs/openant-core/parsers/python/parse_repository.py
+++ b/libs/openant-core/parsers/python/parse_repository.py
@@ -55,7 +55,7 @@ from unit_generator import UnitGenerator
 from utilities.file_io import read_json, write_json, open_utf8
 
 
-def generate_analyzer_output(extractor_result: dict) -> dict:
+def generate_analyzer_output(extractor_result: dict, call_graph_result: dict | None = None) -> dict:
     """
     Generate analyzer_output.json format for Stage 2 verification.
 
@@ -65,9 +65,13 @@ def generate_analyzer_output(extractor_result: dict) -> dict:
 
     Args:
         extractor_result: Output from FunctionExtractor
+        call_graph_result: Optional CallGraphBuilder.export() result. When provided, the
+            top-level callGraph / reverseCallGraph are surfaced (matching the analyzer_output
+            schema consumed by dependency resolvers); omitted when None (back-compat).
 
     Returns:
-        Dict in analyzer_output.json format:
+        Dict in analyzer_output.json format (callGraph/reverseCallGraph included when
+        call_graph_result is provided):
         {
             "functions": {
                 "file.py:func_name": {
@@ -99,7 +103,16 @@ def generate_analyzer_output(extractor_result: dict) -> dict:
         if class_name:
             functions[func_id]["className"] = class_name
 
-    return {"functions": functions}
+    output = {"functions": functions}
+
+    # Surface the call graph top-level: the analyzer_output schema carries callGraph /
+    # reverseCallGraph (func_id -> [func_ids]), already computed in call_graph_result.
+    # (filePath is derived from the func_id key by consumers, so it is not a per-function field.)
+    if call_graph_result is not None:
+        output["callGraph"] = call_graph_result.get("call_graph", {})
+        output["reverseCallGraph"] = call_graph_result.get("reverse_call_graph", {})
+
+    return output
 
 
 def parse_repository(repo_path: str, options: dict = None) -> tuple:
@@ -191,8 +204,9 @@ def parse_repository(repo_path: str, options: dict = None) -> tuple:
     for unit_type, count in sorted(stats['by_type'].items()):
         print(f"    {unit_type}: {count}", file=sys.stderr)
 
-    # Generate analyzer output for Stage 2 verification
-    analyzer_output = generate_analyzer_output(extractor_result)
+    # Generate analyzer output for Stage 2 verification (pass the call graph so the output
+    # surfaces top-level callGraph / reverseCallGraph, matching the analyzer_output schema).
+    analyzer_output = generate_analyzer_output(extractor_result, call_graph_result)
     print(f"\n[Stage 2 Support] Generated analyzer output: {len(analyzer_output['functions'])} functions", file=sys.stderr)
 
     if output_dir:

--- a/libs/openant-core/parsers/python/repository_scanner.py
+++ b/libs/openant-core/parsers/python/repository_scanner.py
@@ -100,7 +100,14 @@ class RepositoryScanner:
 
         # Skip test files by default (can be overridden)
         self.skip_tests = options.get('skip_tests', False)
-        self.test_patterns = {'test_', '_test.py', 'tests/', '/test/', 'conftest.py'}
+        # Native Python test conventions. Directory names are matched as whole
+        # path segments; filename rules are anchored to the basename so that
+        # ordinary sources like ``latest_release.py``/``contests/foo.py`` are
+        # NOT misclassified as tests (an unanchored substring scan would).
+        self.test_dir_names = {'test', 'tests'}
+        self.test_file_prefixes = ('test_',)
+        self.test_file_suffixes = ('_test.py',)
+        self.test_file_names = {'conftest.py'}
 
         # Statistics
         self.stats = {
@@ -133,11 +140,23 @@ class RepositoryScanner:
         return ext in self.source_extensions
 
     def is_test_file(self, relative_path: str) -> bool:
-        """Check if a file is a test file."""
-        path_lower = relative_path.lower()
-        for pattern in self.test_patterns:
-            if pattern in path_lower:
-                return True
+        """Check if a file is a test file.
+
+        Matches on path *components* and *anchored* filename rules rather than
+        unanchored substrings, so non-test files whose name merely contains a
+        token (``latest_release.py``, ``contests/foo.py``) are not skipped.
+        """
+        p = Path(relative_path)
+        # Any directory component named exactly test/tests (case-insensitive).
+        if any(part.lower() in self.test_dir_names for part in p.parts[:-1]):
+            return True
+        name_lower = p.name.lower()
+        if name_lower in self.test_file_names:
+            return True
+        if name_lower.startswith(self.test_file_prefixes):
+            return True
+        if name_lower.endswith(self.test_file_suffixes):
+            return True
         return False
 
     def scan_directory(self, dir_path: Path, relative_path: str = '') -> None:

--- a/libs/openant-core/parsers/ruby/call_graph_builder.py
+++ b/libs/openant-core/parsers/ruby/call_graph_builder.py
@@ -32,6 +32,7 @@ Output (JSON):
 """
 
 import json
+import posixpath
 import re
 import sys
 from pathlib import Path
@@ -131,6 +132,11 @@ class CallGraphBuilder:
         self.functions_by_name: Dict[str, List[str]] = {}
         self.functions_by_file: Dict[str, List[str]] = {}
         self.methods_by_class: Dict[str, List[str]] = {}
+        # Module-level functions, keyed by module_name. Ruby module functions
+        # carry module_name (class_name is None), so methods_by_class never
+        # indexed them and their Module.method / same-module sibling calls were
+        # unresolvable while a bare call to one could leak into an unrelated file.
+        self.methods_by_module: Dict[str, List[str]] = {}
 
         self._build_indexes()
 
@@ -159,6 +165,12 @@ class CallGraphBuilder:
                     self.methods_by_class[class_key] = []
                 self.methods_by_class[class_key].append(func_id)
 
+            module_name = func_data.get('module_name')
+            if module_name and not class_name:
+                if module_name not in self.methods_by_module:
+                    self.methods_by_module[module_name] = []
+                self.methods_by_module[module_name].append(func_id)
+
     def _is_builtin(self, name: str) -> bool:
         """Check if name is a Ruby builtin or common method."""
         return name in RUBY_BUILTINS
@@ -169,6 +181,8 @@ class CallGraphBuilder:
         caller_file = caller_id.split(':')[0]
         caller_func = self.functions.get(caller_id, {})
         caller_class = caller_func.get('class_name')
+        caller_module = caller_func.get('module_name')
+        caller_method = caller_func.get('name')
 
         code_bytes = code.encode('utf-8', errors='replace')
         try:
@@ -180,19 +194,34 @@ class CallGraphBuilder:
         while stack:
             node = stack.pop()
             if node.type == 'call':
-                resolved = self._resolve_call_node(node, code_bytes, caller_file, caller_class)
+                resolved = self._resolve_call_node(node, code_bytes, caller_file,
+                                                   caller_class, caller_module, caller_method)
                 if resolved:
                     calls.add(resolved)
+            elif node.type == 'super':
+                # A bare `super` is its own node (not a `call`); `super(args)` is a
+                # `call` whose first child is a `super` node, handled below.
+                if node.parent is None or node.parent.type != 'call':
+                    resolved = self._resolve_super_call(caller_file, caller_class, caller_method)
+                    if resolved:
+                        calls.add(resolved)
             stack.extend(reversed(node.children))
 
         return calls
 
     def _resolve_call_node(self, node, source: bytes, caller_file: str,
-                           caller_class: Optional[str]) -> Optional[str]:
+                           caller_class: Optional[str],
+                           caller_module: Optional[str] = None,
+                           caller_method: Optional[str] = None) -> Optional[str]:
         """Resolve a tree-sitter call node to a function ID."""
+        # `super(args)` is a call node whose head is a `super` node, not an
+        # identifier method name -- resolve it against the superclass.
+        if any(c.type == 'super' for c in node.children):
+            return self._resolve_super_call(caller_file, caller_class, caller_method)
         # Extract method name
         method_name = None
         receiver = None
+        args_node = None
 
         for child in node.children:
             if child.type == 'identifier' and method_name is None:
@@ -200,6 +229,8 @@ class CallGraphBuilder:
             elif child.type == '.':
                 continue
             elif child.type in ('argument_list', 'block', 'do_block'):
+                if child.type == 'argument_list' and args_node is None:
+                    args_node = child
                 continue
             elif method_name is None and child.type not in ('identifier',):
                 # This might be the receiver
@@ -210,59 +241,195 @@ class CallGraphBuilder:
         if not method_name:
             return None
 
+        # ClassName.new(...) -> the class's initialize. `new` is in RUBY_BUILTINS,
+        # so this must precede the builtin filter below or the edge is dropped.
+        if method_name == 'new' and receiver and receiver[0:1].isupper():
+            return self._resolve_class_call(receiver, 'initialize', caller_file)
+
+        # send/public_send/__send__ with a literal symbol/string argument: the
+        # dispatched method is the first literal arg. Runtime-string targets are
+        # not statically recoverable. These verbs are filtered as builtins below,
+        # so resolve the literal-symbol case before that filter.
+        if method_name in ('send', 'public_send', '__send__'):
+            target = self._literal_symbol_arg(args_node, source)
+            if target is None:
+                return None
+            if receiver == 'self' or receiver is None:
+                if caller_class:
+                    return self._resolve_self_call(target, caller_file, caller_class)
+                return self._resolve_simple_call(target, caller_file, caller_class, caller_module)
+            if receiver[0:1].isupper():
+                return self._resolve_class_call(receiver, target, caller_file)
+            return None
+
         if self._is_builtin(method_name):
             return None
 
         # self.method(...) - same class
         if receiver == 'self' and caller_class:
             return self._resolve_self_call(method_name, caller_file, caller_class)
+        # self.method(...) inside a module function (module_name, no class)
+        if receiver == 'self' and caller_module:
+            return self._resolve_module_call(caller_module, method_name, caller_file)
 
         # No receiver - simple function call
         if receiver is None:
-            return self._resolve_simple_call(method_name, caller_file, caller_class)
+            return self._resolve_simple_call(method_name, caller_file, caller_class, caller_module)
 
-        # Receiver is a constant (ClassName.method) - class method call
+        # Receiver is a constant (ClassName.method or ModuleName.method)
         if receiver and receiver[0:1].isupper():
             return self._resolve_class_call(receiver, method_name, caller_file)
 
         return None
 
+    @staticmethod
+    def _literal_symbol_arg(args_node, source: bytes) -> Optional[str]:
+        """Return the first literal symbol/string argument value, or None.
+
+        Handles ``:foo`` (simple_symbol) and ``"foo"``/``'foo'`` (string). A
+        non-literal first argument (variable, interpolation) has no static target.
+        """
+        if args_node is None:
+            return None
+        for child in args_node.children:
+            if child.type == 'simple_symbol':
+                text = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
+                return text[1:] if text.startswith(':') else text
+            if child.type == 'string':
+                for sc in child.children:
+                    if sc.type == 'string_content':
+                        return source[sc.start_byte:sc.end_byte].decode('utf-8', errors='replace')
+                return None
+            if child.type in ('(', ')', ','):
+                continue
+            # First non-literal positional argument: no static target.
+            return None
+        return None
+
+    def _resolve_super_call(self, caller_file: str, caller_class: Optional[str],
+                            caller_method: Optional[str]) -> Optional[str]:
+        """Resolve a `super` call to the same-named method in the superclass.
+
+        `super` re-dispatches the CURRENT method name (caller_method) up the
+        ancestor chain, so the target is the superclass's method of the same name.
+        """
+        if not caller_class or not caller_method:
+            return None
+        superclass = self._superclass_of(caller_file, caller_class)
+        if not superclass:
+            return None
+        if '::' in superclass:
+            superclass = superclass.rsplit('::', 1)[-1]
+        return self._resolve_class_call(superclass, caller_method, caller_file)
+
+    def _superclass_of(self, caller_file: str, caller_class: str) -> Optional[str]:
+        """Return the superclass of caller_class defined in caller_file, or None."""
+        class_data = self.classes.get(f"{caller_file}:{caller_class}")
+        if class_data:
+            return class_data.get('superclass')
+        for data in self.classes.values():
+            if data.get('name') == caller_class and data.get('file_path') == caller_file:
+                return data.get('superclass')
+        return None
+
     def _resolve_simple_call(self, func_name: str, caller_file: str,
-                             caller_class: Optional[str]) -> Optional[str]:
-        """Resolve a simple function call to a function ID."""
+                             caller_class: Optional[str],
+                             caller_module: Optional[str] = None) -> Optional[str]:
+        """Resolve a simple (no-receiver) function call to a function ID."""
         # 1. Check same class first (implicit self)
         if caller_class:
             result = self._resolve_self_call(func_name, caller_file, caller_class)
             if result:
                 return result
 
-        # 2. Check same file
+        # 1b. Inside a module function, a bare call resolves to a sibling of the
+        #     SAME module first (any file), before falling through to file/global
+        #     lookups. This is the same-module-sibling path.
+        if caller_module:
+            result = self._resolve_module_call(caller_module, func_name, caller_file)
+            if result:
+                return result
+
+        # 2. Check same file. A module function is only a valid same-file target
+        #    when the caller is in the same module (handled in 1b); a bare call
+        #    from outside any module must not bind to a same-file module fn, so
+        #    require both class_name and module_name to be unset here.
         same_file_funcs = self.functions_by_file.get(caller_file, [])
         for func_id in same_file_funcs:
             func_data = self.functions.get(func_id, {})
-            if func_data.get('name') == func_name and not func_data.get('class_name'):
+            if (func_data.get('name') == func_name
+                    and not func_data.get('class_name')
+                    and not func_data.get('module_name')):
                 return func_id
 
-        # 3. Check require-resolved files
+        # 3. Check require-resolved files (anchored).
         file_imports = self.imports.get(caller_file, {})
         for import_name, import_type in file_imports.items():
-            if import_type in ('require', 'require_relative'):
-                # Try matching import path to file
-                for file_path in self.functions_by_file:
-                    if file_path.endswith(f"{import_name}.rb") or import_name in file_path:
-                        file_funcs = self.functions_by_file[file_path]
-                        for func_id in file_funcs:
-                            func_data = self.functions.get(func_id, {})
-                            if func_data.get('name') == func_name:
-                                return func_id
+            if import_type not in ('require', 'require_relative'):
+                continue
+            target_file = self._resolve_import_file(import_name, import_type, caller_file)
+            if target_file is None:
+                continue
+            for func_id in self.functions_by_file.get(target_file, []):
+                func_data = self.functions.get(func_id, {})
+                if (func_data.get('name') == func_name
+                        and not func_data.get('class_name')
+                        and not func_data.get('module_name')):
+                    return func_id
 
-        # 4. Unique name match across files
+        # 4. Unique name match across files. Restrict to genuine top-level
+        #    functions (neither class- nor module-bound) so a module function
+        #    never leaks an edge to an unrelated bare call.
         candidates = self.functions_by_name.get(func_name, [])
-        candidates = [c for c in candidates if not self.functions.get(c, {}).get('class_name')]
+        candidates = [c for c in candidates
+                      if not self.functions.get(c, {}).get('class_name')
+                      and not self.functions.get(c, {}).get('module_name')]
         if len(candidates) == 1:
             return candidates[0]
 
         return None
+
+    def _resolve_import_file(self, import_name: str, import_type: str,
+                             caller_file: str) -> Optional[str]:
+        """Resolve a require / require_relative target to a known file path.
+
+        `require_relative` is anchored to the caller file's directory and
+        normalized (so `./helper` and `../lib/util` resolve correctly even when
+        the basename collides). `require` matches by anchored file name, never an
+        unanchored substring (which over-matched any path containing the string).
+        """
+        if import_type == 'require_relative':
+            base_dir = posixpath.dirname(caller_file)
+            anchored = posixpath.normpath(posixpath.join(base_dir, import_name))
+            target = anchored if anchored.endswith('.rb') else f"{anchored}.rb"
+            return target if target in self.functions_by_file else None
+
+        # `require 'name'` / `require 'path/name'`: match the file by its name
+        # component, anchored -- not a bare substring.
+        candidate = import_name if import_name.endswith('.rb') else f"{import_name}.rb"
+        if candidate in self.functions_by_file:
+            return candidate
+        base = candidate.rsplit('/', 1)[-1]
+        matches = [fp for fp in self.functions_by_file
+                   if fp == base or fp.endswith(f"/{base}")]
+        return matches[0] if len(matches) == 1 else None
+
+    def _resolve_module_call(self, module_name: str, method_name: str,
+                             caller_file: str) -> Optional[str]:
+        """Resolve a ModuleName.method() / same-module sibling call.
+
+        Prefers a same-file definition, then any file defining the module.
+        """
+        fallback = None
+        for func_id in self.methods_by_module.get(module_name, []):
+            func_data = self.functions.get(func_id, {})
+            if func_data.get('name') != method_name:
+                continue
+            if func_data.get('file_path') == caller_file:
+                return func_id
+            if fallback is None:
+                fallback = func_id
+        return fallback
 
     def _resolve_self_call(self, method_name: str, caller_file: str,
                            caller_class: str) -> Optional[str]:
@@ -279,7 +446,11 @@ class CallGraphBuilder:
 
     def _resolve_class_call(self, class_name: str, method_name: str,
                             caller_file: str) -> Optional[str]:
-        """Resolve a ClassName.method() call."""
+        """Resolve a ClassName.method() or ModuleName.method() call.
+
+        A constant receiver may name a class or a module; module functions are not
+        in methods_by_class, so fall back to the module index.
+        """
         # Check same file first
         class_key = f"{caller_file}:{class_name}"
         if class_key in self.methods_by_class:
@@ -296,7 +467,8 @@ class CallGraphBuilder:
                     if func_data.get('name') == method_name:
                         return func_id
 
-        return None
+        # The receiver may be a module (e.g. Utils.helper for a module_function).
+        return self._resolve_module_call(class_name, method_name, caller_file)
 
     def _extract_calls_regex(self, code: str, caller_id: str) -> Set[str]:
         """Fallback regex-based call extraction for unparseable code."""

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -127,8 +127,15 @@ class FunctionExtractor:
 
     def _classify_function(self, func_name: str, class_name: Optional[str],
                            module_name: Optional[str], is_singleton: bool,
-                           file_path: str) -> str:
-        """Classify a function by its type/purpose."""
+                           file_path: str, visibility: str = 'public') -> str:
+        """Classify a function by its type/purpose.
+
+        ``visibility`` ('public' | 'private' | 'protected') is the declared
+        Ruby method visibility threaded from the class body. Only PUBLIC
+        controller methods are real route handlers; private/protected methods
+        in a controller are filter callbacks / params helpers and must not be
+        seeded as entry points.
+        """
         path_lower = file_path.lower()
 
         if func_name == 'initialize':
@@ -137,11 +144,19 @@ class FunctionExtractor:
         if is_singleton:
             return 'singleton_method'
 
+        # Non-public methods inside a class are helpers/callbacks, never
+        # route handlers or callbacks-by-name, regardless of the enclosing
+        # class. This must precede the controller branch so private params
+        # helpers (user_params) and before_action target methods (set_user)
+        # in *Controller classes are not mislabeled as route_handler.
+        if class_name and visibility in ('private', 'protected'):
+            return 'private_method' if visibility == 'private' else 'protected_method'
+
         # Callbacks
         if func_name.startswith(('before_', 'after_', 'around_')):
             return 'callback'
 
-        # Controller actions (route handlers)
+        # Controller actions (route handlers) — public methods only.
         if class_name and 'controller' in (class_name.lower() if class_name else ''):
             return 'route_handler'
         if 'controllers' in path_lower:
@@ -164,6 +179,63 @@ class FunctionExtractor:
 
         # Top-level
         return 'function'
+
+    # Sinatra / Padrino top-level route DSL verbs.
+    _SINATRA_VERBS = frozenset({
+        'get', 'post', 'put', 'patch', 'delete', 'options', 'head', 'link', 'unlink',
+    })
+
+    @staticmethod
+    def _literal_arg_text(arg_node, source: bytes) -> Optional[str]:
+        """Return the literal value of a symbol or string argument node.
+
+        Handles ``:foo`` (simple_symbol), ``:"foo"`` (delimited symbol),
+        and ``"foo"``/``'foo'`` (string). Returns None for non-literals.
+        """
+        t = arg_node.type
+        if t == 'simple_symbol':
+            text = source[arg_node.start_byte:arg_node.end_byte].decode('utf-8', errors='replace')
+            return text[1:] if text.startswith(':') else text
+        if t in ('symbol', 'delimited_symbol'):
+            for sc in arg_node.children:
+                if sc.type in ('string_content', 'identifier', 'constant'):
+                    return source[sc.start_byte:sc.end_byte].decode('utf-8', errors='replace')
+            text = source[arg_node.start_byte:arg_node.end_byte].decode('utf-8', errors='replace')
+            return text.lstrip(':').strip('"\'')
+        if t == 'string':
+            for sc in arg_node.children:
+                if sc.type == 'string_content':
+                    return source[sc.start_byte:sc.end_byte].decode('utf-8', errors='replace')
+            return ''
+        return None
+
+    def _call_receiver_and_method(self, node, source: bytes):
+        """For a 'call' node, return (method_name, [literal positional args]).
+
+        method_name is the identifier of the call (e.g. 'define_method',
+        'alias_method', 'get'); args are the literal symbol/string values in
+        the argument_list, in order. Returns (None, []) if not a simple call.
+        """
+        method_name = None
+        for child in node.children:
+            if child.type == 'identifier':
+                method_name = self._node_text(child, source)
+                break
+        if method_name is None:
+            return None, []
+        args = []
+        for child in node.children:
+            if child.type == 'argument_list':
+                for arg in child.children:
+                    if arg.type in ('simple_symbol', 'symbol', 'delimited_symbol', 'string'):
+                        val = self._literal_arg_text(arg, source)
+                        if val is not None:
+                            args.append(val)
+        return method_name, args
+
+    def _has_block(self, node) -> bool:
+        """True if the call node carries a do..end or { } block."""
+        return any(c.type in ('do_block', 'block') for c in node.children)
 
     def _extract_imports(self, tree, source: bytes) -> Dict[str, str]:
         """Extract require/require_relative/include/extend/prepend from a file."""
@@ -211,24 +283,83 @@ class FunctionExtractor:
 
     def _extract_functions_from_tree(self, tree, source: bytes, file_path: Path,
                                      relative_path: str) -> None:
-        """Extract all method definitions from a parsed tree."""
-        # Stack-based traversal: (node, class_name, module_name)
-        stack = [(tree.root_node, None, None)]
+        """Extract all method definitions from a parsed tree.
+
+        Stack frame: ``(node, class_name, module_name, vis_state)`` where
+        ``vis_state`` is a 1-element mutable list holding the current method
+        visibility ('public'/'private'/'protected'). All direct children of a
+        single class/module body SHARE one vis_state list, so a bare
+        ``private``/``protected``/``public`` marker mutates the visibility seen
+        by subsequent siblings popped from the same body (children are pushed in
+        reverse so they pop in source order).
+        """
+        stack = [(tree.root_node, None, None, ['public'])]
 
         while stack:
-            node, class_name, module_name = stack.pop()
+            node, class_name, module_name, vis_state = stack.pop()
 
             if node.type == 'method':
                 self._process_method_node(
                     node, source, relative_path, class_name, module_name,
-                    is_singleton=False
+                    is_singleton=False, visibility=vis_state[0],
                 )
 
             elif node.type == 'singleton_method':
                 self._process_method_node(
                     node, source, relative_path, class_name, module_name,
-                    is_singleton=True
+                    is_singleton=True, visibility=vis_state[0],
                 )
+
+            elif node.type == 'alias':
+                # `alias new old` keyword form.
+                self._process_alias_node(
+                    node, source, relative_path, class_name, module_name, vis_state[0],
+                )
+
+            elif node.type == 'call':
+                # Metaprogramming / DSL calls: define_method, alias_method
+                # inside a class, and top-level Sinatra route DSL. Non-matching
+                # calls fall through to a normal child descent so nested defs are
+                # still found.
+                method_name, args = self._call_receiver_and_method(node, source)
+                handled = False
+                if method_name == 'define_method' and class_name and args:
+                    self._emit_synthetic_method(
+                        node, source, relative_path, class_name, module_name,
+                        name=args[0], unit_type=None, visibility=vis_state[0],
+                    )
+                    handled = True
+                elif method_name == 'alias_method' and class_name and args:
+                    self._emit_synthetic_method(
+                        node, source, relative_path, class_name, module_name,
+                        name=args[0], unit_type=None, visibility=vis_state[0],
+                    )
+                    handled = True
+                elif (class_name is None and module_name is None
+                      and method_name in self._SINATRA_VERBS
+                      and self._has_block(node) and args):
+                    # Top-level `get '/path' do..end` Sinatra route.
+                    self._emit_synthetic_method(
+                        node, source, relative_path, class_name=None,
+                        module_name=None, name=args[0], unit_type='route_handler',
+                        visibility='public',
+                    )
+                    handled = True
+                elif method_name in ('private', 'protected', 'public'):
+                    # Arg-form visibility, e.g. `private :foo` — privatizes only
+                    # the named symbol(s), NOT subsequent defs. Consume it here
+                    # (without descending) so its inner `private` identifier does
+                    # not leak into the bare-marker toggle below.
+                    handled = True
+                if not handled:
+                    for child in reversed(node.children):
+                        stack.append((child, class_name, module_name, vis_state))
+
+            elif node.type == 'identifier' and class_name is not None and \
+                    self._node_text(node, source) in ('private', 'protected', 'public'):
+                # Bare visibility marker toggles subsequent-sibling visibility
+                # within the current class body.
+                vis_state[0] = self._node_text(node, source)
 
             elif node.type == 'class':
                 # Extract class name
@@ -248,17 +379,7 @@ class FunctionExtractor:
                 if new_class_name:
                     class_id = f"{relative_path}:{new_class_name}"
                     body_node = node.child_by_field_name('body')
-                    methods = []
-                    if body_node:
-                        for child in body_node.children:
-                            if child.type == 'method':
-                                mname = self._get_method_name(child, source)
-                                if mname:
-                                    methods.append(mname)
-                            elif child.type == 'singleton_method':
-                                mname = self._get_method_name(child, source)
-                                if mname:
-                                    methods.append(f"self.{mname}")
+                    methods = self._collect_class_method_names(body_node, source)
 
                     self.classes[class_id] = {
                         'name': new_class_name,
@@ -271,21 +392,33 @@ class FunctionExtractor:
                     }
                     self.stats['total_classes'] += 1
 
-                # Recurse into class body with updated class_name
+                # Recurse into class body with updated class_name and a FRESH
+                # per-body visibility state (defaults to public).
                 body_node = node.child_by_field_name('body')
                 if body_node:
+                    class_vis = ['public']
                     for child in reversed(body_node.children):
-                        stack.append((child, new_class_name, module_name))
+                        stack.append((child, new_class_name, module_name, class_vis))
                 continue  # Don't walk children again
 
             elif node.type == 'module':
-                # Extract module name
-                name_node = None
-                for child in node.children:
-                    if child.type == 'constant':
-                        name_node = child
-                        break
-                new_module_name = self._node_text(name_node, source) if name_node else module_name
+                # Module name: the `name` field is a `constant` (plain module)
+                # or a `scope_resolution` (compact `module A::B`). Concatenate
+                # with any enclosing module so nested + compact forms both keep
+                # the full namespace.
+                name_node = node.child_by_field_name('name')
+                if name_node is None:
+                    for child in node.children:
+                        if child.type in ('constant', 'scope_resolution'):
+                            name_node = child
+                            break
+                this_name = self._node_text(name_node, source) if name_node else None
+                if this_name and module_name:
+                    new_module_name = f"{module_name}::{this_name}"
+                elif this_name:
+                    new_module_name = this_name
+                else:
+                    new_module_name = module_name
 
                 # Recurse into module body
                 body_node = node.child_by_field_name('body')
@@ -297,17 +430,112 @@ class FunctionExtractor:
                             break
 
                 if body_node:
+                    mod_vis = ['public']
                     for child in reversed(body_node.children):
-                        stack.append((child, class_name, new_module_name))
+                        stack.append((child, class_name, new_module_name, mod_vis))
                 continue  # Don't walk children again
 
             else:
                 for child in reversed(node.children):
-                    stack.append((child, class_name, module_name))
+                    stack.append((child, class_name, module_name, vis_state))
+
+    def _collect_class_method_names(self, body_node, source: bytes) -> List[str]:
+        """Names of methods declared in a class body, including alias/metaprog forms."""
+        methods: List[str] = []
+        if body_node is None:
+            return methods
+        for child in body_node.children:
+            if child.type == 'method':
+                mname = self._get_method_name(child, source)
+                if mname:
+                    methods.append(mname)
+            elif child.type == 'singleton_method':
+                mname = self._get_method_name(child, source)
+                if mname:
+                    methods.append(f"self.{mname}")
+            elif child.type == 'alias':
+                mname = self._alias_new_name(child, source)
+                if mname:
+                    methods.append(mname)
+            elif child.type == 'call':
+                method_name, args = self._call_receiver_and_method(child, source)
+                if method_name in ('define_method', 'alias_method') and args:
+                    methods.append(args[0])
+        return methods
+
+    @staticmethod
+    def _alias_new_name(node, source: bytes) -> Optional[str]:
+        """Return the NEW (created) name from an `alias new old` node."""
+        idents = [c for c in node.children if c.type in ('identifier', 'constant', 'simple_symbol')]
+        if idents:
+            text = source[idents[0].start_byte:idents[0].end_byte].decode('utf-8', errors='replace')
+            return text[1:] if text.startswith(':') else text
+        return None
+
+    def _process_alias_node(self, node, source: bytes, relative_path: str,
+                            class_name: Optional[str], module_name: Optional[str],
+                            visibility: str) -> None:
+        """Emit a method unit for an `alias new old` keyword statement."""
+        name = self._alias_new_name(node, source)
+        if name:
+            self._emit_synthetic_method(
+                node, source, relative_path, class_name, module_name,
+                name=name, unit_type=None, visibility=visibility,
+            )
+
+    def _emit_synthetic_method(self, node, source: bytes, relative_path: str,
+                               class_name: Optional[str], module_name: Optional[str],
+                               name: str, unit_type: Optional[str],
+                               visibility: str) -> None:
+        """Register a function unit for a metaprogramming / DSL / alias definition.
+
+        Used for define_method, alias_method, alias, and Sinatra route DSL,
+        where the defining node is not a tree-sitter `method` node. When
+        ``unit_type`` is None the normal classifier is applied.
+        """
+        if not name:
+            return
+        start_line = node.start_point[0] + 1
+        end_line = node.end_point[0] + 1
+        code = self._node_text(node, source)
+
+        if unit_type is None:
+            unit_type = self._classify_function(
+                name, class_name, module_name, False, relative_path, visibility,
+            )
+
+        if class_name:
+            qualified_name = f"{class_name}.{name}"
+        elif module_name:
+            qualified_name = f"{module_name}.{name}"
+        else:
+            qualified_name = name
+
+        func_id = f"{relative_path}:{qualified_name}"
+        self.functions[func_id] = {
+            'name': name,
+            'qualified_name': qualified_name,
+            'file_path': relative_path,
+            'start_line': start_line,
+            'end_line': end_line,
+            'code': code,
+            'class_name': class_name,
+            'module_name': module_name,
+            'parameters': [],
+            'is_singleton': False,
+            'visibility': visibility,
+            'unit_type': unit_type,
+        }
+        self.stats['total_functions'] += 1
+        if class_name:
+            self.stats['total_methods'] += 1
+        else:
+            self.stats['standalone_functions'] += 1
+        self.stats['by_type'][unit_type] = self.stats['by_type'].get(unit_type, 0) + 1
 
     def _process_method_node(self, node, source: bytes, relative_path: str,
                               class_name: Optional[str], module_name: Optional[str],
-                              is_singleton: bool) -> None:
+                              is_singleton: bool, visibility: str = 'public') -> None:
         """Process a single method or singleton_method node."""
         name = self._get_method_name(node, source)
         if not name:
@@ -319,7 +547,7 @@ class FunctionExtractor:
         parameters = self._get_parameters(node, source)
 
         unit_type = self._classify_function(
-            name, class_name, module_name, is_singleton, relative_path
+            name, class_name, module_name, is_singleton, relative_path, visibility
         )
 
         # Build qualified name and function ID
@@ -343,6 +571,7 @@ class FunctionExtractor:
             'module_name': module_name,
             'parameters': parameters,
             'is_singleton': is_singleton,
+            'visibility': visibility,
             'unit_type': unit_type,
         }
 

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -366,7 +366,7 @@ class FunctionExtractor:
             self.stats['files_with_errors'] += 1
             return
 
-        relative_path = str(file_path.relative_to(self.repo_path))
+        relative_path = file_path.relative_to(self.repo_path).as_posix()  # posix-normalize keys for cross-platform call-graph resolution
 
         try:
             tree = self.parser.parse(source)

--- a/libs/openant-core/parsers/ruby/repository_scanner.py
+++ b/libs/openant-core/parsers/ruby/repository_scanner.py
@@ -86,7 +86,13 @@ class RepositoryScanner:
 
         # Skip test files by default (can be overridden)
         self.skip_tests = options.get('skip_tests', False)
-        self.test_patterns = {'test_', '_test.rb', '_spec.rb', 'test/', 'tests/', 'spec/'}
+        # Native Ruby test conventions (Minitest/RSpec). Directory names match
+        # whole path segments; filename rules are anchored to the basename so
+        # that ordinary sources like ``latest_release.rb``/``contest/foo.rb``
+        # are NOT misclassified as tests (an unanchored substring scan would).
+        self.test_dir_names = {'test', 'tests', 'spec'}
+        self.test_file_prefixes = ('test_',)
+        self.test_file_suffixes = ('_test.rb', '_spec.rb')
 
         # Statistics
         self.stats = {
@@ -116,11 +122,20 @@ class RepositoryScanner:
         return ext in self.source_extensions
 
     def is_test_file(self, relative_path: str) -> bool:
-        """Check if a file is a test file."""
-        path_lower = relative_path.lower()
-        for pattern in self.test_patterns:
-            if pattern in path_lower:
-                return True
+        """Check if a file is a test file.
+
+        Matches on path *components* and *anchored* filename rules rather than
+        unanchored substrings, so non-test files whose name merely contains a
+        token (``latest_release.rb``, ``contest/foo.rb``) are not skipped.
+        """
+        p = Path(relative_path)
+        if any(part.lower() in self.test_dir_names for part in p.parts[:-1]):
+            return True
+        name_lower = p.name.lower()
+        if name_lower.startswith(self.test_file_prefixes):
+            return True
+        if name_lower.endswith(self.test_file_suffixes):
+            return True
         return False
 
     def scan_directory(self, dir_path: Path, relative_path: str = '') -> None:

--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -6,7 +6,7 @@ Builds bidirectional call graphs showing function dependencies.
 
 import re
 from collections import defaultdict
-from typing import Dict, Any, List, Set
+from typing import Any, Dict, List, Optional, Set
 
 from utilities.file_io import write_json
 
@@ -137,37 +137,29 @@ class CallGraphBuilder:
         self.imports = extractor_output.get("imports", {})
         self.repository = extractor_output.get("repository", "")
         self.parser = Parser(self.ZIG_LANGUAGE)
+        # Populated by build_call_graph(); read via the canonical API (export/get_statistics/...).
+        self.call_graph: Dict[str, List[str]] = {}
+        self.reverse_call_graph: Dict[str, List[str]] = {}
 
-    def build(self) -> Dict[str, Any]:
-        """
-        Build the call graph.
+    def build_call_graph(self) -> None:
+        """Build the bidirectional call graph, populating self.call_graph / self.reverse_call_graph.
 
-        Returns call_graph.json structure with:
-        - functions (copied from extractor)
-        - classes (copied from extractor)
-        - imports (copied from extractor)
-        - call_graph: {caller_id: [callee_ids]}
-        - reverse_call_graph: {callee_id: [caller_ids]}
+        Canonical API (parity with the c/php/python/ruby CallGraphBuilder): mutates state and returns
+        None. Read results via export() / get_statistics() / get_dependencies() / get_callers().
         """
         call_graph: Dict[str, List[str]] = defaultdict(list)
         reverse_call_graph: Dict[str, List[str]] = defaultdict(list)
 
-        # Build an index of function names to IDs for resolution
         name_to_ids = self._build_name_index()
 
-        # For each function, find calls in its body
         for func_id, func_info in self.functions.items():
             code = func_info.get("code", "")
             file_path = func_info.get("file_path", "")
 
-            # Parse the function code to find call sites
             calls = self._find_calls_in_code(code)
 
-            # Resolve each call to a function ID
             for call_name in calls:
-                resolved_ids = self._resolve_call(
-                    call_name, file_path, name_to_ids
-                )
+                resolved_ids = self._resolve_call(call_name, file_path, name_to_ids)
                 for resolved_id in resolved_ids:
                     if resolved_id != func_id:  # No self-calls
                         if resolved_id not in call_graph[func_id]:
@@ -175,34 +167,84 @@ class CallGraphBuilder:
                         if func_id not in reverse_call_graph[resolved_id]:
                             reverse_call_graph[resolved_id].append(func_id)
 
-        # Calculate statistics
-        total_edges = sum(len(callees) for callees in call_graph.values())
-        out_degrees = [len(callees) for callees in call_graph.values()]
-        avg_out_degree = total_edges / len(self.functions) if self.functions else 0
-        max_out_degree = max(out_degrees) if out_degrees else 0
-        isolated = len(
-            [
-                f
-                for f in self.functions
-                if f not in call_graph and f not in reverse_call_graph
-            ]
-        )
+        self.call_graph = dict(call_graph)
+        self.reverse_call_graph = dict(reverse_call_graph)
 
+    def build(self) -> Dict[str, Any]:
+        """Back-compat wrapper: build the graph and return the exported dict.
+
+        Retained because the pipeline (zig/test_pipeline.py) calls build() and consumes its return
+        value; new code should use build_call_graph() + export() to match the canonical API.
+        """
+        self.build_call_graph()
+        return self.export()
+
+    def export(self) -> Dict[str, Any]:
+        """Export the call graph in the canonical schema."""
         return {
             "repository": self.repository,
             "functions": self.functions,
             "classes": self.classes,
             "imports": self.imports,
-            "call_graph": dict(call_graph),
-            "reverse_call_graph": dict(reverse_call_graph),
-            "statistics": {
-                "total_functions": len(self.functions),
-                "total_edges": total_edges,
-                "avg_out_degree": round(avg_out_degree, 2),
-                "max_out_degree": max_out_degree,
-                "isolated_functions": isolated,
-            },
+            "call_graph": self.call_graph,
+            "reverse_call_graph": self.reverse_call_graph,
+            "statistics": self.get_statistics(),
         }
+
+    def get_statistics(self) -> Dict[str, Any]:
+        """Compute call-graph statistics (parity with the canonical builders, incl. in-degree)."""
+        total_edges = sum(len(callees) for callees in self.call_graph.values())
+        num_funcs = len(self.functions)
+        out_degrees = [len(self.call_graph.get(f, [])) for f in self.functions]
+        in_degrees = [len(self.reverse_call_graph.get(f, [])) for f in self.functions]
+        isolated = sum(
+            1
+            for f in self.functions
+            if not self.call_graph.get(f) and not self.reverse_call_graph.get(f)
+        )
+        return {
+            "total_functions": num_funcs,
+            "total_edges": total_edges,
+            "avg_out_degree": round(total_edges / num_funcs, 2) if num_funcs else 0,
+            "avg_in_degree": round(total_edges / num_funcs, 2) if num_funcs else 0,
+            "max_out_degree": max(out_degrees) if out_degrees else 0,
+            "max_in_degree": max(in_degrees) if in_degrees else 0,
+            "isolated_functions": isolated,
+        }
+
+    def get_dependencies(self, func_id: str, depth: Optional[int] = None) -> List[str]:
+        """Get transitive callees of func_id up to depth (BFS); parity with canonical."""
+        max_d = depth if depth is not None else 3
+        deps: List[str] = []
+        visited = {func_id}
+        queue = [(func_id, 0)]
+        while queue:
+            current, d = queue.pop(0)
+            if d >= max_d:
+                continue
+            for callee in self.call_graph.get(current, []):
+                if callee not in visited:
+                    visited.add(callee)
+                    deps.append(callee)
+                    queue.append((callee, d + 1))
+        return deps
+
+    def get_callers(self, func_id: str, depth: Optional[int] = None) -> List[str]:
+        """Get transitive callers of func_id up to depth (BFS); parity with canonical."""
+        max_d = depth if depth is not None else 3
+        callers: List[str] = []
+        visited = {func_id}
+        queue = [(func_id, 0)]
+        while queue:
+            current, d = queue.pop(0)
+            if d >= max_d:
+                continue
+            for caller in self.reverse_call_graph.get(current, []):
+                if caller not in visited:
+                    visited.add(caller)
+                    callers.append(caller)
+                    queue.append((caller, d + 1))
+        return callers
 
     def _build_name_index(self) -> Dict[str, List[str]]:
         """Build index from function names to function IDs."""
@@ -239,24 +281,48 @@ class CallGraphBuilder:
         self, node: Node, source: bytes, calls: Set[str]
     ) -> None:
         """Recursively extract call sites from AST nodes."""
-        # Look for function call expressions
-        if node.type in ("call_expr", "call_expression", "CallExpr"):
-            # Get the function being called
-            for child in node.children:
-                if child.type in ("identifier", "IDENTIFIER", "field_access"):
-                    call_name = self._get_node_text(child, source)
-                    # Handle method calls (obj.method)
-                    if "." in call_name:
-                        parts = call_name.split(".")
-                        calls.add(parts[-1])  # Add just the method name
-                        calls.add(call_name)  # Also add the full qualified name
-                    else:
-                        calls.add(call_name)
-                    break
+        if node.type in ("call_expression", "call_expr", "CallExpr"):
+            # The callee is the first child: an `identifier` for a plain call foo(), or a
+            # `field_expression` for a method/namespaced call obj.method() / mod.func().
+            callee = node.children[0] if node.children else None
+            if callee is not None and callee.type in ("identifier", "IDENTIFIER"):
+                calls.add(self._get_node_text(callee, source))
+            elif callee is not None and callee.type in ("field_expression", "field_access"):
+                text = self._get_node_text(callee, source)
+                calls.add(text.split(".")[-1])  # trailing member (method / func name)
+                calls.add(text)                  # also the full dotted form
+        elif node.type == "builtin_function":
+            # @call(.modifier, realFn, argsTuple): the wrapped function is the real call target;
+            # other @builtins are filtered out downstream.
+            self._extract_builtin_call_target(node, source, calls)
 
         # Recurse into children
         for child in node.children:
             self._extract_calls_from_node(child, source, calls)
+
+    def _extract_builtin_call_target(
+        self, node: Node, source: bytes, calls: Set[str]
+    ) -> None:
+        """For Zig `@call(.modifier, fn, args)`, add `fn` as a call target (other @builtins: no-op)."""
+        builtin = ""
+        args = None
+        for child in node.children:
+            if child.type == "builtin_identifier":
+                builtin = self._get_node_text(child, source)
+            elif child.type == "arguments":
+                args = child
+        if builtin != "@call" or args is None:
+            return
+        # arguments: '(' , <.modifier field_expression> , ',' , <fn identifier/field_expression> , ...
+        for child in args.children:
+            if child.type not in ("identifier", "field_expression"):
+                continue
+            text = self._get_node_text(child, source)
+            if text.startswith("."):
+                continue  # the leading `.auto`/`.always_inline` call modifier, not the function
+            calls.add(text.split(".")[-1])
+            calls.add(text)
+            return
 
     def _find_calls_with_regex(self, code: str) -> Set[str]:
         """Fallback regex-based call detection."""
@@ -305,20 +371,28 @@ class CallGraphBuilder:
         if same_file:
             return same_file
 
-        # 2. Check imported files
+        # 2. Check imported files. Match by the imported FILE name (not an unanchored substring),
+        # and skip non-file stdlib imports (@import("std")/("builtin")/("root")) which would
+        # otherwise substring-match unrelated candidate paths.
         file_imports = self.imports.get(caller_file, [])
         for candidate in candidates:
             candidate_file = candidate.split(":")[0]
             for imp in file_imports:
-                if imp in candidate_file or candidate_file.endswith(imp):
+                if not imp.endswith(".zig"):
+                    continue  # std / builtin / root are not file imports
+                if candidate_file == imp or candidate_file.endswith("/" + imp):
                     return [candidate]
 
         # 3. If unique match, use it
         if len(candidates) == 1:
             return candidates
 
-        # Multiple matches, return all (conservative)
-        return candidates
+        # 4. Ambiguous across multiple files with no import resolving it. Do NOT emit edges to every
+        # same-named symbol -- that over-connection is a namespace leak (a.deinit() would link to
+        # every struct's deinit). Resolving the receiver's type needs info the extractor does not
+        # carry, so the precise target is unknown; return nothing rather than over-connect.
+        # Trade-off: lowers recall for genuinely-ambiguous bare-name calls to raise precision.
+        return []
 
     def save_results(self, output_path: str, results: Dict[str, Any]) -> None:
         """Save call graph to a JSON file."""

--- a/libs/openant-core/parsers/zig/function_extractor.py
+++ b/libs/openant-core/parsers/zig/function_extractor.py
@@ -10,19 +10,37 @@ from typing import Dict, Any, Optional, List
 
 from utilities.file_io import write_json
 
-import tree_sitter_zig as ts_zig
 from tree_sitter import Language, Parser, Node
+
+
+def _load_zig_language() -> Language:
+    """Load the Zig tree-sitter grammar lazily.
+
+    The grammar package (``tree-sitter-zig``) is an optional runtime
+    dependency. Importing it at module top level made the entire Zig parser
+    unimportable in any environment where the package is absent (e.g. a clean
+    install that does not need Zig support). Resolving it here, on first use,
+    lets the module import unconditionally and surfaces a clear, actionable
+    error only when the Zig parser is actually exercised.
+    """
+    try:
+        import tree_sitter_zig as ts_zig
+    except ImportError as exc:  # pragma: no cover - exercised via the no-dep test
+        raise ImportError(
+            "The Zig parser requires the 'tree-sitter-zig' package, which is not "
+            "installed. Install it with `pip install tree-sitter-zig` "
+            "(declared in pyproject.toml / requirements.txt)."
+        ) from exc
+    return Language(ts_zig.language())
 
 
 class FunctionExtractor:
     """Extracts functions and structs from Zig source files using tree-sitter."""
 
-    ZIG_LANGUAGE = Language(ts_zig.language())
-
     def __init__(self, repo_path: str, scan_results: Dict[str, Any]):
         self.repo_path = Path(repo_path).resolve()
         self.scan_results = scan_results
-        self.parser = Parser(self.ZIG_LANGUAGE)
+        self.parser = Parser(_load_zig_language())
 
     def extract(self) -> Dict[str, Any]:
         """
@@ -95,58 +113,70 @@ class FunctionExtractor:
         imports: List[str],
         current_struct: Optional[str],
     ) -> None:
-        """Recursively walk the AST to extract definitions."""
+        """Recursively walk the AST to extract definitions.
 
-        if node.type == "function_declaration" or node.type == "FnProto":
+        Node-type names match the tree-sitter-zig grammar actually in use
+        (variable_declaration / struct_declaration / function_declaration /
+        builtin_function). Earlier names (VarDecl / container_decl / FnProto /
+        builtin_call_expr) were from a different grammar revision and never
+        matched, leaving struct extraction dead and methods mis-emitted.
+        """
+
+        # The struct context for any children we recurse into. It only changes
+        # when this node is itself a `const Name = struct {...}` declaration.
+        child_struct = current_struct
+
+        if node.type == "function_declaration":
             func_info = self._extract_function(node, source, file_path, current_struct)
             if func_info:
                 func_id = f"{file_path}:{func_info['qualified_name']}"
                 functions[func_id] = func_info
 
-        elif node.type == "VarDecl":
-            # Check if this is a struct/enum definition
+        elif node.type == "variable_declaration":
+            # `const Foo = struct { ... };` -- a named struct/enum definition.
             struct_info = self._extract_struct_from_var_decl(node, source, file_path)
             if struct_info:
                 struct_id = f"{file_path}:{struct_info['name']}"
                 structs[struct_id] = struct_info
-                # Extract methods within the struct
-                self._extract_struct_methods(
-                    node, source, file_path, struct_info["name"], functions
-                )
+                # Thread the struct name down into the body so its method
+                # function_declarations are emitted ONCE, qualified as
+                # Struct.method (a method visited via recursion produces the
+                # same func_id as the eager scan, so there is no bare duplicate).
+                child_struct = struct_info["name"]
 
-        elif node.type == "container_decl" or node.type == "ContainerDecl":
-            # Direct struct/enum declarations
-            struct_info = self._extract_container(node, source, file_path)
-            if struct_info:
-                struct_id = f"{file_path}:{struct_info['name']}"
-                structs[struct_id] = struct_info
-
-        elif node.type == "@import" or (
-            node.type == "builtin_call_expr"
-            and self._get_node_text(node, source).startswith("@import")
-        ):
+        elif node.type == "builtin_function" and self._get_node_text(
+            node, source
+        ).startswith("@import"):
             import_path = self._extract_import(node, source)
             if import_path:
                 imports.append(import_path)
 
-        # Recurse into children
+        # Recurse into children with the (possibly updated) struct context so
+        # nested function_declarations are qualified correctly. Struct FIELDS
+        # (`container_field`) are not function_declarations, so they are never
+        # emitted as units.
         for child in node.children:
             self._walk_node(
-                child, source, file_path, functions, structs, imports, current_struct
+                child, source, file_path, functions, structs, imports, child_struct
             )
 
     def _extract_function(
         self, node: Node, source: bytes, file_path: str, current_struct: Optional[str]
     ) -> Optional[Dict[str, Any]]:
         """Extract function information from a function declaration node."""
-        # Find function name
+        # Find function name. In the grammar a function_declaration is
+        # `[pub] fn <identifier> (params) [return-type] block`; the function
+        # name is the FIRST identifier. A return type can also be a bare
+        # identifier (e.g. `fn init(...) Point {`), so capture the name once
+        # and stop -- otherwise the return-type identifier overwrites it.
         name = None
         parameters = []
 
         for child in node.children:
             if child.type == "identifier" or child.type == "IDENTIFIER":
-                name = self._get_node_text(child, source)
-            elif child.type == "parameters" or child.type == "ParamDeclList":
+                if name is None:
+                    name = self._get_node_text(child, source)
+            elif child.type in ("parameters", "ParamDeclList"):
                 parameters = self._extract_parameters(child, source)
 
         if not name:
@@ -195,9 +225,10 @@ class FunctionExtractor:
         is_struct = False
 
         for child in node.children:
-            if child.type == "identifier" or child.type == "IDENTIFIER":
-                name = self._get_node_text(child, source)
-            elif child.type == "container_decl" or child.type == "ContainerDecl":
+            if child.type in ("identifier", "IDENTIFIER"):
+                if name is None:
+                    name = self._get_node_text(child, source)
+            elif child.type == "struct_declaration":
                 is_struct = True
 
         if name and is_struct:
@@ -209,38 +240,6 @@ class FunctionExtractor:
                 "code": self._get_node_text(node, source),
             }
         return None
-
-    def _extract_container(
-        self, node: Node, source: bytes, file_path: str
-    ) -> Optional[Dict[str, Any]]:
-        """Extract struct/enum from a container declaration."""
-        # Anonymous container - try to find name from parent
-        return None
-
-    def _extract_struct_methods(
-        self,
-        node: Node,
-        source: bytes,
-        file_path: str,
-        struct_name: str,
-        functions: Dict[str, Any],
-    ) -> None:
-        """Extract methods from within a struct definition."""
-        for child in node.children:
-            if child.type == "container_decl" or child.type == "ContainerDecl":
-                for member in child.children:
-                    if (
-                        member.type == "function_declaration"
-                        or member.type == "FnProto"
-                        or member.type == "container_field"
-                    ):
-                        # Check if it's a function field
-                        func_info = self._extract_function(
-                            member, source, file_path, struct_name
-                        )
-                        if func_info:
-                            func_id = f"{file_path}:{func_info['qualified_name']}"
-                            functions[func_id] = func_info
 
     def _extract_import(self, node: Node, source: bytes) -> Optional[str]:
         """Extract import path from an @import call."""

--- a/libs/openant-core/parsers/zig/function_extractor.py
+++ b/libs/openant-core/parsers/zig/function_extractor.py
@@ -269,9 +269,12 @@ class FunctionExtractor:
         if name in ("init", "create", "new"):
             return "constructor"
 
-        # Main entry point
+        # Main entry point. Classify as 'main' (matching the C and Go parsers)
+        # so the reachability seeder recognises a Zig binary's program entry —
+        # 'main' is an ENTRY_POINT_TYPE. Returning the generic 'function' here
+        # left every Zig binary with zero seeded entry points.
         if name == "main":
-            return "function"
+            return "main"
 
         return "function"
 

--- a/libs/openant-core/parsers/zig/repository_scanner.py
+++ b/libs/openant-core/parsers/zig/repository_scanner.py
@@ -31,13 +31,18 @@ class RepositoryScanner:
         "target",
     }
 
-    # Test directory patterns to skip when skip_tests is True
-    TEST_PATTERNS = {"test", "tests", "spec", "specs", "_test", "test_"}
+    # Native Zig test conventions. Directory names are matched as whole path
+    # segments; filenames are matched by anchored stem prefix/suffix. Matching
+    # bare "test"/"spec" as a substring (the prior behaviour) misclassified
+    # ordinary names like ``latest``/``contest``/``fastest.zig`` as tests.
+    TEST_DIR_NAMES = {"test", "tests", "spec", "specs"}
+    TEST_FILE_PREFIXES = ("test_", "spec_")
+    TEST_FILE_SUFFIXES = ("_test.zig", "_spec.zig")
 
     def __init__(
         self,
         repo_path: str,
-        skip_tests: bool = True,
+        skip_tests: bool = False,
         exclude_patterns: Optional[List[str]] = None,
     ):
         self.repo_path = Path(repo_path).resolve()
@@ -113,20 +118,28 @@ class RepositoryScanner:
         return False
 
     def _is_test_directory(self, dirname: str) -> bool:
-        """Check if a directory name indicates test code."""
-        dirname_lower = dirname.lower()
-        return any(pattern in dirname_lower for pattern in self.TEST_PATTERNS)
+        """Check if a directory name indicates test code.
+
+        Exact (whole-name) match so that ``latest``/``contest``/``attestation``
+        are not misclassified as test directories.
+        """
+        return dirname.lower() in self.TEST_DIR_NAMES
 
     def _is_test_file(self, filepath: str) -> bool:
-        """Check if a file path indicates test code."""
-        filepath_lower = filepath.lower()
-        # Check for test in path components
-        parts = Path(filepath_lower).parts
-        for part in parts:
-            if any(pattern in part for pattern in self.TEST_PATTERNS):
-                return True
-        # Check for _test.zig suffix
-        if filepath_lower.endswith("_test.zig"):
+        """Check if a file path indicates test code.
+
+        A file is a test iff one of its directory components is a test
+        directory, or its filename is anchored (stem prefix ``test_``/``spec_``
+        or suffix ``_test.zig``/``_spec.zig``). Anchoring stops ordinary names
+        like ``src/fastest.zig``/``src/latest/main.zig`` from matching.
+        """
+        p = Path(filepath.lower())
+        if any(part in self.TEST_DIR_NAMES for part in p.parts[:-1]):
+            return True
+        name = p.name
+        if name.startswith(self.TEST_FILE_PREFIXES):
+            return True
+        if name.endswith(self.TEST_FILE_SUFFIXES):
             return True
         return False
 

--- a/libs/openant-core/parsers/zig/test_pipeline.py
+++ b/libs/openant-core/parsers/zig/test_pipeline.py
@@ -188,51 +188,66 @@ def apply_processing_filter(
 
 
 def apply_reachability_filter(call_graph_output: dict, repo_path: str) -> dict:
-    """Filter to functions reachable from entry points."""
+    """Filter to functions reachable from entry points.
+
+    Uses the real EntryPointDetector / ReachabilityAnalyzer contract, matching
+    the central core/parser_adapter.apply_reachability_filter and the C/Go/PHP/
+    Ruby/JS sibling pipelines. The previous implementation called an API that
+    never existed (``EntryPointDetector(repo_path)``, ``detector.detect()``,
+    ``ReachabilityAnalyzer(call_graph_output, entry_points)``,
+    ``analyzer.get_reachable_functions()``); because libs/openant-core is on
+    sys.path the imports succeeded, so the ``except ImportError`` guard never
+    fired and the resulting wrong-arity TypeError crashed every Zig parse at
+    --processing-level reachable.
+    """
     try:
-        # Try to import the reachability analyzer
         from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector
         from utilities.agentic_enhancer.reachability_analyzer import ReachabilityAnalyzer
-
-        # Detect entry points
-        detector = EntryPointDetector(repo_path)
-        entry_points = detector.detect()
-
-        # Analyze reachability
-        analyzer = ReachabilityAnalyzer(call_graph_output, entry_points)
-        reachable = analyzer.get_reachable_functions()
-
-        # Filter functions to only reachable ones
-        filtered_functions = {
-            fid: finfo
-            for fid, finfo in call_graph_output["functions"].items()
-            if fid in reachable
-        }
-
-        # Update the output with filtered functions
-        result = call_graph_output.copy()
-        result["functions"] = filtered_functions
-
-        # Filter call graphs too
-        result["call_graph"] = {
-            k: [v for v in vs if v in reachable]
-            for k, vs in call_graph_output.get("call_graph", {}).items()
-            if k in reachable
-        }
-        result["reverse_call_graph"] = {
-            k: [v for v in vs if v in reachable]
-            for k, vs in call_graph_output.get("reverse_call_graph", {}).items()
-            if k in reachable
-        }
-
-        return result
-
     except ImportError:
         print(
             "  Warning: Reachability analyzer not available, skipping filter",
             file=sys.stderr,
         )
         return call_graph_output
+
+    functions = call_graph_output.get("functions", {})
+    call_graph = call_graph_output.get("call_graph", {})
+    reverse_call_graph = call_graph_output.get("reverse_call_graph", {})
+
+    # Detect entry points structurally (functions carry the snake_case
+    # 'unit_type' the Zig extractor emits, which the detector reads directly).
+    detector = EntryPointDetector(functions, call_graph)
+    entry_points = detector.detect_entry_points()
+
+    # Compute the reachable set via reverse-BFS from the entry points.
+    analyzer = ReachabilityAnalyzer(
+        functions=functions,
+        reverse_call_graph=reverse_call_graph,
+        entry_points=entry_points,
+    )
+    reachable = analyzer.get_all_reachable()
+
+    # Filter functions to only reachable ones.
+    filtered_functions = {
+        fid: finfo for fid, finfo in functions.items() if fid in reachable
+    }
+
+    result = call_graph_output.copy()
+    result["functions"] = filtered_functions
+
+    # Filter the call graphs to the reachable subgraph too.
+    result["call_graph"] = {
+        k: [v for v in vs if v in reachable]
+        for k, vs in call_graph.items()
+        if k in reachable
+    }
+    result["reverse_call_graph"] = {
+        k: [v for v in vs if v in reachable]
+        for k, vs in reverse_call_graph.items()
+        if k in reachable
+    }
+
+    return result
 
 
 if __name__ == "__main__":

--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "tree-sitter-cpp>=0.21.0",
     "tree-sitter-ruby>=0.21.0",
     "tree-sitter-php>=0.22.0",
+    "tree-sitter-zig>=1.1.2",
 ]
 
 [project.optional-dependencies]

--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "tree-sitter-cpp>=0.21.0",
     "tree-sitter-ruby>=0.21.0",
     "tree-sitter-php>=0.22.0",
+    "tree-sitter-zig==1.1.2",
 ]
 
 [project.optional-dependencies]

--- a/libs/openant-core/requirements.txt
+++ b/libs/openant-core/requirements.txt
@@ -22,3 +22,4 @@ tree-sitter-c>=0.21.0
 tree-sitter-cpp>=0.21.0
 tree-sitter-ruby>=0.21.0
 tree-sitter-php>=0.22.0
+tree-sitter-zig>=1.1.2

--- a/libs/openant-core/requirements.txt
+++ b/libs/openant-core/requirements.txt
@@ -22,3 +22,4 @@ tree-sitter-c>=0.21.0
 tree-sitter-cpp>=0.21.0
 tree-sitter-ruby>=0.21.0
 tree-sitter-php>=0.22.0
+tree-sitter-zig==1.1.2

--- a/libs/openant-core/tests/parsers/c/test_c_call_resolution_precision.py
+++ b/libs/openant-core/tests/parsers/c/test_c_call_resolution_precision.py
@@ -1,0 +1,180 @@
+"""Regression tests for the C call-graph resolver precision/recall defects.
+
+Defects covered:
+  - regex fallback scans raw code -> phantom edges from identifiers inside // and
+    /* */ comments and "..." string literals.
+  - obj->cb() (field_expression callee) was reduced to the bare field name and
+    name-resolved against the global free-function index, wiring a
+    member/function-pointer call to an unrelated free function.
+  - a function passed by name as a callback argument (qsort(..., my_cmp),
+    pthread_create(..., worker, ...)) produced no edge because only the call's
+    'function' child was inspected, never its args.
+  - the repo-wide unique-name fallback returned a `static` (file-local) function
+    defined in another translation unit, violating C file-scope (a static helper()
+    in b.c resolving a helper() call in a.c).
+
+CallGraphBuilder consumes a plain extractor_output dict, so these drive it directly
+(no repo fixture / extractor run). It builds a tree-sitter C Parser at init, so the
+module skips where tree_sitter_c is unavailable, matching the other C tests.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = Path(__file__).resolve().parents[3]  # libs/openant-core (test is at tests/parsers/c/)
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+pytest.importorskip("tree_sitter_c")  # CallGraphBuilder builds a tree-sitter C Parser at init
+
+from parsers.c.call_graph_builder import CallGraphBuilder  # noqa: E402
+
+
+# --- regex fallback must not match comment/string content ----------------
+
+def test_regex_fallback_ignores_comments_and_string_literals():
+    """A // line comment, a /* */ block comment, and a "..." string literal each
+    contain a call-shaped token (bar/baz/qux). The fallback must not emit edges for
+    them; only real code calls should resolve."""
+    eo = {
+        "functions": {
+            "m.c:f": {"name": "f", "file_path": "m.c", "code": "stub"},
+            "m.c:bar": {"name": "bar", "file_path": "m.c", "code": "void bar(void){}"},
+            "m.c:baz": {"name": "baz", "file_path": "m.c", "code": "void baz(void){}"},
+            "m.c:qux": {"name": "qux", "file_path": "m.c", "code": "void qux(void){}"},
+            "m.c:real": {"name": "real", "file_path": "m.c", "code": "void real(void){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    code = 'void f(void){ // bar()\n /* baz() */ const char *s = "qux()"; real(); }'
+    edges = b._extract_calls_regex(code, "m.c:f")
+    assert "m.c:bar" not in edges, f"phantom edge from // comment: {sorted(edges)}"
+    assert "m.c:baz" not in edges, f"phantom edge from /* */ comment: {sorted(edges)}"
+    assert "m.c:qux" not in edges, f"phantom edge from string literal: {sorted(edges)}"
+    assert "m.c:real" in edges, f"real call dropped after stripping: {sorted(edges)}"
+
+
+# --- field_expression callee must not bind to a free function ------------
+
+def test_field_call_does_not_bind_to_unrelated_free_function():
+    """obj->cb() is a member / function-pointer call. It must not be wired to a
+    repo-unique free function named cb."""
+    eo = {
+        "functions": {
+            "main.c:caller": {"name": "caller", "file_path": "main.c",
+                              "code": "void caller(struct S *obj){ obj->cb(); }"},
+            "util.c:cb": {"name": "cb", "file_path": "util.c", "code": "void cb(void){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code("void caller(struct S *obj){ obj->cb(); }", "main.c:caller")
+    assert "util.c:cb" not in edges, f"false edge obj->cb() -> unrelated free cb: {sorted(edges)}"
+
+
+def test_direct_free_call_still_resolves():
+    """Guard: the field-expression decline must not break ordinary direct calls."""
+    eo = {
+        "functions": {
+            "main.c:caller": {"name": "caller", "file_path": "main.c",
+                              "code": "void caller(void){ helper(); }"},
+            "main.c:helper": {"name": "helper", "file_path": "main.c", "code": "void helper(void){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code("void caller(void){ helper(); }", "main.c:caller")
+    assert "main.c:helper" in edges, f"direct call regressed: {sorted(edges)}"
+
+
+# --- callback function passed by name as an argument -------------------
+
+def test_callback_argument_to_qsort_creates_edge():
+    """qsort(arr, n, sz, my_cmp) invokes my_cmp indirectly; the by-name callback
+    argument must produce a caller -> my_cmp edge."""
+    eo = {
+        "functions": {
+            "m.c:caller": {"name": "caller", "file_path": "m.c",
+                           "code": "void caller(int *a, int n){ qsort(a, n, sizeof(int), my_cmp); }"},
+            "m.c:my_cmp": {"name": "my_cmp", "file_path": "m.c",
+                           "code": "int my_cmp(const void *a, const void *b){ return 0; }"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(
+        "void caller(int *a, int n){ qsort(a, n, sizeof(int), my_cmp); }", "m.c:caller"
+    )
+    assert "m.c:my_cmp" in edges, f"callback arg my_cmp not tracked: {sorted(edges)}"
+
+
+def test_callback_argument_to_pthread_create_creates_edge():
+    """pthread_create(&t, NULL, worker, NULL) launches worker; the by-name argument
+    must produce a caller -> worker edge."""
+    eo = {
+        "functions": {
+            "m.c:caller": {"name": "caller", "file_path": "m.c",
+                           "code": "void caller(void){ pthread_create(&t, NULL, worker, NULL); }"},
+            "m.c:worker": {"name": "worker", "file_path": "m.c",
+                           "code": "void *worker(void *arg){ return NULL; }"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(
+        "void caller(void){ pthread_create(&t, NULL, worker, NULL); }", "m.c:caller"
+    )
+    assert "m.c:worker" in edges, f"callback arg worker not tracked: {sorted(edges)}"
+
+
+def test_non_function_identifier_arguments_do_not_create_edges():
+    """Guard: plain data arguments (variables, not functions) must not produce edges."""
+    eo = {
+        "functions": {
+            "m.c:caller": {"name": "caller", "file_path": "m.c",
+                           "code": "void caller(int x){ helper(x, count); }"},
+            "m.c:helper": {"name": "helper", "file_path": "m.c", "code": "void helper(int a, int b){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code("void caller(int x){ helper(x, count); }", "m.c:caller")
+    assert edges == {"m.c:helper"}, f"data args x/count must not be edges: {sorted(edges)}"
+
+
+# --- static (file-local) over-resolution across translation units -----
+
+def test_unique_name_fallback_skips_static_in_other_file():
+    """A repo-unique helper() that is `static` in b.c must NOT resolve a helper()
+    call in a.c (C file-scope)."""
+    eo = {
+        "functions": {
+            "a.c:caller": {"name": "caller", "file_path": "a.c", "code": "void caller(void){ helper(); }"},
+            "b.c:helper": {"name": "helper", "file_path": "b.c",
+                           "code": "static void helper(void){}", "is_static": True},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    assert b._resolve_call("helper", "a.c") is None, "static helper() in b.c wrongly resolved cross-TU"
+
+
+def test_same_file_static_call_still_resolves():
+    """Guard: a static function is fully callable from its own file."""
+    eo = {
+        "functions": {
+            "a.c:caller": {"name": "caller", "file_path": "a.c", "code": "void caller(void){ helper(); }"},
+            "a.c:helper": {"name": "helper", "file_path": "a.c",
+                           "code": "static void helper(void){}", "is_static": True},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    assert b._resolve_call("helper", "a.c") == "a.c:helper", "same-file static call must resolve"
+
+
+def test_non_static_unique_name_still_resolves_cross_file():
+    """Guard: a non-static repo-unique function still resolves cross-file (extern linkage)."""
+    eo = {
+        "functions": {
+            "a.c:caller": {"name": "caller", "file_path": "a.c", "code": "void caller(void){ shared(); }"},
+            "b.c:shared": {"name": "shared", "file_path": "b.c",
+                           "code": "void shared(void){}", "is_static": False},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    assert b._resolve_call("shared", "a.c") == "b.c:shared", "extern unique-name resolution regressed"

--- a/libs/openant-core/tests/parsers/c/test_c_include_map_determinism.py
+++ b/libs/openant-core/tests/parsers/c/test_c_include_map_determinism.py
@@ -1,0 +1,83 @@
+"""Regression tests for the C parser include-map non-deterministic
+basename/suffix match.
+
+CallGraphBuilder consumes a plain extractor_output dict, so these drive it directly
+(no repo fixture or extractor run needed). It does build a tree-sitter C Parser at
+init, so the module skips where tree_sitter_c is unavailable, like the other C tests.
+Two compounding faults:
+
+  Fault 1 (construction over-match): include_map was filled by
+    `other_file.endswith(inc) or other_file.endswith('/' + inc)` — the bare
+    `endswith(inc)` disjunct matches any path whose tail is the token even across
+    a non-'/' boundary (include "x.h" wrongly matches "src/prefix-x.h").
+
+  Fault 2 (consumption non-determinism): _resolve_call iterated the *unordered*
+    include_map set and returned the first base_name==call_name match, so with two
+    same-basename headers in different dirs each defining f(), the winner depended
+    on set iteration order -> flipped across PYTHONHASHSEED.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = Path(__file__).resolve().parents[3]  # libs/openant-core (test is at tests/parsers/c/)
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+pytest.importorskip("tree_sitter_c")  # CallGraphBuilder builds a tree-sitter C Parser at init
+
+from parsers.c.call_graph_builder import CallGraphBuilder  # noqa: E402
+
+
+def _extractor_output():
+    # foo/x.h and bar/x.h both define f() (same basename header, different dirs).
+    # src/prefix-x.h ends with the token "x.h" but NOT with "/x.h" -> must NOT match.
+    return {
+        "functions": {
+            "F_foo": {"name": "f", "file_path": "foo/x.h", "code": "void f(void){}"},
+            "F_bar": {"name": "f", "file_path": "bar/x.h", "code": "void f(void){}"},
+            "F_prefix": {"name": "g", "file_path": "src/prefix-x.h", "code": "void g(void){}"},
+            "F_main": {"name": "main", "file_path": "main.c", "code": "int main(void){ f(); return 0; }"},
+        },
+        "includes": {"main.c": ["x.h"]},
+    }
+
+
+def test_include_map_no_basename_overmatch():
+    """Fault 1: include 'x.h' matches foo/x.h + bar/x.h (path-component boundary)
+    but must NOT match src/prefix-x.h (bare-suffix tail match = false positive)."""
+    b = CallGraphBuilder(_extractor_output())
+    b._build_indexes()
+    inc = b.include_map.get("main.c", set())
+    assert "foo/x.h" in inc and "bar/x.h" in inc, f"legit same-basename headers must match: {sorted(inc)}"
+    assert "src/prefix-x.h" not in inc, f"over-match: include 'x.h' wrongly matched 'src/prefix-x.h': {sorted(inc)}"
+
+
+_DRIVER = (
+    "import sys; sys.path.insert(0, %r);"
+    "from parsers.c.call_graph_builder import CallGraphBuilder;"
+    "b = CallGraphBuilder(%r); b._build_indexes();"
+    "print(b._resolve_call('f', 'main.c'))"
+)
+
+
+def test_include_resolution_deterministic_across_hashseeds():
+    """Fault 2: with two same-basename headers each defining f(), _resolve_call must be
+    deterministic across PYTHONHASHSEED (set-iteration order must not pick the winner)
+    and must select the lexicographically-first file's func (stable tiebreak)."""
+    eo = _extractor_output()
+    results = []
+    for seed in range(10):
+        env = dict(os.environ, PYTHONHASHSEED=str(seed))
+        out = subprocess.run(
+            [sys.executable, "-c", _DRIVER % (str(CORE), eo)],
+            capture_output=True, text=True, env=env, cwd=str(CORE),
+        )
+        assert out.returncode == 0, f"driver failed (seed={seed}): {out.stderr}"
+        results.append(out.stdout.strip())
+    assert len(set(results)) == 1, f"non-deterministic resolution across PYTHONHASHSEED: {sorted(set(results))}"
+    # stable tiebreak = lexicographically-first file: 'bar/x.h' < 'foo/x.h' -> F_bar
+    assert results[0] == "F_bar", f"expected stable lexicographic winner F_bar, got {results[0]!r}"

--- a/libs/openant-core/tests/parsers/c/test_repository_scanner_is_test_file.py
+++ b/libs/openant-core/tests/parsers/c/test_repository_scanner_is_test_file.py
@@ -1,0 +1,55 @@
+"""Regression tests for the C repository scanner's test-file detection.
+
+``RepositoryScanner.is_test_file`` matched its ``test_patterns`` as bare
+substrings (``if pattern in path_lower``). Because
+``test_patterns`` includes ``'test_'`` and ``'test/'``, ordinary source files
+whose *name or path merely contains* those characters were wrongly skipped as
+tests:
+
+    - ``latest_value.c``  contains ``'test_'`` (la**test_**value) -> skipped
+    - ``contest/foo.c``   contains ``'test/'`` (con**test/**)     -> skipped
+
+The fix anchors the patterns to path *segments* and filename boundaries, so a
+pattern only matches a whole directory segment (``test/``, ``tests/``, ``fuzz/``)
+or a filename prefix/suffix (``test_``, ``_test.c``).
+"""
+
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]  # libs/openant-core
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.c.repository_scanner import RepositoryScanner
+
+
+def _scanner() -> RepositoryScanner:
+    # is_test_file is pure string logic; repo_path is unused by it.
+    return RepositoryScanner(".")
+
+
+def test_is_test_file_true_for_real_tests():
+    """Genuine test files/dirs must still be detected (guards against over-correction)."""
+    s = _scanner()
+    assert s.is_test_file("test/foo.c") is True
+    assert s.is_test_file("src/tests/bar.c") is True
+    assert s.is_test_file("fuzz/baz.c") is True
+    assert s.is_test_file("foo_test.c") is True
+    assert s.is_test_file("test_foo.c") is True
+    assert s.is_test_file("src/util/widget_test.cpp") is True
+    # _test stem before any C/C++ source extension (the old substring check caught
+    # .cc/.cxx via the '.c' prefix; the stem match preserves that):
+    assert s.is_test_file("foo_test.cc") is True
+    assert s.is_test_file("foo_test.cxx") is True
+
+
+def test_is_test_file_false_for_substring_lookalikes():
+    """Non-test files whose name/path merely CONTAINS a pattern
+    must NOT be classified as tests."""
+    s = _scanner()
+    assert s.is_test_file("latest_value.c") is False   # contains 'test_'
+    assert s.is_test_file("contest/foo.c") is False    # contains 'test/'
+    assert s.is_test_file("src/greatest.c") is False   # contains 'test'
+    assert s.is_test_file("attestation.cpp") is False  # contains 'test'
+    assert s.is_test_file("mytest/foo.c") is False     # deceptive dir segment 'mytest'
+    assert s.is_test_file("testing/foo.c") is False    # deceptive dir segment 'testing'

--- a/libs/openant-core/tests/parsers/javascript/test_call_graph_companion.py
+++ b/libs/openant-core/tests/parsers/javascript/test_call_graph_companion.py
@@ -1,0 +1,78 @@
+"""Tests for the call-graph/functions companion invariant.
+
+Every function the analyzer emits into `functions` must also have a key in
+`callGraph` (Pattern-A emit-without-companion).
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def _write(tmp_path, name, content, filename="file.js"):
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / filename
+    fp.write_text(content)
+    return repo, fp
+
+
+def test_module_exports_property_has_companion(tmp_path):
+    """module.exports.fn = function(){} must appear in callGraph too."""
+    repo, fp = _write(
+        tmp_path,
+        "sb3_commonjs",
+        "module.exports.userSearch = function (req, res) { return doThing(); };\n"
+        "function doThing(){ return 1; }\n",
+    )
+    out = _analyze(repo, fp)
+    funcs = set(out["functions"])
+    graph = set(out["callGraph"])
+    missing = funcs - graph
+    assert not missing, f"functions without callGraph companion: {missing}"
+    assert len(out["callGraph"]) == len(out["functions"])
+
+
+def test_all_emit_paths_have_companions(tmp_path):
+    """Object-literal exports, prototype assignments and class-expression
+    methods must each get a callGraph companion."""
+    repo, fp = _write(
+        tmp_path,
+        "sb3_mixed",
+        """
+function Foo(){}
+Foo.prototype.bar = function(){ return helper(); };
+function helper(){ return 1; }
+module.exports = { util: () => doThing() };
+function doThing(){ return 2; }
+const Svc = class { run(){ return helper(); } };
+""",
+    )
+    out = _analyze(repo, fp)
+    funcs = set(out["functions"])
+    graph = set(out["callGraph"])
+    missing = funcs - graph
+    assert not missing, f"functions without callGraph companion: {missing}"
+    assert len(out["callGraph"]) == len(out["functions"])

--- a/libs/openant-core/tests/parsers/javascript/test_call_graph_extraction.py
+++ b/libs/openant-core/tests/parsers/javascript/test_call_graph_extraction.py
@@ -1,0 +1,153 @@
+"""Tests for the JS analyzer call-graph extraction.
+
+These run the typescript_analyzer.js Node script as a subprocess on inline
+fixtures (mirroring test_express_route_handlers.py) and assert on the emitted
+`functions` / `callGraph`.
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def _write(tmp_path, name, content, filename="file.js"):
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / filename
+    fp.write_text(content)
+    return repo, fp
+
+
+def _names(edges):
+    """Collect the textual call names from a callGraph edge list."""
+    out = []
+    for e in edges:
+        if isinstance(e, dict):
+            out.append(e.get("name") or e.get("functionId"))
+        else:
+            out.append(e)
+    return out
+
+
+# --- foundational call-edge extraction ------------------------------
+
+def test_call_graph_records_callee(tmp_path):
+    """`function a(){b();} function b(){}` -> callGraph['file.js:a'] names b.
+
+    Regression for the `getDescendantsOfKind(funcNode.getKind())` bug that
+    made every out-edge list empty.
+    """
+    repo, fp = _write(
+        tmp_path,
+        "sb1",
+        "function a(){ b(); }\nfunction b(){ return 1; }\n",
+    )
+    out = _analyze(repo, fp)
+    edges = out["callGraph"]["file.js:a"]
+    assert "b" in _names(edges), f"expected a->b edge; callGraph['file.js:a']={edges}"
+
+
+def test_arrow_function_call_edges(tmp_path):
+    """Arrow function bodies must also yield out-edges."""
+    repo, fp = _write(
+        tmp_path,
+        "sb1_arrow",
+        "function helper(){ return 1; }\nconst run = () => { helper(); };\n",
+    )
+    out = _analyze(repo, fp)
+    edges = out["callGraph"]["file.js:run"]
+    assert "helper" in _names(edges), f"expected run->helper edge; got {edges}"
+
+
+# --- call-edge content ----------------------------------------------
+
+def test_callback_argument_edges(tmp_path):
+    """`addEventListener('click', handler)` / `setTimeout(cb)` must record the
+    callback identifier as a call edge."""
+    repo, fp = _write(
+        tmp_path,
+        "sb4_cb",
+        """
+function handler(){ return 1; }
+function register(){
+  el.addEventListener('click', handler);
+  setTimeout(handler, 10);
+  [1,2].forEach(handler);
+}
+""",
+    )
+    out = _analyze(repo, fp)
+    edges = out["callGraph"]["file.js:register"]
+    names = _names(edges)
+    assert "handler" in names, (
+        f"callback identifier `handler` must be recorded as a call edge; got {names}"
+    )
+
+
+def test_call_name_normalized_to_identifier(tmp_path):
+    """Chained / element-access callees must normalize to an identifier name,
+    not a multiline raw span."""
+    repo, fp = _write(
+        tmp_path,
+        "sb4_norm",
+        """
+function build(){
+  return foo
+    .bar()
+    .baz();
+}
+""",
+    )
+    out = _analyze(repo, fp)
+    edges = out["callGraph"]["file.js:build"]
+    for name in _names(edges):
+        assert name is not None
+        assert "\n" not in name, f"call name must not be a multiline blob: {name!r}"
+        # A normalized name is a bare identifier (the trailing member name).
+        assert name.replace("$", "_").replace("_", "a").isalnum() or name == "", (
+            f"call name should be a simple identifier, got {name!r}"
+        )
+
+
+def test_unresolved_calls_bucketed_into_indirect_calls(tmp_path):
+    """Dynamic / unresolvable calls populate `indirect_calls` rather than
+    silently vanishing."""
+    repo, fp = _write(
+        tmp_path,
+        "sb4_indirect",
+        """
+function dispatch(cb){
+  cb();
+  obj['method']();
+}
+""",
+    )
+    out = _analyze(repo, fp)
+    assert "indirect_calls" in out, "analyzer output must expose indirect_calls"
+    # The unresolved callee(s) of dispatch should appear under indirect_calls.
+    entry = out["indirect_calls"].get("file.js:dispatch", [])
+    assert len(entry) >= 1, (
+        f"expected dispatch's dynamic call(s) bucketed into indirect_calls; got {out['indirect_calls']}"
+    )

--- a/libs/openant-core/tests/parsers/javascript/test_dependency_resolver_edges.py
+++ b/libs/openant-core/tests/parsers/javascript/test_dependency_resolver_edges.py
@@ -1,0 +1,286 @@
+"""Resolver-level tests for dependency_resolver.js call-edge fidelity.
+
+These drive DependencyResolver directly (no analyzer pipeline) by requiring
+the module from a small Node harness, feeding it a synthetic analyzerOutput
+(functions / classes), building the call graph, and asserting on the resulting
+callGraph JSON. This isolates resolver behaviour from the upstream analyzer.
+
+Covers:
+  - bare call must not bind to a class method (over-resolution).
+  - `const x = new C(); x.m()` must resolve to C.m (local-type dispatch).
+  - a function's own name in its body must not create a self-edge.
+  - CLI on malformed JSON must emit a human-readable diagnostic, not a raw crash.
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+RESOLVER_JS = PARSERS_JS_DIR / "dependency_resolver.js"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _build_call_graph(analyzer_output: dict) -> dict:
+    """Run DependencyResolver on analyzer_output and return the resulting callGraph."""
+    harness = textwrap.dedent(
+        f"""
+        const {{ DependencyResolver }} = require({json.dumps(str(RESOLVER_JS))});
+        const out = JSON.parse(process.argv[1]);
+        const r = new DependencyResolver(out, {{}});
+        r.buildCallGraph();
+        process.stdout.write(JSON.stringify(r.callGraph));
+        """
+    )
+    result = subprocess.run(
+        ["node", "-e", harness, "--", json.dumps(analyzer_output)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0, (
+        f"resolver harness failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# bare-call class-method leak
+# ---------------------------------------------------------------------------
+
+def test_bare_call_does_not_bind_same_file_class_method():
+    """`doWork()` must NOT resolve to same-file class method `Utils.doWork`."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:Utils.doWork": {
+                    "name": "Utils.doWork",
+                    "className": "Utils",
+                    "code": "doWork(){return 1;}",
+                },
+                "a.js:caller": {
+                    "name": "caller",
+                    "code": "function caller(){ doWork(); }",
+                },
+            },
+            "classes": {"a.js:Utils": {}},
+        }
+    )
+    assert "a.js:Utils.doWork" not in cg["a.js:caller"], (
+        f"bare doWork() leaked to class method; edges={cg['a.js:caller']}"
+    )
+
+
+def test_bare_call_does_not_bind_unique_cross_file_class_method():
+    """`format()` must NOT resolve to a unique cross-file class method `Utils.format`."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "u.js:Utils.format": {
+                    "name": "Utils.format",
+                    "className": "Utils",
+                    "code": "format(){return 1;}",
+                },
+                "a.js:caller": {
+                    "name": "caller",
+                    "code": "function caller(){ format(); }",
+                },
+            },
+            "classes": {"u.js:Utils": {}},
+        }
+    )
+    assert "u.js:Utils.format" not in cg["a.js:caller"], (
+        f"bare format() leaked to cross-file class method; edges={cg['a.js:caller']}"
+    )
+
+
+def test_bare_call_to_top_level_function_still_resolves():
+    """Control: a bare call to a genuine top-level function must still resolve."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:doWork": {
+                    "name": "doWork",
+                    "code": "function doWork(){return 1;}",
+                },
+                "a.js:caller": {
+                    "name": "caller",
+                    "code": "function caller(){ doWork(); }",
+                },
+            },
+            "classes": {},
+        }
+    )
+    assert "a.js:doWork" in cg["a.js:caller"], (
+        f"bare call to top-level function should resolve; edges={cg['a.js:caller']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# local-variable type dispatch
+# ---------------------------------------------------------------------------
+
+def test_local_var_constructor_method_resolves():
+    """`const x = new C(); x.m()` must resolve to `C.m`."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:C.m": {"name": "C.m", "className": "C", "code": "m(){return 1;}"},
+                "a.js:doWork": {
+                    "name": "doWork",
+                    "code": "function doWork(){ const x = new C(); x.m(); }",
+                },
+            },
+            "classes": {"a.js:C": {}},
+        }
+    )
+    assert "a.js:C.m" in cg["a.js:doWork"], (
+        f"local-var x.m() should resolve to C.m; edges={cg['a.js:doWork']}"
+    )
+
+
+def test_local_var_let_and_var_forms_resolve():
+    """`let`/`var` constructor declarations also resolve the method call."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:C.m": {"name": "C.m", "className": "C", "code": "m(){return 1;}"},
+                "a.js:withLet": {
+                    "name": "withLet",
+                    "code": "function withLet(){ let y = new C(); y.m(); }",
+                },
+                "a.js:withVar": {
+                    "name": "withVar",
+                    "code": "function withVar(){ var z = new C(); z.m(); }",
+                },
+            },
+            "classes": {"a.js:C": {}},
+        }
+    )
+    assert "a.js:C.m" in cg["a.js:withLet"], f"let form failed; edges={cg['a.js:withLet']}"
+    assert "a.js:C.m" in cg["a.js:withVar"], f"var form failed; edges={cg['a.js:withVar']}"
+
+
+def test_local_var_builtin_constructor_not_resolved():
+    """`const m = new Map(); m.get()` must not spuriously resolve to a repo method."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:Cache.get": {
+                    "name": "Cache.get",
+                    "className": "Cache",
+                    "code": "get(){return 1;}",
+                },
+                "a.js:doWork": {
+                    "name": "doWork",
+                    "code": "function doWork(){ const m = new Map(); m.get('k'); }",
+                },
+            },
+            "classes": {"a.js:Cache": {}},
+        }
+    )
+    assert "a.js:Cache.get" not in cg["a.js:doWork"], (
+        f"built-in Map receiver must not bind to Cache.get; edges={cg['a.js:doWork']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# self-edge from own name in body
+# ---------------------------------------------------------------------------
+
+def test_function_own_name_does_not_create_self_edge():
+    """A function's own name appearing in its body must not produce a self-edge."""
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "auth.js:login": {
+                    "name": "login",
+                    "code": "function login(){ return doStuff(); }",
+                },
+                "auth.js:doStuff": {
+                    "name": "doStuff",
+                    "code": "function doStuff(){ return 1; }",
+                },
+            },
+            "classes": {},
+        }
+    )
+    assert "auth.js:login" not in cg["auth.js:login"], (
+        f"function must not have a self-edge; edges={cg['auth.js:login']}"
+    )
+    # The genuine cross-function edge must survive.
+    assert "auth.js:doStuff" in cg["auth.js:login"], (
+        f"genuine edge to doStuff lost; edges={cg['auth.js:login']}"
+    )
+
+
+def test_genuine_recursion_self_edge_absent():
+    """Even a truly self-recursive function should not list itself as a dependency.
+
+    Self-edges inflate out-degree and create self-dependencies in bundles; the
+    C-sibling call_graph_builder enforces `c != func_id`.
+    """
+    cg = _build_call_graph(
+        {
+            "functions": {
+                "a.js:fact": {
+                    "name": "fact",
+                    "code": "function fact(n){ return n <= 1 ? 1 : n * fact(n - 1); }",
+                },
+            },
+            "classes": {},
+        }
+    )
+    assert "a.js:fact" not in cg["a.js:fact"], (
+        f"recursive function must not self-edge; edges={cg['a.js:fact']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI JSON.parse must fail gracefully
+# ---------------------------------------------------------------------------
+
+def test_cli_malformed_json_emits_diagnostic(tmp_path):
+    """`node dependency_resolver.js <malformed.json>` must print a readable error."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{bad json")
+    result = subprocess.run(
+        ["node", str(RESOLVER_JS), str(bad)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 1, f"expected exit 1, got {result.returncode}"
+    combined = result.stdout + result.stderr
+    assert str(bad) in combined, f"diagnostic should name the input file; got: {combined}"
+    assert "SyntaxError" not in result.stderr.split("\n")[0], (
+        f"first stderr line should be a diagnostic, not a raw V8 SyntaxError; got: {result.stderr}"
+    )
+    # No raw V8 stack trace pointing into the resolver source.
+    assert "dependency_resolver.js:" not in result.stderr, (
+        f"raw stack trace leaked to stderr: {result.stderr}"
+    )
+
+
+def test_cli_missing_file_still_guarded(tmp_path):
+    """Control: the existing missing-file guard must remain intact."""
+    missing = tmp_path / "nope.json"
+    result = subprocess.run(
+        ["node", str(RESOLVER_JS), str(missing)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 1
+    assert "not found" in (result.stdout + result.stderr).lower()

--- a/libs/openant-core/tests/parsers/javascript/test_empty_repo.py
+++ b/libs/openant-core/tests/parsers/javascript/test_empty_repo.py
@@ -1,0 +1,102 @@
+"""Regression test for graceful handling of a zero-JS-file repository.
+
+A directory with zero JS-family source files must NOT be treated as a parser
+failure. repository_scanner.js exits 0 with an empty file list; the JS pipeline
+then hit ``if not files: return False`` in ``run_typescript_analyzer``, which
+made ``run_full_pipeline`` early-return without ``results['success']``, so
+``main`` did ``sys.exit(1)``. ``_parse_javascript`` then raised
+``RuntimeError`` on the non-zero exit, aborting the whole scan instead of
+yielding a 0-unit result.
+
+The Python, Ruby and Zig parsers all treat an empty repo gracefully (zig writes
+an empty dataset and returns 0). This test pins the JS parser to the same
+contract: zero files -> success + empty analyzer/dataset output, so the adapter
+returns a valid empty ParseResult.
+
+Loaded via importlib under a UNIQUE module name to avoid colliding with the
+many other modules named ``test_pipeline`` across the parser packages.
+"""
+
+import importlib.util
+import os
+
+import pytest
+
+from utilities.file_io import write_json
+
+_CORE_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..")
+)
+_JS_PIPELINE = os.path.join(
+    _CORE_ROOT, "parsers", "javascript", "test_pipeline.py"
+)
+
+
+def _load_js_pipeline():
+    spec = importlib.util.spec_from_file_location(
+        "isolated_js_pipeline_under_test", _JS_PIPELINE
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def js_pipeline():
+    return _load_js_pipeline()
+
+
+def _make_pipeline(js_pipeline, tmp_path, repo):
+    repo.mkdir(parents=True, exist_ok=True)
+    out = tmp_path / "out"
+    out.mkdir(parents=True, exist_ok=True)
+    pipeline = js_pipeline.PipelineTest(
+        repo_path=str(repo),
+        output_dir=str(out),
+        processing_level=js_pipeline.ProcessingLevel.ALL,
+        skip_tests=True,
+    )
+    return pipeline, out
+
+
+def _write_empty_scan(pipeline, out):
+    """Simulate repository_scanner.js succeeding with zero JS files."""
+    scan_path = os.path.join(str(out), "scan_results.json")
+    write_json(
+        scan_path,
+        {"files": [], "statistics": {"totalFiles": 0, "byExtension": {}}},
+    )
+    pipeline.scan_results_file = scan_path
+
+
+def test_zero_js_files_analyzer_succeeds_gracefully(js_pipeline, tmp_path):
+    """run_typescript_analyzer must NOT report failure on an empty repo."""
+    pipeline, out = _make_pipeline(js_pipeline, tmp_path, tmp_path / "empty_repo")
+    _write_empty_scan(pipeline, out)
+
+    ok = pipeline.run_typescript_analyzer()
+
+    assert ok is True, (
+        "zero JS files must be a graceful empty result, not a stage failure"
+    )
+
+
+def test_zero_js_files_writes_empty_outputs(js_pipeline, tmp_path):
+    """An empty repo must leave a valid empty analyzer + dataset on disk so the
+    adapter reads units_count=0 instead of crashing."""
+    pipeline, out = _make_pipeline(js_pipeline, tmp_path, tmp_path / "empty_repo")
+    _write_empty_scan(pipeline, out)
+
+    assert pipeline.run_typescript_analyzer() is True
+
+    analyzer_path = os.path.join(str(out), "analyzer_output.json")
+    dataset_path = os.path.join(str(out), "dataset.json")
+    assert os.path.exists(analyzer_path), "empty repo must still write analyzer_output.json"
+    assert os.path.exists(dataset_path), "empty repo must still write dataset.json"
+
+    from utilities.file_io import read_json
+
+    analyzer = read_json(analyzer_path)
+    dataset = read_json(dataset_path)
+    assert analyzer.get("functions", {}) == {}
+    assert dataset.get("units", []) == []

--- a/libs/openant-core/tests/parsers/javascript/test_express_route_handlers.py
+++ b/libs/openant-core/tests/parsers/javascript/test_express_route_handlers.py
@@ -398,3 +398,68 @@ module.exports = router;
     assert any(
         f.get("name") == "namedHandler" for f in out["functions"].values()
     )
+
+
+# --- route REGISTRATION broadened to Fastify/Koa --------
+
+def test_fastify_inline_handler_synthesised(tmp_path):
+    """fastify.get('/users', async (request, reply) => {...}) must synthesise a
+    route_handler unit (is_entry_point) even though the receiver is `fastify`,
+    not an Express app/router. Express-only registration would skip it."""
+    file_path = _write_fixture(
+        tmp_path,
+        "fastify_route",
+        """
+const fastify = require('fastify')();
+fastify.get('/users', async (request, reply) => {
+  return { users: [] };
+});
+""",
+    )
+    repo = file_path.parent
+    out = _analyze(repo, file_path)
+    express_funcs = {k: v for k, v in out["functions"].items() if "express(" in k}
+    assert len(express_funcs) == 1, (
+        f"expected 1 synthesised Fastify handler, got {list(express_funcs)}"
+    )
+    fid, fdata = next(iter(express_funcs.items()))
+    assert fdata["unitType"] == "route_handler"
+    assert fdata["isEntryPoint"] is True
+    meta = fdata["routeMetadata"]
+    assert meta["http_method"] == "GET"
+    assert meta["http_path"] == "/users"
+
+    # End-to-end through unit_generator: is_entry_point must survive.
+    analyzer_path = tmp_path / "analyzer.json"
+    analyzer_path.write_text(json.dumps(out))
+    dataset_path = tmp_path / "dataset.json"
+    dataset = _generate_units(analyzer_path, dataset_path)
+    handler_unit = next(u for u in dataset["units"] if u["id"] == fid)
+    assert handler_unit["unit_type"] == "route_handler"
+    assert handler_unit["is_entry_point"] is True
+
+
+def test_koa_inline_handler_synthesised(tmp_path):
+    """Bare `koa.get('/x', ctx => {})` must also synthesise a route handler.
+    (router.get already works because `router` is an Express stem; this checks
+    the additional `koa` receiver stem.)"""
+    file_path = _write_fixture(
+        tmp_path,
+        "koa_route",
+        """
+const Koa = require('koa');
+const koa = new Koa();
+koa.get('/x', ctx => { ctx.body = 'hi'; });
+""",
+    )
+    repo = file_path.parent
+    out = _analyze(repo, file_path)
+    express_funcs = {k: v for k, v in out["functions"].items() if "express(" in k}
+    assert len(express_funcs) == 1, (
+        f"expected 1 synthesised Koa handler, got {list(express_funcs)}"
+    )
+    fid, fdata = next(iter(express_funcs.items()))
+    assert fdata["unitType"] == "route_handler"
+    assert fdata["isEntryPoint"] is True
+    assert fdata["routeMetadata"]["http_method"] == "GET"
+    assert fdata["routeMetadata"]["http_path"] == "/x"

--- a/libs/openant-core/tests/parsers/javascript/test_framework_classification.py
+++ b/libs/openant-core/tests/parsers/javascript/test_framework_classification.py
@@ -1,0 +1,82 @@
+"""Tests for framework route-handler classification.
+
+Fastify `(request, reply)` handlers must classify as route_handlers, and React
+components that happen to take `(request, response)` must NOT be misclassified as
+routes.
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def _write(tmp_path, name, content, filename="file.js"):
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / filename
+    fp.write_text(content)
+    return repo, fp
+
+
+def test_fastify_request_reply_is_route_handler(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "sb6_fastify",
+        "function fastifyRoute(request, reply) { reply.send({ ok: true }); }\n",
+    )
+    out = _analyze(repo, fp)
+    fn = out["functions"]["file.js:fastifyRoute"]
+    assert fn["unitType"] == "route_handler", (
+        f"Fastify (request, reply) handler must classify as route_handler; got {fn['unitType']}"
+    )
+
+
+def test_koa_ctx_is_route_handler(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "sb6_koa",
+        "function koaRoute(ctx) { ctx.body = 'ok'; }\n",
+    )
+    out = _analyze(repo, fp)
+    fn = out["functions"]["file.js:koaRoute"]
+    assert fn["unitType"] == "route_handler", (
+        f"Koa (ctx) handler must classify as route_handler; got {fn['unitType']}"
+    )
+
+
+def test_react_component_not_misclassified(tmp_path):
+    """A function named like a component taking (request, response) must not be
+    treated as an Express route just because of the parameter names."""
+    repo, fp = _write(
+        tmp_path,
+        "sb6_react",
+        "function MyComponent(request, response) { return null; }\n",
+        filename="file.jsx",
+    )
+    out = _analyze(repo, fp)
+    fn = out["functions"]["file.jsx:MyComponent"]
+    assert fn["unitType"] != "route_handler", (
+        f"React component taking (request, response) must NOT be a route_handler; got {fn['unitType']}"
+    )

--- a/libs/openant-core/tests/parsers/javascript/test_function_inventory_gaps.py
+++ b/libs/openant-core/tests/parsers/javascript/test_function_inventory_gaps.py
@@ -1,0 +1,210 @@
+"""Tests for AST-shape inventory gaps in the JS analyzer.
+
+Each test feeds an inline fixture with a particular function-defining AST
+shape and asserts the function appears in the analyzer's `functions` map.
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def _write(tmp_path, name, content, filename="file.js"):
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / filename
+    fp.write_text(content)
+    return repo, fp
+
+
+# --- ClassExpression (module.exports = class {}) ------------------
+
+def test_class_expression_methods_extracted(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "b073",
+        "module.exports = class Service {\n  doWork() { return 1; }\n};\n",
+    )
+    out = _analyze(repo, fp)
+    keys = list(out["functions"])
+    assert any(k.endswith(":Service.doWork") for k in keys), (
+        f"ClassExpression method `doWork` must be extracted; got {keys}"
+    )
+
+
+# --- anon export default fn, prototype assign, this.method, Object.assign ---
+
+def test_anonymous_export_default_function(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "b088_default",
+        "export default function(){ return secretHelper(); }\nfunction secretHelper(){ return 1; }\n",
+    )
+    out = _analyze(repo, fp)
+    keys = list(out["functions"])
+    assert any("default" in k for k in keys), (
+        f"anonymous `export default function(){{}}` must be extracted; got {keys}"
+    )
+
+
+def test_prototype_method_assignment(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "b088_proto",
+        "function Foo(){}\nFoo.prototype.bar = function(){ return 2; };\n",
+    )
+    out = _analyze(repo, fp)
+    keys = list(out["functions"])
+    assert any(k.endswith(":Foo.bar") for k in keys), (
+        f"`Foo.prototype.bar = fn` must be extracted as Foo.bar; got {keys}"
+    )
+
+
+def test_object_assign_prototype(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "b088_assign",
+        "function Foo(){}\nObject.assign(Foo.prototype, {\n  greet(){ return 'hi'; },\n  wave: function(){ return 'wave'; },\n});\n",
+    )
+    out = _analyze(repo, fp)
+    keys = list(out["functions"])
+    assert any(k.endswith(":Foo.greet") for k in keys), (
+        f"`Object.assign(Foo.prototype, {{greet(){{}}}})` must extract greet; got {keys}"
+    )
+    assert any(k.endswith(":Foo.wave") for k in keys), (
+        f"`Object.assign(Foo.prototype, {{wave: fn}})` must extract wave; got {keys}"
+    )
+
+
+# --- this.method = fn inside a constructor function ----------------
+
+def test_this_method_in_constructor(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "b127",
+        "function Ctor(){\n  this.handleLogin = function(){ return 3; };\n}\n",
+    )
+    out = _analyze(repo, fp)
+    keys = list(out["functions"])
+    assert any(k.endswith(":Ctor.handleLogin") for k in keys), (
+        f"`this.handleLogin = fn` in a constructor must be extracted; got {keys}"
+    )
+
+
+# --- Object.defineProperty(X.prototype, "n", {value: fn}) ----------
+
+def test_define_property_value_function(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "b092",
+        'function X(){}\nObject.defineProperty(X.prototype, "n", { value: function(){ return 1; } });\n',
+    )
+    out = _analyze(repo, fp)
+    keys = list(out["functions"])
+    assert any(k.endswith(":X.n") for k in keys), (
+        f"`Object.defineProperty(X.prototype, 'n', {{value: fn}})` must extract X.n; got {keys}"
+    )
+
+
+# --- top-level side-effect call -----------------------
+
+def test_top_level_side_effect_call_yields_unit(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "m006",
+        "contextBridge.exposeInMainWorld('api', { ping: () => 1 });\n",
+    )
+    out = _analyze(repo, fp)
+    assert len(out["functions"]) >= 1, (
+        f"a file with only a top-level side-effect call must emit >=1 unit; got {list(out['functions'])}"
+    )
+
+
+# --- HOC const initializer (memo/forwardRef/styled) ---
+
+def test_hoc_const_initializer(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "m008",
+        "const Card = memo(() => { return null; });\nconst Wrapped = forwardRef((props, ref) => { return null; });\n",
+        filename="file.jsx",
+    )
+    out = _analyze(repo, fp)
+    keys = list(out["functions"])
+    assert any(k.endswith(":Card") for k in keys), (
+        f"`const Card = memo(() => {{}})` must be extracted; got {keys}"
+    )
+    assert any(k.endswith(":Wrapped") for k in keys), (
+        f"`const Wrapped = forwardRef(...)` must be extracted; got {keys}"
+    )
+
+
+# --- re-export barrel object literal -------------------------------
+
+def test_reexport_barrel_property(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "b109",
+        "module.exports = { foo: require('./x').foo };\n",
+    )
+    out = _analyze(repo, fp)
+    keys = list(out["functions"])
+    assert any(k.endswith(":exports.foo") or k.endswith(":foo") for k in keys), (
+        f"re-export barrel `{{foo: require('./x').foo}}` must surface foo; got {keys}"
+    )
+
+
+# --- class accessors (getters/setters) dropped by getMethods() -----
+
+def test_class_accessors_extracted_with_companion(tmp_path):
+    """`get x(){}` / `set x(v){}` are excluded by ts-morph getMethods(), so they
+    must be iterated via getGetAccessors()/getSetAccessors(). The accessor must
+    appear in `functions` AND have a callGraph companion (Pattern-A)."""
+    repo, fp = _write(
+        tmp_path,
+        "b126",
+        "class Account {\n"
+        "  get balance(){ return 1; }\n"
+        "  set balance(v){ this._v = v; }\n"
+        "  normalMethod(){ return 2; }\n"
+        "}\n",
+    )
+    out = _analyze(repo, fp)
+    funcs = list(out["functions"])
+    graph = set(out["callGraph"])
+    # The accessor `balance` must be emitted as a function.
+    accessor_keys = [k for k in funcs if k.endswith(":Account.balance")]
+    assert accessor_keys, (
+        f"class accessor `get/set balance` must be extracted as Account.balance; got {funcs}"
+    )
+    # And it must have a callGraph companion (no Pattern-A asymmetry).
+    for k in accessor_keys:
+        assert k in graph, (
+            f"accessor {k} present in functions but missing callGraph companion; graph={sorted(graph)}"
+        )
+    # Sanity: the plain method is still emitted.
+    assert any(k.endswith(":Account.normalMethod") for k in funcs), (
+        f"plain method normalMethod must still be extracted; got {funcs}"
+    )

--- a/libs/openant-core/tests/parsers/javascript/test_schema_contract.py
+++ b/libs/openant-core/tests/parsers/javascript/test_schema_contract.py
@@ -1,0 +1,117 @@
+"""Tests for the JS analyzer schema contract.
+
+The analyzer must emit the snake_case `call_graph` / `reverse_call_graph`
+(resolved id lists), `repository`, and per-function `parameters` — the same
+contract the C/Python/Ruby sibling parsers satisfy. A pipeline-level test
+confirms a non-entry reachable function survives the reachability filter.
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+CORE_ROOT = Path(__file__).parent.parent.parent.parent
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def _write(tmp_path, name, content, filename="file.js"):
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / filename
+    fp.write_text(content)
+    return repo, fp
+
+
+def test_analyzer_emits_snake_case_graphs(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "sb5_graphs",
+        "function a(){ b(); }\nfunction b(){ return 1; }\n",
+    )
+    out = _analyze(repo, fp)
+    assert "call_graph" in out, "analyzer must emit snake_case call_graph"
+    assert "reverse_call_graph" in out, "analyzer must emit reverse_call_graph"
+    assert out["call_graph"]["file.js:a"] == ["file.js:b"], (
+        f"call_graph must list resolved callee ids; got {out['call_graph']}"
+    )
+    assert out["reverse_call_graph"].get("file.js:b") == ["file.js:a"], (
+        f"reverse_call_graph must list resolved caller ids; got {out['reverse_call_graph']}"
+    )
+
+
+def test_analyzer_emits_repository(tmp_path):
+    repo, fp = _write(tmp_path, "sb5_repo", "function a(){ return 1; }\n")
+    out = _analyze(repo, fp)
+    assert out.get("repository"), "analyzer must emit a repository path"
+
+
+def test_analyzer_emits_parameters(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "sb5_params",
+        "function add(x, y){ return x + y; }\n",
+    )
+    out = _analyze(repo, fp)
+    fn = out["functions"]["file.js:add"]
+    assert "parameters" in fn, "each function must carry a parameters list"
+    assert fn["parameters"] == ["x", "y"], (
+        f"parameters must list the parameter names; got {fn.get('parameters')}"
+    )
+
+
+def test_reachability_keeps_non_entry_callee(tmp_path):
+    """Pipeline-level: a function reachable only as a callee of an entry point
+    must survive the reachability filter, which depends on the analyzer's
+    reverse_call_graph being populated."""
+    repo, fp = _write(
+        tmp_path,
+        "sb5_reach",
+        """
+const express = require('express');
+const app = express();
+function helper(){ return 1; }
+app.get('/x', (req, res) => { res.json(helper()); });
+module.exports = app;
+""",
+    )
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    parser_script = PARSERS_JS_DIR / "test_pipeline.py"
+    cmd = [
+        sys.executable, str(parser_script),
+        str(repo),
+        "--output", str(output_dir),
+        "--processing-level", "reachable",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, cwd=str(CORE_ROOT))
+    assert result.returncode == 0, (
+        f"pipeline failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+
+    dataset = json.loads((output_dir / "dataset.json").read_text())
+    ids = {u["id"] for u in dataset["units"]}
+    assert any(uid.endswith(":helper") for uid in ids), (
+        f"non-entry callee `helper` must survive reachability; surviving ids={ids}"
+    )

--- a/libs/openant-core/tests/parsers/javascript/test_unit_generator_file_boundary.py
+++ b/libs/openant-core/tests/parsers/javascript/test_unit_generator_file_boundary.py
@@ -1,0 +1,71 @@
+"""Tests for FILE_BOUNDARY module-level export parity in the JS unit generator.
+
+The JavaScript parser declared FILE_BOUNDARY as a
+function-local `const` inside `_assembleEnhancedCode` and never exported it,
+unlike the python/php/c/ruby parsers which expose it as a module-level constant
+(python/unit_generator.py:60, php/c/ruby :35). That made the canonical boundary
+marker un-importable and risked silent drift across language parsers.
+
+These exercise the JS module's exports by running Node.js as a subprocess
+(mirroring tests/parsers/javascript/test_express_route_handlers.py). They skip
+when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+UNIT_GENERATOR_JS = PARSERS_JS_DIR / "unit_generator.js"
+
+# Canonical boundary marker shared with the python/php/c/ruby parsers.
+# (Comment syntax differs by language: JS/PHP/C/Zig use `//`, python/ruby use `#`.)
+EXPECTED_FILE_BOUNDARY = "\n\n// ========== File Boundary ==========\n\n"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _require_exports() -> dict:
+    """require() the module in Node and return its exports as JSON."""
+    script = (
+        f"const m = require({json.dumps(str(UNIT_GENERATOR_JS))});"
+        "process.stdout.write(JSON.stringify({"
+        "keys: Object.keys(m),"
+        "fileBoundaryType: typeof m.FILE_BOUNDARY,"
+        "fileBoundary: m.FILE_BOUNDARY === undefined ? null : m.FILE_BOUNDARY,"
+        "}));"
+    )
+    result = subprocess.run(
+        ["node", "-e", script], capture_output=True, text=True, timeout=30
+    )
+    assert result.returncode == 0, (
+        f"node require() failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def test_FILE_BOUNDARY_exported():
+    """FILE_BOUNDARY must be a module-level export (importable by other modules)."""
+    exports = _require_exports()
+    assert "FILE_BOUNDARY" in exports["keys"], (
+        "FILE_BOUNDARY is not exported from unit_generator.js; "
+        f"module.exports keys = {exports['keys']}"
+    )
+
+
+def test_FILE_BOUNDARY_is_string():
+    """The exported FILE_BOUNDARY must be the canonical boundary marker string."""
+    exports = _require_exports()
+    assert exports["fileBoundaryType"] == "string", (
+        f"FILE_BOUNDARY should be a string, got type {exports['fileBoundaryType']!r}"
+    )
+    assert exports["fileBoundary"] == EXPECTED_FILE_BOUNDARY, (
+        f"FILE_BOUNDARY value mismatch: {exports['fileBoundary']!r}"
+    )

--- a/libs/openant-core/tests/parsers/javascript/test_unit_generator_function_id.py
+++ b/libs/openant-core/tests/parsers/javascript/test_unit_generator_function_id.py
@@ -1,0 +1,106 @@
+"""Tests for unit_generator.js functionId parsing.
+
+A functionId has the shape "<filePath>:<functionName>" where the SEPARATOR is
+the FIRST colon (this is the contract the dependency_resolver enforces with
+`funcId.split(':')[0]`). The functionName itself may contain colons, e.g. an
+Express route id like "src/r.ts:express(GET:/items/:id)".
+
+unit_generator.js previously split on the LAST colon (`lastIndexOf(':')`), which
+mangled both filePath and functionName for any multi-colon id. These tests drive
+UnitGenerator.generateUnits via a node subprocess on a synthetic analyzer output
+whose `functions` dict carries a multi-colon id, and assert the recovered
+file_path is correct.
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _generate_units(tmp_path, analyzer_output):
+    """Run UnitGenerator.generateUnits(analyzer_output) via node and return the result dict."""
+    out_json = tmp_path / "analyzer_output.json"
+    out_json.write_text(json.dumps(analyzer_output))
+    driver = tmp_path / "driver.js"
+    driver.write_text(
+        textwrap.dedent(
+            f"""
+            const fs = require('fs');
+            const {{ UnitGenerator }} = require({json.dumps(str(PARSERS_JS_DIR / "unit_generator.js"))});
+            const analyzerOutput = JSON.parse(fs.readFileSync({json.dumps(str(out_json))}, 'utf8'));
+            const gen = new UnitGenerator('/repo', 'testds', {{ maxDepth: 1 }});
+            const result = gen.generateUnits(analyzerOutput, null);
+            process.stdout.write(JSON.stringify(result));
+            """
+        )
+    )
+    proc = subprocess.run(
+        ["node", str(driver)], capture_output=True, text=True, timeout=30
+    )
+    assert proc.returncode == 0, f"driver failed:\nstdout={proc.stdout}\nstderr={proc.stderr}"
+    return json.loads(proc.stdout)
+
+
+def test_multi_colon_function_id_recovers_file_path(tmp_path):
+    """A multi-colon Express functionId must recover the true file path
+    (everything before the FIRST colon), not be mangled by last-colon split.
+
+    Regression guard: unit_generator.js used lastIndexOf(':'),
+    so "src/r.ts:express(GET:/items/:id)" produced file_path
+    "src/r.ts:express(GET:/items/" instead of "src/r.ts".
+    """
+    func_id = "src/r.ts:express(GET:/items/:id)"
+    analyzer_output = {
+        "functions": {
+            func_id: {
+                "name": "express(GET:/items/:id)",
+                "code": "function(req,res){ return res.send('ok'); }",
+                "startLine": 42,
+                "endLine": 44,
+            }
+        },
+        "classes": {},
+        "callGraph": {},
+    }
+    result = _generate_units(tmp_path, analyzer_output)
+    units = result["units"]
+    assert len(units) == 1, f"expected 1 unit, got {len(units)}"
+    file_path = units[0]["code"]["primary_origin"]["file_path"]
+    assert file_path == "src/r.ts", (
+        f"multi-colon id file_path must be 'src/r.ts' (first-colon split), "
+        f"got {file_path!r}"
+    )
+
+
+def test_single_colon_function_id_still_parses(tmp_path):
+    """The common single-colon id must still parse correctly (no regression)."""
+    func_id = "src/util.ts:helper"
+    analyzer_output = {
+        "functions": {
+            func_id: {
+                "name": "helper",
+                "code": "function helper(){ return 1; }",
+                "startLine": 1,
+                "endLine": 1,
+            }
+        },
+        "classes": {},
+        "callGraph": {},
+    }
+    result = _generate_units(tmp_path, analyzer_output)
+    file_path = result["units"][0]["code"]["primary_origin"]["file_path"]
+    assert file_path == "src/util.ts", f"single-colon file_path wrong: {file_path!r}"

--- a/libs/openant-core/tests/parsers/php/test_call_graph_builder.py
+++ b/libs/openant-core/tests/parsers/php/test_call_graph_builder.py
@@ -1,0 +1,77 @@
+r"""PHP call-graph resolution: a bare function call must not resolve across namespaces.
+
+`_resolve_simple_call` consulted class_name but never namespace_name, so a bare
+`helper()` from namespace App\Other leaked an edge to App\Utils\helper.
+
+The module basename ``call_graph_builder.py`` recurs across every parser, so the
+PHP builder is loaded under a UNIQUE importlib name.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[3]
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+
+def _load(unique_name, relpath):
+    spec = importlib.util.spec_from_file_location(unique_name, str(CORE / relpath))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_cgb = _load("php_call_graph_builder_isolated", "parsers/php/call_graph_builder.py")
+CallGraphBuilder = _cgb.CallGraphBuilder
+
+
+def _build(funcs):
+    b = CallGraphBuilder({"functions": funcs, "classes": {}, "imports": {}, "repository": "/r"})
+    b.build_call_graph()
+    return b
+
+
+def test_bare_call_does_not_leak_across_namespaces():
+    """A bare helper() in App\\Other must NOT edge to App\\Utils\\helper.
+
+    Driven through the full call-graph build so the caller's namespace is threaded
+    exactly as in production; the base builder ignores namespace_name and leaks the
+    edge.
+    """
+    funcs = {
+        "utils.php:helper": {
+            "name": "helper", "file_path": "utils.php",
+            "class_name": None, "namespace_name": "App\\Utils",
+            "code": "<?php function helper($x) { return $x; }",
+        },
+        "other.php:caller": {
+            "name": "caller", "file_path": "other.php",
+            "class_name": None, "namespace_name": "App\\Other",
+            "code": "<?php function caller() { helper(1); }",
+        },
+    }
+    b = _build(funcs)
+    assert b.call_graph.get("other.php:caller") == [], (
+        f"namespace leak: App\\Other caller resolved to a App\\Utils function: {b.call_graph}"
+    )
+
+
+def test_bare_call_resolves_within_same_namespace():
+    """Guard: a bare helper() within App\\Utils still resolves (no over-tightening)."""
+    funcs = {
+        "utils.php:helper": {
+            "name": "helper", "file_path": "utils.php",
+            "class_name": None, "namespace_name": "App\\Utils",
+            "code": "<?php function helper($x) { return $x; }",
+        },
+        "consumer.php:caller": {
+            "name": "caller", "file_path": "consumer.php",
+            "class_name": None, "namespace_name": "App\\Utils",
+            "code": "<?php function caller() { helper(1); }",
+        },
+    }
+    b = _build(funcs)
+    assert b.call_graph.get("consumer.php:caller") == ["utils.php:helper"], (
+        f"same-namespace bare call must still resolve: {b.call_graph}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_php_extractor.py
+++ b/libs/openant-core/tests/parsers/php/test_php_extractor.py
@@ -1,0 +1,265 @@
+"""Regression tests for the PHP function extractor + entry-point detector.
+
+Covers three confirmed defects:
+
+  * Procedural top-level blackout:
+    parsers/php/function_extractor.py only emits units for
+    function/method/class/interface/trait/namespace nodes; top-level
+    procedural statements (assignments, echo, hook registrations) fall
+    through the catch-all else branch and produce NO unit. The Python
+    parser has a module-level synthesizer (extract_module_level_code ->
+    unit_type='module_level'); PHP had none, so a WordPress-style
+    plugin.php is invisible to reachability seeding.
+
+  * Entry-point seeding for PHP:
+    utilities/agentic_enhancer/entry_point_detector.py USER_INPUT_PATTERNS
+    and MODULE_LEVEL_INPUT_PATTERNS were Python/JS-only; no PHP superglobal
+    ($_GET/$_POST/$_REQUEST/...) was ever recognised, so a PHP handler that
+    reads $_POST was never flagged as an entry point.
+
+  * Closures not modeled as units:
+    anonymous_function and arrow_function nodes fell through the same else
+    branch, so closures and arrow functions were never extracted as units.
+
+NOTE on import strategy: ``function_extractor.py`` is a basename shared by
+every parser (php/python/go/...), so a bare ``import function_extractor``
+would collide. Each module is loaded under a UNIQUE name via
+``importlib.util.spec_from_file_location``.
+
+The call-graph dispatch portions (closure dispatch edges, WordPress
+do_action edges, XML-RPC dispatch, alias->FQN resolution) live in
+parsers/php/call_graph_builder.py, which is out of this unit's file scope;
+they are covered/tracked elsewhere. These tests assert only the
+extraction-layer + entry-point-seeding behavior owned by this unit.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_unique(rel_path: str, unique_name: str):
+    """Load a module from libs/openant-core/<rel_path> under a unique name.
+
+    function_extractor.py recurs across parsers, so a bare import would
+    collide; spec_from_file_location with a unique name avoids that.
+    """
+    abs_path = _CORE_ROOT / rel_path
+    spec = importlib.util.spec_from_file_location(unique_name, abs_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[unique_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_php_fe = _load_unique("parsers/php/function_extractor.py", "isolated_php_function_extractor")
+PhpFunctionExtractor = _php_fe.FunctionExtractor
+
+_epd = _load_unique(
+    "utilities/agentic_enhancer/entry_point_detector.py", "isolated_entry_point_detector"
+)
+EntryPointDetector = _epd.EntryPointDetector
+
+
+def _extract(tmp_path: Path, filename: str, source: str):
+    """Write a PHP file and run the real extractor over the repo dir."""
+    repo = tmp_path
+    (repo / filename).write_text(source)
+    extractor = PhpFunctionExtractor(str(repo))
+    return extractor.extract_all()
+
+
+# ---------------------------------------------------------------------------
+# Procedural top-level code must become a unit
+# ---------------------------------------------------------------------------
+
+PROCEDURAL_PLUGIN = """<?php
+$config = $_GET['mode'];
+echo do_query($config);
+add_action('wp_ajax_x', 'handler');
+
+function handler() {
+    $v = $_POST['data'];
+    return run_sql($v);
+}
+
+function do_query($q) {
+    return run_sql($q);
+}
+
+function run_sql($s) {
+    return $s;
+}
+"""
+
+
+def test_procedural_top_level_extracted_as_module_level_unit(tmp_path):
+    """Top-level PHP statements must produce a synthetic module_level unit."""
+    result = _extract(tmp_path, "plugin.php", PROCEDURAL_PLUGIN)
+    units = result["functions"]
+
+    # Pre-fix: only the 3 named functions exist, no module-level unit.
+    module_units = [
+        fid for fid, fd in units.items() if fd.get("unit_type") == "module_level"
+    ]
+    assert module_units, (
+        "expected a module_level unit synthesised for top-level procedural code; "
+        f"got unit_types={sorted({fd.get('unit_type') for fd in units.values()})}"
+    )
+
+    # The synthesized unit's code must include the top-level statements
+    # (the $_GET read and the add_action hook registration).
+    mod_code = units[module_units[0]]["code"]
+    assert "$_GET" in mod_code
+    assert "add_action" in mod_code
+
+
+def test_named_functions_still_extracted_alongside_module_level(tmp_path):
+    """The module-level synthesis must not drop the named function units."""
+    result = _extract(tmp_path, "plugin.php", PROCEDURAL_PLUGIN)
+    names = {fd["name"] for fd in result["functions"].values()}
+    assert {"handler", "do_query", "run_sql"}.issubset(names)
+
+
+CLASS_ONLY_SOURCE = """<?php
+namespace App;
+
+use Foo\\Bar;
+
+class C {
+    public function m() {
+        return 1;
+    }
+}
+"""
+
+
+def test_class_only_file_has_no_module_level_unit(tmp_path):
+    """A file with no file-scope executable code must NOT get a module_level unit.
+
+    Guards against the synthesizer treating namespace/use tokens or class
+    declarations as 'top-level code'.
+    """
+    result = _extract(tmp_path, "clean.php", CLASS_ONLY_SOURCE)
+    module_units = [
+        fid
+        for fid, fd in result["functions"].items()
+        if fd.get("unit_type") == "module_level"
+    ]
+    assert not module_units, (
+        "class-only file must not synthesise a module_level unit; "
+        f"got {module_units}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# PHP superglobals must seed entry points
+# ---------------------------------------------------------------------------
+
+
+def test_php_superglobal_handler_is_entry_point(tmp_path):
+    """A handler reading $_POST must be flagged as an entry point (Check 3)."""
+    result = _extract(tmp_path, "plugin.php", PROCEDURAL_PLUGIN)
+    detector = EntryPointDetector(result["functions"], {})
+    detector.detect_entry_points()
+
+    handler_id = next(
+        fid for fid, fd in result["functions"].items() if fd["name"] == "handler"
+    )
+    assert detector.is_entry_point(handler_id), (
+        "handler reads $_POST['data'] and must be an entry point; "
+        f"reason={detector.get_entry_point_reason(handler_id)!r}"
+    )
+
+
+def test_php_module_level_with_superglobal_is_entry_point(tmp_path):
+    """The synthesized module_level unit reading $_GET must seed via Check 4."""
+    result = _extract(tmp_path, "plugin.php", PROCEDURAL_PLUGIN)
+    detector = EntryPointDetector(result["functions"], {})
+    detector.detect_entry_points()
+
+    module_ids = [
+        fid
+        for fid, fd in result["functions"].items()
+        if fd.get("unit_type") == "module_level"
+    ]
+    assert module_ids, "no module_level unit was synthesised"
+    assert any(detector.is_entry_point(mid) for mid in module_ids), (
+        "the module_level unit reads $_GET and registers a wp_ajax hook; "
+        "it must be flagged as an entry point"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anonymous closures and arrow functions must become units
+# ---------------------------------------------------------------------------
+
+CLOSURE_SOURCE = """<?php
+function outer() {
+    $cb = function ($x) {
+        return helper($x);
+    };
+    $cb(5);
+    $arrow = fn($z) => transform($z);
+    $arrow(1);
+}
+
+function helper($x) {
+    return $x;
+}
+
+function transform($z) {
+    return $z;
+}
+"""
+
+
+def test_anonymous_closure_extracted_as_unit(tmp_path):
+    """An anonymous_function must be emitted as a closure unit."""
+    result = _extract(tmp_path, "closures.php", CLOSURE_SOURCE)
+    closure_units = [
+        fid
+        for fid, fd in result["functions"].items()
+        if fd.get("unit_type") == "closure"
+    ]
+    assert closure_units, (
+        "expected at least one closure unit for the anonymous_function / "
+        f"arrow_function; unit_types="
+        f"{sorted({fd.get('unit_type') for fd in result['functions'].values()})}"
+    )
+
+
+def test_arrow_function_extracted_as_unit(tmp_path):
+    """Both the anonymous closure and the arrow function must be units (2 total)."""
+    result = _extract(tmp_path, "closures.php", CLOSURE_SOURCE)
+    closure_units = [
+        fd
+        for fd in result["functions"].values()
+        if fd.get("unit_type") == "closure"
+    ]
+    assert len(closure_units) == 2, (
+        "expected exactly two closure units (one anonymous_function + one "
+        f"arrow_function); got {len(closure_units)}"
+    )
+
+
+def test_closure_units_capture_their_body(tmp_path):
+    """Closure units must carry the closure body in their code field."""
+    result = _extract(tmp_path, "closures.php", CLOSURE_SOURCE)
+    bodies = "\n".join(
+        fd["code"]
+        for fd in result["functions"].values()
+        if fd.get("unit_type") == "closure"
+    )
+    assert "helper" in bodies  # from the anonymous closure body
+    assert "transform" in bodies  # from the arrow function body
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/libs/openant-core/tests/parsers/php/test_repository_scanner_is_test_file.py
+++ b/libs/openant-core/tests/parsers/php/test_repository_scanner_is_test_file.py
@@ -1,0 +1,64 @@
+"""Regression tests for the PHP RepositoryScanner.is_test_file anchoring.
+
+is_test_file previously used an unanchored
+``pattern.lower() in path_lower`` substring scan over {'test_', '_test.php',
+'Test.php', 'test/', 'tests/', 'spec/', 'phpunit'}. Because 'Test.php'
+lowercased to 'test.php', ordinary PascalCase sources like ``Contest.php``
+(``contest.php``) matched mid-token, and ``latest_helper.php`` matched
+``test_``. Fix: match directory components exactly + anchor filename rules
+(PSR PascalCase ``*Test.php`` on the original-case basename) using PHP's own
+native PHPUnit conventions.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_scanner():
+    path = _CORE_ROOT / "parsers" / "php" / "repository_scanner.py"
+    spec = importlib.util.spec_from_file_location("rs_php_is_test_file", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.RepositoryScanner
+
+
+SCANNER = _load_scanner()
+
+
+def _scan(repo="/tmp/repo"):
+    return SCANNER(repo)
+
+
+# --- non-test sources that the substring scan wrongly flagged (the bug) ---
+def test_contest_pascalcase_is_not_a_test():
+    # 'Contest.php' -> lowercased 'contest.php' ends with 'test.php' (substring bug)
+    assert _scan().is_test_file("src/Contest.php") is False
+
+
+def test_latest_helper_is_not_a_test():
+    assert _scan().is_test_file("src/latest_helper.php") is False
+
+
+# --- genuine PHP test files must still be detected ---
+def test_psr_pascalcase_test_suffix_is_a_test():
+    assert _scan().is_test_file("tests/FooTest.php") is True
+
+
+def test_psr_pascalcase_test_suffix_outside_tests_dir_is_a_test():
+    assert _scan().is_test_file("src/FooTest.php") is True
+
+
+def test_tests_dir_is_a_test():
+    assert _scan().is_test_file("tests/Foo.php") is True
+
+
+def test_spec_dir_is_a_test():
+    assert _scan().is_test_file("spec/FooSpec.php") is True
+
+
+def test_snake_test_suffix_is_a_test():
+    assert _scan().is_test_file("src/widget_test.php") is True

--- a/libs/openant-core/tests/parsers/python/test_repository_scanner_is_test_file.py
+++ b/libs/openant-core/tests/parsers/python/test_repository_scanner_is_test_file.py
@@ -1,0 +1,64 @@
+"""Regression tests for the Python RepositoryScanner.is_test_file anchoring.
+
+is_test_file previously used an unanchored
+``pattern in path_lower`` substring scan over {'test_', '_test.py', 'tests/',
+'/test/', 'conftest.py'}, so ordinary sources whose name merely *contains* a
+token were misclassified as tests and silently dropped when skip_tests=True
+(e.g. ``src/latest_release.py`` matched ``test_``; ``contests/foo.py`` matched
+``tests/``). Fix: match directory components exactly + anchor filename rules to
+the basename, using Python's own native conventions.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_scanner():
+    # Unique module name: parsers/{python,php,ruby,zig}/repository_scanner.py
+    # all share the basename, so importlib gets a per-parser unique name here.
+    path = _CORE_ROOT / "parsers" / "python" / "repository_scanner.py"
+    spec = importlib.util.spec_from_file_location("rs_python_is_test_file", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.RepositoryScanner
+
+
+SCANNER = _load_scanner()
+
+
+def _scan(repo="/tmp/repo"):
+    return SCANNER(repo)
+
+
+# --- non-test sources that the substring scan wrongly flagged (the bug) ---
+def test_latest_release_is_not_a_test():
+    assert _scan().is_test_file("src/latest_release.py") is False
+
+
+def test_contests_dir_is_not_a_test_dir():
+    assert _scan().is_test_file("contests/foo.py") is False
+
+
+def test_pytest_helper_is_not_a_test():
+    assert _scan().is_test_file("tools/pytest_helper.py") is False
+
+
+# --- genuine Python test files must still be detected ---
+def test_tests_dir_is_a_test():
+    assert _scan().is_test_file("tests/test_x.py") is True
+
+
+def test_test_prefix_basename_is_a_test():
+    assert _scan().is_test_file("src/test_x.py") is True
+
+
+def test_underscore_test_suffix_is_a_test():
+    assert _scan().is_test_file("src/widget_test.py") is True
+
+
+def test_conftest_is_a_test():
+    assert _scan().is_test_file("src/conftest.py") is True

--- a/libs/openant-core/tests/parsers/ruby/test_call_graph_builder.py
+++ b/libs/openant-core/tests/parsers/ruby/test_call_graph_builder.py
@@ -1,0 +1,191 @@
+"""Ruby call-graph resolution defects in parsers/ruby/call_graph_builder.py.
+
+Each test pins one resolution defect. The module basename ``call_graph_builder.py``
+(and ``function_extractor.py``) recurs across every parser, so both modules are
+loaded under UNIQUE importlib names.
+
+Defects covered:
+  - module self/sibling call dropped (no methods_by_module index)
+  - module fn leaks to an outside-module bare call (false edge)
+  - Module.method cross-file unresolved
+  - module-function same-module sibling resolved only by accident
+  - module_function Module.method call edge dropped
+  - super dispatch unresolved
+  - Class.new(...) -> initialize untracked
+  - send/public_send/__send__ literal-symbol dispatch dropped
+  - require_relative not anchored to caller dir (basename collision)
+  - require import matched by unanchored substring (wrong file)
+  - require_relative '../...' not normalized against caller dir
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[3]
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+
+def _load(unique_name, relpath):
+    spec = importlib.util.spec_from_file_location(unique_name, str(CORE / relpath))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_cgb = _load("ruby_call_graph_builder_isolated", "parsers/ruby/call_graph_builder.py")
+_fe = _load("ruby_function_extractor_isolated", "parsers/ruby/function_extractor.py")
+CallGraphBuilder = _cgb.CallGraphBuilder
+FunctionExtractor = _fe.FunctionExtractor
+
+
+def _build_from_sources(files):
+    """Write Ruby sources, run the real extractor + builder, return the builder."""
+    d = tempfile.mkdtemp()
+    for name, code in files.items():
+        path = os.path.join(d, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as fh:
+            fh.write(code)
+    extractor = FunctionExtractor(d)
+    result = extractor.extract_all(list(files.keys()))
+    builder = CallGraphBuilder(result)
+    builder.build_call_graph()
+    return builder
+
+
+# --------------------------------------------------------------------------
+# Module-function resolution cluster (shared root: no methods_by_module index)
+# --------------------------------------------------------------------------
+
+def test_module_singleton_self_call_resolves():
+    """`def self.api` calling `self.helper` must edge to the module's helper."""
+    b = _build_from_sources({
+        "u.rb": "module Utils\n  def self.helper(x)\n    x\n  end\n"
+                "  def self.api(i)\n    self.helper(i)\n  end\nend\n",
+    })
+    assert b.call_graph.get("u.rb:Utils.api") == ["u.rb:Utils.helper"], b.call_graph
+
+
+def test_module_function_call_does_not_leak_to_outside_caller():
+    """a bare `helper()` OUTSIDE Utils must NOT resolve to Utils.helper."""
+    b = _build_from_sources({
+        "utils.rb": "module Utils\n  def helper(x)\n    x\n  end\nend\n",
+        "main.rb": "class App\n  def run\n    helper(1)\n  end\nend\n",
+    })
+    assert b.call_graph.get("main.rb:App.run") == [], (
+        f"module leak: outside-module bare call resolved to a module fn: {b.call_graph}"
+    )
+
+
+def test_module_method_resolved_cross_file():
+    """`Utils.helper(1)` from another file must edge to the module fn."""
+    b = _build_from_sources({
+        "utils.rb": "module Utils\n  module_function\n  def helper(x)\n    x\n  end\nend\n",
+        "main.rb": "class App\n  def run\n    Utils.helper(1)\n  end\nend\n",
+    })
+    assert b.call_graph.get("main.rb:App.run") == ["utils.rb:Utils.helper"], b.call_graph
+
+
+def test_module_function_sibling_resolves_by_module_not_accident():
+    """A cross-file same-module sibling must resolve by module.
+
+    `Utils.api` (a.rb) calls bare `helper`, defined in `Utils` in b.rb; a decoy
+    `Other.helper` in c.rb makes the unsound unique-name fallback ambiguous, so at
+    base the edge is dropped. The module-scoped resolution must pick b.rb's helper.
+    """
+    b = _build_from_sources({
+        "a.rb": "module Utils\n  module_function\n  def api(i)\n    helper(i)\n  end\nend\n",
+        "b.rb": "module Utils\n  module_function\n  def helper(x)\n    x\n  end\nend\n",
+        "c.rb": "module Other\n  module_function\n  def helper(y)\n    y\n  end\nend\n",
+    })
+    assert b.call_graph.get("a.rb:Utils.api") == ["b.rb:Utils.helper"], b.call_graph
+
+
+# --------------------------------------------------------------------------
+# Inheritance / dispatch
+# --------------------------------------------------------------------------
+
+def test_super_resolves_to_superclass_method():
+    """`super` in Child#greet must edge to Base#greet."""
+    b = _build_from_sources({
+        "a.rb": "class Base\n  def greet\n    1\n  end\nend\n"
+                "class Child < Base\n  def greet\n    super\n  end\nend\n",
+    })
+    assert b.call_graph.get("a.rb:Child.greet") == ["a.rb:Base.greet"], b.call_graph
+
+
+def test_constructor_new_resolves_to_initialize():
+    """`Widget.new(1)` must edge to Widget#initialize."""
+    b = _build_from_sources({
+        "a.rb": "class Widget\n  def initialize(x)\n    @x = x\n  end\nend\n"
+                "class App\n  def run\n    Widget.new(1)\n  end\nend\n",
+    })
+    assert b.call_graph.get("a.rb:App.run") == ["a.rb:Widget.initialize"], b.call_graph
+
+
+def test_send_literal_symbol_dispatch_resolves():
+    """send/public_send/__send__ with a literal symbol resolve the target."""
+    for verb in ("send", "public_send", "__send__"):
+        b = _build_from_sources({
+            "a.rb": f"class App\n  def target\n    1\n  end\n"
+                    f"  def run\n    {verb}(:target)\n  end\nend\n",
+        })
+        assert b.call_graph.get("a.rb:App.run") == ["a.rb:App.target"], (
+            f"{verb}(:target) not resolved: {b.call_graph}"
+        )
+
+
+# --------------------------------------------------------------------------
+# require_relative anchoring (one line-252 root: substring + no caller-dir anchor)
+# --------------------------------------------------------------------------
+
+def test_require_relative_anchored_to_caller_dir_on_collision():
+    """`require_relative './helper'` must anchor to the caller's dir.
+
+    Two files share the basename helper.rb; only the caller-dir one is the target.
+    """
+    b = _build_from_sources({
+        "lib/sub/a.rb": "require_relative './helper'\ndef go\n  do_help(1)\nend\n",
+        "lib/sub/helper.rb": "def do_help(x)\n  x\nend\n",
+        "lib/other/helper.rb": "def do_help(y)\n  y\nend\n",
+    })
+    assert b.call_graph.get("lib/sub/a.rb:go") == ["lib/sub/helper.rb:do_help"], b.call_graph
+
+
+def test_require_relative_parent_dir_normalized():
+    """`require_relative '../lib/util'` normalized against the caller dir."""
+    b = _build_from_sources({
+        "app/main.rb": "require_relative '../lib/util'\ndef run\n  helper2(1)\nend\n",
+        "lib/util.rb": "def helper2(x)\n  x\nend\n",
+        "app/decoy.rb": "def helper2(y)\n  y\nend\n",
+    })
+    assert b.call_graph.get("app/main.rb:run") == ["lib/util.rb:helper2"], b.call_graph
+
+
+def test_require_import_matches_anchored_file_not_substring():
+    """`require 'util'` must bind lib/util.rb, not lib/util_extra.rb.
+
+    Both files define `helper`, so the unique-name fallback cannot decide; only an
+    anchored require match resolves it. The unanchored `'util' in file_path`
+    substring would also match the decoy lib/util_extra.rb.
+    """
+    # The decoy is indexed FIRST so the unanchored substring scan reaches it
+    # before the real target -- pinning the wrong-file binding at base.
+    funcs = {
+        "lib/util_extra.rb:helper": {
+            "name": "helper", "file_path": "lib/util_extra.rb",
+            "class_name": None, "module_name": None, "code": "",
+        },
+        "lib/util.rb:helper": {
+            "name": "helper", "file_path": "lib/util.rb",
+            "class_name": None, "module_name": None, "code": "",
+        },
+    }
+    b = CallGraphBuilder({"functions": funcs, "classes": {},
+                          "imports": {"caller.rb": {"util": "require"}}, "repository": "/r"})
+    assert b._resolve_simple_call("helper", "caller.rb", None) == "lib/util.rb:helper", (
+        "require 'util' must anchor to lib/util.rb, not the substring-matched decoy"
+    )

--- a/libs/openant-core/tests/parsers/ruby/test_function_extractor.py
+++ b/libs/openant-core/tests/parsers/ruby/test_function_extractor.py
@@ -1,0 +1,229 @@
+"""Regression tests for the Ruby FunctionExtractor (7 extraction defects).
+
+Each test pins one defect in
+``libs/openant-core/parsers/ruby/function_extractor.py``.
+
+Defects covered:
+  - nested + compact module name flattening
+  - define_method(:sym) { } metaprogramming
+  - alias_method :a, :b class-body aliases
+  - alias kw form (alias node) not extracted
+  - visibility (private/protected) not tracked
+  - controller privates over-flagged route_handler
+  - top-level Sinatra DSL routes silently skipped
+
+The module-basename ``function_extractor.py`` recurs across parsers
+(python/ruby/php), so the import is package-qualified to load the Ruby one
+unambiguously.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.ruby.function_extractor import FunctionExtractor
+
+
+def _extract(tmp_path: Path, filename: str, source: str) -> dict:
+    """Write a Ruby source file under tmp_path and run the extractor over it."""
+    rb = tmp_path / filename
+    rb.write_text(source)
+    extractor = FunctionExtractor(str(tmp_path))
+    return extractor.extract_all([filename])
+
+
+def _names(result: dict) -> set:
+    """Set of bare method names across all extracted function units."""
+    return {fd["name"] for fd in result["functions"].values()}
+
+
+def _by_name(result: dict, name: str) -> dict:
+    for fd in result["functions"].values():
+        if fd["name"] == name:
+            return fd
+    raise AssertionError(f"no function unit named {name!r}; have {_names(result)}")
+
+
+# --------------------------------------------------------------------------
+# Nested & compact module name flattening
+# --------------------------------------------------------------------------
+
+def test_nested_module_name_concatenated(tmp_path):
+    """`module Outer; module Inner` must qualify foo as Outer::Inner.foo."""
+    result = _extract(
+        tmp_path,
+        "nested.rb",
+        "module Outer\n  module Inner\n    def foo\n    end\n  end\nend\n",
+    )
+    foo = _by_name(result, "foo")
+    assert foo["module_name"] == "Outer::Inner", (
+        f"expected nested module Outer::Inner, got {foo['module_name']!r}"
+    )
+    assert "nested.rb:Outer::Inner.foo" in result["functions"]
+
+
+def test_compact_module_name_preserved(tmp_path):
+    """`module Outer::Inner` (scope_resolution) must keep the full namespace."""
+    result = _extract(
+        tmp_path,
+        "compact.rb",
+        "module Outer::Inner\n  def run\n  end\nend\n",
+    )
+    run = _by_name(result, "run")
+    assert run["module_name"] == "Outer::Inner", (
+        f"compact module name dropped: module_name={run['module_name']!r}, "
+        f"unit_type={run['unit_type']!r}"
+    )
+    # And it must NOT be misclassified as a bare top-level function.
+    assert run["unit_type"] != "function"
+
+
+# --------------------------------------------------------------------------
+# define_method metaprogramming
+# --------------------------------------------------------------------------
+
+def test_define_method_block_and_brace_extracted(tmp_path):
+    """define_method(:sym) with do..end and { } blocks must emit method units."""
+    result = _extract(
+        tmp_path,
+        "dm.rb",
+        "class C\n"
+        "  define_method(:dynamic_hello) do\n    1\n  end\n"
+        "  define_method(:another_dyn) { |x| x }\n"
+        "  def regular_method\n  end\nend\n",
+    )
+    names = _names(result)
+    assert "dynamic_hello" in names, f"define_method do..end dropped; have {names}"
+    assert "another_dyn" in names, f"define_method {{ }} dropped; have {names}"
+    # The dynamically defined methods must also appear on the class methods list.
+    cls = result["classes"]["dm.rb:C"]
+    assert "dynamic_hello" in cls["methods"]
+    assert "another_dyn" in cls["methods"]
+
+
+# --------------------------------------------------------------------------
+# alias_method call form
+# --------------------------------------------------------------------------
+
+def test_alias_method_call_form_extracted(tmp_path):
+    """`alias_method :aliased, :original` must emit a method unit for aliased."""
+    result = _extract(
+        tmp_path,
+        "am.rb",
+        "class Foo\n"
+        "  def original\n  end\n"
+        "  alias_method :aliased, :original\n"
+        "  alias_method \"strkey\", \"original\"\nend\n",
+    )
+    names = _names(result)
+    assert "aliased" in names, f"alias_method symbol form dropped; have {names}"
+    assert "strkey" in names, f"alias_method string form dropped; have {names}"
+    assert "aliased" in result["classes"]["am.rb:Foo"]["methods"]
+
+
+# --------------------------------------------------------------------------
+# alias keyword form
+# --------------------------------------------------------------------------
+
+def test_alias_keyword_form_extracted(tmp_path):
+    """`alias kw_aliased original` (alias node) must emit a method unit."""
+    result = _extract(
+        tmp_path,
+        "ak.rb",
+        "class Foo\n"
+        "  def original\n  end\n"
+        "  alias kw_aliased original\nend\n",
+    )
+    names = _names(result)
+    assert "kw_aliased" in names, f"alias keyword form dropped; have {names}"
+    assert "kw_aliased" in result["classes"]["ak.rb:Foo"]["methods"]
+
+
+# --------------------------------------------------------------------------
+# Visibility tracking
+# --------------------------------------------------------------------------
+
+def test_visibility_tracked_and_threaded(tmp_path):
+    """Methods after a bare `private` marker must carry visibility=private."""
+    result = _extract(
+        tmp_path,
+        "vis.rb",
+        "class Bar\n"
+        "  def pub\n  end\n"
+        "  private\n"
+        "  def priv\n  end\n"
+        "  protected\n"
+        "  def prot\n  end\nend\n",
+    )
+    assert _by_name(result, "pub")["visibility"] == "public"
+    assert _by_name(result, "priv")["visibility"] == "private"
+    assert _by_name(result, "prot")["visibility"] == "protected"
+
+
+def test_arg_form_private_does_not_leak_visibility(tmp_path):
+    """`private :sym` (call form) must NOT privatize subsequent defs.
+
+    Regression guard for the visibility fix: the inner `private` identifier of
+    the `private :sym` call node must not leak into the bare-marker toggle.
+    """
+    result = _extract(
+        tmp_path,
+        "argvis.rb",
+        "class Svc\n"
+        "  def pub\n  end\n"
+        "  private :pub\n"
+        "  def still_public\n  end\nend\n",
+    )
+    assert _by_name(result, "still_public")["visibility"] == "public"
+
+
+# --------------------------------------------------------------------------
+# Controller privates over-flagged route_handler
+# --------------------------------------------------------------------------
+
+def test_controller_private_methods_not_route_handlers(tmp_path):
+    """Private params helpers / before_action targets are NOT route_handlers."""
+    result = _extract(
+        tmp_path,
+        "users_controller.rb",
+        "class UsersController\n"
+        "  def index\n  end\n"
+        "  private\n"
+        "  def user_params\n  end\n"
+        "  def set_user\n  end\nend\n",
+    )
+    # Public action stays a route handler.
+    assert _by_name(result, "index")["unit_type"] == "route_handler"
+    # Private helpers must NOT be route handlers (entry-point over-claim).
+    assert _by_name(result, "user_params")["unit_type"] != "route_handler"
+    assert _by_name(result, "set_user")["unit_type"] != "route_handler"
+
+
+# --------------------------------------------------------------------------
+# Top-level Sinatra DSL routes
+# --------------------------------------------------------------------------
+
+def test_sinatra_top_level_routes_extracted(tmp_path):
+    """Top-level `get '/path' do..end` must emit a route_handler unit."""
+    result = _extract(
+        tmp_path,
+        "app.rb",
+        "get '/hello' do\n  'hi'\nend\n\n"
+        "post '/items' do\n  'created'\nend\n",
+    )
+    handlers = [
+        fd for fd in result["functions"].values()
+        if fd["unit_type"] == "route_handler"
+    ]
+    routes = {fd["name"] for fd in handlers}
+    assert "/hello" in routes or any("/hello" in (fd.get("qualified_name") or "") for fd in handlers), (
+        f"Sinatra GET route not extracted as route_handler; handlers={routes}"
+    )
+    assert "/items" in routes or any("/items" in (fd.get("qualified_name") or "") for fd in handlers), (
+        f"Sinatra POST route not extracted as route_handler; handlers={routes}"
+    )

--- a/libs/openant-core/tests/parsers/ruby/test_repository_scanner_is_test_file.py
+++ b/libs/openant-core/tests/parsers/ruby/test_repository_scanner_is_test_file.py
@@ -1,0 +1,58 @@
+"""Regression tests for the Ruby RepositoryScanner.is_test_file anchoring.
+
+is_test_file previously used an unanchored
+``pattern in path_lower`` substring scan over {'test_', '_test.rb', '_spec.rb',
+'test/', 'tests/', 'spec/'}, so ordinary sources whose name merely *contains* a
+token were misclassified (e.g. ``lib/latest_release.rb`` matched ``test_``;
+``contest/foo.rb`` matched ``test``... via ``tests/`` only on 'contests/').
+Fix: match directory components exactly + anchor filename rules to the basename
+using Ruby's own native Minitest/RSpec conventions.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_scanner():
+    path = _CORE_ROOT / "parsers" / "ruby" / "repository_scanner.py"
+    spec = importlib.util.spec_from_file_location("rs_ruby_is_test_file", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.RepositoryScanner
+
+
+SCANNER = _load_scanner()
+
+
+def _scan(repo="/tmp/repo"):
+    return SCANNER(repo)
+
+
+# --- non-test sources that the substring scan wrongly flagged (the bug) ---
+def test_latest_release_is_not_a_test():
+    assert _scan().is_test_file("lib/latest_release.rb") is False
+
+
+def test_contest_dir_is_not_a_test_dir():
+    assert _scan().is_test_file("contest/foo.rb") is False
+
+
+# --- genuine Ruby test files must still be detected ---
+def test_spec_suffix_is_a_test():
+    assert _scan().is_test_file("spec/widget_spec.rb") is True
+
+
+def test_minitest_test_suffix_is_a_test():
+    assert _scan().is_test_file("test/widget_test.rb") is True
+
+
+def test_test_prefix_basename_is_a_test():
+    assert _scan().is_test_file("lib/test_widget.rb") is True
+
+
+def test_spec_dir_is_a_test():
+    assert _scan().is_test_file("spec/foo.rb") is True

--- a/libs/openant-core/tests/parsers/zig/test_repository_scanner_is_test_file.py
+++ b/libs/openant-core/tests/parsers/zig/test_repository_scanner_is_test_file.py
@@ -1,0 +1,81 @@
+"""Regression tests for the Zig RepositoryScanner test detection anchoring.
+
+TEST_PATTERNS previously held bare tokens
+{'test','tests','spec','specs','_test','test_'} matched as substrings in BOTH
+_is_test_directory (``pattern in dirname_lower``) and _is_test_file
+(``pattern in part``), so ``latest``/``contest``/``attestation`` directories and
+``src/fastest.zig`` were misclassified as tests and pruned/skipped when
+skip_tests is on. Two-part fix: (1) anchor directory matching to whole names
+and filename matching to stem prefix/suffix using Zig's native conventions;
+(2) align the constructor skip_tests default to False (the other four parsers'
+default), fixing the active-by-default silent data loss.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_scanner():
+    path = _CORE_ROOT / "parsers" / "zig" / "repository_scanner.py"
+    spec = importlib.util.spec_from_file_location("rs_zig_is_test_file", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.RepositoryScanner
+
+
+SCANNER = _load_scanner()
+
+
+def _scan(repo="/tmp/repo"):
+    return SCANNER(repo)
+
+
+# --- directories: bare 'test' substring no longer over-matches ---
+def test_latest_dir_is_not_a_test_dir():
+    assert _scan()._is_test_directory("latest") is False
+
+
+def test_contest_dir_is_not_a_test_dir():
+    assert _scan()._is_test_directory("contest") is False
+
+
+def test_attestation_dir_is_not_a_test_dir():
+    assert _scan()._is_test_directory("attestation") is False
+
+
+def test_exact_test_dir_is_a_test_dir():
+    assert _scan()._is_test_directory("test") is True
+
+
+def test_exact_spec_dir_is_a_test_dir():
+    assert _scan()._is_test_directory("spec") is True
+
+
+# --- files: bare 'test' substring no longer over-matches ---
+def test_fastest_file_is_not_a_test():
+    assert _scan()._is_test_file("src/fastest.zig") is False
+
+
+def test_file_under_latest_dir_is_not_a_test():
+    assert _scan()._is_test_file("src/latest/main.zig") is False
+
+
+def test_underscore_test_suffix_is_a_test():
+    assert _scan()._is_test_file("src/main_test.zig") is True
+
+
+def test_test_prefix_basename_is_a_test():
+    assert _scan()._is_test_file("src/test_main.zig") is True
+
+
+def test_file_under_test_dir_is_a_test():
+    assert _scan()._is_test_file("test/main.zig") is True
+
+
+# --- constructor default aligned with the other four parsers ---
+def test_skip_tests_defaults_to_false():
+    assert _scan().skip_tests is False

--- a/libs/openant-core/tests/parsers/zig/test_zig_extractor_followup.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_extractor_followup.py
@@ -1,0 +1,229 @@
+"""Regression tests for the Zig function/struct extractor.
+
+Pinned against the actual tree-sitter-zig 1.1.2 grammar (the AST node-type
+names below were confirmed by parsing sample Zig with the live grammar):
+
+  - struct FIELDS (`container_field` nodes) must not be emitted as function
+    units, and struct extraction must actually run. The extractor previously
+    gated struct handling on grammar node types `VarDecl` / `container_decl` /
+    `ContainerDecl` that the real 1.1.2 grammar never emits (it emits
+    `variable_declaration` / `struct_declaration`), so struct extraction was
+    dead code (0 classes) and the field/method paths were unreachable.
+
+  - a struct method must appear exactly once, qualified as `<Struct>.<method>`,
+    not duplicated as a bare top-level function. `_extract_struct_methods`
+    emitted the qualified entry, then the unconditional child recursion in
+    `_walk_node` re-descended into the same struct body and re-emitted the
+    method bare because `current_struct` was never threaded through.
+
+  - `tree_sitter_zig` was imported hard at module top level and called at
+    class-body time, so a clean environment without the grammar package raised
+    ImportError on import. The parser must degrade gracefully (importable; a
+    clear error only when actually used).
+
+The basename `function_extractor.py` recurs across parser packages
+(c/cpp/php/python/ruby/zig), so this module is loaded under a unique name via
+importlib to avoid any sys.modules cache collision.
+"""
+
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+# tree-sitter-zig is required to exercise the extractor; skip cleanly if absent.
+ts_zig = pytest.importorskip("tree_sitter_zig")
+
+_EXTRACTOR_PATH = _CORE_ROOT / "parsers" / "zig" / "function_extractor.py"
+
+
+def _load_extractor_module():
+    """Load parsers/zig/function_extractor.py under a unique module name."""
+    spec = importlib.util.spec_from_file_location(
+        "zig_function_extractor_isolated", _EXTRACTOR_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _extract(source: str) -> dict:
+    """Run FunctionExtractor over a single in-memory main.zig file."""
+    module = _load_extractor_module()
+    repo = tempfile.mkdtemp()
+    (Path(repo) / "main.zig").write_text(source)
+    extractor = module.FunctionExtractor(repo, {"files": [{"path": "main.zig"}]})
+    return extractor.extract()
+
+
+# A struct with two fields and two methods, plus a free function.
+_SAMPLE = """const std = @import("std");
+
+const Point = struct {
+    x: i32,
+    y: i32,
+
+    pub fn init(x: i32, y: i32) Point {
+        return Point{ .x = x, .y = y };
+    }
+
+    pub fn distance(self: Point) i32 {
+        return self.x + self.y;
+    }
+};
+
+fn helper(n: i32) i32 {
+    return n * 2;
+}
+"""
+
+
+def test_struct_field_is_not_a_function():
+    """`container_field` struct fields must never become function units."""
+    result = _extract(_SAMPLE)
+    func_names = {info["name"] for info in result["functions"].values()}
+    assert "x" not in func_names, f"struct field 'x' emitted as a function: {func_names}"
+    assert "y" not in func_names, f"struct field 'y' emitted as a function: {func_names}"
+
+
+def test_struct_is_extracted_as_a_class():
+    """The struct must be extracted as a class (grammar-drift had killed this)."""
+    result = _extract(_SAMPLE)
+    class_names = {info["name"] for info in result["classes"].values()}
+    assert "Point" in class_names, (
+        f"struct 'Point' was not extracted as a class; classes={class_names}. "
+        "Struct handling is gated on grammar node types the 1.1.2 grammar "
+        "does not emit (VarDecl/container_decl)."
+    )
+
+
+def test_only_real_methods_extracted_and_qualified_once():
+    """Each method appears exactly once, qualified as Point.<name>; no bare dup."""
+    result = _extract(_SAMPLE)
+    funcs = result["functions"]
+    qualified = [info["qualified_name"] for info in funcs.values()]
+
+    # The two methods must be present, qualified, exactly once each.
+    assert qualified.count("Point.init") == 1, f"Point.init not uniquely qualified: {qualified}"
+    assert qualified.count("Point.distance") == 1, (
+        f"Point.distance not uniquely qualified: {qualified}"
+    )
+
+    # No bare duplicate of a method that also exists qualified.
+    assert "init" not in qualified, f"method 'init' emitted bare (duplicate): {qualified}"
+    assert "distance" not in qualified, (
+        f"method 'distance' emitted bare (duplicate): {qualified}"
+    )
+
+    # The return-type identifier of init ('Point') must not be captured as a function name.
+    assert "Point" not in qualified, (
+        f"return-type identifier 'Point' captured as a function name: {qualified}"
+    )
+
+    # The free function is still extracted, bare.
+    assert qualified.count("helper") == 1, f"free function 'helper' missing: {qualified}"
+
+
+def test_nested_struct_and_import_not_dropped():
+    """De-duplicating methods must not drop nested declarations.
+
+    A naive fix that simply stops recursing into a struct body to avoid the
+    bare-duplicate emission would also lose nested structs, their methods, and
+    nested @import calls. The correct fix threads the struct context through
+    recursion (same func_id => natural de-dup), so everything below is kept.
+    """
+    source = (
+        "const Outer = struct {\n"
+        '    const builtin = @import("builtin");\n'
+        "\n"
+        "    const Inner = struct {\n"
+        "        pub fn innerFn() void {}\n"
+        "    };\n"
+        "\n"
+        "    pub fn outerFn() void {}\n"
+        "};\n"
+    )
+    result = _extract(source)
+    qualified = [info["qualified_name"] for info in result["functions"].values()]
+    class_names = {info["name"] for info in result["classes"].values()}
+
+    assert "Outer.outerFn" in qualified, qualified
+    assert "Inner.innerFn" in qualified, qualified
+    assert "Outer" in class_names, class_names
+    assert "Inner" in class_names, class_names
+    assert "builtin" in result["imports"]["main.zig"], result["imports"]
+
+
+def test_methods_marked_as_methods_with_class_name():
+    """Qualified methods carry unit_type=method and class_name=Point."""
+    result = _extract(_SAMPLE)
+    methods = {
+        info["qualified_name"]: info
+        for info in result["functions"].values()
+        if info["qualified_name"].startswith("Point.")
+    }
+    assert set(methods) == {"Point.init", "Point.distance"}, sorted(methods)
+    for info in methods.values():
+        assert info["unit_type"] == "method", info
+        assert info["class_name"] == "Point", info
+
+
+def test_module_imports_without_grammar_package(monkeypatch):
+    """The parser module must import even when tree_sitter_zig is absent.
+
+    Simulate a clean environment by hiding `tree_sitter_zig` from import, then
+    load the module fresh. A hard top-level import + class-body call raises
+    ImportError here; a graceful (lazy/guarded) parser imports fine and only
+    fails when the grammar is actually needed.
+    """
+    # Drop any cached copies so the fresh import re-evaluates the import machinery.
+    for name in list(sys.modules):
+        if name == "tree_sitter_zig" or name.startswith("tree_sitter_zig."):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+        if name.startswith("zig_function_extractor_isolated"):
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _blocked_import(name, *args, **kwargs):
+        if name == "tree_sitter_zig" or name.startswith("tree_sitter_zig."):
+            raise ImportError("No module named 'tree_sitter_zig' (simulated clean env)")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", _blocked_import)
+
+    spec = importlib.util.spec_from_file_location(
+        "zig_function_extractor_isolated_nodep", _EXTRACTOR_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        # Must not raise: importing the parser cannot require the grammar package.
+        spec.loader.exec_module(module)
+    except ImportError as exc:  # pragma: no cover - this is the failure we pin against
+        pytest.fail(
+            "Zig parser module raised ImportError on import when tree_sitter_zig "
+            f"is absent (no graceful degradation): {exc}"
+        )
+    finally:
+        sys.modules.pop(spec.name, None)
+
+
+def test_pyproject_declares_tree_sitter_zig():
+    """The zig grammar must be declared as a dependency (it is imported)."""
+    pyproject = (_CORE_ROOT / "pyproject.toml").read_text()
+    requirements = (_CORE_ROOT / "requirements.txt").read_text()
+    assert "tree-sitter-zig" in pyproject, (
+        "tree-sitter-zig imported by parsers/zig but missing from pyproject.toml dependencies"
+    )
+    assert "tree-sitter-zig" in requirements, (
+        "tree-sitter-zig imported by parsers/zig but missing from requirements.txt"
+    )

--- a/libs/openant-core/tests/parsers/zig/test_zig_main_classification.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_main_classification.py
@@ -1,0 +1,59 @@
+"""Zig `main` classification.
+
+The Zig FunctionExtractor has a dedicated branch for `main` that returned the
+generic 'function' unit_type instead of an entry-point type:
+
+    # Main entry point
+    if name == "main":
+        return "function"
+
+C and Go classify a top-level main as unit_type='main'; Zig folded it into
+'function'. With 'main' an ENTRY_POINT_TYPE in the central detector, Zig must emit
+'main' so a Zig binary's entry point seeds reachability — otherwise the Zig
+classifier is the lone divergent parser and Zig binaries stay blacked out.
+
+function_extractor.py recurs across parser packages, so this module is loaded
+under a unique name via importlib to avoid sys.modules collisions with the
+C/Python sibling extractors.
+"""
+
+import importlib.util
+import pathlib
+
+_CORE = pathlib.Path(__file__).resolve().parents[3]
+_ZIG_FE = _CORE / "parsers" / "zig" / "function_extractor.py"
+
+
+def _load_zig_extractor():
+    spec = importlib.util.spec_from_file_location("isolated_zig_function_extractor", _ZIG_FE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _classify(name: str) -> str:
+    mod = _load_zig_extractor()
+    # _classify_function only uses (name, file_path); construct a minimal
+    # extractor (scan_results unused by the classifier).
+    extractor = mod.FunctionExtractor.__new__(mod.FunctionExtractor)
+    return extractor._classify_function(name, "src/main.zig")
+
+
+def test_zig_main_classified_as_main():
+    assert _classify("main") == "main", (
+        "Zig must classify a top-level `main` as unit_type='main' (matching C/Go) "
+        "so it is recognised as a program entry point"
+    )
+
+
+def test_zig_main_is_distinct_from_plain_function():
+    # A regular function still classifies as 'function'; only `main` is special.
+    assert _classify("handleRequest") == "function"
+    assert _classify("main") != _classify("handleRequest")
+
+
+def test_zig_other_classifications_unchanged():
+    # Guard against over-broadening the fix.
+    assert _classify("init") == "constructor"
+    assert _classify("create") == "constructor"
+    assert _classify("testThing") == "test"

--- a/libs/openant-core/tests/parsers/zig/test_zig_reachability_api.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_reachability_api.py
@@ -1,0 +1,102 @@
+"""Zig reachability-filter API crash.
+
+parsers/zig/test_pipeline.py apply_reachability_filter was written against an
+EntryPointDetector / ReachabilityAnalyzer API that never existed:
+
+    detector = EntryPointDetector(repo_path)        # ctor needs (functions, call_graph)
+    entry_points = detector.detect()                # real: detect_entry_points()
+    analyzer = ReachabilityAnalyzer(call_graph_output, entry_points)
+                                                    # real: (functions, reverse_call_graph, entry_points)
+    reachable = analyzer.get_reachable_functions()  # real: get_all_reachable()
+
+Because test_pipeline.py puts libs/openant-core on sys.path, the two imports
+SUCCEED, so the `except ImportError` guard never fires — the wrong-arity call
+raises a TypeError that escapes the helper and crashes the whole Zig parse
+(exit 1, zero output) at the default --processing-level reachable.
+
+This test calls apply_reachability_filter directly with a tiny call graph whose
+`main` is an entry point and which calls a helper; the fixed function must (a)
+not raise, and (b) keep the reachable functions (main + helper) while dropping an
+unreachable orphan.
+
+test_pipeline.py shares its basename across all six parsers, so it is loaded
+under a unique module name via importlib.
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+_CORE = pathlib.Path(__file__).resolve().parents[3]
+_ZIG_TP = _CORE / "parsers" / "zig" / "test_pipeline.py"
+
+
+def _load_zig_pipeline():
+    # The Zig pipeline does bare local imports (`from repository_scanner import`)
+    # relative to its own dir, mirroring how it is invoked as a script.
+    zig_dir = str(_ZIG_TP.parent)
+    core_dir = str(_CORE)
+    added = []
+    for p in (zig_dir, core_dir):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+            added.append(p)
+    spec = importlib.util.spec_from_file_location("isolated_zig_test_pipeline", _ZIG_TP)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _call_graph_output():
+    # main (entry) -> helper ; orphan is unreachable.
+    return {
+        "functions": {
+            "src/main.zig:main": {
+                "name": "main",
+                "unit_type": "main",
+                "code": "pub fn main() void { helper(); }",
+            },
+            "src/main.zig:helper": {
+                "name": "helper",
+                "unit_type": "function",
+                "code": "fn helper() void {}",
+            },
+            "src/main.zig:orphan": {
+                "name": "orphan",
+                "unit_type": "function",
+                "code": "fn orphan() void {}",
+            },
+        },
+        "call_graph": {
+            "src/main.zig:main": ["src/main.zig:helper"],
+        },
+        "reverse_call_graph": {
+            "src/main.zig:helper": ["src/main.zig:main"],
+        },
+        "statistics": {"total_edges": 1},
+    }
+
+
+def test_apply_reachability_filter_does_not_crash_and_seeds_main():
+    mod = _load_zig_pipeline()
+    out = mod.apply_reachability_filter(_call_graph_output(), repo_path="/tmp/repo")
+
+    fids = set(out["functions"].keys())
+    assert "src/main.zig:main" in fids, (
+        "main is an entry point and must survive the reachability filter"
+    )
+    assert "src/main.zig:helper" in fids, (
+        "helper is reachable from main and must survive"
+    )
+    assert "src/main.zig:orphan" not in fids, (
+        "orphan is unreachable and must be filtered out — proving the filter "
+        "actually ran rather than passing everything through"
+    )
+
+
+def test_apply_reachability_filter_filters_call_graph_too():
+    mod = _load_zig_pipeline()
+    out = mod.apply_reachability_filter(_call_graph_output(), repo_path="/tmp/repo")
+    # orphan must not linger in the (reverse) call graphs either.
+    assert "src/main.zig:orphan" not in out.get("call_graph", {})
+    assert "src/main.zig:orphan" not in out.get("reverse_call_graph", {})

--- a/libs/openant-core/tests/report/test_build_pipeline_output_return_contract.py
+++ b/libs/openant-core/tests/report/test_build_pipeline_output_return_contract.py
@@ -1,0 +1,89 @@
+"""Regression test for the ``build_pipeline_output`` return-contract bug.
+
+``build_pipeline_output`` was annotated ``-> str``
+with a docstring claiming it returns "The output_path written to" (a single
+str), but its sole ``return`` statement is ``return output_path,
+len(findings_data)`` — a ``tuple[str, int]``. The annotation/docstring grew
+stale when the function gained a second return value (the findings count);
+the one binding caller (``openant/cli.py`` ``cmd_report``) was migrated to
+unpack the tuple, but the signature + docstring were left behind.
+
+This test pins the *real* runtime contract: the function returns a 2-tuple of
+``(output_path: str, findings_count: int)``, and the declared return
+annotation must agree with that real return type. It fails at base because
+the annotation is ``str`` while the value is a tuple.
+"""
+
+import json
+import sys
+import typing
+from pathlib import Path
+
+import pytest
+
+# Allow `import core.reporter` when tests run from repo root or elsewhere.
+_CORE_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from core import reporter  # noqa: E402
+
+
+@pytest.fixture
+def results_file(tmp_path: Path) -> Path:
+    """Minimal results.json (no confirmed findings) accepted by the reporter."""
+    results = {
+        "results": [],
+        "code_by_route": {},
+        "metrics": {"total": 0, "vulnerable": 0, "safe": 0},
+    }
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps(results))
+    return path
+
+
+def test_returns_tuple_of_path_and_findings_count(tmp_path: Path, results_file: Path):
+    """The actual return value is a 2-tuple ``(str, int)``, not a bare str."""
+    out_path = tmp_path / "pipeline_output.json"
+    ret = reporter.build_pipeline_output(
+        results_path=str(results_file),
+        output_path=str(out_path),
+        repo_name="example/return-contract",
+        language="python",
+    )
+
+    assert isinstance(ret, tuple), f"expected a tuple return, got {type(ret).__name__}"
+    assert len(ret) == 2, f"expected a 2-tuple, got len {len(ret)}"
+    path, findings_count = ret
+    assert isinstance(path, str)
+    assert path == str(out_path)
+    assert isinstance(findings_count, int)
+
+
+def test_return_annotation_matches_real_tuple_contract():
+    """The declared ``-> ...`` annotation must agree with the real tuple return.
+
+    At base the annotation is ``str`` (single value) which contradicts the
+    real ``tuple[str, int]`` return — this assertion is the RED.
+    """
+    hints = typing.get_type_hints(reporter.build_pipeline_output)
+    ret_ann = hints.get("return")
+
+    origin = typing.get_origin(ret_ann)
+    assert origin is tuple, (
+        "build_pipeline_output return annotation must be a tuple to match its "
+        f"real `return output_path, len(findings_data)`; got {ret_ann!r}"
+    )
+
+    args = typing.get_args(ret_ann)
+    assert args == (str, int), (
+        f"return annotation should be tuple[str, int]; got tuple{list(args)!r}"
+    )
+
+
+def test_docstring_no_longer_claims_single_path_return():
+    """The Returns: docstring must not claim a single ``output_path`` return."""
+    doc = reporter.build_pipeline_output.__doc__ or ""
+    assert "The *output_path* written to." not in doc, (
+        "docstring still claims a single output_path return; it should describe "
+        "the (output_path, findings_count) tuple"
+    )

--- a/libs/openant-core/tests/test_agent.py
+++ b/libs/openant-core/tests/test_agent.py
@@ -1,0 +1,93 @@
+"""Regression tests for the agentic enhancer input budget.
+
+The agentic context enhancer built the LLM conversation with no input
+token/char budget: ``primary_code`` was inlined verbatim into the initial
+user prompt, and raw, untruncated tool results were appended to ``messages``
+every iteration. On a large unit the constructed input grew unbounded across
+iterations until it overflowed the model context (400 error), losing the
+enhancement.
+
+Operative guard: an INPUT BUDGET applied at the consumption points.
+  - ``get_user_prompt`` caps the inlined ``primary_code`` (prompts.py).
+  - ``cap_tool_result_content`` caps each serialized tool result before it is
+    appended to ``messages`` (agent.py).
+
+These tests exercise the pure, deterministic guard functions (no network).
+"""
+import json
+
+from utilities.agentic_enhancer.prompts import get_user_prompt
+from utilities.agentic_enhancer import agent as agent_mod
+
+
+def test_primary_code_is_capped_in_user_prompt():
+    """A huge primary_code must not be inlined verbatim — the constructed
+    prompt must stay bounded (well under any model context budget)."""
+    huge_code = "x = 1\n" * 500_000  # ~3 MB of source
+    prompt = get_user_prompt(
+        unit_id="big.py:huge",
+        unit_type="function",
+        primary_code=huge_code,
+        static_deps=[],
+        static_callers=[],
+    )
+    # The whole prompt (not just the code) must be bounded.
+    assert len(prompt) <= agent_mod.MAX_PROMPT_CHARS + 4096, (
+        f"prompt length {len(prompt)} exceeds budget "
+        f"{agent_mod.MAX_PROMPT_CHARS}; primary_code was not capped"
+    )
+    # Truncation must be signalled so the model knows content was elided.
+    assert "truncated" in prompt.lower()
+
+
+def test_small_primary_code_is_not_altered():
+    """Small code must pass through verbatim (no spurious truncation)."""
+    small_code = "def f():\n    return 1\n"
+    prompt = get_user_prompt(
+        unit_id="small.py:f",
+        unit_type="function",
+        primary_code=small_code,
+        static_deps=[],
+        static_callers=[],
+    )
+    assert small_code in prompt
+    assert "... (truncated" not in prompt
+
+
+def test_tool_result_content_is_capped():
+    """A very large tool result must be truncated before being appended to
+    the messages list so the constructed input cannot grow unbounded."""
+    huge_result = {"found": True, "code": "A" * 1_000_000}
+    content = agent_mod.cap_tool_result_content(huge_result)
+    assert isinstance(content, str)
+    assert len(content) <= agent_mod.MAX_TOOL_RESULT_CHARS + 256, (
+        f"tool-result content length {len(content)} exceeds budget "
+        f"{agent_mod.MAX_TOOL_RESULT_CHARS}"
+    )
+    assert "truncated" in content.lower()
+
+
+def test_small_tool_result_round_trips_as_json():
+    """A small tool result must serialize losslessly (parseable JSON)."""
+    result = {"found": True, "id": "a.py:f", "code": "def f(): pass"}
+    content = agent_mod.cap_tool_result_content(result)
+    assert json.loads(content) == result
+
+
+def test_messages_do_not_grow_unbounded_across_iterations():
+    """Simulate the loop's append behaviour: repeatedly appending capped tool
+    results keeps total input bounded per iteration (no unbounded growth from
+    a single oversized result)."""
+    messages = []
+    oversized = {"found": True, "code": "Z" * 5_000_000}
+    for _ in range(agent_mod.MAX_ITERATIONS):
+        content = agent_mod.cap_tool_result_content(oversized)
+        messages.append({"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t", "content": content}
+        ]})
+    total = sum(len(m["content"][0]["content"]) for m in messages)
+    bound = agent_mod.MAX_ITERATIONS * (agent_mod.MAX_TOOL_RESULT_CHARS + 256)
+    assert total <= bound, (
+        f"accumulated tool-result input {total} exceeds bounded "
+        f"expectation {bound}"
+    )

--- a/libs/openant-core/tests/test_analyzer_limit_priority.py
+++ b/libs/openant-core/tests/test_analyzer_limit_priority.py
@@ -1,0 +1,96 @@
+"""Regression tests for priority-sorted ``--limit`` truncation.
+
+`run_analysis(..., limit=N)` truncates the unit list with a raw head-slice
+``units = units[:limit]`` (analyzer.py). The units arrive from the parser in
+alphabetical-by-path order (repository_scanner.py: ``self.files.sort(key=lambda
+f: f['path'])``), so a ``--limit`` run deterministically kept the first N
+alphabetical units (e.g. ``Doc/`` before ``Lib/``) and dropped high-value code
+with NO relevance/priority weighting.
+
+The fix sorts by enhancement security_classification (exploitable >
+vulnerable_internal > other) BEFORE the head-slice, stably (alphabetical order
+preserved within a classification tier), and reads the classification
+mode-agnostically (agentic writes agent_context, single-shot writes
+llm_context). These tests drive the extracted ``_apply_limit`` helper directly.
+"""
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).parent.parent
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+from core.analyzer import _apply_limit  # noqa: E402
+
+
+def _unit(uid, classification=None, mode="agentic"):
+    u = {"id": uid}
+    if classification is not None:
+        ctx_key = "agent_context" if mode == "agentic" else "llm_context"
+        u[ctx_key] = {"security_classification": classification}
+    return u
+
+
+def test_no_limit_returns_units_unchanged():
+    units = [_unit("a"), _unit("b"), _unit("c")]
+    assert _apply_limit(units, None) is units
+    assert _apply_limit(units, 0) is units
+
+
+def test_limit_keeps_exploitable_over_alphabetically_early_neutral():
+    # Parser order: Doc/ neutral units come first alphabetically, the
+    # exploitable Lib/ unit comes last. A raw head-slice with limit=2 would
+    # keep the two Doc/ neutrals and DROP the exploitable unit.
+    units = [
+        _unit("Doc/a", "neutral"),
+        _unit("Doc/b", "neutral"),
+        _unit("Lib/danger", "exploitable"),
+    ]
+    kept = _apply_limit(units, 2)
+    kept_ids = [u["id"] for u in kept]
+    assert "Lib/danger" in kept_ids, (
+        "exploitable unit must survive a --limit truncation over neutral units; "
+        f"got {kept_ids}"
+    )
+    assert len(kept) == 2
+
+
+def test_priority_order_exploitable_then_vulnerable_internal_then_other():
+    units = [
+        _unit("a", "neutral"),
+        _unit("b", "vulnerable_internal"),
+        _unit("c", "exploitable"),
+        _unit("d", None),
+    ]
+    kept_ids = [u["id"] for u in _apply_limit(units, 4)]
+    # exploitable first, then vulnerable_internal, then the rest (stable).
+    assert kept_ids[0] == "c"
+    assert kept_ids[1] == "b"
+    assert set(kept_ids[2:]) == {"a", "d"}
+
+
+def test_stable_within_same_classification_tier():
+    # Equal-priority units retain their original (alphabetical) order.
+    units = [
+        _unit("Lib/a", "exploitable"),
+        _unit("Lib/b", "exploitable"),
+        _unit("Lib/c", "exploitable"),
+    ]
+    kept_ids = [u["id"] for u in _apply_limit(units, 2)]
+    assert kept_ids == ["Lib/a", "Lib/b"]
+
+
+def test_classification_read_mode_agnostically_single_shot():
+    # Single-shot enhance writes llm_context, not agent_context.
+    units = [
+        _unit("Doc/a", "neutral", mode="single-shot"),
+        _unit("Lib/danger", "exploitable", mode="single-shot"),
+    ]
+    kept_ids = [u["id"] for u in _apply_limit(units, 1)]
+    assert kept_ids == ["Lib/danger"]
+
+
+def test_limit_larger_than_list_returns_all_reprioritized():
+    units = [_unit("a", "neutral"), _unit("b", "exploitable")]
+    kept_ids = [u["id"] for u in _apply_limit(units, 10)]
+    assert kept_ids == ["b", "a"]

--- a/libs/openant-core/tests/test_application_context_entry_points_anchored.py
+++ b/libs/openant-core/tests/test_application_context_entry_points_anchored.py
@@ -1,0 +1,56 @@
+"""Regression tests for detect_entry_points unanchored-substring path-exclusion.
+
+Two sites exclude files via `token in str(absolute_path)` —
+  Python branch (application_context.py:290): tokens incl 'test','tests','venv'
+  JS branch     (application_context.py:310): tokens incl 'dist','build'
+So a path SEGMENT (or a PARENT dir) merely CONTAINING a token wrongly skips a real entry point.
+Vividly, pytest's own tmp_path contains 'test', so PRE-FIX every fixture below is excluded.
+Fix: match on relative-path COMPONENTS + anchored test-file detection.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+from context.application_context import detect_entry_points  # noqa: E402
+
+FASTAPI = "from fastapi import FastAPI\napp = FastAPI()\n"
+EXPRESS = "const express = require('express')\nconst app = express()\n"
+
+
+def _w(p: Path, text: str):
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+
+
+def test_substring_false_positive_python(tmp_path):
+    # 'protest_api.py' contains 'test' as a substring but is a real FastAPI entry point.
+    _w(tmp_path / "protest_api.py", FASTAPI)
+    out = detect_entry_points(tmp_path)
+    assert "protest_api.py" in out, f"real entry point wrongly excluded by 'test' substring: {out!r}"
+
+
+def test_parent_path_token_does_not_kill_all(tmp_path):
+    # repo under a parent dir named 'latest' (contains 'test') — pre-fix excludes EVERY file.
+    repo = tmp_path / "latest" / "app"
+    _w(repo / "server.py", FASTAPI)
+    out = detect_entry_points(repo)
+    assert "server.py" in out, f"parent-path token wrongly excluded all files: {out!r}"
+
+
+def test_js_substring_false_positive(tmp_path):
+    # 'redistribute.js' contains 'dist' as a substring but is a real express entry point.
+    _w(tmp_path / "redistribute.js", EXPRESS)
+    out = detect_entry_points(tmp_path)
+    assert "redistribute.js" in out, f"real JS entry point wrongly excluded by 'dist' substring: {out!r}"
+
+
+def test_genuine_exclusions_preserved(tmp_path):
+    # post-fix: a clean entry point IS detected; a real tests/ file and node_modules stay excluded.
+    _w(tmp_path / "real_app.py", FASTAPI)
+    _w(tmp_path / "tests" / "test_real.py", FASTAPI)
+    _w(tmp_path / "node_modules" / "pkg" / "mod.py", FASTAPI)
+    out = detect_entry_points(tmp_path)
+    assert "real_app.py" in out, f"clean entry point should be detected: {out!r}"
+    assert "test_real.py" not in out, f"genuine test file should stay excluded: {out!r}"
+    assert "mod.py" not in out, f"node_modules should stay excluded: {out!r}"

--- a/libs/openant-core/tests/test_c_extract_all_path_components.py
+++ b/libs/openant-core/tests/test_c_extract_all_path_components.py
@@ -40,7 +40,7 @@ def test_extract_all_excludes_on_path_components_not_substring(tmp_path, monkeyp
     ex = FunctionExtractor(str(repo))
     processed = []
     monkeypatch.setattr(ex, "process_file",
-                        lambda fp: processed.append(str(Path(fp).relative_to(ex.repo_path))))
+                        lambda fp: processed.append(Path(fp).relative_to(ex.repo_path).as_posix()))
     ex.extract_all()
     procset = set(processed)
 

--- a/libs/openant-core/tests/test_c_extract_all_path_components.py
+++ b/libs/openant-core/tests/test_c_extract_all_path_components.py
@@ -1,0 +1,53 @@
+"""Regression: c/function_extractor extract_all over-excludes by substring.
+
+extract_all filters discovered files with `any(excl in str(file_path) for excl in [.git,build,test,
+node_modules])` — an unanchored SUBSTRING test against the absolute path. So a file whose path merely
+*contains* a token is wrongly skipped ('src/latest/main.c' contains 'test'; 'contest/sol.c' too), and an
+ANCESTOR dir of repo_path that contains a token poisons the whole scan (a checkout under '/home/tester/'
+excludes everything — pytest's own tmp_path, which contains 'test', reproduces this). Fix: match on path
+COMPONENTS relative to repo_path, using c's own token set.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[1]                              # libs/openant-core
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))                                       # for utilities.file_io
+
+# Load the C parser's function_extractor under a UNIQUE module name (not the bare
+# 'function_extractor') so we do NOT pollute sys.modules for sibling parser tests:
+# parsers/python also ships a 'function_extractor' module, and a bare import here would
+# shadow it for the whole pytest session. The C module imports only stdlib + tree_sitter_c +
+# utilities.file_io, so no parsers/c entry on sys.path is required.
+_spec = importlib.util.spec_from_file_location(
+    "c_function_extractor_isolated", str(CORE / "parsers" / "c" / "function_extractor.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+FunctionExtractor = _mod.FunctionExtractor
+
+
+def test_extract_all_excludes_on_path_components_not_substring(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    for d in ("src/latest", "contest", "src", "test", ".git"):
+        (repo / d).mkdir(parents=True, exist_ok=True)
+    (repo / "src" / "latest" / "main.c").write_text("int latest_fn(void){return 1;}\n")
+    (repo / "contest" / "sol.c").write_text("int contest_fn(void){return 2;}\n")
+    (repo / "src" / "clean.c").write_text("int clean_fn(void){return 3;}\n")
+    (repo / "test" / "helper.c").write_text("int test_helper(void){return 4;}\n")   # real test/ dir
+    (repo / ".git" / "hook.c").write_text("int git_fn(void){return 5;}\n")          # .git
+
+    ex = FunctionExtractor(str(repo))
+    processed = []
+    monkeypatch.setattr(ex, "process_file",
+                        lambda fp: processed.append(str(Path(fp).relative_to(ex.repo_path))))
+    ex.extract_all()
+    procset = set(processed)
+
+    # path merely CONTAINS a token -> must still be processed (substring match was the bug)
+    assert "src/latest/main.c" in procset, f"'latest' wrongly excluded by 'test' substring: {sorted(procset)}"
+    assert "contest/sol.c" in procset, f"'contest' wrongly excluded: {sorted(procset)}"
+    assert "src/clean.c" in procset
+    # genuine excluded directory NAMES stay excluded
+    assert "test/helper.c" not in procset, "a real test/ directory should stay excluded"
+    assert ".git/hook.c" not in procset, ".git should stay excluded"

--- a/libs/openant-core/tests/test_c_pipeline.py
+++ b/libs/openant-core/tests/test_c_pipeline.py
@@ -1,0 +1,78 @@
+"""Regression tests for three defects in parsers/c/test_pipeline.py.
+
+1. The C CodeQL `database create` command omits `--build-mode=none`, so cpp
+   defaults to autobuild and silently degrades (drops findings) on no-build/autotools repos.
+2. Overall success ANDed over ALL stages, so an OPTIONAL stage (CodeQL,
+   reachability, context enhancer, exploitable) failing/skipping forced a spurious pipeline failure.
+3. The six same-named parsers/<lang>/test_pipeline.py orchestrators (CLI
+   runners, not tests) collide under `pytest parsers/` (import-file-mismatch). __init__.py does NOT fix
+   it -- their bare local imports make them un-importable as package modules -- so a root conftest
+   collect_ignore_glob excludes them from collection.
+
+The _compute_success test contains its import: c/test_pipeline.py does bare local imports
+(`from repository_scanner import ...`) that would pollute sys.modules with c's parser modules and
+shadow the python parser tests -- so the import is done inside the test under a unique name and the
+polluting entries are popped in a finally.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[1]                 # libs/openant-core
+C_SRC = CORE / "parsers" / "c" / "test_pipeline.py"
+
+
+# source-read (the codeql cmd cannot run without the CodeQL CLI)
+def test_codeql_create_uses_build_mode_none():
+    text = C_SRC.read_text()
+    create_idx = text.index("'codeql', 'database', 'create'")
+    overwrite_idx = text.index("'--overwrite'", create_idx)
+    create_cmd = text[create_idx:overwrite_idx]
+    assert "'--build-mode=none'" in create_cmd, \
+        "C codeql `database create` must pass --build-mode=none (no autobuild on no-build cpp repos)"
+
+
+# behavioral, with contained import + sys.modules cleanup
+def test_compute_success_ignores_optional_stage_failures():
+    cdir = str(CORE / "parsers" / "c")
+    added = cdir not in sys.path
+    if added:
+        sys.path.insert(0, cdir)
+    before = set(sys.modules)
+    try:
+        spec = importlib.util.spec_from_file_location("c_test_pipeline_isolated", str(C_SRC))
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        ct = mod.CPipelineTest.__new__(mod.CPipelineTest)  # skip __init__ (no repo I/O needed)
+
+        # required stage ok, optional stages failed -> overall success is True
+        ct.results = {"stages": {
+            "c_parser": {"success": True},
+            "codeql_analysis": {"success": False},
+            "reachability_filter": {"success": False},
+        }}
+        assert ct._compute_success() is True, "optional-stage failures must not fail the pipeline"
+
+        # required stage fails -> overall success is False
+        ct.results["stages"]["c_parser"]["success"] = False
+        assert ct._compute_success() is False, "a required stage failure must fail the pipeline"
+    finally:
+        if added:
+            sys.path.remove(cdir)
+        for m in set(sys.modules) - before:
+            root = m.split(".")[0]
+            if root in ("repository_scanner", "function_extractor", "call_graph_builder",
+                        "unit_generator", "c_test_pipeline_isolated"):
+                sys.modules.pop(m, None)
+
+
+# the parsers/<lang>/test_pipeline.py orchestrators (CLI runners, NOT
+# pytest tests) must be excluded from collection so their shared basename does not collide under
+# `pytest parsers/` (import-file-mismatch). __init__.py does not fix it -- the orchestrators' bare
+# local imports make them un-importable as package modules -- so we exclude them from collection.
+def test_parser_orchestrators_excluded_from_pytest_collection():
+    conftest = CORE / "conftest.py"
+    assert conftest.exists(), "libs/openant-core/conftest.py missing (collect_ignore for orchestrators)"
+    text = conftest.read_text()
+    assert "collect_ignore_glob" in text and "parsers/*/test_pipeline.py" in text, \
+        "root conftest must collect_ignore_glob the parsers/*/test_pipeline.py orchestrators"

--- a/libs/openant-core/tests/test_context_assembler_mjs.py
+++ b/libs/openant-core/tests/test_context_assembler_mjs.py
@@ -1,0 +1,49 @@
+"""Regression: context_assembler must not omit .mjs/.cjs (silent edge drop).
+
+context_assembler.js's source-discovery glob (findSourceFiles, ~:87) and its import-resolution extension
+lists (~:322, ~:465) only cover .js/.ts/.jsx/.tsx — never .mjs/.cjs. So ESM (.mjs) / CommonJS (.cjs) modules are
+never loaded into the TypeScript program (getSourceFile -> undefined) and imports targeting them are silently
+unresolved. The sibling repository_scanner.js already includes .mjs/.cjs in its sourceExtensions. Fix: add
+.mjs/.cjs to the discovery glob and the resolution extension lists.
+
+This drives the discovery root via the exported ContextAssembler.findSourceFiles (a .mjs/.cjs file must be
+discovered). Skips portably where the JS parser's node deps aren't installed.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PARSERS_JS_DIR = Path(__file__).parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def test_findsourcefiles_discovers_mjs_and_cjs(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "main.js").write_text("export {};\n")
+    (repo / "esm.mjs").write_text("export const x = 1;\n")
+    (repo / "cjs.cjs").write_text("module.exports = {};\n")
+
+    ca_path = str(PARSERS_JS_DIR / "context_assembler.js")
+    script = (
+        "const {ContextAssembler}=require(%r);"
+        "const path=require('path');"
+        "const ca=new ContextAssembler(%r);"
+        "const f=ca.findSourceFiles(%r);"
+        "console.log(JSON.stringify(f.map(p=>path.basename(p))));"
+    ) % (ca_path, str(repo), str(repo))
+
+    r = subprocess.run(["node", "-e", script], capture_output=True, text=True, timeout=30)
+    assert r.returncode == 0, f"node failed: {r.stderr}"
+    found = json.loads(r.stdout.strip().splitlines()[-1])
+    assert "esm.mjs" in found, f".mjs not discovered (discovery glob omits it): {found}"
+    assert "cjs.cjs" in found, f".cjs not discovered (discovery glob omits it): {found}"
+    assert "main.js" in found  # control: .js still discovered

--- a/libs/openant-core/tests/test_enhance_limit.py
+++ b/libs/openant-core/tests/test_enhance_limit.py
@@ -1,0 +1,82 @@
+"""Regression tests: `enhance` lacked a `--limit` (max-units) capability at all
+three layers (Go CLI, Python CLI, core), while `analyze`/`scan` have it.
+
+These tests cover the two Python layers behaviorally:
+- the core `enhance_dataset(limit=N)` actually slices the dataset to N units (the LLM is stubbed);
+- the CLI path `enhance ... --limit N` (parser `enhance_p` + `cmd_enhance`) forwards N to enhance_dataset.
+
+(The Go layer is covered by apps/openant-cli/cmd/enhance_limit_test.go.)
+"""
+import sys
+
+import core.enhancer as enh
+import utilities.context_enhancer as _ce
+import utilities.llm_client as _llm
+
+
+_received = {}
+
+
+class _DummyEnhancer:
+    def __init__(self, **kw):
+        pass
+
+    def enhance_dataset(self, dataset, progress_callback=None, workers=8):
+        _received["units"] = len(dataset.get("units", []))
+        return dataset
+
+    def enhance_dataset_agentic(self, dataset, **kw):
+        _received["units"] = len(dataset.get("units", []))
+        return dataset
+
+
+def test_enhance_dataset_limit_slices_units(tmp_path, monkeypatch):
+    five = [{"id": f"u{i}", "llm_context": {}} for i in range(5)]
+    monkeypatch.setattr(enh, "read_json", lambda p: {"units": list(five)})
+    monkeypatch.setattr(enh, "write_json", lambda p, d: None)
+    monkeypatch.setattr(enh, "configure_rate_limiter", lambda **k: None)
+    monkeypatch.setattr(_llm, "AnthropicClient", lambda **k: object())
+    monkeypatch.setattr(_llm, "get_global_tracker", lambda: None)
+    monkeypatch.setattr(_ce, "ContextEnhancer", _DummyEnhancer)
+
+    _received.clear()
+    res = enh.enhance_dataset(
+        dataset_path=str(tmp_path / "x.json"),
+        output_path=str(tmp_path / "out.json"),
+        mode="single-shot",
+        limit=2,
+    )
+    # The enhancer must RECEIVE only the limited units -- this guards the load-bearing
+    # `dataset["units"] = units` slice (a local-only slice would leave 5 units reaching the enhancer).
+    assert _received["units"] == 2, f"enhancer received {_received.get('units')} units, expected 2"
+    assert res.units_enhanced == 2, f"limit=2 should enhance 2 of 5 units, got {res.units_enhanced}"
+
+
+def test_enhance_cli_forwards_limit_end_to_end(tmp_path, monkeypatch):
+    from openant import cli
+
+    captured = {}
+
+    def _fake_enhance_dataset(**kwargs):
+        captured.update(kwargs)
+
+        class _R:
+            enhanced_dataset_path = str(tmp_path / "out.json")
+            units_enhanced = 3
+            error_count = 0
+            classifications: dict = {}
+            error_summary: dict = {}
+
+            def to_dict(self):
+                return {"units_enhanced": 3}
+
+        return _R()
+
+    # cmd_enhance does `from core.enhancer import enhance_dataset` at call time -> patch the source attr
+    monkeypatch.setattr(enh, "enhance_dataset", _fake_enhance_dataset)
+    monkeypatch.setattr(sys, "argv", ["openant", "enhance", str(tmp_path / "x.json"), "--limit", "3"])
+
+    rc = cli.main()
+    assert rc == 0, f"enhance command returned {rc}"
+    assert captured.get("limit") == 3, \
+        f"`enhance --limit 3` must forward limit=3 to enhance_dataset, got {captured.get('limit')!r}"

--- a/libs/openant-core/tests/test_enhance_limit.py
+++ b/libs/openant-core/tests/test_enhance_limit.py
@@ -11,17 +11,72 @@ import sys
 
 import core.enhancer as enh
 import utilities.context_enhancer as _ce
+import utilities.llm as _llm_mod
 import utilities.llm_client as _llm
 
 
 _received = {}
 
 
+class _FakeAdapter:
+    """Inert LLMAdapter stand-in; never called (ContextEnhancer is stubbed)."""
+
+    name = "anthropic"
+    supports_tools = True
+
+    def complete(self, *, model, system, messages, max_tokens, tools=None):  # pragma: no cover
+        raise AssertionError("adapter.complete must not be called")
+
+    def validate(self, model):  # pragma: no cover
+        pass
+
+
+class _StubRegistry:
+    """Stand-in PhaseRegistry: returns a fake binding and skips probing.
+
+    #69 routes ``core.enhancer.enhance_dataset`` through the registry
+    (build_phase_registry -> probe_registry_or_raise -> registry.get('enhance'))
+    instead of constructing an AnthropicClient directly. ``_DummyEnhancer``
+    ignores the binding, but enhance_dataset reads ``binding.provider_name`` /
+    ``binding.model`` for a log line, so we hand back a real PhaseBinding
+    wrapping an inert adapter. The point is to keep the path fully offline.
+    """
+
+    config_name = "openant-default"
+
+    def get(self, phase):
+        from utilities.llm import PhaseBinding
+
+        return PhaseBinding(
+            phase=phase,
+            adapter=_FakeAdapter(),
+            model="claude-test",
+            provider_name="anthropic",
+        )
+
+
+def _stub_registry_plumbing(monkeypatch):
+    """Replace the real (network-probing) registry build with offline stubs.
+
+    Mirrors the canonical pattern in tests/test_entrypoint_bindings.py:
+    stub config load + resolve + build on the importing module, and the probe
+    on utilities.llm (enhance_dataset imports probe_registry_or_raise lazily
+    from there). Replaces the old ``AnthropicClient`` monkeypatch #69 deleted.
+    """
+    monkeypatch.setattr(enh, "load_config_file", lambda *a, **k: object())
+    monkeypatch.setattr(enh, "resolve_llm_config", lambda *a, **k: object())
+    monkeypatch.setattr(enh, "build_phase_registry", lambda *a, **k: _StubRegistry())
+    monkeypatch.setattr(_llm_mod, "probe_registry_or_raise", lambda *a, **k: None)
+
+
 class _DummyEnhancer:
     def __init__(self, **kw):
         pass
 
-    def enhance_dataset(self, dataset, progress_callback=None, workers=8):
+    def enhance_dataset(self, dataset, progress_callback=None, workers=8, **kw):
+        # **kw absorbs checkpoint_path (added post-#69 single-shot resume) and
+        # any other keywords core.enhancer threads through; this dummy only
+        # cares about the unit count it received.
         _received["units"] = len(dataset.get("units", []))
         return dataset
 
@@ -35,7 +90,7 @@ def test_enhance_dataset_limit_slices_units(tmp_path, monkeypatch):
     monkeypatch.setattr(enh, "read_json", lambda p: {"units": list(five)})
     monkeypatch.setattr(enh, "write_json", lambda p, d: None)
     monkeypatch.setattr(enh, "configure_rate_limiter", lambda **k: None)
-    monkeypatch.setattr(_llm, "AnthropicClient", lambda **k: object())
+    _stub_registry_plumbing(monkeypatch)
     monkeypatch.setattr(_llm, "get_global_tracker", lambda: None)
     monkeypatch.setattr(_ce, "ContextEnhancer", _DummyEnhancer)
 

--- a/libs/openant-core/tests/test_enhance_resilience.py
+++ b/libs/openant-core/tests/test_enhance_resilience.py
@@ -1,0 +1,194 @@
+"""Regression tests for enhance/analyzer resilience fixes.
+
+Covers four confirmed bugs:
+
+  - is_retryable_error() string branch omits "529" and "overloaded" ->
+    Anthropic-overloaded errors never retried on the analyzer detection path
+    (which feeds str(e), not a dict).
+  - agentic post-loop transient-error retry was a single pass; a unit that
+    fails again on the one retry is never re-attempted.
+  - single-shot enhance_dataset had no checkpoint/resume, so a --checkpoint path
+    was silently dropped and an interrupted run reprocessed every unit.
+  - single-shot enhance writes only llm_context
+    (no agent_context.security_classification), so --exploitable-only/all
+    silently dropped every single-shot unit with no operator signal.
+
+No external network: ContextEnhancer.enhance_unit is monkeypatched.
+"""
+import os
+
+import pytest
+
+from utilities.rate_limiter import is_retryable_error
+
+
+# --------------------------------------------------------------------------
+# 529 / overloaded must be retryable via the string branch.
+# --------------------------------------------------------------------------
+class TestIsRetryable529:
+    def test_529_overloaded_string_is_retryable(self):
+        # The exact shape the Anthropic SDK stringifies a 529 into. The
+        # analyzer detection path stores str(e), forcing the string branch.
+        err = "Error code: 529 - {'type': 'error', 'error': {'type': 'overloaded_error', 'message': 'Overloaded'}}"
+        assert is_retryable_error(err) is True
+
+    def test_overloaded_word_alone_is_retryable(self):
+        assert is_retryable_error("server overloaded, try again") is True
+
+    def test_existing_5xx_strings_still_retryable(self):
+        for code in ("500", "502", "503", "504"):
+            assert is_retryable_error(f"Error code: {code} - server error") is True
+
+    def test_client_error_400_still_not_retryable(self):
+        # Guard against over-broadening: a 400 must remain non-retryable.
+        assert is_retryable_error("Error code: 400 - bad request") is False
+
+    def test_structured_529_dict_still_retryable(self):
+        assert is_retryable_error({"type": "api_status", "status_code": 529}) is True
+
+
+# --------------------------------------------------------------------------
+# Shared helpers for the ContextEnhancer-level tests.
+# --------------------------------------------------------------------------
+def _make_enhancer():
+    from utilities.context_enhancer import ContextEnhancer
+
+    return ContextEnhancer(client=None, tracker=None)
+
+
+def _dataset(n=3):
+    return {"units": [{"id": f"u{i}", "code": f"def f{i}(): pass"} for i in range(n)]}
+
+
+# --------------------------------------------------------------------------
+# agentic retry must be a bounded multi-round loop.
+# --------------------------------------------------------------------------
+class TestAgenticBoundedRetry:
+    def test_unit_failing_on_first_retry_is_retried_again(self, monkeypatch, tmp_path):
+        """A transient error that persists for one retry must get another round
+        (up to the cap), instead of being abandoned after a single pass."""
+        from unittest.mock import MagicMock
+
+        from utilities import context_enhancer as ce
+
+        enh = _make_enhancer()
+        # Avoid building a real repository index (no analyzer output / repo).
+        fake_index = MagicMock()
+        fake_index.get_statistics.return_value = {
+            "total_functions": 0, "total_files": 0,
+        }
+        monkeypatch.setattr(ce, "load_index_from_file", lambda *a, **k: fake_index)
+
+        # attempts[uid] = how many times we've enhanced that unit.
+        attempts = {}
+
+        def fake_agent(unit, index, tracker, verbose, client=None):
+            uid = unit.get("id")
+            attempts[uid] = attempts.get(uid, 0) + 1
+            # u1 stays transiently-broken for the first 2 attempts, then succeeds.
+            if uid == "u1" and attempts[uid] < 3:
+                unit["agent_context"] = {
+                    "error": {"type": "api_status", "status_code": 529},
+                    "security_classification": "neutral",
+                    "confidence": 0.0,
+                }
+            else:
+                unit["agent_context"] = {
+                    "security_classification": "neutral",
+                    "confidence": 0.5,
+                }
+
+        monkeypatch.setattr(ce, "enhance_unit_with_agent", fake_agent)
+
+        ds = _dataset(2)
+        result = enh.enhance_dataset_agentic(
+            dataset=ds,
+            analyzer_output_path=None,
+            repo_path=None,
+            workers=1,
+        )
+
+        # With a bounded multi-round retry, u1 is attempted 3 times total
+        # (initial + 2 retry rounds) and ends without an error.
+        u1 = next(u for u in result["units"] if u["id"] == "u1")
+        assert attempts["u1"] >= 3, f"u1 only attempted {attempts['u1']}x (single-pass retry bug)"
+        assert not u1.get("agent_context", {}).get("error"), "u1 still errored after bounded retry"
+
+
+# --------------------------------------------------------------------------
+# single-shot enhance must support checkpoint/resume.
+# --------------------------------------------------------------------------
+class TestSingleShotCheckpoint:
+    def test_enhance_dataset_accepts_checkpoint_path(self, monkeypatch, tmp_path):
+        """Single-shot enhance_dataset must accept a checkpoint dir and persist
+        per-unit results so an interrupted run can resume."""
+        from utilities.context_enhancer import ContextEnhancer
+
+        enh = ContextEnhancer(client=None, tracker=None)
+
+        def fake_enhance_unit(unit, units_by_id):
+            unit["llm_context"] = {
+                "reasoning": "ok",
+                "confidence": 0.9,
+                "security_classification": "neutral",
+            }
+            return unit
+
+        monkeypatch.setattr(enh, "enhance_unit", fake_enhance_unit)
+
+        cp_dir = str(tmp_path / "enhance_checkpoints")
+        enh.enhance_dataset(_dataset(3), workers=1, checkpoint_path=cp_dir)
+
+        files = [f for f in os.listdir(cp_dir) if f.endswith(".json")]
+        assert len(files) == 3, f"expected 3 per-unit checkpoints, found {files}"
+
+    def test_resume_skips_already_completed_units(self, monkeypatch, tmp_path):
+        """On resume, units already checkpointed must not be re-enhanced."""
+        from utilities.context_enhancer import ContextEnhancer
+
+        cp_dir = str(tmp_path / "enhance_checkpoints")
+
+        # First run: complete all units.
+        enh1 = ContextEnhancer(client=None, tracker=None)
+        monkeypatch.setattr(
+            enh1, "enhance_unit",
+            lambda unit, by_id: unit.update(
+                {"llm_context": {"reasoning": "ok", "confidence": 0.9}}
+            ) or unit,
+        )
+        enh1.enhance_dataset(_dataset(3), workers=1, checkpoint_path=cp_dir)
+
+        # Second run: count how many units get (re-)enhanced.
+        enh2 = ContextEnhancer(client=None, tracker=None)
+        seen = []
+
+        def counting_enhance(unit, by_id):
+            seen.append(unit.get("id"))
+            unit["llm_context"] = {"reasoning": "ok", "confidence": 0.9}
+            return unit
+
+        monkeypatch.setattr(enh2, "enhance_unit", counting_enhance)
+        enh2.enhance_dataset(_dataset(3), workers=1, checkpoint_path=cp_dir)
+
+        assert seen == [], f"resume re-enhanced units that were already done: {seen}"
+
+
+# --------------------------------------------------------------------------
+# exploitable filter must not silently drop single-shot units.
+# --------------------------------------------------------------------------
+class TestExploitableFilterSingleShot:
+    def test_filter_reads_llm_context_classification_fallback(self):
+        """The analyzer exploitable filter must fall back to llm_context's
+        security_classification when agent_context is absent (single-shot)."""
+        from core.analyzer import _unit_security_classification
+
+        # single-shot unit: classification lives under llm_context
+        u = {"id": "x", "llm_context": {"security_classification": "exploitable"}}
+        assert _unit_security_classification(u) == "exploitable"
+
+        # agentic unit: classification under agent_context still works
+        a = {"id": "y", "agent_context": {"security_classification": "vulnerable_internal"}}
+        assert _unit_security_classification(a) == "vulnerable_internal"
+
+        # no classification anywhere
+        assert _unit_security_classification({"id": "z"}) is None

--- a/libs/openant-core/tests/test_enhance_resilience.py
+++ b/libs/openant-core/tests/test_enhance_resilience.py
@@ -22,6 +22,15 @@ import pytest
 from utilities.rate_limiter import is_retryable_error
 
 
+@pytest.fixture(autouse=True)
+def _anthropic_api_key(monkeypatch):
+    """Provide a dummy API key so ContextEnhancer's default AnthropicClient
+    constructs without a real credential. No network call is made: every test
+    monkeypatches the actual enhancement methods, so the SDK client is never
+    used to issue a request."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+
 # --------------------------------------------------------------------------
 # 529 / overloaded must be retryable via the string branch.
 # --------------------------------------------------------------------------

--- a/libs/openant-core/tests/test_enhance_resilience.py
+++ b/libs/openant-core/tests/test_enhance_resilience.py
@@ -24,11 +24,42 @@ from utilities.rate_limiter import is_retryable_error
 
 @pytest.fixture(autouse=True)
 def _anthropic_api_key(monkeypatch):
-    """Provide a dummy API key so ContextEnhancer's default AnthropicClient
-    constructs without a real credential. No network call is made: every test
-    monkeypatches the actual enhancement methods, so the SDK client is never
-    used to issue a request."""
+    """Provide a dummy API key for parity with real runs. No network call is
+    made: every test monkeypatches the actual enhancement methods, and the
+    ContextEnhancer is handed a fake PhaseBinding whose adapter is never
+    exercised, so no SDK client ever issues a request."""
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test-key")
+
+
+class _FakeAdapter:
+    """Minimal LLMAdapter stand-in. Never called: these tests monkeypatch the
+    enhancement entry points, so the binding's adapter is inert."""
+
+    name = "anthropic"
+    supports_tools = True
+
+    def complete(self, *, model, system, messages, max_tokens, tools=None):  # pragma: no cover
+        raise AssertionError("adapter.complete must not be called in these tests")
+
+    def validate(self, model):  # pragma: no cover
+        pass
+
+
+def _fake_binding():
+    """Build a PhaseBinding the post-#69 ContextEnhancer requires.
+
+    Mirrors the canonical helper in tests/test_llm_helpers.py: a frozen
+    PhaseBinding wrapping a fake adapter, used wherever a real (provider,
+    model) binding would otherwise be needed.
+    """
+    from utilities.llm import PhaseBinding
+
+    return PhaseBinding(
+        phase="enhance",
+        adapter=_FakeAdapter(),
+        model="claude-test",
+        provider_name="anthropic",
+    )
 
 
 # --------------------------------------------------------------------------
@@ -62,7 +93,7 @@ class TestIsRetryable529:
 def _make_enhancer():
     from utilities.context_enhancer import ContextEnhancer
 
-    return ContextEnhancer(client=None, tracker=None)
+    return ContextEnhancer(binding=_fake_binding(), tracker=None)
 
 
 def _dataset(n=3):
@@ -91,7 +122,7 @@ class TestAgenticBoundedRetry:
         # attempts[uid] = how many times we've enhanced that unit.
         attempts = {}
 
-        def fake_agent(unit, index, tracker, verbose, client=None):
+        def fake_agent(unit, index, binding, tracker, verbose):
             uid = unit.get("id")
             attempts[uid] = attempts.get(uid, 0) + 1
             # u1 stays transiently-broken for the first 2 attempts, then succeeds.
@@ -133,7 +164,7 @@ class TestSingleShotCheckpoint:
         per-unit results so an interrupted run can resume."""
         from utilities.context_enhancer import ContextEnhancer
 
-        enh = ContextEnhancer(client=None, tracker=None)
+        enh = ContextEnhancer(binding=_fake_binding(), tracker=None)
 
         def fake_enhance_unit(unit, units_by_id):
             unit["llm_context"] = {
@@ -158,7 +189,7 @@ class TestSingleShotCheckpoint:
         cp_dir = str(tmp_path / "enhance_checkpoints")
 
         # First run: complete all units.
-        enh1 = ContextEnhancer(client=None, tracker=None)
+        enh1 = ContextEnhancer(binding=_fake_binding(), tracker=None)
         monkeypatch.setattr(
             enh1, "enhance_unit",
             lambda unit, by_id: unit.update(
@@ -168,7 +199,7 @@ class TestSingleShotCheckpoint:
         enh1.enhance_dataset(_dataset(3), workers=1, checkpoint_path=cp_dir)
 
         # Second run: count how many units get (re-)enhanced.
-        enh2 = ContextEnhancer(client=None, tracker=None)
+        enh2 = ContextEnhancer(binding=_fake_binding(), tracker=None)
         seen = []
 
         def counting_enhance(unit, by_id):

--- a/libs/openant-core/tests/test_entry_point_detector_native_seeds.py
+++ b/libs/openant-core/tests/test_entry_point_detector_native_seeds.py
@@ -1,0 +1,97 @@
+"""EntryPointDetector cross-language entry-point gaps.
+
+Covers two central-detector faults:
+
+* Program-entry unit_types the parsers actually emit ('main' from C/Go/Zig,
+  'http_handler' / 'middleware' from Go) are absent from ENTRY_POINT_TYPES, so a
+  native program entry seeds ZERO entry points -> total reachability blackout for
+  C/Go/Zig binaries.
+
+* The per-parser reachable path normalizes func metadata under the camelCase key
+  'unitType' (c/php/ruby test_pipeline.py:257), but _get_entry_point_reasons reads
+  the snake_case 'unit_type' only -> Check-1 (and the module_level Check-4) are
+  dead on the real subprocess path even for an entry type that IS in the set.
+
+These assertions are written against the central detector contract, so they hold
+regardless of which parser produced the data.
+"""
+
+from utilities.agentic_enhancer.entry_point_detector import (
+    ENTRY_POINT_TYPES,
+    EntryPointDetector,
+)
+
+
+def _detect(func_data: dict, func_id: str = "src/main.c:main"):
+    detector = EntryPointDetector({func_id: func_data}, call_graph={})
+    return detector.detect_entry_points(), detector
+
+
+# --- Cluster A: program-entry types missing from the central set ----------
+
+def test_main_unit_type_is_an_entry_point_type():
+    """C/Go emit unit_type='main'; Zig (after its classifier fix) does too.
+    Without 'main' in ENTRY_POINT_TYPES a native program entry seeds nothing."""
+    assert "main" in ENTRY_POINT_TYPES, (
+        "'main' must be in ENTRY_POINT_TYPES so a native program entry "
+        "(C/Go/Zig main) seeds reachability"
+    )
+
+
+def test_native_main_seeds_an_entry_point():
+    eps, _ = _detect(
+        {"name": "main", "unit_type": "main", "code": "int main(void){return 0;}"}
+    )
+    assert "src/main.c:main" in eps, (
+        "a function with unit_type='main' must be detected as an entry point"
+    )
+
+
+def test_go_http_handler_and_middleware_are_entry_point_types():
+    """The Go parser emits 'http_handler' and 'middleware' (go_parser/types.go
+    UnitTypeHTTPHandler / UnitTypeMiddleware) but the detector only knew the
+    Python/Express vocabulary -> Go web servers seeded no entry points."""
+    assert "http_handler" in ENTRY_POINT_TYPES
+    assert "middleware" in ENTRY_POINT_TYPES
+
+
+# --- Cluster B: camelCase 'unitType' key must also be honoured ------------
+
+def test_unit_type_read_handles_camelcase_unitType_key():
+    """The C/PHP/Ruby reachable path writes the camelCase 'unitType' key; the
+    detector previously read snake-case 'unit_type' only, so Check-1 was dead on
+    that path even for a valid entry type."""
+    eps, _ = _detect(
+        {"name": "handler", "unitType": "route_handler", "code": ""},
+        func_id="app.py:handler",
+    )
+    assert "app.py:handler" in eps, (
+        "an entry unit normalized under the camelCase 'unitType' key must still "
+        "be recognised as an entry point"
+    )
+
+
+def test_camelcase_main_is_an_entry_point():
+    """End-to-end of Cluster A + B together: a C 'main' normalized to the
+    camelCase key must seed reachability."""
+    eps, _ = _detect(
+        {"name": "main", "unitType": "main", "code": "int main(void){return 0;}"}
+    )
+    assert "src/main.c:main" in eps
+
+
+def test_module_level_check4_handles_camelcase_key():
+    """Check-4 keys off unit_type=='module_level'; it must also see the
+    camelCase 'unitType' so module-level scripts on the camel path still seed."""
+    # Use a code pattern that ONLY Check-4 (module_level) matches — the
+    # __name__ guard is in MODULE_LEVEL_INPUT_PATTERNS but NOT in
+    # USER_INPUT_PATTERNS, so Check-3 cannot mask the result.
+    eps, _ = _detect(
+        {
+            "name": "__module__",
+            "unitType": "module_level",
+            "code": 'if __name__ == "__main__":\n    run()',
+        },
+        func_id="script.py:__module__",
+    )
+    assert "script.py:__module__" in eps

--- a/libs/openant-core/tests/test_export_csv_formula_injection.py
+++ b/libs/openant-core/tests/test_export_csv_formula_injection.py
@@ -1,0 +1,48 @@
+"""Regression tests for CSV / formula injection in export_csv (CWE-1236).
+
+export_csv() writes the verbatim scanned source (unit_code = primary_code) and LLM text columns into the CSV
+with no neutralization. A scanned snippet beginning with =, +, -, @ (or a leading tab / CR) is interpreted as a
+formula by Excel / Google Sheets when the analyst opens the file, enabling formula execution / data exfiltration
+on the analyst's machine. Fix: prefix any cell whose first character is a formula trigger with a single quote
+(the OWASP CSV-Injection defense), applied to every cell.
+"""
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+import export_csv as ec  # noqa: E402
+
+PAYLOAD = "=cmd|'/c calc'!A1"
+
+
+def test__csv_safe_neutralizes_formula_triggers():
+    """Unit: cells starting with a formula trigger get a leading quote; safe cells are unchanged."""
+    for trigger in ("=", "+", "-", "@", "\t", "\r"):
+        assert ec._csv_safe(trigger + "x") == "'" + trigger + "x", f"{trigger!r} not neutralized"
+    assert ec._csv_safe("safe value") == "safe value"
+    assert ec._csv_safe("") == ""
+    assert ec._csv_safe(None) == ""
+
+
+def test_export_csv_neutralizes_formula_in_unit_code(tmp_path):
+    """Integration: a scanned snippet that is a spreadsheet formula is neutralized in the exported CSV."""
+    ds = tmp_path / "dataset.json"
+    exp = tmp_path / "experiment.json"
+    out = tmp_path / "out.csv"
+    ds.write_text(
+        '{"units": [{"id": "f.py:foo", "code": {"primary_code": "' + PAYLOAD + '"},'
+        ' "llm_context": {"reasoning": "r", "security_classification": "c"}}]}'
+    )
+    exp.write_text(
+        '{"results": [{"route_key": "f.py:foo", "verification": {"explanation": "e"},'
+        ' "finding": "vulnerable", "reasoning": "r1", "confidence": "high"}]}'
+    )
+    ec.export_csv(str(exp), str(ds), str(out))
+    with open(out, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows, "no rows exported"
+    cell = rows[0]["unit_code"]
+    assert not cell.startswith(("=", "+", "-", "@")), f"formula cell not neutralized: {cell!r}"
+    assert cell == "'" + PAYLOAD, f"expected leading-quote neutralization, got {cell!r}"

--- a/libs/openant-core/tests/test_file_io_atomic_write.py
+++ b/libs/openant-core/tests/test_file_io_atomic_write.py
@@ -1,0 +1,42 @@
+"""Regression test — write_json is non-atomic (truncate-then-write).
+
+write_json opens the target in "w" (truncating it to 0 bytes) and then streams json.dump. If the process is
+killed mid-serialization (SIGKILL / OOM / power loss), the target is left partial/empty and the previous good
+content is lost → the next read_json raises JSONDecodeError. Fix: write to a temp file in the same directory and
+os.replace it onto the target (atomic rename), so an interrupted write never clobbers the prior version.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+import utilities.file_io as fio  # noqa: E402
+from utilities.file_io import read_json, write_json  # noqa: E402
+
+
+def test_write_json_atomic_preserves_original_on_crash(tmp_path, monkeypatch):
+    """An interrupted write must leave the prior good file intact (atomic replace)."""
+    p = tmp_path / "checkpoint.json"
+    write_json(p, {"v": 1})
+    assert read_json(p) == {"v": 1}
+
+    def boom(*a, **k):
+        raise RuntimeError("killed mid-write")
+
+    monkeypatch.setattr(fio.json, "dump", boom)
+    with pytest.raises(RuntimeError):
+        write_json(p, {"v": 2})
+
+    # Post-fix: the original is untouched. Pre-fix: p was truncated -> empty -> this raises/!= {"v":1}.
+    assert read_json(p) == {"v": 1}, "interrupted write clobbered the prior checkpoint"
+    leftovers = list(tmp_path.glob(".tmp*"))
+    assert not leftovers, f"temp file leaked after failed write: {leftovers}"
+
+
+def test_write_json_normal_roundtrip(tmp_path):
+    """Guard: the normal write path still round-trips correctly."""
+    p = tmp_path / "x.json"
+    write_json(p, {"a": [1, 2, 3], "b": "héllo"})
+    assert read_json(p) == {"a": [1, 2, 3], "b": "héllo"}

--- a/libs/openant-core/tests/test_go_test_pipeline_codeql_timeout.py
+++ b/libs/openant-core/tests/test_go_test_pipeline_codeql_timeout.py
@@ -1,0 +1,51 @@
+"""Regression: go test_pipeline CodeQL stage timeouts must not be inverted.
+
+The CodeQL `database create` step (which COMPILES the source — the slower stage for compiled languages)
+was given timeout=600s while `database analyze` got 1800s. The slower stage with the smaller budget times
+out first; on timeout run_codeql_analysis records the codeql stage success=False and returns, the pipeline
+prints "continuing with reachable units only" and proceeds, and apply_codeql_filter is skipped — so the
+written dataset is reachable-only with CodeQL findings dropped. (The run reports success=False / exit 1, so
+an exit-code CI gate still catches it; the harm is the silently-degraded artifact for any consumer that
+reads the results rather than the exit code.) The create budget must be at least the analyze budget.
+
+This reads the source (the timeout values are module constants) rather than importing test_pipeline, which
+does module-level sys.path manipulation and shares its module name with the other parsers' test_pipeline.py.
+"""
+import re
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parents[1] / "parsers" / "go" / "test_pipeline.py"
+
+
+def _const(name: str) -> int:
+    m = re.search(rf"^{name}\s*=\s*(\d+)", SRC.read_text(), re.M)
+    assert m, f"{name} constant not found in {SRC}"
+    return int(m.group(1))
+
+
+def test_codeql_db_create_timeout_not_less_than_analyze():
+    create = _const("CODEQL_DB_CREATE_TIMEOUT_SECS")
+    analyze = _const("CODEQL_ANALYZE_TIMEOUT_SECS")
+    assert create >= analyze, (
+        f"codeql DB-create timeout ({create}s) < analyze timeout ({analyze}s): the slower "
+        f"compile-the-DB stage gets the smaller budget, so it times out first, the stage is "
+        f"recorded failed, and the pipeline writes a reachable-only dataset with CodeQL findings "
+        f"dropped"
+    )
+
+
+def test_codeql_timeouts_are_wired_to_the_constants():
+    """The create/analyze subprocess calls must USE the constants, not inline literals — otherwise a
+    future edit could revert a call site to timeout=600 while the constant stays 1800 and the value
+    check above would still pass green. Pre-fix the call sites passed literal timeouts (no constants
+    existed), so these assertions are RED before the fix and GREEN after — they lock the wiring, not
+    just the values."""
+    src = SRC.read_text()
+    assert "timeout=CODEQL_DB_CREATE_TIMEOUT_SECS" in src, (
+        "codeql `database create` must pass timeout=CODEQL_DB_CREATE_TIMEOUT_SECS, not an inline "
+        "literal — otherwise the create budget can silently drift below analyze again"
+    )
+    assert "timeout=CODEQL_ANALYZE_TIMEOUT_SECS" in src, (
+        "codeql `database analyze` must pass timeout=CODEQL_ANALYZE_TIMEOUT_SECS, not an inline "
+        "literal"
+    )

--- a/libs/openant-core/tests/test_parse_repository_analyzer_schema.py
+++ b/libs/openant-core/tests/test_parse_repository_analyzer_schema.py
@@ -1,0 +1,44 @@
+"""Regression test — python parse_repository analyzer_output omits the call graph.
+
+generate_analyzer_output() emitted only {"functions": {...}}, dropping the top-level callGraph /
+reverseCallGraph that the analyzer_output schema carries (per the JS reference dependency_resolver +
+PARSER_UPGRADE_PLAN) and that are already computed in call_graph_result. (The indirect_calls part of the
+original filing is phantom and is excluded; filePath is derived from the func_id key by consumers
+(RepositoryIndex / dependency_resolver do funcId.split(':')[0]), so it is not a per-function field.)
+Fix: pass call_graph_result in and emit top-level callGraph / reverseCallGraph.
+"""
+import sys
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[1]  # libs/openant-core
+sys.path.insert(0, str(CORE))
+sys.path.insert(0, str(CORE / "parsers" / "python"))  # parse_repository's bare imports
+
+import parse_repository  # noqa: E402
+
+EXTRACTOR = {"functions": {
+    "f.py:foo": {"name": "foo", "code": "def foo():\n    bar()", "unit_type": "function", "start_line": 1, "end_line": 2},
+    "f.py:bar": {"name": "bar", "code": "def bar():\n    pass", "unit_type": "function", "start_line": 4, "end_line": 5},
+}}
+CALL_GRAPH = {
+    "repository": "/x", "functions": EXTRACTOR["functions"], "classes": {}, "imports": {},
+    "call_graph": {"f.py:foo": ["f.py:bar"]},
+    "reverse_call_graph": {"f.py:bar": ["f.py:foo"]},
+    "statistics": {},
+}
+
+
+def test_analyzer_output_includes_call_graph():
+    """Post-fix: the analyzer output surfaces the top-level callGraph / reverseCallGraph from
+    call_graph_result. Pre-fix generate_analyzer_output took only the extractor result (no call graph)."""
+    out = parse_repository.generate_analyzer_output(EXTRACTOR, CALL_GRAPH)
+    assert out["functions"]["f.py:foo"]["name"] == "foo"  # functions unchanged
+    assert out.get("callGraph") == {"f.py:foo": ["f.py:bar"]}, f"callGraph missing/empty: {out.get('callGraph')!r}"
+    assert out.get("reverseCallGraph") == {"f.py:bar": ["f.py:foo"]}, f"reverseCallGraph missing: {out.get('reverseCallGraph')!r}"
+
+
+def test_analyzer_output_backward_compatible_without_call_graph():
+    """Guard: with only the extractor result (no call graph), it still returns functions and simply omits
+    the call-graph keys (back-compat for any 1-arg caller)."""
+    out = parse_repository.generate_analyzer_output(EXTRACTOR)
+    assert "functions" in out and out["functions"]["f.py:bar"]["name"] == "bar"

--- a/libs/openant-core/tests/test_php_call_graph.py
+++ b/libs/openant-core/tests/test_php_call_graph.py
@@ -1,0 +1,134 @@
+"""Regression tests for defects in parsers/php/call_graph_builder.py + function_extractor.py.
+
+#1 (tag): the re-parser used the tag-requiring grammar on tag-stripped function bodies, so
+   the whole PHP call graph was empty (0 edges). Fixed by language_php_only().
+#2 (callbacks): higher-order builtins (call_user_func, array_map,
+   ...) dropped their callback argument. Now resolved via CALLBACK_BUILTINS.
+#5 (new): `new Foo()` (object_creation_expression) was not traversed -> __construct untracked.
+#6 (parent::): parent:: was resolved in the caller's own class, not the superclass.
+#4 (import): use/require resolution used an unanchored `import_name in file_path` substring.
+#7 (case): _is_builtin compared case-sensitively though PHP names are case-insensitive.
+#3 (use node type): _extract_imports checked `use_declaration` but tree-sitter-php emits
+   `namespace_use_declaration`, so use-imports were never recorded.
+(#8: `indirect_calls` is a phantom field -- documented, no code.)
+
+Loads both modules under UNIQUE importlib names (call_graph_builder / function_extractor are basenames
+shared by every parser).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+import tree_sitter_php as _tsphp
+from tree_sitter import Language, Parser
+
+CORE = Path(__file__).resolve().parents[1]
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+
+def _load(unique, relpath):
+    spec = importlib.util.spec_from_file_location(unique, str(CORE / relpath))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_cgb = _load("php_call_graph_builder_isolated", "parsers/php/call_graph_builder.py")
+_fe = _load("php_function_extractor_isolated", "parsers/php/function_extractor.py")
+CallGraphBuilder = _cgb.CallGraphBuilder
+FunctionExtractor = _fe.FunctionExtractor
+
+
+def _build(funcs, classes=None, imports=None):
+    b = CallGraphBuilder({"functions": funcs, "classes": classes or {}, "imports": imports or {},
+                          "repository": "/r"})
+    b.build_call_graph()
+    return b
+
+
+# #1 tag-grammar: tagless function bodies now parse -> edges exist at all
+def test_tagless_body_produces_edges():
+    b = _build({
+        "a.php:a": {"name": "a", "file_path": "a.php", "class_name": None, "code": "function a() { b(); }"},
+        "a.php:b": {"name": "b", "file_path": "a.php", "class_name": None, "code": "function b() {}"},
+    })
+    assert b.call_graph.get("a.php:a") == ["a.php:b"], b.call_graph
+
+
+# #2 callbacks: call_user_func('cb') and array_map('cb2', ...) resolve their callback arg
+def test_callback_builtins_resolve_callback_arg():
+    b = _build({
+        "f.php:f": {"name": "f", "file_path": "f.php", "class_name": None,
+                    "code": "function f() { call_user_func('cb'); array_map('cb2', $x); }"},
+        "f.php:cb": {"name": "cb", "file_path": "f.php", "class_name": None, "code": "function cb() {}"},
+        "f.php:cb2": {"name": "cb2", "file_path": "f.php", "class_name": None, "code": "function cb2($v) {}"},
+    })
+    edges = set(b.call_graph.get("f.php:f", []))
+    assert edges == {"f.php:cb", "f.php:cb2"}, edges
+
+
+# #5 new Foo() -> Foo::__construct
+def test_new_resolves_to_construct():
+    b = _build({
+        "a.php:f": {"name": "f", "file_path": "a.php", "class_name": None, "code": "function f() { new Foo(); }"},
+        "a.php:Foo.__construct": {"name": "__construct", "file_path": "a.php", "class_name": "Foo",
+                                  "code": "function __construct() {}"},
+    }, classes={"a.php:Foo": {"name": "Foo", "file_path": "a.php", "superclass": None}})
+    assert b.call_graph.get("a.php:f") == ["a.php:Foo.__construct"], b.call_graph
+
+
+# #6 parent::m() resolves in the superclass
+def test_parent_resolves_in_superclass():
+    b = _build({
+        "a.php:Child.doit": {"name": "doit", "file_path": "a.php", "class_name": "Child",
+                             "code": "function doit() { parent::base_m(); }"},
+        "a.php:Base.base_m": {"name": "base_m", "file_path": "a.php", "class_name": "Base",
+                              "code": "function base_m() {}"},
+    }, classes={
+        "a.php:Child": {"name": "Child", "file_path": "a.php", "superclass": "Base"},
+        "a.php:Base": {"name": "Base", "file_path": "a.php", "superclass": None},
+    })
+    assert b.call_graph.get("a.php:Child.doit") == ["a.php:Base.base_m"], b.call_graph
+
+
+# #6 parent:: with a NAMESPACED superclass (extends App\Base) resolves by the unqualified class name
+def test_parent_resolves_namespaced_superclass():
+    b = _build({
+        "a.php:Child.doit": {"name": "doit", "file_path": "a.php", "class_name": "Child",
+                             "code": "function doit() { parent::base_m(); }"},
+        "b.php:Base.base_m": {"name": "base_m", "file_path": "b.php", "class_name": "Base",
+                              "code": "function base_m() {}"},
+    }, classes={
+        "a.php:Child": {"name": "Child", "file_path": "a.php", "superclass": "App\\Base"},
+        "b.php:Base": {"name": "Base", "file_path": "b.php", "superclass": None},
+    })
+    assert b.call_graph.get("a.php:Child.doit") == ["b.php:Base.base_m"], b.call_graph
+
+
+# #7 _is_builtin is case-insensitive (PHP function names are case-insensitive)
+def test_is_builtin_case_insensitive():
+    b = CallGraphBuilder({"functions": {}, "classes": {}, "imports": {}, "repository": "/r"})
+    assert b._is_builtin("CALL_USER_FUNC") is True
+    assert b._is_builtin("StrLen") is True
+    assert b._is_builtin("myCustomFunc") is False
+
+
+# #4 import resolution matches the import FILE name, not an unanchored substring
+def test_import_match_anchored_not_substring():
+    # 'app/BarBaz/x.php' contains the substring 'Bar' but is NOT Bar.php; the real target is sub/Bar.php.
+    b = CallGraphBuilder({"functions": {
+        "app/BarBaz/x.php:helper": {"name": "helper", "file_path": "app/BarBaz/x.php", "class_name": None, "code": ""},
+        "sub/Bar.php:helper": {"name": "helper", "file_path": "sub/Bar.php", "class_name": None, "code": ""},
+    }, "classes": {}, "imports": {"caller.php": {"Bar": "use"}}, "repository": "/r"})
+    assert b._resolve_simple_call("helper", "caller.php", None) == "sub/Bar.php:helper"
+
+
+# #3 _extract_imports records `namespace_use_declaration` (the real tree-sitter-php node type)
+def test_extract_imports_namespace_use_declaration():
+    src = b"<?php use App\\Service\\Foo; use App\\Bar as B;"
+    parser = Parser(Language(_tsphp.language_php()))
+    tree = parser.parse(src)
+    imports = FunctionExtractor("/r")._extract_imports(tree, src)
+    assert "App\\Service\\Foo" in imports, imports
+    assert "App\\Bar" in imports, imports  # alias stripped to the namespace path

--- a/libs/openant-core/tests/test_progress_eta_no_underflow.py
+++ b/libs/openant-core/tests/test_progress_eta_no_underflow.py
@@ -1,0 +1,31 @@
+"""Regression test for ProgressReporter ETA underflow on retry double-count.
+
+`report()` does an unconditional `self.completed += 1`, so a retried unit re-reports and `completed` can
+exceed `total`. `_estimate_remaining` then computes `remaining_units = total - completed` < 0 → a negative
+`remaining_secs` → the ETA is rendered as a negative duration (e.g. "~-30s"). Fix: floor remaining at 0.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+from core.progress import ProgressReporter  # noqa: E402
+
+
+def test_eta_never_negative_when_completed_exceeds_total():
+    """After more report() calls than `total` (retry double-count), the ETA must not be negative."""
+    r = ProgressReporter("Verify", total=2)
+    r.report("u1")
+    r.report("u1")  # retry of the same unit -> double-count
+    r.report("u2")
+    assert r.completed > r.total  # precondition: the double-count occurred (3 > 2)
+    eta = r._estimate_remaining(10.0)
+    assert not eta.lstrip("~").startswith("-"), f"ETA underflowed to a negative duration: {eta!r}"
+
+
+def test_eta_normal_case_still_positive():
+    """Guard: the normal (no over-count) path still produces a sensible positive ETA."""
+    r = ProgressReporter("Verify", total=10)
+    r.report("u1")
+    eta = r._estimate_remaining(5.0)
+    assert eta.startswith("~") and not eta.lstrip("~").startswith("-")

--- a/libs/openant-core/tests/test_python_call_graph_builder.py
+++ b/libs/openant-core/tests/test_python_call_graph_builder.py
@@ -1,0 +1,150 @@
+"""Regression tests for Python call-graph builder (parsers/python/call_graph_builder.py) edge-fidelity bugs.
+
+Seven independent defects in the Python CallGraphBuilder, each pinned by its own test:
+
+__init__.py re-export: _resolve_import never probes package ``__init__.py`` nor follows
+  ``from .submodule import name`` re-exports, so a call to a name re-exported via a package
+  __init__.py (ubiquitous in Python public APIs) gets no call edge.
+Local-variable type dispatch: obj.method() on a local variable of a locally-known type
+  (``v = ClassName(); v.method()``) is routed to _resolve_module_call, which only knows
+  imports/same-file class NAMES, never a local var's bound type -> edge dropped.
+super() resolution: the super().method() branch in
+  _resolve_call_node returns None unconditionally ("skip for now"), so an inherited
+  parent method reachable only via super() is dropped from the graph -- even when the
+  parent class is in the repo (cross-file inheritance).
+Deterministic ordering: per-function callee lists are built by iterating a Python
+  ``set`` with no sorted(), so call_graph / reverse_call_graph value ORDER is
+  PYTHONHASHSEED-dependent -> non-deterministic output on identical input.
+HOF callback arguments: higher-order-function callback arguments
+  (``map(func, xs)``, ``sorted(xs, key=func)``) are never read -- _resolve_call_node only
+  inspects node.func, never node.args/node.keywords -> callback-only functions look
+  unreachable.
+
+Loads call_graph_builder under a UNIQUE importlib module name (the bare
+'call_graph_builder' basename is shared by the c/go/php/ruby/zig parsers, so a plain
+import would pollute sys.modules for the rest of the suite).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[1]                  # libs/openant-core
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))                           # for utilities.* imported by the module
+
+_spec = importlib.util.spec_from_file_location(
+    "py_call_graph_builder_isolated", str(CORE / "parsers" / "python" / "call_graph_builder.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+CallGraphBuilder = _mod.CallGraphBuilder
+
+
+def _fn(file_path, name, code, class_name=None):
+    """Build one entry in the extractor 'functions' map."""
+    fid = f"{file_path}:{class_name + '.' if class_name else ''}{name}"
+    data = {"name": name, "file_path": file_path, "code": code}
+    if class_name:
+        data["class_name"] = class_name
+    return fid, data
+
+
+def _build(functions, imports=None, classes=None):
+    out = {
+        "repository": "/tmp/fake",
+        "functions": functions,
+        "imports": imports or {},
+        "classes": classes or {},
+    }
+    b = CallGraphBuilder(out)
+    b.build_call_graph()
+    return b
+
+
+# ---- __init__.py re-export resolution ----
+def test_init_reexport_resolved_to_origin():
+    helpers = "utils/helpers.py"
+    init = "utils/__init__.py"
+    main = "main.py"
+    fns = {}
+    fns.update(dict([_fn(helpers, "sanitize", "def sanitize(x):\n    return x\n")]))
+    # utils/__init__.py re-exports sanitize via `from .helpers import sanitize`
+    fid, data = _fn(main, "handler", "def handler(self):\n    return sanitize(self.value)\n")
+    fns[fid] = data
+    imports = {
+        # main.py imports sanitize from the package `utils` (re-export consumer)
+        main: {"sanitize": "utils.sanitize"},
+        init: {"sanitize": "utils.helpers.sanitize"},
+    }
+    # function_extractor records __init__.py imports under the package file path.
+    b = _build(fns, imports=imports)
+    edges = b.call_graph.get(f"{main}:handler", [])
+    assert f"{helpers}:sanitize" in edges, (
+        f"re-exported sanitize not resolved through utils/__init__.py: {edges}")
+
+
+# ---- local-variable type dispatch ----
+def test_local_var_type_dispatch_resolved():
+    f = "app.py"
+    fns = {}
+    fid_m, data_m = _fn(f, "run", "def run(self):\n    return self.x\n", class_name="Service")
+    fns[fid_m] = data_m
+    caller = ("def use():\n"
+              "    svc = Service()\n"
+              "    return svc.run()\n")
+    fid_c, data_c = _fn(f, "use", caller)
+    fns[fid_c] = data_c
+    classes = {f"{f}:Service": {"name": "Service", "file_path": f, "bases": []}}
+    b = _build(fns, classes=classes)
+    edges = b.call_graph.get(f"{f}:use", [])
+    assert f"{f}:Service.run" in edges, (
+        f"svc.run() on local var of known type Service not resolved: {edges}")
+
+
+# ---- super().method() resolution ----
+def test_super_call_resolved_cross_file():
+    base_f = "base.py"
+    child_f = "main.py"
+    fns = {}
+    fid_b, data_b = _fn(base_f, "process", "def process(self):\n    return 1\n", class_name="Base")
+    fns[fid_b] = data_b
+    child_code = "def process(self):\n    return super().process()\n"
+    fid_c, data_c = _fn(child_f, "process", child_code, class_name="Child")
+    fns[fid_c] = data_c
+    classes = {
+        f"{base_f}:Base": {"name": "Base", "file_path": base_f, "bases": []},
+        f"{child_f}:Child": {"name": "Child", "file_path": child_f, "bases": ["Base"]},
+    }
+    b = _build(fns, classes=classes)
+    edges = b.call_graph.get(f"{child_f}:Child.process", [])
+    assert f"{base_f}:Base.process" in edges, (
+        f"super().process() not resolved to cross-file parent Base.process: {edges}")
+
+
+# ---- deterministic ordering ----
+def test_call_lists_are_sorted_deterministic():
+    f = "m.py"
+    fns = {}
+    for name in ("zeta", "alpha", "mid"):
+        fid, data = _fn(f, name, f"def {name}():\n    return 1\n")
+        fns[fid] = data
+    caller = "def driver():\n    return zeta() + alpha() + mid()\n"
+    fid_d, data_d = _fn(f, "driver", caller)
+    fns[fid_d] = data_d
+    b = _build(fns)
+    edges = b.call_graph.get(f"{f}:driver", [])
+    assert edges == sorted(edges), f"call_graph edge list is not deterministically sorted: {edges}"
+
+
+# ---- HOF callback arguments tracked ----
+def test_hof_callback_arg_tracked():
+    f = "h.py"
+    fns = {}
+    fid_cb, data_cb = _fn(f, "scorer", "def scorer(x):\n    return x\n")
+    fns[fid_cb] = data_cb
+    caller = "def driver(items):\n    return sorted(items, key=scorer)\n"
+    fid_d, data_d = _fn(f, "driver", caller)
+    fns[fid_d] = data_d
+    b = _build(fns)
+    edges = b.call_graph.get(f"{f}:driver", [])
+    assert f"{f}:scorer" in edges, (
+        f"HOF callback 'scorer' passed to sorted(key=...) not tracked as an edge: {edges}")

--- a/libs/openant-core/tests/test_python_function_extractor.py
+++ b/libs/openant-core/tests/test_python_function_extractor.py
@@ -1,0 +1,81 @@
+"""Regression tests for three independent defects in parsers/python/function_extractor.py.
+
+Segment-vs-substring exclusion: extract_all() no-args branch excludes files via an UNANCHORED
+  substring test (`any(excl in str(file_path) ...)`), so a file whose path merely contains a token
+  ('myvenv/keep.py' contains 'venv') is wrongly skipped. Fix: match whole path SEGMENTS.
+Entry-point classification: classify_function uses `'<token>' in path_lower` substring tests to
+  assign ENTRY-POINT unit_types, so 'interviews/api.py' is classified 'view_function' (a false
+  reachability seed). Fix: match the 'views'/'middleware' tokens as whole path segments. ('test' is
+  intentionally left as a substring -- see the in-code note; it is not an entry-point type.)
+Relative-import anchor: extract_imports ignores ast.ImportFrom.level, so relative imports lose their
+  package anchor ('from . import X' -> bare 'X'). Fix: reconstruct the absolute anchor from the
+  importing file's location.
+
+Loads function_extractor under a UNIQUE module name (not the bare 'function_extractor', which the c/
+go/php/ruby/zig parsers also ship) so a bare import cannot pollute sys.modules for sibling tests.
+"""
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[1]                  # libs/openant-core
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))                           # for utilities.* if imported
+
+_spec = importlib.util.spec_from_file_location(
+    "py_function_extractor_isolated", str(CORE / "parsers" / "python" / "function_extractor.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+FunctionExtractor = _mod.FunctionExtractor
+
+
+# ---- extract_all excludes by path segment, not substring ----
+def test_extract_all_excludes_on_path_segments_not_substring(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    for d in ("myvenv", "venv", ".git", "pkg/__pycache__", "src"):
+        (repo / d).mkdir(parents=True, exist_ok=True)
+    (repo / "myvenv" / "keep.py").write_text("def f(): pass\n")      # 'venv' substring -> wrongly skipped pre-fix
+    (repo / "src" / "clean.py").write_text("def g(): pass\n")
+    (repo / "venv" / "skip.py").write_text("def h(): pass\n")        # real venv/ -> excluded
+    (repo / ".git" / "hook.py").write_text("def i(): pass\n")        # .git -> excluded
+    (repo / "pkg" / "__pycache__" / "c.py").write_text("def j(): pass\n")  # __pycache__ -> excluded
+
+    ex = FunctionExtractor(str(repo))
+    processed = []
+    monkeypatch.setattr(ex, "process_file",
+                        lambda fp: processed.append(str(Path(fp).relative_to(ex.repo_path))))
+    ex.extract_all()
+    seen = set(processed)
+
+    assert "myvenv/keep.py" in seen, f"'myvenv' wrongly excluded by 'venv' substring: {sorted(seen)}"
+    assert "src/clean.py" in seen
+    assert "venv/skip.py" not in seen, "a real venv/ directory must stay excluded"
+    assert ".git/hook.py" not in seen, ".git must stay excluded"
+    assert "pkg/__pycache__/c.py" not in seen, "__pycache__ must stay excluded"
+
+
+# ---- classify_function matches entry-point tokens by segment, not substring ----
+def test_classify_function_entrypoint_tokens_match_segments_not_substring(tmp_path):
+    ex = FunctionExtractor(str(tmp_path))
+    c = lambda path: ex.classify_function("handler", [], None, path)
+
+    # genuine segments still classify (no regression)
+    assert c("app/views.py") == "view_function"
+    assert c("app/views/handlers.py") == "view_function"
+    assert c("app/middleware/auth.py") == "middleware"
+    # substring over-matches must NOT seed entry-point types
+    assert c("interviews/api.py") != "view_function", "'interviews' wrongly matched 'views'"
+    assert c("app/previews/x.py") != "view_function", "'previews' wrongly matched 'views'"
+    assert c("app/previewmiddleware.py") != "middleware", "'previewmiddleware' wrongly matched 'middleware'"
+
+
+# ---- extract_imports preserves the relative-import package anchor (node.level) ----
+def test_extract_imports_preserves_relative_package_anchor(tmp_path):
+    ex = FunctionExtractor(str(tmp_path))
+    src = "from . import helpers\nfrom ..util import U\nfrom os import path\n"
+    imports = ex.extract_imports(ast.parse(src), "pkg/sub/mod.py")
+
+    assert imports["helpers"] == "pkg.sub.helpers", f"relative 'from . import' lost anchor: {imports}"
+    assert imports["U"] == "pkg.util.U", f"relative 'from ..util import' lost anchor: {imports}"
+    assert imports["path"] == "os.path", f"absolute import must be unchanged: {imports}"

--- a/libs/openant-core/tests/test_python_function_extractor.py
+++ b/libs/openant-core/tests/test_python_function_extractor.py
@@ -44,7 +44,7 @@ def test_extract_all_excludes_on_path_segments_not_substring(tmp_path, monkeypat
     ex = FunctionExtractor(str(repo))
     processed = []
     monkeypatch.setattr(ex, "process_file",
-                        lambda fp: processed.append(str(Path(fp).relative_to(ex.repo_path))))
+                        lambda fp: processed.append(Path(fp).relative_to(ex.repo_path).as_posix()))
     ex.extract_all()
     seen = set(processed)
 

--- a/libs/openant-core/tests/test_rate_limiter_deadline_recheck.py
+++ b/libs/openant-core/tests/test_rate_limiter_deadline_recheck.py
@@ -1,0 +1,65 @@
+"""Regression test for the wait_if_needed TOCTOU on the backoff deadline.
+
+wait_if_needed reads _backoff_until under the lock, releases it, then sleeps for the *entry-time* duration.
+If another worker extends _backoff_until (via report_rate_limit on a fresh 429) while this worker sleeps, this
+worker wakes before the new deadline and issues a request into the still-active backoff window -> more 429s,
+thundering herd. Fix: after sleeping, re-check the deadline and keep waiting until it has actually passed.
+"""
+import sys
+import threading
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+import utilities.rate_limiter as rl  # noqa: E402
+
+
+def test_wait_if_needed_rechecks_extended_deadline(monkeypatch):
+    # Fresh, isolated instance (bypass the singleton) so the test doesn't touch global state.
+    limiter = object.__new__(rl.GlobalRateLimiter)
+    limiter._lock = threading.Lock()
+    limiter._total_waits = 0
+    limiter._total_wait_time = 0.0
+
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(rl.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(rl.random, "uniform", lambda a, b: 0.0)  # deterministic: no jitter
+    limiter._backoff_until = 1005.0  # 5s backoff from t=1000
+
+    sleeps = []
+    state = {"extended": False}
+
+    def fake_sleep(d):
+        clock["t"] += d
+        sleeps.append(d)
+        if not state["extended"]:
+            # Simulate another worker extending the backoff (a fresh 429) DURING this sleep.
+            limiter._backoff_until = clock["t"] + 3.0
+            state["extended"] = True
+
+    monkeypatch.setattr(rl.time, "sleep", fake_sleep)
+
+    limiter.wait_if_needed()
+
+    assert clock["t"] >= limiter._backoff_until, (
+        f"woke before the extended deadline: t={clock['t']} < backoff_until={limiter._backoff_until}"
+    )
+    assert len(sleeps) >= 2, f"did not re-check the deadline after it was extended (slept {len(sleeps)}x)"
+    # counters increment once per waiting call (not per loop iteration) and accumulate actual slept time
+    assert limiter._total_waits == 1, f"expected _total_waits == 1 (once per call), got {limiter._total_waits}"
+    assert limiter._total_wait_time == sum(sleeps), "should accumulate total slept time"
+
+
+def test_wait_if_needed_returns_zero_when_not_in_backoff(monkeypatch):
+    """Guard: when not in a backoff window, it returns immediately (0.0) and does not sleep."""
+    limiter = object.__new__(rl.GlobalRateLimiter)
+    limiter._lock = threading.Lock()
+    limiter._total_waits = 0
+    limiter._total_wait_time = 0.0
+    monkeypatch.setattr(rl.time, "monotonic", lambda: 2000.0)
+    limiter._backoff_until = 1000.0  # already past
+    slept = []
+    monkeypatch.setattr(rl.time, "sleep", lambda d: slept.append(d))
+    assert limiter.wait_if_needed() == 0.0
+    assert slept == []
+    assert limiter._total_waits == 0  # no-wait fast path must not increment the counter

--- a/libs/openant-core/tests/test_reachability_cache.py
+++ b/libs/openant-core/tests/test_reachability_cache.py
@@ -1,0 +1,36 @@
+"""Regression test -- ReachabilityAnalyzer stale-cache.
+
+is_reachable_from_entry_point() is a depth-BOUNDED reverse BFS: for a function farther than max_depth
+hops from an entry point it caches False (a false negative). get_all_reachable() is an UNBOUNDED forward
+BFS (the complete answer), but it used to update the cache only for keys NOT already present -- so the
+stale bounded False was frozen and never corrected. Fix: get_all_reachable() overwrites the cache.
+"""
+from utilities.agentic_enhancer.reachability_analyzer import ReachabilityAnalyzer
+
+
+def _analyzer(max_depth):
+    # E -> A -> B -> C  (forward).  reverse: A<-E, B<-A, C<-B.  Entry point: E.
+    functions = {"E": {}, "A": {}, "B": {}, "C": {}}
+    reverse_call_graph = {"A": ["E"], "B": ["A"], "C": ["B"]}
+    return ReachabilityAnalyzer(functions, reverse_call_graph, entry_points={"E"}, max_depth=max_depth)
+
+
+def test_get_all_reachable_overwrites_stale_bounded_false():
+    ra = _analyzer(max_depth=2)
+    # C is reachable (E->A->B->C) but 3 reverse hops away, so the depth-2 reverse BFS caches False:
+    assert ra.is_reachable_from_entry_point("C") is False
+    # the unbounded forward pass must CORRECT that stale cached False:
+    assert "C" in ra.get_all_reachable()
+    assert ra.is_reachable_from_entry_point("C") is True, \
+        "get_all_reachable() must overwrite the stale depth-bounded False, not freeze it"
+
+
+def test_get_all_reachable_does_not_break_true_or_unreachable():
+    # With ample depth, nothing is stale; reachable stays reachable, a disconnected node stays unreachable.
+    ra = ReachabilityAnalyzer(
+        {"E": {}, "A": {}, "X": {}}, {"A": ["E"]}, entry_points={"E"}, max_depth=15)
+    reachable = ra.get_all_reachable()
+    assert "A" in reachable and "E" in reachable
+    assert "X" not in reachable
+    assert ra.is_reachable_from_entry_point("A") is True
+    assert ra.is_reachable_from_entry_point("X") is False

--- a/libs/openant-core/tests/test_reachability_empty_seed.py
+++ b/libs/openant-core/tests/test_reachability_empty_seed.py
@@ -1,0 +1,109 @@
+"""Empty-seed reachability blackout safety-net.
+
+When EntryPointDetector finds ZERO entry points (the dominant case for a non-web
+library/stdlib target — ordinary Python functions are unit_type='function', which
+is not seedable), core.parser_adapter.apply_reachability_filter ran the BFS over
+an empty seed, kept nothing, and emptied dataset['units'] entirely — reporting
+100% reduction as SUCCESS with no error or warning. `--level reachable` thus
+produced a silent total blackout.
+
+A zero-entry-point seed must NOT silently drop every unit. The filter degrades to
+pass-through (units preserved) and records a loud warning in the filter metadata
+so the blackout can never be silent.
+
+(The broader generic-library / public-API seeding heuristic is an architectural
+change with an undetermined approach and is deliberately out of scope; this test
+pins only the no-silent-blackout invariant.)
+"""
+
+import importlib.util
+import pathlib
+
+_CORE = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_parser_adapter():
+    spec = importlib.util.spec_from_file_location(
+        "isolated_parser_adapter", _CORE / "core" / "parser_adapter.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _write_json(path, obj):
+    import json
+
+    path.write_text(json.dumps(obj))
+
+
+def test_zero_entry_points_does_not_silently_empty_dataset(tmp_path):
+    pa = _load_parser_adapter()
+
+    # A library: two ordinary functions, neither a seedable entry point.
+    call_graph = {
+        "functions": {
+            "lib.py:add": {"name": "add", "unit_type": "function", "code": "return a + b"},
+            "lib.py:sub": {"name": "sub", "unit_type": "function", "code": "return a - b"},
+        },
+        "call_graph": {"lib.py:add": ["lib.py:sub"]},
+        "reverse_call_graph": {"lib.py:sub": ["lib.py:add"]},
+    }
+    _write_json(tmp_path / "call_graph.json", call_graph)
+
+    dataset = {
+        "units": [
+            {"id": "lib.py:add"},
+            {"id": "lib.py:sub"},
+        ],
+        "metadata": {},
+    }
+
+    out = pa.apply_reachability_filter(dataset, str(tmp_path), "reachable")
+
+    # The dataset must NOT be silently emptied.
+    assert len(out["units"]) == 2, (
+        "zero entry points must not drop every unit (silent blackout) — the "
+        "filter should degrade to pass-through"
+    )
+
+    # The blackout-avoidance must be recorded loudly, not silently.
+    meta = out.get("metadata", {}).get("reachability_filter", {})
+    assert meta.get("entry_points") == 0
+    assert meta.get("warning"), (
+        "a zero-entry-point pass-through must record a warning so the degraded "
+        "result is never silent"
+    )
+
+
+def test_normal_seed_still_filters(tmp_path):
+    """Guard: when there IS an entry point, the filter still prunes unreachable
+    units (the safety-net must not disable real filtering)."""
+    pa = _load_parser_adapter()
+
+    call_graph = {
+        "functions": {
+            "app.py:main": {"name": "main", "unit_type": "main", "code": "handler()"},
+            "app.py:handler": {"name": "handler", "unit_type": "function", "code": ""},
+            "app.py:dead": {"name": "dead", "unit_type": "function", "code": ""},
+        },
+        "call_graph": {"app.py:main": ["app.py:handler"]},
+        "reverse_call_graph": {"app.py:handler": ["app.py:main"]},
+    }
+    _write_json(tmp_path / "call_graph.json", call_graph)
+
+    dataset = {
+        "units": [
+            {"id": "app.py:main"},
+            {"id": "app.py:handler"},
+            {"id": "app.py:dead"},
+        ],
+        "metadata": {},
+    }
+
+    out = pa.apply_reachability_filter(dataset, str(tmp_path), "reachable")
+    ids = {u["id"] for u in out["units"]}
+    assert ids == {"app.py:main", "app.py:handler"}, (
+        "with a real entry point the unreachable 'dead' unit must still be pruned"
+    )
+    assert not out["metadata"]["reachability_filter"].get("warning")

--- a/libs/openant-core/tests/test_scanner.py
+++ b/libs/openant-core/tests/test_scanner.py
@@ -37,6 +37,26 @@ from core import scanner as scanner_mod  # noqa: E402
 from core.schemas import AnalysisMetrics, ScanResult  # noqa: E402
 
 
+@pytest.fixture(autouse=True)
+def _stub_registry_probe(monkeypatch):
+    """Neutralize the real Anthropic credential probe.
+
+    Post-#69, ``scan_repository`` calls ``probe_registry_or_raise(registry)``
+    (core/scanner.py) which issues a real 1-token Anthropic request to
+    validate credentials before any work begins. These orchestration tests
+    run fully offline, so we replace the probe with a no-op. The registry is
+    still built (from the dummy key) and threaded through every stage exactly
+    as in production; only the network round-trip is removed. ``scan_repository``
+    does ``from utilities.llm import ... probe_registry_or_raise`` at call time,
+    so patching the attribute on ``utilities.llm`` takes effect.
+    """
+    import utilities.llm as llm_mod
+
+    monkeypatch.setattr(
+        llm_mod, "probe_registry_or_raise", lambda *a, **k: None, raising=True
+    )
+
+
 # ---------------------------------------------------------------------------
 # Shared stubs — make parse + analyze succeed cheaply, with no LLM/network.
 # ---------------------------------------------------------------------------

--- a/libs/openant-core/tests/test_scanner.py
+++ b/libs/openant-core/tests/test_scanner.py
@@ -1,0 +1,287 @@
+"""Unit tests for scanner optional-stage isolation and skip-cause reporting.
+
+Covers two areas:
+
+- error-handling: the OPTIONAL stages (enhance, verify, dynamic-test) were
+  wrapped in ``step_context`` but had NO inner try/except. ``step_context``
+  re-raises (core/step_report.py:57), so an optional-stage error escaped
+  ``scan_repository`` to cli.py's blanket ``except`` and discarded all completed
+  parse/analyze work. The fix adds an inner warn-and-continue try/except around
+  each optional stage, matching the existing app-context / llm-reachability
+  pattern.
+
+- skip-cause conflation: ``skipped_steps`` recorded the IDENTICAL bare string
+  for distinct skip causes (verify auto-skip vs opt-out both -> 'verify';
+  dynamic-test collapsed ~3 causes -> 'dynamic-test'). The fix ADDITIVELY records
+  a disambiguated reason per skipped step in a NEW ``skipped_step_reasons`` dict,
+  WITHOUT changing the existing bare ``skipped_steps`` list (telemetry consumers
+  read it).
+
+These tests monkeypatch the heavy LLM/Docker stages so we exercise the
+orchestration control-flow without real API/Docker calls.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Project root must be importable (mirrors conftest). core.scanner is a unique
+# module name, so a normal import is safe; we do NOT import any parser modules
+# here, so we cannot pollute sys.modules with shared parser basenames.
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core import scanner as scanner_mod  # noqa: E402
+from core.schemas import AnalysisMetrics, ScanResult  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared stubs — make parse + analyze succeed cheaply, with no LLM/network.
+# ---------------------------------------------------------------------------
+
+class _ParseResult:
+    def __init__(self, output_dir):
+        self.dataset_path = str(Path(output_dir) / "dataset.json")
+        self.analyzer_output_path = str(Path(output_dir) / "analyzer.json")
+        self.units_count = 3
+        self.language = "python"
+        self.processing_level = "all"
+
+
+def _install_minimal_pipeline(monkeypatch, *, vulnerable=0, bypassable=0):
+    """Stub parse + analyze + build_pipeline_output so a scan runs offline.
+
+    Returns nothing; the caller drives optional-stage behaviour via flags /
+    further monkeypatching.
+    """
+    import core.parser_adapter as parser_adapter
+    import core.analyzer as analyzer
+    import core.reporter as reporter
+    import core.tracking as tracking
+
+    def _fake_parse(*, output_dir, **kwargs):
+        pr = _ParseResult(output_dir)
+        # Write the files downstream stages expect to exist.
+        Path(pr.dataset_path).write_text('{"units": []}')
+        Path(pr.analyzer_output_path).write_text("{}")
+        return pr
+
+    metrics = AnalysisMetrics(
+        total=3,
+        vulnerable=vulnerable,
+        bypassable=bypassable,
+        inconclusive=0,
+        protected=0,
+        safe=3 - vulnerable - bypassable,
+        errors=0,
+    )
+
+    class _AnalyzeResult:
+        def __init__(self, output_dir):
+            self.results_path = str(Path(output_dir) / "results.json")
+            Path(self.results_path).write_text("[]")
+            self.metrics = metrics
+
+    def _fake_analysis(*, output_dir, **kwargs):
+        return _AnalyzeResult(output_dir)
+
+    def _fake_build_output(*, results_path, output_path, **kwargs):
+        Path(output_path).write_text("{}")
+        return output_path
+
+    monkeypatch.setattr(parser_adapter, "parse_repository", _fake_parse)
+    monkeypatch.setattr(analyzer, "run_analysis", _fake_analysis)
+    monkeypatch.setattr(reporter, "build_pipeline_output", _fake_build_output)
+    # Keep tracking quiet/deterministic.
+    tracking.reset_tracking()
+
+
+# ---------------------------------------------------------------------------
+# Optional-stage errors must NOT abort the scan.
+# ---------------------------------------------------------------------------
+
+def test_enhance_failure_does_not_abort_scan(monkeypatch, tmp_path):
+    """An exception in the OPTIONAL enhance stage must be caught (warn+continue),
+    not propagated out of scan_repository (which would discard parse/analyze)."""
+    _install_minimal_pipeline(monkeypatch)
+
+    import core.enhancer as enhancer
+
+    def _boom(**kwargs):
+        raise RuntimeError("enhance blew up")
+
+    monkeypatch.setattr(enhancer, "enhance_dataset", _boom)
+
+    out = tmp_path / "out"
+    # Must NOT raise. Pre-fix this propagates RuntimeError out of scan_repository.
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(out),
+        generate_context=False,
+        enhance=True,
+        verify=False,
+        generate_report=False,
+        dynamic_test=False,
+    )
+    assert isinstance(result, ScanResult)
+    # The completed analyze work survived.
+    assert result.metrics.total == 3
+
+
+def test_verify_failure_does_not_abort_scan(monkeypatch, tmp_path):
+    """An exception in the OPTIONAL verify stage must be caught, not propagated."""
+    _install_minimal_pipeline(monkeypatch, vulnerable=1)
+
+    import core.verifier as verifier
+
+    def _boom(**kwargs):
+        raise RuntimeError("verify blew up")
+
+    monkeypatch.setattr(verifier, "run_verification", _boom)
+
+    out = tmp_path / "out"
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(out),
+        generate_context=False,
+        enhance=False,
+        verify=True,
+        generate_report=False,
+        dynamic_test=False,
+    )
+    assert isinstance(result, ScanResult)
+    assert result.metrics.total == 3
+
+
+def test_dynamic_test_failure_does_not_abort_scan(monkeypatch, tmp_path):
+    """An exception in the OPTIONAL dynamic-test stage must be caught."""
+    _install_minimal_pipeline(monkeypatch, vulnerable=1)
+
+    import shutil as _shutil
+    import core.dynamic_tester as dynamic_tester
+
+    # Force the "docker present" branch so we reach run_tests.
+    monkeypatch.setattr(scanner_mod.shutil, "which", lambda name: "/usr/bin/docker")
+
+    def _boom(**kwargs):
+        raise RuntimeError("docker blew up")
+
+    monkeypatch.setattr(dynamic_tester, "run_tests", _boom)
+
+    out = tmp_path / "out"
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(out),
+        generate_context=False,
+        enhance=False,
+        verify=False,
+        generate_report=False,
+        dynamic_test=True,
+    )
+    assert isinstance(result, ScanResult)
+    assert result.metrics.total == 3
+
+
+def test_required_stage_failure_still_propagates(monkeypatch, tmp_path):
+    """The REQUIRED analyze stage must still propagate its error (regression
+    guard so the fix does not over-broadly swallow required-stage failures)."""
+    _install_minimal_pipeline(monkeypatch)
+
+    import core.analyzer as analyzer
+
+    def _boom(**kwargs):
+        raise RuntimeError("analyze blew up")
+
+    monkeypatch.setattr(analyzer, "run_analysis", _boom)
+
+    out = tmp_path / "out"
+    with pytest.raises(RuntimeError, match="analyze blew up"):
+        scanner_mod.scan_repository(
+            repo_path=str(tmp_path),
+            output_dir=str(out),
+            generate_context=False,
+            enhance=False,
+            verify=False,
+            generate_report=False,
+            dynamic_test=False,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Disambiguated skip reasons (ADDITIVE; bare list unchanged).
+# ---------------------------------------------------------------------------
+
+def test_verify_skip_reasons_distinguish_autoskip_vs_optout(monkeypatch, tmp_path):
+    """verify auto-skip (no findings) vs opt-out (--no-verify) must record
+    DISTINCT reasons in the new skipped_step_reasons dict, while the existing
+    bare skipped_steps list stays IDENTICAL ('verify')."""
+    # Case A: verify requested but no findings -> auto-skip.
+    _install_minimal_pipeline(monkeypatch, vulnerable=0)
+    out_a = tmp_path / "out_a"
+    res_a = scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out_a),
+        generate_context=False, enhance=False, verify=True,
+        generate_report=False, dynamic_test=False,
+    )
+
+    # Case B: verify not requested -> opt-out.
+    out_b = tmp_path / "out_b"
+    res_b = scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out_b),
+        generate_context=False, enhance=False, verify=False,
+        generate_report=False, dynamic_test=False,
+    )
+
+    # Bare list unchanged in BOTH cases (consumers read this).
+    assert "verify" in res_a.skipped_steps
+    assert "verify" in res_b.skipped_steps
+
+    # New disambiguated reasons differ.
+    assert res_a.skipped_step_reasons["verify"] != res_b.skipped_step_reasons["verify"]
+
+
+def test_dynamic_test_skip_reasons_distinct(monkeypatch, tmp_path):
+    """dynamic-test no-findings skip vs not-enabled skip must record DISTINCT
+    reasons, with the bare list still 'dynamic-test'."""
+    # Case A: dynamic_test requested but no findings.
+    _install_minimal_pipeline(monkeypatch, vulnerable=0)
+    out_a = tmp_path / "dt_a"
+    res_a = scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out_a),
+        generate_context=False, enhance=False, verify=False,
+        generate_report=False, dynamic_test=True,
+    )
+
+    # Case B: dynamic_test not enabled.
+    out_b = tmp_path / "dt_b"
+    res_b = scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out_b),
+        generate_context=False, enhance=False, verify=False,
+        generate_report=False, dynamic_test=False,
+    )
+
+    assert "dynamic-test" in res_a.skipped_steps
+    assert "dynamic-test" in res_b.skipped_steps
+    assert res_a.skipped_step_reasons["dynamic-test"] != res_b.skipped_step_reasons["dynamic-test"]
+
+
+def test_skipped_step_reasons_serialized_in_scan_report(monkeypatch, tmp_path):
+    """The new reason map must be emitted in scan.report.json alongside the
+    existing flat steps_skipped, and steps_skipped must be unchanged."""
+    import json
+    _install_minimal_pipeline(monkeypatch, vulnerable=0)
+    out = tmp_path / "out"
+    scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out),
+        generate_context=False, enhance=False, verify=True,
+        generate_report=False, dynamic_test=False,
+    )
+    report = json.loads((out / "scan.report.json").read_text())
+    summary = report["summary"]
+    # Existing flat list still present and bare.
+    assert "verify" in summary["steps_skipped"]
+    # New disambiguated map present.
+    assert "steps_skipped_reasons" in summary
+    assert "verify" in summary["steps_skipped_reasons"]

--- a/libs/openant-core/tests/test_zig_call_graph_builder.py
+++ b/libs/openant-core/tests/test_zig_call_graph_builder.py
@@ -1,0 +1,82 @@
+"""Regression tests for defects in parsers/zig/call_graph_builder.py.
+
+API parity: zig exposed build()->Dict + save_results() only, missing the canonical
+  build_call_graph()->None / export() / get_statistics() / get_dependencies() / get_callers() surface.
+Statistics: statistics omitted avg_in_degree / max_in_degree.
+@call extraction: @call(.modifier, fn, args) -- a `builtin_function` node -- dropped its
+  wrapped function, so the real callee was never recorded.
+Method-call recall + safe resolution: method calls (`obj.method()`, a `call_expression` over a
+  `field_expression`) were not extracted at all -- the code checked the non-existent `field_access`
+  node type -- a recall gap; and _resolve_call returned ALL same-named candidates on a bare-name
+  collision (a namespace leak). Fixed: extract field_expression callees +
+  resolve conservatively (return [] when genuinely ambiguous).
+Import-file matching: import resolution used an unanchored `imp in candidate_file` substring.
+Stdlib import filter: @import("std")/("builtin") leaked in and substring-matched candidate paths.
+(Phantom field: `indirect_calls` is a phantom field -- 0 repo hits, by design -- documented,
+  no code change.)
+
+Loads the module under a UNIQUE importlib name (call_graph_builder is a basename shared by every parser).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[1]
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+_spec = importlib.util.spec_from_file_location(
+    "zig_call_graph_builder_isolated", str(CORE / "parsers" / "zig" / "call_graph_builder.py"))
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+CallGraphBuilder = _mod.CallGraphBuilder
+
+
+def _ext(funcs, imports=None):
+    return {"functions": funcs, "classes": {}, "imports": imports or {}, "repository": "/r"}
+
+
+# canonical API parity + in-degree statistics
+def test_canonical_api_parity_and_in_degree_stats():
+    b = CallGraphBuilder(_ext({
+        "a.zig:f": {"name": "f", "file_path": "a.zig", "code": "fn f() void { g(); }"},
+        "a.zig:g": {"name": "g", "file_path": "a.zig", "code": "fn g() void {}"},
+    }))
+    for m in ("build_call_graph", "export", "get_statistics", "get_dependencies", "get_callers"):
+        assert hasattr(b, m), f"missing canonical API method: {m}"
+    b.build_call_graph()                                  # mutates state, returns None
+    assert b.call_graph.get("a.zig:f") == ["a.zig:g"], b.call_graph
+    stats = b.export()["statistics"]
+    assert "avg_in_degree" in stats and "max_in_degree" in stats, stats
+    assert b.get_dependencies("a.zig:f") == ["a.zig:g"]
+    assert b.get_callers("a.zig:g") == ["a.zig:f"]
+
+
+# @call extracts the wrapped function
+def test_at_call_extracts_wrapped_function():
+    out = CallGraphBuilder(_ext({
+        "a.zig:f": {"name": "f", "file_path": "a.zig", "code": "fn f() void { @call(.auto, g, .{}); }"},
+        "a.zig:g": {"name": "g", "file_path": "a.zig", "code": "fn g() void {}"},
+    })).build()
+    assert out["call_graph"].get("a.zig:f") == ["a.zig:g"], \
+        f"@call(.auto, g, ...) should edge to g, got {out['call_graph']}"
+
+
+# method-call recall via field_expression
+def test_method_call_extracted_via_field_expression():
+    out = CallGraphBuilder(_ext({
+        "a.zig:f": {"name": "f", "file_path": "a.zig", "code": "fn f() void { obj.method(); }"},
+        "a.zig:method": {"name": "method", "file_path": "a.zig", "code": "fn method() void {}"},
+    })).build()
+    assert out["call_graph"].get("a.zig:f") == ["a.zig:method"], out["call_graph"]
+
+
+# exact-import / stdlib-filter / conservative resolution
+def test_resolve_call_exact_import_stdlib_filter_and_conservative():
+    b = CallGraphBuilder(_ext({}, imports={"main.zig": ["util.zig", "std"]}))
+    # (a) exact import-FILE match, not substring: 'util.zig' picks src/util.zig, not myutil.zig_x/
+    nm = {"helper": ["myutil.zig_x/x.zig:helper", "src/util.zig:helper"]}
+    assert b._resolve_call("helper", "main.zig", nm) == ["src/util.zig:helper"]
+    # (b) 'std' is a non-file import (filtered); two std_*-pathed candidates, none import-resolved ->
+    #     ambiguous -> [] (no namespace-leak over-connection, no stdlib substring match)
+    nm3 = {"bar": ["lib/std_x.zig:bar", "other/std_y.zig:bar"]}
+    assert b._resolve_call("bar", "main.zig", nm3) == []

--- a/libs/openant-core/utilities/agentic_enhancer/agent.py
+++ b/libs/openant-core/utilities/agentic_enhancer/agent.py
@@ -32,6 +32,30 @@ AGENT_MODEL = "claude-sonnet-4-20250514"
 MAX_ITERATIONS = 20
 MAX_TOKENS_PER_RESPONSE = 4096
 
+# Input budget.
+# The conversation input had no budget: primary_code was inlined verbatim and
+# raw tool results were appended every iteration, so input grew unbounded until
+# it overflowed the model context (400). We cap each oversized input at its
+# consumption point. ~4 chars/token, so these stay well under the model window.
+MAX_PROMPT_CHARS = 60_000          # cap on inlined primary_code in the prompt
+MAX_TOOL_RESULT_CHARS = 24_000     # cap on each serialized tool result
+
+
+def cap_tool_result_content(result: dict, limit: int = MAX_TOOL_RESULT_CHARS) -> str:
+    """Serialize a tool result to JSON, truncating to ``limit`` chars.
+
+    Tool results (e.g. ``read_function`` returning a whole function body) are
+    otherwise appended raw to the conversation, growing the input without
+    bound across iterations. Small results round-trip as valid JSON; oversized
+    results are truncated with an explicit marker so the model knows content
+    was elided.
+    """
+    content = json.dumps(result)
+    if len(content) <= limit:
+        return content
+    marker = "\n... (truncated)"
+    return content[: limit - len(marker)] + marker
+
 
 class AgentResult:
     """Result from agent analysis."""
@@ -213,6 +237,28 @@ class ContextAgent:
                     "output_tokens": total_output_tokens,
                 }
                 raise
+            except anthropic.BadRequestError:
+                # 400 (e.g. constructed input still overflows the context
+                # window). Degrade gracefully instead of losing the whole
+                # enhancement — return a neutral, incomplete result. The input
+                # budget above makes this path rare, but it guards the residual.
+                if self.verbose:
+                    print(f"  BadRequest at iteration {iterations}; "
+                          "returning incomplete result")
+                return AgentResult(
+                    include_functions=[],
+                    usage_context="Analysis terminated - request rejected (400)",
+                    security_classification="neutral",
+                    classification_reasoning="Analysis incomplete - request rejected",
+                    confidence=0.2,
+                    iterations=iterations,
+                    total_tokens=total_input_tokens + total_output_tokens,
+                    is_entry_point=is_entry_point,
+                    reachable_from_entry=reachable_from_entry,
+                    entry_point_path=entry_point_path,
+                    input_tokens=total_input_tokens,
+                    output_tokens=total_output_tokens,
+                )
             except Exception as exc:
                 # Attach agent state so the caller knows how far we got
                 exc.agent_state = {
@@ -285,14 +331,14 @@ class ContextAgent:
                         tool_results.append({
                             "type": "tool_result",
                             "tool_use_id": tool_use_id,
-                            "content": json.dumps(result)
+                            "content": cap_tool_result_content(result)
                         })
                         break
                     else:
                         tool_results.append({
                             "type": "tool_result",
                             "tool_use_id": tool_use_id,
-                            "content": json.dumps(result)
+                            "content": cap_tool_result_content(result)
                         })
 
             # If finish was called, return result

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -92,6 +92,12 @@ USER_INPUT_PATTERNS = [
     # WebSocket message handlers
     r'on_message|onmessage|message\.data',
     r'websocket\.receive',
+    # PHP superglobals (request/server/file/cookie input)
+    r'\$_(GET|POST|REQUEST|COOKIE|SERVER|FILES|ENV|SESSION)\b',
+    r'\$HTTP_RAW_POST_DATA\b',
+    r'php://input',
+    r'\bfile_get_contents\s*\(\s*["\']php://input',
+    r'\bfilter_input\s*\(',
 ]
 
 # Patterns that indicate module-level scripts with user input
@@ -100,6 +106,14 @@ MODULE_LEVEL_INPUT_PATTERNS = [
     r'sys\.argv',
     r'\binput\s*\(',
     r'argparse\.',
+    # PHP file-scope scripts: superglobal reads and WordPress hook dispatch
+    # (procedural plugins/themes register handlers at the top level).
+    r'\$_(GET|POST|REQUEST|COOKIE|SERVER|FILES|ENV|SESSION)\b',
+    r'php://input',
+    r'\badd_action\s*\(',
+    r'\badd_filter\s*\(',
+    r'\bdo_action\s*\(',
+    r'\bapply_filters\s*\(',
 ]
 
 

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -22,6 +22,19 @@ import re
 from typing import Dict, List, Set
 
 
+def _unit_type(func_data: Dict) -> str:
+    """Read a unit's type tolerating both key casings.
+
+    The per-parser reachable path normalizes function metadata under the
+    camelCase key ``unitType`` (parsers/{c,php,ruby}/test_pipeline.py), while the
+    central Python path and this detector historically used the snake_case
+    ``unit_type``. Reading only one casing left Check-1 (and the module_level
+    Check-4) dead on the camelCase path — a valid entry type was silently
+    ignored. Prefer snake_case, fall back to camelCase.
+    """
+    return func_data.get('unit_type') or func_data.get('unitType') or ''
+
+
 # Entry point patterns by unit_type (from function extractor classification)
 ENTRY_POINT_TYPES = {
     'route_handler',      # Flask/FastAPI/Express routes
@@ -29,6 +42,15 @@ ENTRY_POINT_TYPES = {
     'view_function',      # Django views
     'websocket_handler',  # WebSocket endpoints
     'cli_handler',        # CLI commands
+    # Native program entry points emitted by the systems-language parsers.
+    # The C and Go extractors classify a top-level `main` as unit_type='main'
+    # (parsers/c/function_extractor.py, go_parser/types.go UnitTypeMain); the
+    # Zig extractor does too once its `main` classifier branch is fixed. Without
+    # these the only seed for a compiled binary is absent, so reachability seeds
+    # zero entry points and silently empties the dataset for every C/Go/Zig repo.
+    'main',               # C/Go/Zig program entry
+    'http_handler',       # Go net/http handlers (go_parser/types.go UnitTypeHTTPHandler)
+    'middleware',         # Go HTTP middleware (go_parser/types.go UnitTypeMiddleware)
 }
 
 # Decorator patterns indicating entry points (case-insensitive matching)
@@ -154,7 +176,7 @@ class EntryPointDetector:
                 self.entry_points.add(func_id)
                 self.entry_point_details[func_id] = {
                     'reasons': reasons,
-                    'unit_type': func_data.get('unit_type'),
+                    'unit_type': _unit_type(func_data),
                     'name': func_data.get('name'),
                 }
 
@@ -173,7 +195,7 @@ class EntryPointDetector:
         reasons = []
 
         # Check 1: Unit type indicates entry point
-        unit_type = func_data.get('unit_type', '')
+        unit_type = _unit_type(func_data)
         if unit_type in ENTRY_POINT_TYPES:
             reasons.append(f'unit_type:{unit_type}')
 
@@ -194,7 +216,7 @@ class EntryPointDetector:
                 break  # One input pattern is enough
 
         # Check 4: Module-level code with input patterns
-        if func_data.get('unit_type') == 'module_level':
+        if unit_type == 'module_level':
             for pattern in self._module_input_patterns:
                 if pattern.search(code):
                     reasons.append('module_level_with_input')

--- a/libs/openant-core/utilities/agentic_enhancer/prompts.py
+++ b/libs/openant-core/utilities/agentic_enhancer/prompts.py
@@ -9,6 +9,20 @@ vulnerabilities from internal-only vulnerabilities.
 from typing import List, Optional
 
 
+# Input budget for the inlined unit code.
+# primary_code was previously inlined verbatim, so a large unit overflowed the
+# model context. ~4 chars/token, so this stays well under the model window.
+MAX_PRIMARY_CODE_CHARS = 60_000
+
+
+def _cap_primary_code(primary_code: str, limit: int = MAX_PRIMARY_CODE_CHARS) -> str:
+    """Cap inlined unit code so the prompt stays within the input budget."""
+    if len(primary_code) <= limit:
+        return primary_code
+    marker = "\n... (truncated)"
+    return primary_code[: limit - len(marker)] + marker
+
+
 SYSTEM_PROMPT = """You are a security code analyst. Your task is to classify code based on:
 
 1. Does it contain security flaws (dangerous operations)?
@@ -100,6 +114,9 @@ def get_user_prompt(
     """
     deps_str = ", ".join(static_deps[:10]) if static_deps else "None identified"
     callers_str = ", ".join(static_callers[:10]) if static_callers else "None identified"
+
+    # Cap the inlined code so a large unit cannot overflow the model context.
+    primary_code = _cap_primary_code(primary_code)
 
     # Build reachability section
     reachability_section = ""

--- a/libs/openant-core/utilities/agentic_enhancer/reachability_analyzer.py
+++ b/libs/openant-core/utilities/agentic_enhancer/reachability_analyzer.py
@@ -185,10 +185,14 @@ class ReachabilityAnalyzer:
                     reachable.add(callee)
                     queue.append(callee)
 
-        # Update cache
+        # Update cache. get_all_reachable() is the AUTHORITATIVE result -- an UNBOUNDED forward BFS over
+        # the full graph. is_reachable_from_entry_point() is a depth-BOUNDED reverse BFS that caches
+        # False for functions farther than max_depth from an entry point (a false negative). Overwrite
+        # unconditionally (the old "only if absent" froze whichever pass ran first) so this complete
+        # pass corrects any stale bounded result. The forward graph is built from the same reverse
+        # edges, so this can only flip stale False->True, never introduce a false positive.
         for func_id in self.functions:
-            if func_id not in self._reachability_cache:
-                self._reachability_cache[func_id] = func_id in reachable
+            self._reachability_cache[func_id] = func_id in reachable
 
         return reachable
 

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -48,6 +48,11 @@ _null_logger.addHandler(logging.NullHandler())
 # Use Sonnet for context enhancement (cost-effective auxiliary task)
 CONTEXT_ENHANCEMENT_MODEL = "claude-sonnet-4-20250514"
 
+# Max bounded rounds of the post-loop transient-error retry. Each round
+# re-attempts units still carrying a retryable error; rounds stop early once
+# none remain or a round recovers nothing.
+MAX_RETRY_ROUNDS = 3
+
 
 def _build_error_info(exc: Exception) -> dict:
     """Build a structured error dict from an exception.
@@ -326,11 +331,17 @@ class ContextEnhancer:
         batch_size: int = 10,
         progress_callback: Optional[Callable] = None,
         workers: int = 10,
+        checkpoint_path: str = None,
     ) -> dict:
         """
         Enhance all units in a dataset (single-shot mode).
 
         Uses ThreadPoolExecutor for parallel processing when workers > 1.
+
+        Supports checkpoint/resume symmetrically with the agentic path
+        when ``checkpoint_path`` is provided, each completed
+        unit's ``llm_context`` is saved to its own file under that directory and
+        an interrupted run resumes without re-enhancing finished units.
 
         Args:
             dataset: The dataset from unit_generator.js
@@ -338,6 +349,8 @@ class ContextEnhancer:
             progress_callback: Optional callback(unit_id, classification, unit_elapsed)
                 called after each unit completes.
             workers: Number of parallel workers (default: 10).
+            checkpoint_path: Path to a checkpoint directory (enables resume).
+                When None, no checkpoints are written (prior behavior).
 
         Returns:
             Enhanced dataset
@@ -354,13 +367,41 @@ class ContextEnhancer:
 
         total = len(units)
 
+        # Checkpoint directory setup + resume (mirror enhance_dataset_agentic).
+        checkpoint_dir = None
+        processed_ids = set()
+        if checkpoint_path:
+            checkpoint_dir = (
+                checkpoint_path
+                if os.path.isdir(checkpoint_path) or not checkpoint_path.endswith(".json")
+                else os.path.splitext(checkpoint_path)[0] + "_checkpoints"
+            )
+            os.makedirs(checkpoint_dir, exist_ok=True)
+            processed_ids = self._load_completed_units(checkpoint_dir, context_key="llm_context")
+            # Restore llm_context for already-completed units.
+            for unit in units:
+                unit_id = unit.get("id")
+                if unit_id in processed_ids:
+                    cp_file = os.path.join(checkpoint_dir, f"{self._safe_filename(unit_id)}.json")
+                    if os.path.exists(cp_file):
+                        cp_data = read_json(cp_file)
+                        unit["llm_context"] = cp_data.get("llm_context", {})
+                        if "code" in cp_data:
+                            unit["code"] = cp_data["code"]
+            if processed_ids:
+                self._log("info",
+                          f"Restored {len(processed_ids)} already-processed units from checkpoints",
+                          units=len(processed_ids))
+
         self._log("info", f"Enhancing {total} units with LLM context (single-shot mode)", units=total)
         self._log("info", f"Model: {CONTEXT_ENHANCEMENT_MODEL}")
         mode = "sequential" if workers <= 1 else f"parallel ({workers} workers)"
         self._log("info", f"Mode: {mode}")
 
-        # Build lookup dict for context gathering
+        # Build lookup dict for context gathering (over ALL units, so cross-unit
+        # context lookup still works even when some are restored/skipped).
         units_by_id = {u.get("id"): u for u in units}
+        units_to_process = [u for u in units if u.get("id") not in processed_ids]
 
         def _process_one(unit):
             """Process a single unit. Mutates unit in-place."""
@@ -370,20 +411,33 @@ class ContextEnhancer:
             ctx = unit.get("llm_context", {})
             classification = ctx.get("confidence", "unknown")
             worker = threading.current_thread().name
+            if checkpoint_dir:
+                self._save_unit_checkpoint(unit, checkpoint_dir, context_key="llm_context")
             return unit.get("id", "?"), str(classification), unit_elapsed, worker
 
         if workers <= 1:
-            for unit in units:
-                uid, classification, elapsed, _worker = _process_one(unit)
-                if progress_callback:
-                    progress_callback(uid, classification, elapsed)
+            try:
+                for unit in units_to_process:
+                    uid, classification, elapsed, _worker = _process_one(unit)
+                    if progress_callback:
+                        progress_callback(uid, classification, elapsed)
+            except KeyboardInterrupt:
+                self._log("warning", "Interrupted — progress saved to checkpoints")
+                return dataset
         else:
-            with ThreadPoolExecutor(max_workers=workers) as executor:
-                futures = {executor.submit(_process_one, unit): unit for unit in units}
+            executor = ThreadPoolExecutor(max_workers=workers)
+            futures = {executor.submit(_process_one, unit): unit for unit in units_to_process}
+            try:
                 for future in as_completed(futures):
                     uid, classification, elapsed, worker = future.result()
                     if progress_callback:
                         progress_callback(uid, f"{classification}  [{worker}]", elapsed)
+            except KeyboardInterrupt:
+                self._log("warning", "Interrupted — cancelling pending work...")
+                executor.shutdown(wait=False, cancel_futures=True)
+                self._log("info", "Progress saved to checkpoints")
+                return dataset
+            executor.shutdown(wait=False)
 
         # Recompute stats from unit results (thread-safe)
         self.stats = {
@@ -675,23 +729,35 @@ class ContextEnhancer:
                 return dataset
             executor.shutdown(wait=False)
 
-        # Auto-retry failed units with transient errors (rate limit, connection, timeout, 5xx)
-        retryable_units = [
-            (i, unit) for i, unit in enumerate(units)
-            if is_retryable_error(unit.get("agent_context", {}).get("error"))
-        ]
-        if retryable_units:
+        # Auto-retry failed units with transient errors (rate limit, connection,
+        # timeout, 5xx). This is a BOUNDED MULTI-ROUND loop: a unit that fails
+        # again with a still-transient error gets re-attempted on the next round
+        # (up to MAX_RETRY_ROUNDS). The previous single-pass version abandoned a
+        # unit after one retry even if its error was still transient
+        # Rounds stop early once no retryable
+        # units remain or no progress is made.
+        for _retry_round in range(MAX_RETRY_ROUNDS):
+            retryable_units = [
+                (i, unit) for i, unit in enumerate(units)
+                if is_retryable_error(unit.get("agent_context", {}).get("error"))
+            ]
+            if not retryable_units:
+                break
+
             rate_limiter = get_rate_limiter()
             backoff = rate_limiter.time_until_ready()
             if backoff > 0:
                 self._log("info",
-                    f"Retrying {len(retryable_units)} failed units "
+                    f"Retry round {_retry_round + 1}/{MAX_RETRY_ROUNDS}: "
+                    f"{len(retryable_units)} failed units "
                     f"(waiting {backoff:.0f}s for rate limit to clear)...")
                 rate_limiter.wait_if_needed()
             else:
                 self._log("info",
-                    f"Retrying {len(retryable_units)} failed units (transient errors)...")
+                    f"Retry round {_retry_round + 1}/{MAX_RETRY_ROUNDS}: "
+                    f"{len(retryable_units)} failed units (transient errors)...")
 
+            round_recovered = 0
             # Retry sequentially to avoid re-triggering rate limit
             for i, unit in retryable_units:
                 # Clear previous error
@@ -700,6 +766,7 @@ class ContextEnhancer:
 
                 # Update summary: retry succeeded → flip error to completed
                 if classification != "error":
+                    round_recovered += 1
                     _summary_errors = max(0, _summary_errors - 1)
                     _summary_completed += 1
                     # Decrement the old error type count (best effort)
@@ -722,6 +789,11 @@ class ContextEnhancer:
 
                 if progress_callback:
                     progress_callback(uid, f"{classification} (retry)", elapsed)
+
+            # No unit recovered this round → further rounds would just repeat the
+            # same persistent failures. Stop to avoid burning quota.
+            if round_recovered == 0:
+                break
 
         # Write final summary with phase="done"
         if _summary_cp is not None:
@@ -771,20 +843,27 @@ class ContextEnhancer:
         from utilities.safe_filename import safe_filename
         return safe_filename(unit_id)
 
-    def _save_unit_checkpoint(self, unit: dict, checkpoint_dir: str):
-        """Save a single unit's result to its own checkpoint file."""
+    def _save_unit_checkpoint(self, unit: dict, checkpoint_dir: str, context_key: str = "agent_context"):
+        """Save a single unit's result to its own checkpoint file.
+
+        ``context_key`` selects which enhancement context to persist:
+        ``agent_context`` for agentic mode, ``llm_context`` for single-shot.
+        The key is recorded so resume knows where to restore.
+        """
         unit_id = unit.get("id", "unknown")
         filename = self._safe_filename(unit_id) + ".json"
         filepath = os.path.join(checkpoint_dir, filename)
+        ctx = unit.get(context_key, {})
         cp_data = {
             "id": unit_id,
-            "agent_context": unit.get("agent_context", {}),
+            "context_key": context_key,
+            context_key: ctx,
         }
         # Include code if it was modified by the agent
         if "code" in unit:
             cp_data["code"] = unit["code"]
-        # Include per-unit usage from agent_metadata
-        meta = cp_data["agent_context"].get("agent_metadata", {})
+        # Include per-unit usage from agent_metadata (agentic only)
+        meta = ctx.get("agent_metadata", {}) if isinstance(ctx, dict) else {}
         if meta.get("input_tokens") or meta.get("output_tokens"):
             cp_data["usage"] = {
                 "input_tokens": meta.get("input_tokens", 0),
@@ -793,8 +872,13 @@ class ContextEnhancer:
             }
         write_json(filepath, cp_data)
 
-    def _load_completed_units(self, checkpoint_dir: str) -> set:
-        """Load the set of completed unit IDs from per-unit checkpoint files."""
+    def _load_completed_units(self, checkpoint_dir: str, context_key: str = "agent_context") -> set:
+        """Load the set of completed unit IDs from per-unit checkpoint files.
+
+        A unit counts as completed if its persisted context (for the relevant
+        ``context_key``) is present and carries no error. Older agentic-only
+        checkpoints have no ``context_key`` field and are read as agent_context.
+        """
         completed = set()
         if not os.path.isdir(checkpoint_dir):
             return completed
@@ -805,8 +889,9 @@ class ContextEnhancer:
             try:
                 cp_data = read_json(filepath)
                 unit_id = cp_data.get("id")
-                agent_ctx = cp_data.get("agent_context", {})
-                if unit_id and agent_ctx and not agent_ctx.get("error"):
+                key = cp_data.get("context_key", context_key)
+                ctx = cp_data.get(key, {})
+                if unit_id and ctx and not (isinstance(ctx, dict) and ctx.get("error")):
                     completed.add(unit_id)
             except (json.JSONDecodeError, OSError):
                 continue

--- a/libs/openant-core/utilities/file_io.py
+++ b/libs/openant-core/utilities/file_io.py
@@ -9,6 +9,7 @@ explicitly, preventing ``'charmap' codec can't decode byte ...`` errors.
 import json
 import os
 import subprocess
+import tempfile
 from typing import Any, Union
 
 # Accept str, Path, or any os.PathLike
@@ -34,10 +35,31 @@ def read_json(path: PathLike) -> Any:
 
 
 def write_json(path: PathLike, data: Any, **kwargs) -> None:
-    """Write data as JSON to a file using UTF-8 encoding."""
+    """Write data as JSON to a file using UTF-8 encoding, atomically.
+
+    Serialize to a temp file in the same directory, fsync, then ``os.replace`` onto the
+    target. An interrupted write (SIGKILL / OOM / power loss) leaves the temp file behind
+    but never truncates or clobbers the existing target — the prior good copy survives.
+    """
     kwargs.setdefault("indent", 2)
-    with open_utf8(path, "w") as f:
-        json.dump(data, f, **kwargs)
+    target = os.fspath(path)
+    directory = os.path.dirname(target) or "."
+    # `.tmp` suffix (not `.json`): a leftover from a hard crash (where the except-cleanup
+    # below never runs) must not match directory scanners that do `endswith(".json")`
+    # (e.g. core/checkpoint.py's os.listdir loops, which also see dotfiles).
+    fd, tmp = tempfile.mkstemp(dir=directory, prefix=".tmp-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, **kwargs)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, target)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
 
 
 def run_utf8(*args, **kwargs) -> subprocess.CompletedProcess:

--- a/libs/openant-core/utilities/rate_limiter.py
+++ b/libs/openant-core/utilities/rate_limiter.py
@@ -67,22 +67,29 @@ class GlobalRateLimiter:
 
         Call this before every API request. Returns the time waited (0 if none).
         """
-        with self._lock:
-            now = time.monotonic()
-            if now >= self._backoff_until:
-                return 0.0
+        total_wait = 0.0
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                if now >= self._backoff_until:
+                    break
 
-            wait_time = self._backoff_until - now
-            # Add jitter (0-2s) to prevent thundering herd when backoff expires
-            jitter = random.uniform(0, 2.0)
-            total_wait = wait_time + jitter
+                wait_time = self._backoff_until - now
+                # Add jitter (0-2s) to prevent thundering herd when backoff expires
+                jitter = random.uniform(0, 2.0)
+                this_wait = wait_time + jitter
 
-        # Sleep outside the lock so other threads can also read backoff_until
-        time.sleep(total_wait)
+            # Sleep outside the lock so other threads can also read backoff_until.
+            # Re-check after sleeping: another worker may have EXTENDED _backoff_until
+            # (a fresh 429 via report_rate_limit) while we slept. Without the re-check we
+            # would wake into the still-active backoff window and re-trigger the storm.
+            time.sleep(this_wait)
+            total_wait += this_wait
 
-        with self._lock:
-            self._total_waits += 1
-            self._total_wait_time += total_wait
+        if total_wait > 0.0:
+            with self._lock:
+                self._total_waits += 1
+                self._total_wait_time += total_wait
 
         return total_wait
 

--- a/libs/openant-core/utilities/rate_limiter.py
+++ b/libs/openant-core/utilities/rate_limiter.py
@@ -236,8 +236,17 @@ def is_retryable_error(error_info: dict | str | None) -> bool:
         
         return False
     
-    # String-based error checking
+    # String-based error checking.
+    # NOTE: the analyzer detection path (core/analyzer.py) stores the raw
+    # str(e) of an exception rather than a structured dict, so an Anthropic
+    # HTTP 529 surfaces here as e.g.
+    #   "Error code: 529 - {...'type':'overloaded_error'...}"
+    # 529 ("overloaded") is the most common transient Anthropic failure under
+    # load and is a 5xx, so it must be retried. The structured dict branch
+    # above already retries it via status_code >= 500; mirror that here so the
+    # string path is not silently non-retryable.
     error_str = str(error_info).lower()
     return any(term in error_str for term in (
-        "rate_limit", "connection", "timeout", "500", "502", "503", "504"
+        "rate_limit", "connection", "timeout",
+        "500", "502", "503", "504", "529", "overloaded",
     ))

--- a/libs/openant-core/validate_dataset_schema.py
+++ b/libs/openant-core/validate_dataset_schema.py
@@ -18,7 +18,7 @@ def validate_unit(unit, index):
     if not unit.get("id"):
         errors.append(f"Unit {index}: missing 'id'")
 
-    # 2. Check unit.code structure (experiment.py lines 186-196)
+    # 2. Check unit.code structure (built by experiment.py analyze_unit())
     code_field = unit.get("code", {})
     if not isinstance(code_field, dict):
         errors.append(f"Unit {index}: 'code' must be dict, got {type(code_field)}")
@@ -43,7 +43,7 @@ def validate_unit(unit, index):
     elif not isinstance(primary_origin.get(deps_inlined_key), bool):
         errors.append(f"Unit {index}: 'code.primary_origin.deps_inlined' must be bool")
 
-    # 6. CRITICAL: Check files_included (experiment.py line 192)
+    # 6. CRITICAL: Check files_included (set by experiment.py analyze_unit())
     if "files_included" not in primary_origin:
         errors.append(f"Unit {index}: MISSING 'code.primary_origin.files_included'")
     elif not isinstance(primary_origin.get("files_included"), list):


### PR DESCRIPTION
- **fix(parsers/c): exclude on path components in extract_all, not a substring of the abspath**
- **fix(parsers/php): repair the PHP call-graph builder (tag grammar, callbacks, new, scopes, imports)**
- **fix(parsers/python): repair 6 call-graph edge-fidelity bugs in the Python CallGraphBuilder**
- **Fix JS DependencyResolver call-edge fidelity**
- **fix(parsers/go): correct call-graph receiver classification, package resolution, dispatch, os filtering**
- **fix(parsers/zig): canonical call-graph API + correct call extraction and resolution**
- **fix(parsers/python): segment-match path exclusion/classification + resolve relative-import anchors**
- **fix(parsers): repair Ruby + PHP call-graph resolution**
- **fix(parsers/zig): align function_extractor with the real tree-sitter-zig grammar + lazy import**
- **fix(reachability): seed native/cross-language entry points, fix Zig reachability crash, stop silent zero-seed blackout**
- **fix(scanner): isolate optional-stage failures and disambiguate skip causes**
- **fix(parsers/go): give CodeQL DB-create the same timeout budget as analyze**
- **fix(parsers/php): extract procedural top-level + closure units; seed PHP entry points**
- **fix(parsers/c): codeql build-mode-none, optional-stage success, exclude orchestrators from pytest**
- **fix(c-parser): deterministic include resolution + call-graph precision/recall**
- **fix(parsers/js): discover and resolve .mjs/.cjs modules in context_assembler**
- **fix(ruby-extractor): repair 7 Ruby FunctionExtractor extraction/classification bugs**
- **fix(parsers): anchor is_test_file detection to path components + basename (zig/python/php/ruby)**
- **fix(c-parser): anchor is_test_file patterns to path segments / filename boundaries**
- **fix(file_io): write_json atomically (temp + os.replace) to survive interrupted writes**
- **fix(openant-cli): bound Python subprocess in Invoke with an automatic timeout**
- **fix(parsers/python): surface top-level callGraph/reverseCallGraph in analyzer_output**
- **fix(js-analyzer): repair JS/TS analyzer inventory, call-graph, schema and functionId bugs**
- **fix(reachability): make get_all_reachable() overwrite the cache so a stale bounded False is corrected**
- **docs(validate_dataset_schema): cite experiment.py analyze_unit() instead of drifting line numbers**
- **fix(progress): floor ETA remaining at 0 so retry double-counts don't show negative time**
- **fix(analyze): add Go --exploitable-all parity; priority-sort --limit truncation**
- **fix(js-parser): export FILE_BOUNDARY at module level for cross-parser parity**
- **fix(cli/runtime): key dependency-staleness on corePath, not only the pyproject hash**
- **fix(cli/config): enforce 0600 on the config file even when it pre-exists (CWE-732)**
- **fix(export_csv): neutralize CSV/formula injection in exported cells (CWE-1236)**
- **fix(context): anchor entry-point path exclusions on components, not substrings**
- **fix(js-parser): treat a zero-JS-file repo as an empty result, not a crash**
- **fix(cli): add --limit to the enhance command across all three layers**
- **fix(enhance/analyzer): retry 529-overloaded, single-shot checkpoint, exploitable filter + bounded agentic retry**
- **fix(rate_limiter): re-check the backoff deadline after sleeping (close TOCTOU)**
- **fix(agentic-enhancer): cap conversation input to avoid context overflow**
- **fix(reporter): correct build_pipeline_output return annotation + docstring to tuple[str, int]**
- **fix(parsers/ruby): posix-normalize call-graph file keys for cross-platform resolution**
- **test(parsers/c): normalize recorded path to forward slashes for Windows CI**
- **test(parsers/python): normalize recorded path to forward slashes for Windows CI**
- **test(cli/config): skip POSIX-perms test on Windows**
- **test(enhance): supply dummy ANTHROPIC_API_KEY so resilience tests run without a real credential**
- **build(deps): declare tree-sitter-zig so the zig parser imports on a clean install**
- **build(deps): declare tree-sitter-zig so the zig parser imports on a clean install**
- **fix(parsers/php): anchor file-discovery exclusion to repo-relative path components**
