### PR TITLE
fix(parsers/ruby): emit + seed file-scope top-level script code

### DIFF
--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -673,6 +673,74 @@ class FunctionExtractor:
         # Extract functions
         self._extract_functions_from_tree(tree, source, file_path, relative_path)
 
+        # Extract file-scope top-level script code
+        self._extract_module_level_code(tree, source, relative_path)
+
+    # Top-level program children that are NOT file-scope script statements:
+    # definitions (their bodies are their own units) and comments.
+    _MODULE_LEVEL_SKIP = frozenset({
+        'method', 'singleton_method', 'class', 'module', 'comment',
+    })
+    # Import/mixin DSL calls are not "significant" executable script code on
+    # their own -- a file that is only requires/includes gets no module unit.
+    _MODULE_LEVEL_IMPORTS = frozenset({
+        'require', 'require_relative', 'load', 'include', 'extend', 'prepend',
+    })
+
+    def _extract_module_level_code(self, tree, source: bytes, relative_path: str) -> None:
+        """Emit file-scope top-level script code as a synthetic module_level unit.
+
+        Ruby scripts run statements at the file top level (`name = ARGV[0];
+        process_input(name)`) with no enclosing class/module. Function-only
+        extraction dropped that code entirely, so it was neither a call-graph
+        node (its calls unreachable) nor an entry-point seed. Mirroring the
+        Python/PHP extractors, collect the top-level non-definition statements
+        into a `__module__` unit (unit_type='module_level') carrying the ARGV/
+        $stdin code, so the call-graph builder wires its calls and
+        entry_point_detector Check-4 can seed it.
+        """
+        stmts = [
+            child for child in tree.root_node.children
+            if child.type not in self._MODULE_LEVEL_SKIP
+        ]
+        if not stmts:
+            return
+
+        # Require at least one statement that is not a bare import/mixin call,
+        # so pure require/include files produce no module unit.
+        def _is_import_call(node) -> bool:
+            if node.type != 'call':
+                return False
+            method_name, _ = self._call_receiver_and_method(node, source)
+            return method_name in self._MODULE_LEVEL_IMPORTS
+
+        if all(_is_import_call(node) for node in stmts):
+            return
+
+        code = '\n'.join(self._node_text(node, source) for node in stmts).strip()
+        if not code:
+            return
+
+        func_id = f"{relative_path}:__module__"
+        self._store_function(func_id, {
+            'name': '__module__',
+            'qualified_name': '__module__',
+            'file_path': relative_path,
+            'start_line': stmts[0].start_point[0] + 1,
+            'end_line': stmts[-1].end_point[0] + 1,
+            'code': code,
+            'class_name': None,
+            'module_name': None,
+            'parameters': [],
+            'is_singleton': False,
+            'visibility': 'public',
+            'unit_type': 'module_level',
+            'is_module_level': True,
+        })
+        self.stats['total_functions'] += 1
+        self.stats['standalone_functions'] += 1
+        self.stats['by_type']['module_level'] = self.stats['by_type'].get('module_level', 0) + 1
+
     def extract_from_scan(self, scan_result: Dict) -> Dict:
         """Extract functions from files listed in a scan result."""
         for file_info in scan_result.get('files', []):

--- a/libs/openant-core/tests/parsers/ruby/test_ruby_module_level_seed.py
+++ b/libs/openant-core/tests/parsers/ruby/test_ruby_module_level_seed.py
@@ -1,0 +1,130 @@
+"""Bug B12 (Ruby): file-scope top-level script code must be emitted as a
+`module_level` unit so it is a call-graph node and an entry-point seed.
+
+A Ruby script whose top level runs `name = ARGV[0]; process_input(name)` (no
+enclosing class/module) is executable code that reads untrusted input (ARGV)
+and dispatches into a helper. The Ruby function extractor only emitted `def`
+methods, so this file-scope code was NEITHER a unit NOR a call-graph node:
+`process_input` had no reachable caller and entry_point_detector Check-4
+(unit_type == 'module_level' with an input pattern) had nothing to seed.
+
+Mirror the Python/PHP extractors: emit the top-level statements as a synthetic
+`__module__` unit with unit_type='module_level', carrying the ARGV/$stdin code,
+so the call-graph builder wires its calls and the detector can seed it.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+CORE = Path(__file__).resolve().parents[3]
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+
+def _load(unique_name, relpath):
+    spec = importlib.util.spec_from_file_location(unique_name, str(CORE / relpath))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_fe = _load("ruby_function_extractor_b12", "parsers/ruby/function_extractor.py")
+_cgb = _load("ruby_call_graph_builder_b12", "parsers/ruby/call_graph_builder.py")
+FunctionExtractor = _fe.FunctionExtractor
+CallGraphBuilder = _cgb.CallGraphBuilder
+
+
+def _build(files):
+    d = tempfile.mkdtemp()
+    for name, code in files.items():
+        with open(os.path.join(d, name), "w") as fh:
+            fh.write(code)
+    extractor = FunctionExtractor(d)
+    result = extractor.extract_all(list(files.keys()))
+    builder = CallGraphBuilder(result)
+    builder.build_call_graph()
+    return result, builder
+
+
+SCRIPT = (
+    "name = ARGV[0]\n"
+    "process_input(name)\n"
+    "def process_input(x)\n"
+    "  system(x)\n"
+    "end\n"
+)
+
+
+def test_file_scope_script_is_module_level_unit_and_reaches_helper():
+    result, builder = _build({"script.rb": SCRIPT})
+
+    # (1) A module_level unit exists whose code carries ARGV.
+    module_units = [
+        (fid, d)
+        for fid, d in result["functions"].items()
+        if d.get("unit_type") == "module_level"
+    ]
+    assert module_units, (
+        "expected a module_level unit for file-scope script code; got unit types "
+        f"{[d.get('unit_type') for d in result['functions'].values()]}"
+    )
+    mod_id, mod_data = module_units[0]
+    assert "ARGV" in mod_data.get("code", ""), (
+        f"module_level unit code must carry ARGV; got {mod_data.get('code')!r}"
+    )
+
+    # (2) process_input is reachable from the module_level unit.
+    proc_id = "script.rb:process_input"
+    assert proc_id in result["functions"], list(result["functions"])
+    reachable = builder.get_dependencies(mod_id)
+    assert proc_id in reachable, (
+        f"process_input must be reachable from the module_level unit; "
+        f"deps={reachable}, edges={builder.call_graph.get(mod_id)}"
+    )
+
+
+def test_module_level_script_is_seeded_as_entry_point():
+    """The emitted module_level unit must actually be SEEDED by the detector
+    (Check-4: unit_type=='module_level' carrying a user-input pattern) — else the
+    ARGV -> system(x) sink stays unreachable from any taint entry point."""
+    from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector
+
+    result, builder = _build({"script.rb": SCRIPT})
+    mod_id = next(
+        fid for fid, d in result["functions"].items()
+        if d.get("unit_type") == "module_level"
+    )
+    detector = EntryPointDetector(result["functions"], builder.call_graph)
+    entry_points = detector.detect_entry_points()
+    assert mod_id in entry_points, (
+        "the module_level unit reading ARGV must be seeded as an entry point; "
+        f"reasons={detector.entry_point_details.get(mod_id)}"
+    )
+
+
+def test_method_reading_argv_behind_main_guard_is_seeded():
+    """The dominant Ruby CLI shape: ARGV read inside a method invoked from an
+    `if __FILE__ == $0` guard. The sink lives in a `function` unit, so ARGV must
+    seed via Check-3 (USER_INPUT_PATTERNS) — the module-level guard itself has no
+    input pattern to seed on. Parity with the Python main-guard (sys.argv)."""
+    from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector
+
+    script = (
+        "def run\n"
+        "  system(ARGV[0])\n"
+        "end\n"
+        "if __FILE__ == $0\n"
+        "  run\n"
+        "end\n"
+    )
+    result, builder = _build({"cli.rb": script})
+    detector = EntryPointDetector(result["functions"], builder.call_graph)
+    entry_points = detector.detect_entry_points()
+    run_id = "cli.rb:run"
+    assert run_id in result["functions"], list(result["functions"])
+    assert run_id in entry_points, (
+        "a method reading ARGV must be seeded even when the ARGV read is behind a "
+        f"main-guard method; reasons={detector.entry_point_details.get(run_id)}, all={entry_points}"
+    )

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -96,6 +96,15 @@ USER_INPUT_PATTERNS = [
     r'argparse\.',
     r'\bArgumentParser\s*\(',
     r'click\.(argument|option)',
+    # Ruby CLI / stdin / env: a method that reads these IS a user-input entry
+    # point, including the dominant `def run; ...ARGV...; end` behind an
+    # `if __FILE__ == $0` guard (the sink lives in a `function` unit, so it must
+    # be seeded by this check, not only the module_level check). Mirrors sys.argv.
+    r'\bARGV\b',
+    r'\bgets\b',
+    r'\bSTDIN\b',
+    r'\$stdin\b',
+    r'\bENV\s*(\[|\.(fetch|values_at|dig|to_h|slice)\b)',
     # Standard input
     r'\binput\s*\(',
     r'sys\.stdin',
@@ -136,6 +145,14 @@ MODULE_LEVEL_INPUT_PATTERNS = [
     r'\badd_filter\s*\(',
     r'\bdo_action\s*\(',
     r'\bapply_filters\s*\(',
+    # Ruby file-scope scripts (bin/ executables, Rakefiles): CLI args, stdin and
+    # env reads that run on load, so a module_level unit carrying them is a
+    # user-input entry point.
+    r'\bARGV\b',
+    r'\bSTDIN\b',
+    r'\$stdin\b',
+    r'\bgets\b',
+    r'\bENV\[',
 ]
 
 


### PR DESCRIPTION
A Ruby script whose top level runs on load — e.g. `name = ARGV[0];
process_input(name)` in a bin/ executable or Rakefile, no enclosing class —
was neither emitted as a unit nor a call-graph node, so its callees (a sink
reached only from that top-level code) were invisible to reachability whenever
another entry point kept the seed set non-empty.

Emit the file-scope statements as a synthetic module_level unit (mirrors the
python/php extractors) so the call-graph builder wires its calls, and add the
Ruby CLI/stdin/env patterns (ARGV, STDIN, $stdin, gets, ENV[]) to
MODULE_LEVEL_INPUT_PATTERNS so entry_point_detector Check-4 actually seeds it.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>



---
Found by a deep reachability/call-graph validation of the parser corpus: the 2026 release fixed this bug **class** at some parser sites but left this sibling. Ships with a RED->GREEN regression test driving the real parser/detector pipeline (not a mock). One of a 9-PR series of independent, region-disjoint fixes; verified together (full suite green, no collisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)