### PR TITLE
fix(parsers/zig): keep all units when no entry point seeds reachability (N4)

### DIFF
--- a/libs/openant-core/parsers/zig/test_pipeline.py
+++ b/libs/openant-core/parsers/zig/test_pipeline.py
@@ -239,6 +239,15 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
     )
     reachable = analyzer.get_all_reachable()
 
+    # N4 fix: empty-seed safety-net (mirrors core/parser_adapter.py). No entry
+    # points => the reachable set is empty => every function pruned, silently
+    # blacking out the dataset (dominant failure for library / no-entry targets).
+    # Degrade to keep-all + warn instead of a silent 0-unit result.
+    if not entry_points and functions:
+        print("  [Warning] No entry points detected — keeping all units unfiltered "
+              "to avoid a silent blackout.", file=sys.stderr)
+        reachable = set(functions.keys())
+
     # Filter functions to only reachable ones.
     filtered_functions = {
         fid: finfo for fid, finfo in functions.items() if fid in reachable

--- a/libs/openant-core/tests/parsers/zig/test_empty_seed_keep_all.py
+++ b/libs/openant-core/tests/parsers/zig/test_empty_seed_keep_all.py
@@ -1,0 +1,66 @@
+"""Bug (N4): the Zig reachability filter silently blacks out a no-entry-point
+module.
+
+`apply_reachability_filter` seeds its BFS from the detected entry points. A Zig
+library / no-entry target (no `pub fn main`, no entry marker) yields ZERO entry
+points, so the reachable set is empty, every function is pruned, and the parse
+reports a clean 0-unit success — a silent blackout at the default
+`--processing-level reachable`.
+
+The fix mirrors core/parser_adapter.py: no entry points but functions present →
+keep all + warn instead of emptying the module.
+
+This drives the REAL module-level `apply_reachability_filter` over a two-function
+library fixture with no `main`. RED→GREEN verified against master's unfixed file.
+Companion to test_zig_reachability_api.py (which covers the seeded path).
+
+test_pipeline.py shares its basename across all six parsers, so it is loaded
+under a unique module name via importlib.
+"""
+import importlib.util
+import pathlib
+import sys
+
+_CORE = pathlib.Path(__file__).resolve().parents[3]
+_ZIG_TP = _CORE / "parsers" / "zig" / "test_pipeline.py"
+
+
+def _load_zig_pipeline():
+    for p in (str(_ZIG_TP.parent), str(_CORE)):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+    spec = importlib.util.spec_from_file_location("isolated_zig_empty_seed", _ZIG_TP)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _no_entry_call_graph_output():
+    # Two ordinary library functions, NO `main`, no entry marker → zero seeds.
+    return {
+        "functions": {
+            "src/lib.zig:add": {
+                "name": "add",
+                "unit_type": "function",
+                "code": "fn add(a: i32, b: i32) i32 { return a + b; }",
+            },
+            "src/lib.zig:scale": {
+                "name": "scale",
+                "unit_type": "function",
+                "code": "fn scale(a: i32) i32 { return add(a, a); }",
+            },
+        },
+        "call_graph": {"src/lib.zig:scale": ["src/lib.zig:add"]},
+        "reverse_call_graph": {"src/lib.zig:add": ["src/lib.zig:scale"]},
+        "statistics": {"total_edges": 1},
+    }
+
+
+def test_empty_seed_keeps_all_functions():
+    mod = _load_zig_pipeline()
+    out = mod.apply_reachability_filter(_no_entry_call_graph_output(), repo_path="/tmp/repo")
+    fids = set(out["functions"].keys())
+    assert fids == {"src/lib.zig:add", "src/lib.zig:scale"}, (
+        "empty-seed safety-net must keep all functions when no entry point can "
+        f"seed the frontier; got {fids} (blackout = the N4 bug)"
+    )


### PR DESCRIPTION
What: apply_reachability_filter degrades to keep-all + a stderr warning when
EntryPointDetector finds zero entry points but the dataset has units, instead
of pruning every unit.

Why: a library / no-entry-point target (no main, no route/CLI/decorator marker)
seeds zero entry points, so the reachable set is empty and every unit is pruned
-- a silent 0-unit "success" (blackout) at the default --level reachable, the
dominant failure mode for library targets. Mirrors the guard already present in
core/parser_adapter.py.

Tests: tests/parsers/zig/test_empty_seed_keep_all.py drives the REAL
apply_reachability_filter over a no-entry two-function library fixture.
1 test function(s) (grep -c "def test_" = 1). RED->GREEN: with master's
parsers/zig/test_pipeline.py overlaid the keep-all assertions fail (Units 2 -> 0,
100% reduction = the blackout); with the fix they pass.

Compatibility: union-only degrade; when entry points exist the seeded-path
filter still prunes unreachable units, so behavior is unchanged there.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
