### PR TITLE
fix(parsers/php): recover 5 reachability false-negatives in the call graph

### DIFF
--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -147,6 +147,8 @@ class CallGraphBuilder:
         self.methods_by_class: Dict[str, List[str]] = {}
         # class_key -> list of trait names the class composes via in-class `use`.
         self.traits_by_class: Dict[str, List[str]] = {}
+        # class_key -> {alias -> [trait_or_None, orig]} from `use T { orig as alias; }`.
+        self.aliases_by_class: Dict[str, Dict[str, list]] = {}
 
         self._build_indexes()
 
@@ -181,6 +183,9 @@ class CallGraphBuilder:
             traits = class_data.get('traits')
             if traits:
                 self.traits_by_class[class_key] = list(traits)
+            aliases = class_data.get('trait_aliases')
+            if aliases:
+                self.aliases_by_class[class_key] = aliases
 
     def _is_builtin(self, name: str) -> bool:
         """Check if name is a PHP builtin or common function."""
@@ -532,6 +537,25 @@ class CallGraphBuilder:
                            caller_class: str) -> Optional[str]:
         """Resolve a $this->method() or self::method() call within a class."""
         class_key = f"{caller_file}:{caller_class}"
+
+        # Trait method alias: `use T { orig as method_name; }` invokes the trait's
+        # original method under the alias. Resolve to the pinned trait (qualified
+        # form) or one of the class's composed traits (unqualified form). Scoped via
+        # _resolve_class_call to those traits, so an unrelated same-named method in
+        # another class is never connected.
+        alias = self.aliases_by_class.get(class_key, {}).get(method_name)
+        if alias:
+            trait_name, orig = alias[0], alias[1]
+            if trait_name:
+                resolved = self._resolve_class_call(trait_name, orig, caller_file)
+                if resolved:
+                    return resolved
+            else:
+                for trait in self.traits_by_class.get(class_key, []):
+                    resolved = self._resolve_class_call(trait, orig, caller_file)
+                    if resolved:
+                        return resolved
+
         class_methods = self.methods_by_class.get(class_key, [])
 
         for func_id in class_methods:

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -469,17 +469,26 @@ class CallGraphBuilder:
                             if func_data.get('name') == func_name:
                                 return func_id
 
-        # 4. Unique name match across files. An unqualified call resolves within
-        #    the caller's own namespace; a function in a different namespace is not
-        #    reachable this way, so a same-named function elsewhere must not leak an
-        #    edge across the namespace boundary.
-        candidates = self.functions_by_name.get(func_name, [])
-        candidates = [c for c in candidates
-                      if not self.functions.get(c, {}).get('class_name')
-                      and self._namespace_compatible(
-                          self.functions.get(c, {}).get('namespace_name'), caller_namespace)]
-        if len(candidates) == 1:
-            return candidates[0]
+        # 4. Unqualified call resolution across files. PHP resolves an unqualified
+        #    function call within the caller's own namespace FIRST; if there is no such
+        #    function it FALLS BACK to the global namespace. A same-named function in an
+        #    unrelated namespace is never reachable this way, so it must not leak an edge.
+        non_method = [c for c in self.functions_by_name.get(func_name, [])
+                      if not self.functions.get(c, {}).get('class_name')]
+        # (a) same-namespace binding takes precedence
+        same_ns = [c for c in non_method
+                   if self._namespace_compatible(
+                       self.functions.get(c, {}).get('namespace_name'), caller_namespace)]
+        if len(same_ns) == 1:
+            return same_ns[0]
+        # (b) global-namespace fallback for an unqualified call (only when the caller's
+        #     own namespace has no such function); still requires a unique target so an
+        #     ambiguous global name does not leak an edge.
+        if not same_ns:
+            global_ns = [c for c in non_method
+                         if not (self.functions.get(c, {}).get('namespace_name') or '').strip('\\')]
+            if len(global_ns) == 1:
+                return global_ns[0]
 
         return None
 

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -235,7 +235,7 @@ class CallGraphBuilder:
             return self._resolve_function_call(node, source, caller_file, caller_class,
                                                caller_namespace, root)
         elif node.type == 'member_call_expression':
-            return self._resolve_member_call(node, source, caller_file, caller_class)
+            return self._resolve_member_call(node, source, caller_file, caller_class, root)
         elif node.type == 'scoped_call_expression':
             return self._resolve_scoped_call(node, source, caller_file, caller_class)
         elif node.type == 'object_creation_expression':
@@ -381,29 +381,59 @@ class CallGraphBuilder:
 
     @staticmethod
     def _string_literal_value(node, source: bytes) -> Optional[str]:
-        """Return the content of a string-literal node, else None."""
-        if node.type != 'string':
-            return None
-        for child in node.children:
-            if child.type == 'string_content':
-                return source[child.start_byte:child.end_byte].decode(
-                    'utf-8', errors='replace')
-        # Empty string literal ('') has no string_content child.
-        return ''
+        """Return the content of a string-literal node, else None.
+
+        Single-quoted strings parse as `string`; double-quoted as `encapsed_string`.
+        An `encapsed_string` is accepted only when it has NO interpolation (its only
+        meaningful child is a single `string_content`), so `"dang$p"` is not treated
+        as a static literal.
+        """
+        if node.type == 'string':
+            for child in node.children:
+                if child.type == 'string_content':
+                    return source[child.start_byte:child.end_byte].decode(
+                        'utf-8', errors='replace')
+            # Empty string literal ('') has no string_content child.
+            return ''
+        if node.type == 'encapsed_string':
+            content = None
+            for child in node.children:
+                if child.type == '"':
+                    continue
+                if child.type == 'string_content':
+                    if content is not None:
+                        return None  # multiple chunks -> unusual, decline
+                    content = source[child.start_byte:child.end_byte].decode(
+                        'utf-8', errors='replace')
+                else:
+                    return None  # interpolation / embedded expression -> not static
+            return content if content is not None else ''
+        return None
 
     def _resolve_member_call(self, node, source: bytes, caller_file: str,
-                              caller_class: Optional[str]) -> Optional[str]:
-        """Resolve a member call like $obj->method()."""
-        method_name = None
-        receiver = None
+                              caller_class: Optional[str], root=None) -> Optional[str]:
+        """Resolve a member call `$obj->method()`, including `$this->$m()` with a
+        literal-bound dynamic method name."""
+        obj_node = node.child_by_field_name('object')
+        name_node = node.child_by_field_name('name')
 
-        for child in node.children:
-            if child.type == 'name':
-                method_name = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
-            elif child.type in ('->', 'arguments'):
-                continue
-            elif child.type == 'variable_name':
-                receiver = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
+        receiver = None
+        if obj_node is not None and obj_node.type == 'variable_name':
+            receiver = source[obj_node.start_byte:obj_node.end_byte].decode(
+                'utf-8', errors='replace')
+
+        method_name = None
+        if name_node is not None:
+            if name_node.type == 'name':
+                method_name = source[name_node.start_byte:name_node.end_byte].decode(
+                    'utf-8', errors='replace')
+            elif name_node.type == 'variable_name':
+                # Dynamic method name `$this->$m()`: resolve ONLY a single literal
+                # binding of $m in the enclosing body; a param/runtime/interpolated
+                # name yields None (no guessing -> no phantom).
+                var_name = source[name_node.start_byte:name_node.end_byte].decode(
+                    'utf-8', errors='replace')
+                method_name = self._resolve_variable_function(var_name, root, source)
 
         if not method_name:
             return None

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -416,6 +416,13 @@ class CallGraphBuilder:
         if not method_name or not scope:
             return None
 
+        # Closure::fromCallable('foo') / (['Class','method']) names a real callable
+        # statically. Resolve the string/array-literal target as a callback (the
+        # resulting Closure object's later invocation via $c() is untracked, but the
+        # referenced function is a genuine edge). Reuses the higher-order-builtin path.
+        if scope == 'Closure' and method_name == 'fromCallable':
+            return self._resolve_callback_arg(node, source, caller_file, caller_class, 0)
+
         if self._is_builtin(method_name):
             return None
 

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -98,6 +98,17 @@ CALLBACK_BUILTINS = {
     'usort': 1, 'uasort': 1, 'uksort': 1, 'preg_replace_callback': 1,
 }
 
+# Framework / registration functions that dispatch to a callback argument but are NOT
+# PHP builtins. A user could define a same-named function, so these are resolved as a
+# dispatcher only when NOT shadowed by a user function (see _resolve_function_call).
+# Maps name -> 0-based position of the callback argument.
+FRAMEWORK_CALLBACKS = {
+    'add_action': 1, 'add_filter': 1,                 # WordPress hooks
+    'register_shutdown_function': 0,
+    'set_error_handler': 0, 'set_exception_handler': 0,
+    'spl_autoload_register': 0,
+}
+
 # PHP keywords to skip in regex fallback
 PHP_KEYWORDS = {
     'if', 'else', 'elseif', 'while', 'for', 'foreach',
@@ -260,6 +271,14 @@ class CallGraphBuilder:
             if cb_idx is not None:
                 return self._resolve_callback_arg(node, source, caller_file, caller_class, cb_idx)
             return None
+
+        # Framework registration dispatchers (add_action, register_shutdown_function,
+        # ...) route to a callback argument. They are not PHP builtins, so treat them as
+        # a dispatcher only when NOT shadowed by a user-defined function of the same name
+        # (which would be the real call target).
+        fw_idx = FRAMEWORK_CALLBACKS.get(func_name.lower())
+        if fw_idx is not None and func_name not in self.functions_by_name:
+            return self._resolve_callback_arg(node, source, caller_file, caller_class, fw_idx)
 
         return self._resolve_simple_call(func_name, caller_file, caller_class, caller_namespace)
 

--- a/libs/openant-core/parsers/php/function_extractor.py
+++ b/libs/openant-core/parsers/php/function_extractor.py
@@ -155,6 +155,44 @@ class FunctionExtractor:
                     names.append(trait)
         return names
 
+    def _extract_trait_aliases(self, use_node, source: bytes) -> Dict[str, List[Optional[str]]]:
+        """Extract `use T { orig as alias; }` mappings: alias -> [trait_or_None, orig].
+
+        The trait is None for the unqualified `orig as alias` form (resolve against
+        the class's composed traits); the qualified `T::orig as alias` form pins the
+        trait. A visibility-only clause (`orig as protected`) defines no new callable
+        name and is skipped.
+        """
+        aliases: Dict[str, List[Optional[str]]] = {}
+        use_list = next((c for c in use_node.children if c.type == 'use_list'), None)
+        if use_list is None:
+            return aliases
+        for clause in use_list.children:
+            if clause.type != 'use_as_clause':
+                continue
+            kids = clause.children
+            as_idx = next((i for i, c in enumerate(kids) if c.type == 'as'), None)
+            if as_idx is None:
+                continue
+            alias_node = next((c for c in kids[as_idx + 1:] if c.type == 'name'), None)
+            if alias_node is None:  # visibility-only clause: no new callable name
+                continue
+            alias = self._node_text(alias_node, source)
+            trait_name = None
+            method_name = None
+            for c in kids[:as_idx]:
+                if c.type == 'name':
+                    method_name = self._node_text(c, source)
+                elif c.type == 'class_constant_access_expression':
+                    parts = [self._node_text(g, source) for g in c.children
+                             if g.type in ('name', 'qualified_name')]
+                    if len(parts) >= 2:
+                        trait_name = parts[0].rsplit('\\', 1)[-1]
+                        method_name = parts[1]
+            if alias and method_name:
+                aliases[alias] = [trait_name, method_name]
+        return aliases
+
     def _get_visibility(self, node, source: bytes) -> Optional[str]:
         """Extract visibility modifier from a method_declaration node."""
         for child in node.children:
@@ -324,6 +362,7 @@ class FunctionExtractor:
                     class_id = f"{relative_path}:{new_class_name}"
                     methods = []
                     traits = []
+                    trait_aliases = {}
                     # Find declaration_list (class body)
                     body_node = node.child_by_field_name('body')
                     if body_node is None:
@@ -348,6 +387,8 @@ class FunctionExtractor:
                                 # `name`/`qualified_name` child. Record the unqualified trait name so
                                 # the call-graph builder can resolve $this->/self:: into the trait.
                                 traits.extend(self._extract_trait_names(child, source))
+                                trait_aliases.update(
+                                    self._extract_trait_aliases(child, source))
 
                     self.classes[class_id] = {
                         'name': new_class_name,
@@ -356,6 +397,7 @@ class FunctionExtractor:
                         'end_line': node.end_point[0] + 1,
                         'methods': methods,
                         'traits': traits,
+                        'trait_aliases': trait_aliases,
                         'superclass': superclass,
                         'interfaces': interfaces,
                         'namespace_name': namespace_name,

--- a/libs/openant-core/tests/parsers/php/test_callgraph_closure_fromcallable.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_closure_fromcallable.py
@@ -1,0 +1,50 @@
+"""Closure::fromCallable('foo') records an edge to foo (reachability FN fix).
+
+`Closure::fromCallable('dangerous')` names a real callable statically, but the scoped-call
+resolver sent it to _resolve_class_call('Closure', 'fromCallable') (Closure is not a user
+class -> None) and never inspected the string-literal argument, so the edge to `dangerous`
+(a sink) was dropped.
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "app.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _edges(b, caller_suffix):
+    keys = [k for k in b.call_graph if k.endswith(caller_suffix)]
+    return [e for k in keys for e in b.call_graph[k]]
+
+
+def test_closure_fromcallable_string_target_resolved():
+    b = _build(
+        "<?php\n"
+        "function dangerous($cmd){ system($cmd); }\n"
+        "function viaClosure(){ $c = Closure::fromCallable('dangerous'); $c('x'); }\n"
+    )
+    assert any(e.endswith(":dangerous") for e in _edges(b, ":viaClosure")), (
+        f"Closure::fromCallable('dangerous') must record an edge to dangerous; "
+        f"got {_edges(b, ':viaClosure')}"
+    )
+
+
+def test_closure_fromcallable_unknown_target_no_phantom():
+    # Precision: a fromCallable naming a function that does not exist yields no edge.
+    b = _build(
+        "<?php\n"
+        "function viaClosure(){ $c = Closure::fromCallable('nope_missing'); $c('x'); }\n"
+    )
+    assert _edges(b, ":viaClosure") == [], (
+        f"unknown fromCallable target must not invent an edge; got {_edges(b, ':viaClosure')}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_dynamic_method_name.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_dynamic_method_name.py
@@ -1,0 +1,55 @@
+"""Literal-bound dynamic method `$this->$m()` resolves (reachability FN fix).
+
+`$m = "danger"; $this->$m()` invokes danger(), but the dynamic-name member call was
+dropped. Determinate-only: resolve when $m has a SINGLE literal binding in the method;
+a parameter / runtime / interpolated name stays unresolved (0 phantom).
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "app.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _edges(b, suffix):
+    keys = [k for k in b.call_graph if k.endswith(suffix)]
+    return [e for k in keys for e in b.call_graph[k]]
+
+
+_SRC = (
+    "<?php\n"
+    "class C {\n"
+    "  public function danger($x){ system($x); }\n"
+    "  public function safe(){ return 1; }\n"
+    "  public function runLiteral(){ $m = \"danger\"; return $this->$m(); }\n"
+    "  public function runTainted($x){ return $this->$x(); }\n"
+    "  public function runRuntime(){ $m = $_GET['x']; return $this->$m(); }\n"
+    "  public function runInterp($p){ $m = \"dang$p\"; return $this->$m(); }\n"
+    "}\n"
+)
+
+
+def test_literal_dynamic_method_resolves():
+    b = _build(_SRC)
+    assert any(e.endswith(":C.danger") for e in _edges(b, ":C.runLiteral")), (
+        f"$m=\"danger\"; $this->$m() must resolve to C.danger; got {_edges(b, ':C.runLiteral')}"
+    )
+
+
+def test_nondeterminate_dynamic_names_stay_unresolved():
+    b = _build(_SRC)
+    for caller in (":C.runTainted", ":C.runRuntime", ":C.runInterp"):
+        assert not any("C.danger" in e or "C.safe" in e for e in _edges(b, caller)), (
+            f"{caller}: a param/runtime/interpolated dynamic name must not resolve "
+            f"(0 phantom); got {_edges(b, caller)}"
+        )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_framework_callback.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_framework_callback.py
@@ -1,0 +1,67 @@
+"""Framework registration functions dispatch to their callback (reachability FN fix).
+
+add_action/add_filter/register_shutdown_function/set_error_handler/spl_autoload_register
+register a callback that PHP later invokes. The callback-argument resolver only fired for
+PHP builtins (call_user_func, array_map, ...); these framework dispatchers are not builtins,
+so their string/array callback target was dropped -> the registered handler (and its sink)
+was unreachable.
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "plugin.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _all_edges(b):
+    return [e for edges in b.call_graph.values() for e in edges]
+
+
+def test_framework_callbacks_resolved():
+    b = _build(
+        "<?php\n"
+        "add_action('init', 'cleanup');\n"
+        "add_filter('the_content', 'filter_it');\n"
+        "register_shutdown_function('shutdown_task');\n"
+        "function cleanup(){ system('x'); }\n"
+        "function filter_it($c){ system($c); return $c; }\n"
+        "function shutdown_task(){ exec('danger'); }\n"
+    )
+    edges = _all_edges(b)
+    for target in ("cleanup", "filter_it", "shutdown_task"):
+        assert any(e.endswith(":" + target) for e in edges), (
+            f"framework callback '{target}' not registered as an edge; edges={edges}"
+        )
+
+
+def test_framework_callback_unknown_target_no_phantom():
+    b = _build("<?php\nadd_action('init', 'does_not_exist');\n")
+    assert _all_edges(b) == [], f"unknown callback must invent no edge; edges={_all_edges(b)}"
+
+
+def test_user_defined_shadow_not_treated_as_dispatcher():
+    # Precision: if the app defines its OWN add_action, a call to it must bind the
+    # user function, not be mis-resolved as a WordPress hook dispatcher.
+    b = _build(
+        "<?php\n"
+        "function add_action($a, $b){ real_impl(); }\n"
+        "function real_impl(){ system('z'); }\n"
+        "add_action('x', 'y');\n"
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith(":add_action") for e in edges), (
+        f"call to user-defined add_action must bind the user function; edges={edges}"
+    )
+    assert not any(e.endswith(":y") for e in edges), (
+        f"must not treat user add_action's 2nd arg as a callback; edges={edges}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_namespace_fallback.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_namespace_fallback.py
@@ -1,0 +1,83 @@
+"""PHP unqualified-call global-namespace fallback (reachability FN fix).
+
+PHP resolves an unqualified function call within the caller's namespace first, then
+FALLS BACK to the global namespace. The call-graph builder's step-4 filter required
+exact namespace equality, dropping the global-ns candidate -> a namespaced caller could
+not reach a global-ns sink (e.g. system()) = a reachability false-negative.
+
+RED before the fix: the namespaced caller's edge to the global sink is dropped.
+Precision guard: a same-named function in an UNRELATED namespace must NOT be connected
+(0 phantom). No-regression: an exact same-namespace target still takes precedence.
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    paths = []
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+        paths.append(p)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all(paths))
+    b.build_call_graph()
+    return b
+
+
+def _edges(b, caller_suffix):
+    keys = [k for k in b.call_graph if k.endswith(caller_suffix)]
+    return [e for k in keys for e in b.call_graph[k]]
+
+
+def test_unqualified_call_resolves_global_ns_fallback():
+    b = _build({
+        "src/a.php": "<?php\nnamespace App\\Controllers;\n"
+                     "class H { public function run(){ danger($_GET['c']); } }\n",
+        "src/b.php": "<?php\nfunction danger($x){ system($x); }\n",
+    })
+    edges = _edges(b, ":H.run")
+    assert any(e.endswith("b.php:danger") for e in edges), (
+        f"unqualified danger() from App\\Controllers must fall back to global \\danger "
+        f"(the system() sink); got edges: {edges}"
+    )
+
+
+def test_global_ns_fallback_does_not_connect_unrelated_namespace():
+    # Precision guard: a same-named function in an UNRELATED namespace is NOT a fallback
+    # target and must not be connected (0 phantom).
+    b = _build({
+        "src/a.php": "<?php\nnamespace App\\Controllers;\n"
+                     "class H { public function run(){ danger($_GET['c']); } }\n",
+        "src/b.php": "<?php\nfunction danger($x){ system($x); }\n",           # global sink (true)
+        "src/c.php": "<?php\nnamespace App\\Vendor;\nfunction danger($x){ echo $x; }\n",  # phantom risk
+    })
+    edges = _edges(b, ":H.run")
+    assert any(e.endswith("b.php:danger") for e in edges), f"true global edge missing; got {edges}"
+    assert not any("c.php" in e or "Vendor" in e for e in edges), (
+        f"PHANTOM: connected the unrelated App\\Vendor\\danger; got {edges}"
+    )
+
+
+def test_same_namespace_target_takes_precedence():
+    # No-regression: when a same-namespace function AND a global one both exist, the
+    # unqualified call must bind the SAME-namespace one (PHP precedence), not drop or
+    # bind global.
+    b = _build({
+        "src/a.php": "<?php\nnamespace App\\Controllers;\n"
+                     "class H { public function run(){ helper($_GET['c']); } }\n"
+                     "function helper($x){ system($x); }\n",   # same-ns (App\\Controllers)
+        "src/b.php": "<?php\nfunction helper($x){ echo $x; }\n",  # global namesake
+    })
+    edges = _edges(b, ":H.run")
+    assert any(e.endswith("a.php:App\\Controllers\\helper") or "a.php" in e for e in edges), (
+        f"same-namespace helper() must take precedence over the global namesake; got {edges}"
+    )
+    assert not any("b.php" in e for e in edges), (
+        f"must NOT bind the global namesake when a same-ns target exists; got {edges}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_trait_alias.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_trait_alias.py
@@ -1,0 +1,56 @@
+"""Trait method aliasing `use T { foo as bar; }` resolves (reachability FN fix).
+
+_extract_trait_names captured only bare trait names, dropping the `foo as bar` alias, so
+`$this->bar()` did not resolve to the trait's `T::foo` and the edge (potentially to a sink)
+was lost. Precision: the alias resolves ONLY to the aliased trait method, never to an
+unrelated same-named method in another class.
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "app.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _edges(b, caller_suffix):
+    keys = [k for k in b.call_graph if k.endswith(caller_suffix)]
+    return [e for k in keys for e in b.call_graph[k]]
+
+
+def test_trait_alias_resolves_to_trait_method():
+    b = _build(
+        "<?php\n"
+        "trait Greet { public function hello(){ system('x'); } }\n"
+        "class A { use Greet { hello as greeting; }\n"
+        "  public function run(){ return $this->greeting(); } }\n"
+    )
+    assert any(e.endswith(":Greet.hello") for e in _edges(b, ":A.run")), (
+        f"$this->greeting() (alias of Greet::hello) must resolve to Greet.hello; "
+        f"got {_edges(b, ':A.run')}"
+    )
+
+
+def test_trait_alias_does_not_leak_to_unrelated_same_named_method():
+    # Precision: an unrelated class D with a real method `greeting` must NOT be connected.
+    b = _build(
+        "<?php\n"
+        "trait Greet { public function hello(){ system('x'); } }\n"
+        "class A { use Greet { hello as greeting; }\n"
+        "  public function run(){ return $this->greeting(); } }\n"
+        "class D { public function greeting(){ return 99; } }\n"
+    )
+    edges = _edges(b, ":A.run")
+    assert any(e.endswith(":Greet.hello") for e in edges), f"true trait edge missing; got {edges}"
+    assert not any("D.greeting" in e for e in edges), (
+        f"PHANTOM: alias leaked to unrelated D.greeting; got {edges}"
+    )


### PR DESCRIPTION
## What
5 call-graph reachability false-negative fix(es) in the PHP parser. Each recovers a dropped unit or call edge so a sink behind that construct is no longer unreachable.

## Why
A dropped node/edge in the reachability call graph silently removes code from the reachable set — a false-negative for a SAST engine. Each construct below yielded no unit or no edge, so a reachable sink behind it was pruned.

## How
- fix(parsers/php): resolve unqualified calls via global-namespace fallback (55e027d)
- fix(parsers/php): resolve Closure::fromCallable() string/array targets (dfbdcb3)
- fix(parsers/php): resolve framework registration callbacks (5824679)
- fix(parsers/php): resolve trait method aliases (use T { orig as alias }) (8c5a955)
- fix(parsers/php): resolve literal-bound dynamic method calls $this->$m() (ee99c38)

## Tests
5 regression test(s) added under `tests/parsers/php/`, one per fix. Each was written RED (fails on master for the stated drop), turned GREEN by the fix, and carries a false-edge precision guard asserting the fix adds **no phantom edge** to the resolved call graph. Full PHP parser suite green after the change; each commit body records the passing suite.

## Compatibility
Additive: recovers previously-dropped edges/units only. Verified 0 phantom edges — no false edge added to the reachability call graph.

## Note — per-parser test infrastructure
This parser does not yet ship `tests/parsers/php/test_callgraph_symmetry.py` (only Python has one today). These fixes carry their own targeted regression tests; the systemic per-parser symmetry/construct-coverage suite is planned as separate follow-up (to be tracked as its own issue).
