### PR TITLE
fix(parsers/php): keep all units when no entry point seeds reachability (N4)

### DIFF
--- a/libs/openant-core/parsers/php/test_pipeline.py
+++ b/libs/openant-core/parsers/php/test_pipeline.py
@@ -301,6 +301,16 @@ class PHPPipelineTest:
             units = dataset.get("units", [])
             original_count = len(units)
 
+            # N4 fix: empty-seed safety-net (mirrors core/parser_adapter.py). No
+            # entry points => the reachable set is empty => every unit is pruned,
+            # silently blacking out the dataset (the dominant failure mode for
+            # library / no-entry-point targets). Degrade to keep-all + warn instead
+            # of a silent 0-unit result.
+            if not self.entry_points and original_count > 0:
+                print("  [Warning] No entry points detected — keeping all units "
+                      "unfiltered to avoid a silent blackout.", file=sys.stderr)
+                self.reachable_units = {u.get("id", "") for u in units}
+
             filtered_units = []
             for u in units:
                 unit_id = u.get("id", "")

--- a/libs/openant-core/tests/parsers/php/test_empty_seed_keep_all.py
+++ b/libs/openant-core/tests/parsers/php/test_empty_seed_keep_all.py
@@ -1,0 +1,93 @@
+"""Bug (N4): the PHP reachability filter silently blacks out a no-entry-point
+dataset.
+
+`apply_reachability_filter` seeds the BFS from EntryPointDetector's result. A
+library / no-entry-point target (no `main`, no route/CLI/decorator marker) yields
+ZERO entry points, so `ReachabilityAnalyzer.get_all_reachable()` returns the
+empty set, every unit is pruned, and the scan reports a clean 0-unit success —
+a silent blackout (the dominant failure mode for library targets) at the default
+`--processing-level reachable`.
+
+The fix mirrors core/parser_adapter.py: when there are no entry points but there
+ARE units, degrade to keep-all + a stderr warning instead of an empty dataset.
+
+(PHP) This drives the REAL `apply_reachability_filter` (real EntryPointDetector + real
+ReachabilityAnalyzer) over a two-function library fixture with no entry marker.
+RED→GREEN verified against master's unfixed parser file.
+
+test_pipeline.py shares its basename across all six parsers, so it is loaded
+under a unique module name via importlib (mirrors test_zig_reachability_api.py).
+"""
+import importlib.util
+import json
+import pathlib
+import sys
+import tempfile
+
+_CORE = pathlib.Path(__file__).resolve().parents[3]
+_TP = _CORE / "parsers" / "php" / "test_pipeline.py"
+
+
+def _load_pipeline():
+    for p in (str(_TP.parent), str(_CORE)):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+    spec = importlib.util.spec_from_file_location("isolated_php_test_pipeline", _TP)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Two ordinary library functions: no `main`, no route/CLI/decorator marker, no
+# user-input pattern in the code → EntryPointDetector must return zero seeds.
+_FUNCTIONS = {
+    "lib.php:add": {"name": "add", "unit_type": "function", "file_path": "lib.php", "code": "return a + b"},
+    "lib.php:scale": {"name": "scale", "unit_type": "function", "file_path": "lib.php",
+                    "code": "return add(a, a)"},
+}
+_UNITS = [
+    {"id": "lib.php:add",
+     "metadata": {"direct_calls": [], "direct_callers": ["lib.php:scale"]}},
+    {"id": "lib.php:scale",
+     "metadata": {"direct_calls": ["lib.php:add"], "direct_callers": []}},
+]
+
+
+def _make_pipeline():
+    mod = _load_pipeline()
+    tmp = pathlib.Path(tempfile.mkdtemp()).resolve()
+    (tmp / "analyzer.json").write_text(json.dumps({"functions": _FUNCTIONS}))
+    (tmp / "dataset.json").write_text(json.dumps({"units": [dict(u) for u in _UNITS]}))
+    p = mod.PHPPipelineTest(repo_path=str(tmp))
+    p.analyzer_output_file = str(tmp / "analyzer.json")
+    p.dataset_file = str(tmp / "dataset.json")
+    return p
+
+
+def test_no_entry_points_is_the_precondition():
+    # Guard the guard: if this fixture ever grows an accidental entry point the
+    # keep-all path would not be what's under test, so assert the precondition.
+    p = _make_pipeline()
+    assert p.apply_reachability_filter() is True
+    assert p.entry_points == set(), (
+        f"fixture unexpectedly produced entry points: {p.entry_points}"
+    )
+
+
+def test_empty_seed_keeps_all_units():
+    p = _make_pipeline()
+    p.apply_reachability_filter()
+    assert p.reachable_units == {"lib.php:add", "lib.php:scale"}, (
+        "empty-seed safety-net must keep all units; got "
+        f"{p.reachable_units} (blackout = the N4 bug)"
+    )
+
+
+def test_written_dataset_retains_every_unit_at_zero_reduction():
+    p = _make_pipeline()
+    p.apply_reachability_filter()
+    dataset = json.loads(pathlib.Path(p.dataset_file).read_text())
+    ids = {u["id"] for u in dataset["units"]}
+    assert ids == {"lib.php:add", "lib.php:scale"}, "units were dropped (blackout)"
+    assert all(u.get("reachable") for u in dataset["units"])
+    assert dataset["metadata"]["reachability_filter"]["reduction_percentage"] == 0.0


### PR DESCRIPTION
What: apply_reachability_filter degrades to keep-all + a stderr warning when
EntryPointDetector finds zero entry points but the dataset has units, instead
of pruning every unit.

Why: a library / no-entry-point target (no main, no route/CLI/decorator marker)
seeds zero entry points, so the reachable set is empty and every unit is pruned
-- a silent 0-unit "success" (blackout) at the default --level reachable, the
dominant failure mode for library targets. Mirrors the guard already present in
core/parser_adapter.py.

Tests: tests/parsers/php/test_empty_seed_keep_all.py drives the REAL
apply_reachability_filter over a no-entry two-function library fixture.
3 test function(s) (grep -c "def test_" = 3). RED->GREEN: with master's
parsers/php/test_pipeline.py overlaid the keep-all assertions fail (Units 2 -> 0,
100% reduction = the blackout); with the fix they pass.

Compatibility: union-only degrade; when entry points exist the seeded-path
filter still prunes unreachable units, so behavior is unchanged there.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
