### PR TITLE
fix(parsers/js): capture decorators so framework route handlers are seeded

### DIFF
--- a/libs/openant-core/parsers/javascript/typescript_analyzer.js
+++ b/libs/openant-core/parsers/javascript/typescript_analyzer.js
@@ -366,6 +366,7 @@ class TypeScriptAnalyzer {
           endLine: method.getEndLineNumber(),
           className: className,
           parameters: this._extractParameters(method),
+          decorators: this._decoratorTexts(classDecl, method),
         };
       }
 
@@ -550,6 +551,7 @@ class TypeScriptAnalyzer {
           startLine: method.getStartLineNumber(),
           endLine: method.getEndLineNumber(),
           className: className,
+          decorators: this._decoratorTexts(classExpr, method),
         };
         this.callGraph[functionId] = this.extractCallsFromFunction(
           method,
@@ -825,6 +827,7 @@ class TypeScriptAnalyzer {
       startLine: fnNode.getStartLineNumber(),
       endLine: fnNode.getEndLineNumber(),
       className: className,
+      decorators: this._decoratorTexts(fnNode),
     };
     // Pattern-A companion: emit the callGraph entry alongside the function so
     // `len(callGraph) === len(functions)` holds.
@@ -832,6 +835,33 @@ class TypeScriptAnalyzer {
       fnNode,
       relativePath,
     );
+  }
+
+  /**
+   * Decorator source texts for the given ts-morph nodes (a method and,
+   * optionally, its enclosing class), e.g. ['@Get()', '@Controller("users")'].
+   * The reachability EntryPointDetector reads func_data.decorators to seed
+   * framework route handlers (NestJS @Get/@Post/@Controller, Angular, ...); the
+   * analyzer previously never emitted them, so decorated handlers were never
+   * detected as entry points.
+   */
+  _decoratorTexts(...nodes) {
+    const out = [];
+    for (const node of nodes) {
+      if (!node || typeof node.getDecorators !== "function") continue;
+      for (const d of node.getDecorators()) {
+        try {
+          out.push(d.getText().replace(/\s+/g, " ").trim());
+        } catch (e) {
+          try {
+            out.push("@" + d.getName());
+          } catch (e2) {
+            /* skip an unreadable decorator */
+          }
+        }
+      }
+    }
+    return out;
   }
 
   /**

--- a/libs/openant-core/tests/parsers/javascript/test_decorator_entry_points.py
+++ b/libs/openant-core/tests/parsers/javascript/test_decorator_entry_points.py
@@ -1,0 +1,88 @@
+"""A framework route handler identified only by a decorator (NestJS @Get /
+@Controller, Angular, ...) must be captured as a decorator by the TS analyzer
+and seeded as a reachability entry point.
+
+The analyzer emitted function records with no `decorators` field at all, so the
+detector's decorator check (@Get/@Post/@Controller in ENTRY_POINT_DECORATORS)
+could never fire for JS/TS — a decorated handler with no other input signal
+seeded zero entry points and its whole subtree (the sink it calls) was a
+reachability false negative.
+"""
+import json
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = Path(__file__).resolve().parents[3]
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+_NODE_MODULES = CORE / "parsers" / "javascript" / "node_modules"
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not _NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+from core.parser_adapter import parse_repository  # noqa: E402
+from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector  # noqa: E402
+
+NEST_TS = (
+    "import { Controller, Get } from '@nestjs/common';\n"
+    "@Controller('users')\n"
+    "export class UsersController {\n"
+    "  @Get()\n"
+    "  findAll() {\n"
+    "    return dangerousQuery();\n"
+    "  }\n"
+    "}\n"
+    "function dangerousQuery() { return 1; }\n"
+)
+
+
+def _run(tmp_path):
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    (repo / "src" / "users.controller.ts").write_text(NEST_TS)
+    out = tmp_path / "out"
+    out.mkdir()
+    parse_repository(
+        str(repo), str(out), language="javascript",
+        processing_level="all", skip_tests=True, name="t",
+    )
+    return json.loads((out / "call_graph.json").read_text())
+
+
+def test_decorated_nest_handler_is_captured_and_seeded(tmp_path):
+    cg = _run(tmp_path)
+    funcs = cg["functions"]
+    call_graph = cg.get("call_graph", {})
+    hid = "src/users.controller.ts:UsersController.findAll"
+    assert hid in funcs, list(funcs)
+
+    # 1. The analyzer captured the decorators (@Get / @Controller).
+    decs = funcs[hid].get("decorators") or []
+    assert any("Get" in d or "Controller" in d for d in decs), (
+        f"the @Get/@Controller decorators must be captured; got {decs!r}"
+    )
+
+    # 2. The handler is seeded as an entry point via the decorator check.
+    detector = EntryPointDetector(funcs, call_graph)
+    seeds = detector.detect_entry_points()
+    assert hid in seeds, (
+        f"a @Get-decorated handler must be seeded; reasons={detector.entry_point_details.get(hid)}"
+    )
+
+    # 3. Its callee (the sink it invokes) is therefore reachable.
+    reach = set(seeds)
+    stack = list(seeds)
+    while stack:
+        for callee in call_graph.get(stack.pop(), []):
+            if callee not in reach:
+                reach.add(callee)
+                stack.append(callee)
+    sink = "src/users.controller.ts:dangerousQuery"
+    assert sink in reach, (
+        f"the handler's callee must be reachable via the decorated entry point; reachable={reach}"
+    )


### PR DESCRIPTION
The TypeScript analyzer emitted function records with no 'decorators' field, so
the reachability detector's decorator check (@Get/@Post/@Controller in
ENTRY_POINT_DECORATORS) could never fire for JS/TS. A NestJS/Angular handler
identified only by a decorator (e.g. @Get() findAll() { ... }) seeded zero entry
points and its whole subtree was pruned from reachability — a false negative.

Extract the decorator source texts (method decorators plus the enclosing class's,
so @Controller is captured too) on class-method records via ts-morph
getDecorators(). The js reachable pipeline already reads analyzer_output
functions directly, so no normalization change is needed. A decorated handler is
now seeded and its callees stay reachable.

This is the JS sibling of the PHP #[Route] attribute-seeding fix (same class of
decorator-based entry point missed by a parser).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

---
Found during review of the PHP #[Route] fix (#138) as its JS sibling. The TS analyzer never captured decorators, so `@Get`/`@Controller` handlers were undetected as entry points on every path. Ships with an end-to-end test (parse -> detect -> reachable). One of the reachability-fix series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)