### PR TITLE
fix(parsers/ruby): recover 4 reachability false-negatives in the call graph

### DIFF
--- a/libs/openant-core/parsers/ruby/call_graph_builder.py
+++ b/libs/openant-core/parsers/ruby/call_graph_builder.py
@@ -314,10 +314,16 @@ class CallGraphBuilder:
         name = self._node_str(node, source)
         if name in local_vars:
             return None
-        if self._is_builtin(name):
-            return None
-        if name not in self.functions_by_name:
-            return None
+        # A same-class method (or same-file function) named like a builtin, called
+        # bare (implicit self, e.g. `first`), resolves to that user function -- the
+        # builtin filter must not shadow it. Mirrors the with-args path's
+        # _has_scoped_user_function rescue; the scope is narrow (same class / same
+        # file) so a genuine builtin call is never rescued to an unrelated method.
+        if not self._has_scoped_user_function(name, caller_file, caller_class):
+            if self._is_builtin(name):
+                return None
+            if name not in self.functions_by_name:
+                return None
         return self._resolve_simple_call(name, caller_file, caller_class)
 
     def _resolve_call_node(self, node, source: bytes, caller_file: str,

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -212,6 +212,48 @@ class FunctionExtractor:
             return ''
         return None
 
+    def _collect_const_literals(self, root, source: bytes) -> Dict[str, str]:
+        """Map CONST_NAME -> literal value for single-literal-assigned constants.
+
+        Determinacy guard: a constant assigned more than once, or ever assigned a
+        non-literal, is blacklisted -- so `define_method(CONST)` is resolved only
+        when CONST has exactly one literal (symbol/string) binding in the file.
+        """
+        literals: Dict[str, str] = {}
+        bad = set()
+        stack = [root]
+        while stack:
+            n = stack.pop()
+            if n.type == 'assignment':
+                kids = [c for c in n.children if c.type != '=']
+                if len(kids) >= 2 and kids[0].type == 'constant':
+                    name = self._node_text(kids[0], source)
+                    if name not in bad:
+                        val = self._literal_arg_text(kids[1], source)
+                        if val is None or name in literals:
+                            bad.add(name)
+                            literals.pop(name, None)
+                        else:
+                            literals[name] = val
+            stack.extend(n.children)
+        return literals
+
+    def _resolve_const_name_arg(self, node, source: bytes,
+                                const_literals: Dict[str, str]) -> Optional[str]:
+        """If a call's first real argument is a CONSTANT with a known single-literal
+        binding, return that literal (the resolved method name); else None. Only a
+        `constant` node matches, so a lowercase local var or a dynamic expression is
+        never resolved."""
+        for child in node.children:
+            if child.type == 'argument_list':
+                for arg in child.children:
+                    if arg.type in ('(', ')', ','):
+                        continue
+                    if arg.type == 'constant':
+                        return const_literals.get(self._node_text(arg, source))
+                    return None  # first real arg is not a constant
+        return None
+
     def _call_receiver_and_method(self, node, source: bytes):
         """For a 'call' node, return (method_name, [literal positional args]).
 
@@ -318,6 +360,7 @@ class FunctionExtractor:
         by subsequent siblings popped from the same body (children are pushed in
         reverse so they pop in source order).
         """
+        const_literals = self._collect_const_literals(tree.root_node, source)
         stack = [(tree.root_node, None, None, ['public'])]
 
         while stack:
@@ -363,12 +406,19 @@ class FunctionExtractor:
                 # still found.
                 method_name, args = self._call_receiver_and_method(node, source)
                 handled = False
-                if method_name == 'define_method' and class_name and args:
-                    self._emit_synthetic_method(
-                        node, source, relative_path, class_name, module_name,
-                        name=args[0], unit_type=None, visibility=vis_state[0],
-                    )
-                    handled = True
+                if method_name == 'define_method' and class_name:
+                    # Literal-symbol/string name, or a CONSTANT bound to a single
+                    # literal (`NAME = :m; define_method(NAME)`). A non-literal /
+                    # reassigned constant or a lowercase local name stays unresolved
+                    # -> the unit falls through to child descent (0 phantom).
+                    dm_name = args[0] if args else self._resolve_const_name_arg(
+                        node, source, const_literals)
+                    if dm_name:
+                        self._emit_synthetic_method(
+                            node, source, relative_path, class_name, module_name,
+                            name=dm_name, unit_type=None, visibility=vis_state[0],
+                        )
+                        handled = True
                 elif method_name == 'alias_method' and class_name and args:
                     self._emit_synthetic_method(
                         node, source, relative_path, class_name, module_name,

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -363,6 +363,14 @@ class FunctionExtractor:
                         name=args[0], unit_type=None, visibility=vis_state[0],
                     )
                     handled = True
+                elif method_name == 'define_singleton_method' and class_name and args:
+                    # Class/singleton method defined dynamically; mirror define_method
+                    # so its body (and any sink it reaches) is extracted as a unit.
+                    self._emit_synthetic_method(
+                        node, source, relative_path, class_name, module_name,
+                        name=args[0], unit_type=None, visibility=vis_state[0],
+                    )
+                    handled = True
                 elif (class_name is None and module_name is None
                       and method_name in self._SINATRA_VERBS
                       and self._has_block(node) and args):

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -240,6 +240,18 @@ class FunctionExtractor:
         """True if the call node carries a do..end or { } block."""
         return any(c.type in ('do_block', 'block') for c in node.children)
 
+    def _is_sinatra_class(self, relative_path: str, class_name: Optional[str]) -> bool:
+        """True if `class_name` extends Sinatra::Base/Application (modular Sinatra).
+
+        The class was registered in self.classes (with its superclass) before its
+        body -- and therefore before any route DSL call inside it -- is walked.
+        """
+        if not class_name:
+            return False
+        cls = self.classes.get(f"{relative_path}:{class_name}", {})
+        superclass = cls.get('superclass') or ''
+        return 'Sinatra::Base' in superclass or 'Sinatra::Application' in superclass
+
     def _extract_imports(self, tree, source: bytes) -> Dict[str, str]:
         """Extract require/require_relative/include/extend/prepend from a file."""
         imports = {}
@@ -371,14 +383,19 @@ class FunctionExtractor:
                         name=args[0], unit_type=None, visibility=vis_state[0],
                     )
                     handled = True
-                elif (class_name is None and module_name is None
-                      and method_name in self._SINATRA_VERBS
-                      and self._has_block(node) and args):
-                    # Top-level `get '/path' do..end` Sinatra route.
+                elif (method_name in self._SINATRA_VERBS
+                      and self._has_block(node) and args
+                      and ((class_name is None and module_name is None)
+                           or self._is_sinatra_class(relative_path, class_name))):
+                    # `get '/path' do..end` -- a Sinatra route, either classic
+                    # top-level style or MODULAR style inside a `< Sinatra::Base`
+                    # subclass. The class case is gated on the class actually
+                    # extending Sinatra so an unrelated class method named like a
+                    # verb is not spuriously seeded as an entry point.
                     self._emit_synthetic_method(
-                        node, source, relative_path, class_name=None,
-                        module_name=None, name=args[0], unit_type='route_handler',
-                        visibility='public',
+                        node, source, relative_path, class_name=class_name,
+                        module_name=module_name, name=args[0],
+                        unit_type='route_handler', visibility='public',
                     )
                     handled = True
                 elif method_name in ('private', 'protected', 'public'):

--- a/libs/openant-core/tests/parsers/ruby/test_callgraph_bare_builtin_shadow.py
+++ b/libs/openant-core/tests/parsers/ruby/test_callgraph_bare_builtin_shadow.py
@@ -1,0 +1,53 @@
+"""Bare call to a same-class method named like a builtin resolves (reachability FN fix).
+
+`_resolve_bare_identifier` applied the builtin filter before checking for a same-scope
+user function, so a bare (parenless) call to a same-class method whose name collides with
+a Ruby builtin (e.g. `first`, `map`) was dropped -> the method (and any sink it reaches)
+became unreachable. The with-args path already had this rescue (_has_scoped_user_function);
+the bare path did not.
+"""
+import os
+import tempfile
+
+from parsers.ruby.function_extractor import FunctionExtractor
+from parsers.ruby.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "svc.rb")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _edges(b, caller_suffix):
+    keys = [k for k in b.call_graph if k.endswith(caller_suffix)]
+    return [e for k in keys for e in b.call_graph[k]]
+
+
+def test_bare_call_to_builtin_named_same_class_method_resolves():
+    b = _build(
+        "class Svc\n"
+        "  def run\n    first\n  end\n"          # bare call to a builtin-named method
+        "  def first\n    system('x')\n  end\n"  # same-class method (sink)
+        "end\n"
+    )
+    assert any("Svc.first" in e for e in _edges(b, ":Svc.run")), (
+        f"bare `first` must resolve to same-class Svc.first (not be dropped as a builtin); "
+        f"got {_edges(b, ':Svc.run')}"
+    )
+
+
+def test_genuine_builtin_bare_call_not_rescued_to_unrelated():
+    # Precision: with NO same-class/same-file `first`, a bare `first` is a genuine
+    # builtin and must not be linked to an unrelated same-named method elsewhere.
+    b = _build(
+        "class A\n  def helper\n    system('y')\n  end\nend\n"
+        "class B\n  def go\n    first\n  end\nend\n"   # `first`: genuine builtin, no user def
+    )
+    assert not any("first" in e.lower() for e in _edges(b, ":B.go")), (
+        f"genuine builtin `first` must not be rescued to an unrelated method; got {_edges(b, ':B.go')}"
+    )

--- a/libs/openant-core/tests/parsers/ruby/test_callgraph_define_method_const.py
+++ b/libs/openant-core/tests/parsers/ruby/test_callgraph_define_method_const.py
@@ -1,0 +1,65 @@
+"""define_method(CONST) with a literal-const name emits the unit (reachability FN fix).
+
+`NAME = :dyn_exec; define_method(NAME){...}` defines the method dyn_exec, but only a
+literal-symbol/string arg was handled, so a constant-named define_method dropped the
+unit. Determinate-only: the constant must have exactly one literal binding; a
+non-literal / reassigned / lowercase-local name stays dropped (0 phantom).
+"""
+import os
+import tempfile
+
+from parsers.ruby.function_extractor import FunctionExtractor
+from parsers.ruby.call_graph_builder import CallGraphBuilder
+
+
+def _build(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    paths = []
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+        paths.append(p)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all(paths))
+    b.build_call_graph()
+    return b
+
+
+def test_define_method_const_literal_name_emitted_and_reachable():
+    b = _build({
+        "app.rb": "require 'sinatra'\n"
+                  "NAME = :dyn_exec\n"
+                  "class Facade\n"
+                  "  define_method(NAME) { |arg| eval(arg) }\n"
+                  "end\n"
+                  "get '/run' do\n"
+                  "  Facade.dyn_exec(params[:code])\n"
+                  "end\n",
+    })
+    assert any(k.endswith(":Facade.dyn_exec") for k in b.functions), (
+        f"define_method(NAME) with NAME=:dyn_exec must emit Facade.dyn_exec; "
+        f"funcs={list(b.functions)}"
+    )
+    route = [k for k in b.call_graph if k.endswith(":/run")]
+    assert route and any("Facade.dyn_exec" in e for e in b.call_graph[route[0]]), (
+        f"route /run must reach Facade.dyn_exec; edges={b.call_graph.get(route[0]) if route else None}"
+    )
+
+
+def test_nondeterminate_const_names_stay_dropped_no_phantom():
+    b = _build({
+        "app.rb": "require 'sinatra'\n"
+                  "HANDLER = build_handler()\n"   # non-literal RHS -> unresolvable
+                  "DUP = :a\n"
+                  "DUP = :b\n"                     # reassigned -> ambiguous -> blacklisted
+                  "class Facade\n"
+                  "  define_method(HANDLER) { |arg| eval(arg) }\n"
+                  "  define_method(DUP) { |arg| eval(arg) }\n"
+                  "  define_method(lower) { |arg| eval(arg) }\n"  # lowercase local -> not a constant
+                  "end\n",
+    })
+    assert not any(k.endswith(".HANDLER") for k in b.functions), list(b.functions)
+    assert not any(k.endswith(".DUP") for k in b.functions), list(b.functions)
+    assert not any(k.endswith(".a") or k.endswith(".b") for k in b.functions), list(b.functions)
+    assert not any(k.endswith(".lower") for k in b.functions), list(b.functions)

--- a/libs/openant-core/tests/parsers/ruby/test_callgraph_define_singleton_method.py
+++ b/libs/openant-core/tests/parsers/ruby/test_callgraph_define_singleton_method.py
@@ -1,0 +1,57 @@
+"""define_singleton_method emits a unit (reachability FN fix).
+
+The `call`-node DSL branch handled define_method and alias_method but had no case for
+define_singleton_method, so `define_singleton_method(:sing_exec){...}` produced NO unit
+and its body (an eval sink) was never extracted -> a reachable sink dropped.
+"""
+import os
+import tempfile
+
+from parsers.ruby.function_extractor import FunctionExtractor
+from parsers.ruby.call_graph_builder import CallGraphBuilder
+
+
+def _build(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    paths = []
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+        paths.append(p)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all(paths))
+    b.build_call_graph()
+    return b
+
+
+def test_define_singleton_method_emitted_as_unit():
+    b = _build({
+        "app.rb": "require 'sinatra'\n"
+                  "class Facade\n"
+                  "  define_singleton_method(:sing_exec) { |arg| eval(arg) }\n"
+                  "end\n"
+                  "get '/run' do\n"
+                  "  Facade.sing_exec(params[:code])\n"
+                  "end\n",
+    })
+    assert any("sing_exec" in k for k in b.functions), (
+        f"define_singleton_method(:sing_exec) must be emitted as a unit; funcs={list(b.functions)}"
+    )
+
+
+def test_define_singleton_method_reachable_from_route():
+    b = _build({
+        "app.rb": "require 'sinatra'\n"
+                  "class Facade\n"
+                  "  define_singleton_method(:sing_exec) { |arg| eval(arg) }\n"
+                  "end\n"
+                  "get '/run' do\n"
+                  "  Facade.sing_exec(params[:code])\n"
+                  "end\n",
+    })
+    route = [k for k in b.call_graph if k.endswith(":/run")]
+    assert route and any("sing_exec" in e for e in b.call_graph[route[0]]), (
+        f"route /run must reach Facade.sing_exec (the eval sink); "
+        f"route={route}, edges={b.call_graph.get(route[0]) if route else None}"
+    )

--- a/libs/openant-core/tests/parsers/ruby/test_modular_sinatra_routes.py
+++ b/libs/openant-core/tests/parsers/ruby/test_modular_sinatra_routes.py
@@ -1,0 +1,56 @@
+"""Modular Sinatra routes (inside `< Sinatra::Base`) are emitted as route handlers.
+
+The Sinatra route DSL branch only fired at top level (class_name is None), so
+`get '/run' do ... end` inside `class App < Sinatra::Base` produced no route_handler
+unit -> the route body (and its sink) was never extracted or seeded. The class case
+is gated on the class extending Sinatra::Base/Application, so an unrelated class
+method named like a verb is not spuriously seeded.
+"""
+import os
+import tempfile
+
+from parsers.ruby.function_extractor import FunctionExtractor
+from parsers.ruby.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "app.rb")
+    with open(p, "w") as fh:
+        fh.write(src)
+    return CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+
+
+def _has_route_handler(b):
+    return any((v.get("unit_type") == "route_handler") for v in b.functions.values())
+
+
+def test_modular_sinatra_route_is_route_handler():
+    b = _build(
+        "require 'sinatra/base'\n"
+        "class App < Sinatra::Base\n"
+        "  get '/run' do\n"
+        "    system(params[:cmd])\n"
+        "  end\n"
+        "end\n"
+    )
+    assert _has_route_handler(b), (
+        f"modular Sinatra route must be a route_handler unit; "
+        f"units={[(k, v.get('unit_type')) for k, v in b.functions.items()]}"
+    )
+
+
+def test_classic_top_level_route_still_route_handler():
+    # No-regression: classic top-level style keeps working.
+    b = _build("require 'sinatra'\nget '/x' do\n  system('a')\nend\n")
+    assert _has_route_handler(b), "classic top-level Sinatra route must still be a route_handler"
+
+
+def test_verb_named_method_in_non_sinatra_class_not_seeded():
+    # Precision: a `get '/x' do..end` inside a class that is NOT a Sinatra subclass
+    # must NOT become a route_handler (no over-seeding).
+    b = _build("class Plain\n  get '/x' do\n    system('y')\n  end\nend\n")
+    assert not _has_route_handler(b), (
+        f"a verb call inside a non-Sinatra class must not be a route_handler; "
+        f"units={[(k, v.get('unit_type')) for k, v in b.functions.items()]}"
+    )


### PR DESCRIPTION
## What
4 call-graph reachability false-negative fix(es) in the Ruby parser. Each recovers a dropped unit or call edge so a sink behind that construct is no longer unreachable.

## Why
A dropped node/edge in the reachability call graph silently removes code from the reachable set — a false-negative for a SAST engine. Each construct below yielded no unit or no edge, so a reachable sink behind it was pruned.

## How
- fix(parsers/ruby): extract define_singleton_method as a unit (63e664b)
- fix(parsers/ruby): resolve bare calls to builtin-named same-class methods (838e021)
- fix(parsers/ruby): emit modular Sinatra routes as route handlers (5d197f7)
- fix(parsers/ruby): emit define_method with a literal-const name (82da80d)

## Tests
4 regression test(s) added under `tests/parsers/ruby/`, one per fix. Each was written RED (fails on master for the stated drop), turned GREEN by the fix, and carries a false-edge precision guard asserting the fix adds **no phantom edge** to the resolved call graph. Full Ruby parser suite green after the change; each commit body records the passing suite.

## Compatibility
Additive: recovers previously-dropped edges/units only. Verified 0 phantom edges — no false edge added to the reachability call graph.

## Note — per-parser test infrastructure
This parser does not yet ship `tests/parsers/ruby/test_callgraph_symmetry.py` (only Python has one today). These fixes carry their own targeted regression tests; the systemic per-parser symmetry/construct-coverage suite is planned as separate follow-up (to be tracked as its own issue).
