### PR TITLE
fix(parsers/zig): resolve struct field-init function pointers

### DIFF
--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -315,9 +315,67 @@ class CallGraphBuilder:
                 # Only record when the target is a known function name.
                 if alias_name and target_name in name_to_ids:
                     aliases[alias_name] = target_name
+            # Struct field-init fn pointers: `const h = T{ .cb = knownFn };` binds
+            # `h.cb` -> knownFn so a later `h.cb()` resolves. The first identifier
+            # child is the bound variable; the struct type name is nested inside the
+            # struct_initializer and is ignored.
+            if ident_children:
+                var_name = self._get_node_text(ident_children[0], source)
+                struct_init = next(
+                    (c for c in node.children
+                     if c.type in ("struct_initializer", "StructInit")),
+                    None,
+                )
+                if var_name and struct_init is not None:
+                    self._collect_field_fn_bindings(
+                        struct_init, source, name_to_ids, aliases, var_name
+                    )
 
         for child in node.children:
             self._collect_aliases_from_node(child, source, name_to_ids, aliases)
+
+    def _collect_field_fn_bindings(
+        self, struct_init, source, name_to_ids, aliases, var_name
+    ):
+        """Record `.field = knownFn` struct-init bindings as `<var>.<field>` aliases.
+
+        For `const h = T{ .cb = fn };` bind `h.cb` -> `fn` so a later `h.cb()`
+        resolves via the dotted-alias dereference. Only DETERMINATE bindings are
+        kept: the field value must be a bare identifier naming a KNOWN function. A
+        runtime/param funcptr (RHS not a known function) or an indeterminate
+        expression (e.g. a call `make()`) is skipped, so an unknown callback never
+        over-connects.
+        """
+        init_list = next(
+            (c for c in struct_init.children
+             if c.type in ("initializer_list", "InitList")),
+            None,
+        )
+        if init_list is None:
+            return
+        for child in init_list.children:
+            if child.type not in ("assignment_expression", "AssignExpr"):
+                continue
+            field_name = None
+            target_name = None
+            seen_eq = False
+            for sub in child.children:
+                if sub.type == "=":
+                    seen_eq = True
+                    continue
+                if not seen_eq and sub.type in ("field_expression", "field_access"):
+                    # Leading-dot `.field` has exactly one identifier (the field);
+                    # a qualified `a.b` has two and is not a field-init target.
+                    idents = [
+                        g for g in sub.children
+                        if g.type in ("identifier", "IDENTIFIER")
+                    ]
+                    if len(idents) == 1:
+                        field_name = self._get_node_text(idents[0], source)
+                elif seen_eq and sub.type in ("identifier", "IDENTIFIER"):
+                    target_name = self._get_node_text(sub, source)
+            if field_name and target_name and target_name in name_to_ids:
+                aliases[f"{var_name}.{field_name}"] = target_name
 
     def _find_calls_in_code(self, code: str, caller_file: str = "") -> Set[str]:
         """Find all function calls in a code snippet."""

--- a/libs/openant-core/tests/parsers/zig/test_callgraph_funcptr_field.py
+++ b/libs/openant-core/tests/parsers/zig/test_callgraph_funcptr_field.py
@@ -1,0 +1,61 @@
+"""Struct field-init function pointers resolve (reachability FN fix).
+
+`const h = T{ .cb = knownFn }; h.cb()` invokes knownFn, but only `const alias = fn`
+bindings were indexed, not struct field-init bindings, so the h.cb() -> knownFn edge
+was dropped. Precision: only a determinate `.field = <known function>` is bound; a
+param/runtime funcptr never over-connects.
+"""
+import json
+import os
+import tempfile
+
+from core.parser_adapter import parse_repository
+
+
+def _cg(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+    out = tempfile.mkdtemp()
+    parse_repository(repo, out, language="zig", processing_level="all",
+                     skip_tests=True, name="r")
+    return json.load(open(os.path.join(out, "call_graph.json")))
+
+
+def _edges(cg, caller_suffix):
+    keys = [k for k in cg["call_graph"] if k.endswith(caller_suffix)]
+    return [e for k in keys for e in cg["call_graph"][k]]
+
+
+def test_struct_field_funcptr_call_resolves():
+    cg = _cg({
+        "main.zig": "const std = @import(\"std\");\n"
+                    "const Handler = struct { callback: *const fn () void };\n"
+                    "fn dangerousSink() void { std.process.exit(1); }\n"
+                    "fn normalCallee() void {}\n"
+                    "pub fn main() void {\n"
+                    "    normalCallee();\n"
+                    "    const h = Handler{ .callback = dangerousSink };\n"
+                    "    h.callback();\n"
+                    "}\n",
+    })
+    assert any("dangerousSink" in e for e in _edges(cg, ":main")), (
+        f"h.callback() bound to dangerousSink must resolve; got {_edges(cg, ':main')}"
+    )
+
+
+def test_param_funcptr_does_not_over_connect():
+    # Precision: a funcptr received as a parameter (not a determinate .field=fn
+    # binding) must not connect to any function.
+    cg = _cg({
+        "main.zig": "fn sink() void {}\n"
+                    "fn run(cb: *const fn () void) void { cb(); }\n"
+                    "pub fn main() void { run(sink); }\n",
+    })
+    # run's cb() must NOT phantom-connect to sink (cb is a param, undecidable here)
+    assert not any("sink" in e for e in _edges(cg, ":run")), (
+        f"param funcptr cb() must not over-connect to sink; got {_edges(cg, ':run')}"
+    )


### PR DESCRIPTION
## What
1 call-graph reachability false-negative fix(es) in the Zig parser. Each recovers a dropped unit or call edge so a sink behind that construct is no longer unreachable.

## Why
A dropped node/edge in the reachability call graph silently removes code from the reachable set — a false-negative for a SAST engine. Each construct below yielded no unit or no edge, so a reachable sink behind it was pruned.

## How
- fix(parsers/zig): resolve struct field-init function pointers (d9b4388)

## Tests
1 regression test(s) added under `tests/parsers/zig/`, one per fix. Each was written RED (fails on master for the stated drop), turned GREEN by the fix, and carries a false-edge precision guard asserting the fix adds **no phantom edge** to the resolved call graph. Full Zig parser suite green after the change; each commit body records the passing suite.

## Compatibility
Additive: recovers previously-dropped edges/units only. Verified 0 phantom edges — no false edge added to the reachability call graph.

## Note — per-parser test infrastructure
This parser does not yet ship `tests/parsers/zig/test_callgraph_symmetry.py` (only Python has one today). These fixes carry their own targeted regression tests; the systemic per-parser symmetry/construct-coverage suite is planned as separate follow-up (to be tracked as its own issue).
