### PR TITLE
fix(parsers): bound the JS and Go parse subprocesses with a timeout

### DIFF
--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -579,6 +579,7 @@ def _parse_javascript(repo_path: str, output_dir: str, processing_level: str, sk
         stdout=sys.stderr,
         stderr=sys.stderr,
         cwd=str(_CORE_ROOT),
+        timeout=1800,  # 30 min — parity with the C/Ruby/PHP/Zig parse subprocesses
     )
 
     if result.returncode != 0:
@@ -637,6 +638,7 @@ def _parse_go(repo_path: str, output_dir: str, processing_level: str, skip_tests
         stdout=sys.stderr,
         stderr=sys.stderr,
         cwd=str(_CORE_ROOT),
+        timeout=1800,  # 30 min — parity with the C/Ruby/PHP/Zig parse subprocesses
     )
 
     if result.returncode != 0:

--- a/libs/openant-core/tests/test_parser_adapter_timeout.py
+++ b/libs/openant-core/tests/test_parser_adapter_timeout.py
@@ -1,0 +1,64 @@
+"""Regression lock: the JS and Go parse subprocesses must pass a wall-clock timeout,
+so a hung inner Node/Go parser fails cleanly instead of blocking the Python parent forever.
+
+C/Ruby/PHP/Zig already pass timeout=1800; JS and Go did not, so a direct-Python caller of
+parse_repository / _parse_javascript / _parse_go had no bound. These tests fail on master
+(no timeout) and pass with the fix.
+"""
+import inspect
+import tempfile
+
+from core import parser_adapter
+
+
+class _FakeCompleted:
+    returncode = 0
+
+
+def _capture_run_calls(monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return _FakeCompleted()
+
+    monkeypatch.setattr(parser_adapter.subprocess, "run", fake_run)
+    return calls
+
+
+def _parse_call_timeout(calls, script_name):
+    """timeout kwarg of the subprocess.run whose cmd invokes <script_name> (the parse step)."""
+    for cmd, kwargs in calls:
+        if any(script_name in str(part) for part in cmd):
+            return kwargs.get("timeout")
+    return "NO-PARSE-CALL"
+
+
+def test_js_parse_subprocess_has_timeout(monkeypatch):
+    calls = _capture_run_calls(monkeypatch)
+    d = tempfile.mkdtemp()
+    try:
+        parser_adapter._parse_javascript(d, d, "reachable")
+    except Exception:
+        pass  # we only care that the parse subprocess.run received a timeout
+    assert _parse_call_timeout(calls, "test_pipeline.py") == 1800
+
+
+def test_go_parse_subprocess_has_timeout(monkeypatch):
+    calls = _capture_run_calls(monkeypatch)
+    d = tempfile.mkdtemp()
+    try:
+        parser_adapter._parse_go(d, d, "reachable")
+    except Exception:
+        pass
+    assert _parse_call_timeout(calls, "test_pipeline.py") == 1800
+
+
+def test_all_subprocess_parsers_are_uniformly_timed():
+    """Every language whose *parse step* runs as a subprocess must carry a timeout — not just
+    4 of them. (Python parses in-process, so it is intentionally excluded; the npm-install
+    dependency bootstrap in _ensure_js_parser_dependencies is a separate concern, not a parse.)"""
+    for lang in ("_parse_javascript", "_parse_go", "_parse_c",
+                 "_parse_ruby", "_parse_php", "_parse_zig"):
+        src = inspect.getsource(getattr(parser_adapter, lang))
+        assert "timeout=" in src, f"{lang} subprocess.run is missing a timeout"


### PR DESCRIPTION
## What
Add a 30-minute timeout to the JavaScript and Go parse subprocesses in `core/parser_adapter.py`, matching the four other parsers.

## Root cause
`_parse_javascript` and `_parse_go` call `subprocess.run(...)` with no `timeout=`, while `_parse_c` / `_parse_ruby` / `_parse_php` / `_parse_zig` all pass `timeout=1800`. When the inner Node/Go parser hangs, the Python parent blocks with no bound for any direct caller of `parse_repository` (library API, tests, tooling). The four already-timed parsers fail cleanly instead.

## How
- `core/parser_adapter.py`: add `timeout=1800` to the `subprocess.run` in `_parse_javascript` and `_parse_go`, at the same placement and value as the four already-timed parsers.

## Regression test
`tests/test_parser_adapter_timeout.py` monkeypatches `subprocess.run` to capture the `timeout` kwarg the parse step passes (asserting JS and Go each pass `1800`), plus a parity assertion that every language whose parse runs as a subprocess carries a timeout.

RED on `origin/master` (98f5504):

    $ python -m pytest tests/test_parser_adapter_timeout.py -q
    3 failed

GREEN on this branch:

    $ python -m pytest tests/test_parser_adapter_timeout.py -q
    3 passed

Full parser test suite unchanged vs base (delta is exactly these 3 new tests).

## Compatibility / scope
- A parse that legitimately runs past 30 minutes now raises `TimeoutExpired` rather than hanging — the same policy the four other parsers already apply.
- The `npm install` in `_ensure_js_parser_dependencies` (`parser_adapter.py:499`) is a separate unbounded subprocess (dependency bootstrap, not a parse step); a tracked follow-up, out of scope here.
- Complementary to #98, which bounds the outer Go-CLI to python subprocess; this bounds the inner python to node/go parse subprocess one level deeper (direct-Python callers get no protection from #98).

## Author notes
- Implements: the two `timeout=1800` lines in `_parse_javascript` and `_parse_go`.
- Input previously handled wrong: a repo whose Node/ts-morph or Go parser hangs (e.g. a pathological generated file) blocked the caller forever; it now fails after 30 minutes with `TimeoutExpired`.
- Likely reviewer pushback: "why 1800 / why not also bound npm install?" — 1800 matches the four existing parsers verbatim; npm-install is disclosed above as a separate follow-up to keep this change single-purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
