### PR TITLE
fix(parsers/python): keep the enclosing class on conditionally-defined methods

### DIFF
--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -393,7 +393,8 @@ class FunctionExtractor:
                 bodies.append(b)
         return bodies
 
-    def _descend_into_blocks(self, stmts: list, file_path: Path, content: str) -> None:
+    def _descend_into_blocks(self, stmts: list, file_path: Path, content: str,
+                             enclosing_class: Optional[str] = None) -> None:
         """Find def/class nodes inside block statements at ANY depth and emit them.
 
         A `def`/`class` inside an `if`/`try`/`for`/`while`/`with`/`match` block is
@@ -411,10 +412,15 @@ class FunctionExtractor:
             for body in self._block_bodies(stmt):
                 for child in body:
                     if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                        self._process_function_tree(child, file_path, content, class_name=None)
+                        # A def surfaced from a class-body block is still a method
+                        # of that class; keep its enclosing class so it is keyed
+                        # (and classified) as a method, not module-level.
+                        self._process_function_tree(child, file_path, content,
+                                                    class_name=enclosing_class)
                     elif isinstance(child, ast.ClassDef):
-                        self._process_class_tree(child, file_path, content, outer_qualifier=None)
-                self._descend_into_blocks(body, file_path, content)
+                        self._process_class_tree(child, file_path, content,
+                                                 outer_qualifier=enclosing_class)
+                self._descend_into_blocks(body, file_path, content, enclosing_class)
 
     def _process_function_tree(self, node: ast.AST, file_path: Path, content: str,
                                class_name: Optional[str] = None) -> None:
@@ -465,8 +471,10 @@ class FunctionExtractor:
             if isinstance(item, ast.ClassDef):
                 self._process_class_tree(item, file_path, content, outer_qualifier=qualified_class)
         # defs/classes wrapped in a block inside the class body (e.g. an
-        # `if TYPE_CHECKING:` block declaring conditional members).
-        self._descend_into_blocks(node.body, file_path, content)
+        # `if TYPE_CHECKING:` block declaring conditional members). Thread the
+        # class so a block-nested def stays a method of this class.
+        self._descend_into_blocks(node.body, file_path, content,
+                                  enclosing_class=qualified_class)
 
     def extract_assigned_lambdas(self, tree: ast.AST, file_path: Path, content: str) -> None:
         """Emit a function unit for each module-level `name = lambda ...`.

--- a/libs/openant-core/tests/parsers/python/test_block_scoped_defs.py
+++ b/libs/openant-core/tests/parsers/python/test_block_scoped_defs.py
@@ -105,6 +105,40 @@ def test_block_def_colliding_with_top_level_keeps_both():
     assert len(dups) == 2, f"block def must not clobber top-level same-name: {dups}"
 
 
+def test_class_body_block_def_keeps_class_and_resolves_self_edge():
+    # REGRESSION from #134: a method defined under a conditional in a class
+    # body was mis-keyed module-level (class_name=None) because
+    # _descend_into_blocks, called from _process_class_tree, hardcoded
+    # class_name=None. The def must keep its enclosing class, and the sibling
+    # method's `self.handle()` self-call must resolve to it.
+    from parsers.python.call_graph_builder import CallGraphBuilder
+
+    src = (
+        "class Service:\n"
+        "    def caller(self): return self.handle()\n"
+        "    if True:\n"
+        "        def handle(self): return 1\n"
+    )
+    repo = Path(tempfile.mkdtemp()).resolve()
+    (repo / "m.py").write_text(src)
+    ex = FunctionExtractor(str(repo))
+    ex.process_file(repo / "m.py")
+    fns = ex.functions
+
+    handle = next(v for v in fns.values() if v["name"] == "handle")
+    assert handle["class_name"] == "Service", (
+        f"block-scoped class-body def mis-keyed: class_name={handle['class_name']!r}"
+    )
+
+    builder = CallGraphBuilder(ex.export())
+    builder.build_call_graph()
+    caller_id = next(k for k, v in fns.items() if v["name"] == "caller")
+    handle_id = next(k for k, v in fns.items() if v["name"] == "handle")
+    assert handle_id in builder.call_graph[caller_id], (
+        f"caller -> handle self-edge missing; got {builder.call_graph[caller_id]}"
+    )
+
+
 def test_module_unit_does_not_leak_block_def_body():
     # The block def's body (incl. its sink) must move into its own unit, not
     # leak verbatim into the synthetic :__module__ text.


### PR DESCRIPTION
_descend_into_blocks (surfacing defs nested in if/try blocks so version-gated
members are captured, added in the 2026-06 release) hardcoded class_name=None.
Correct when descending a function body, but when descending a CLASS body it
mis-keyed a conditionally-defined method (e.g. `if sys.version_info>=(3,8):
def handle(self): ...`) as a module-level function, so every self.<m>() call
to it dropped from the call graph (and it collided with the global namespace).

Thread the enclosing class_name through _descend_into_blocks; the class-body
call site passes the qualified class, the function-body and module-level sites
keep the default None.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>



---
Found by a deep reachability/call-graph validation of the parser corpus: the 2026 release fixed this bug **class** at some parser sites but left this sibling. Ships with a RED->GREEN regression test driving the real parser/detector pipeline (not a mock). One of a 9-PR series of independent, region-disjoint fixes; verified together (full suite green, no collisions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)