### PR TITLE
fix(zig): Set[str] alias values to keep both caller edges on branch-scoped rebind

### DIFF
--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -269,8 +269,8 @@ class CallGraphBuilder:
 
     def _build_alias_index(
         self, name_to_ids: Dict[str, List[str]]
-    ) -> Dict[str, Dict[str, Optional[str]]]:
-        """Index simple const fn-aliases per function: `const f = handler;` -> {f: handler}.
+    ) -> Dict[str, Dict[str, Set[str]]]:
+        """Index simple const fn-aliases per function: `const f = handler;` -> {f: {handler}}.
 
         Only bindings whose right-hand side is a bare identifier naming a known
         function are tracked (a genuine fn alias), so arbitrary const dataflow
@@ -278,8 +278,15 @@ class CallGraphBuilder:
         per file: two functions in the same file may bind the same alias name to
         different targets (`const doit = foo` vs `const doit = bar`), and each
         caller must resolve to its own target rather than clobbering the other.
+
+        Each alias maps to a SET of targets, not a single one: within one
+        function the same alias name may bind to different targets on different
+        control-flow paths (`const doit = foo` in one branch, `= bar` in
+        another). We over-approximate by keeping every target so a later
+        `doit()` resolves to edges for all of them rather than last-wins losing
+        one.
         """
-        alias_to_target: Dict[str, Dict[str, Optional[str]]] = defaultdict(dict)
+        alias_to_target: Dict[str, Dict[str, Set[str]]] = defaultdict(dict)
 
         for func_id, func_info in self.functions.items():
             code = func_info.get("code", "")
@@ -303,7 +310,7 @@ class CallGraphBuilder:
         node: Node,
         source: bytes,
         name_to_ids: Dict[str, List[str]],
-        aliases: Dict[str, Optional[str]],
+        aliases: Dict[str, Set[str]],
     ) -> None:
         """Collect `const <alias> = <known-fn>;` bindings from a parse tree."""
         if node.type in ("variable_declaration", "VarDecl"):
@@ -315,11 +322,13 @@ class CallGraphBuilder:
                 alias_name = self._get_node_text(ident_children[0], source)
                 target_name = self._get_node_text(ident_children[1], source)
                 # Only record when the target is a known function name. A Zig
-                # `const` binding is immutable and cannot be rebound within a
-                # function, so a plain assignment (scoped per function by the
-                # caller) is sufficient here.
+                # `const` binding is immutable, but the SAME alias name can be
+                # declared on distinct control-flow paths within one function
+                # (`const doit = foo` in one branch, `= bar` in another).
+                # Accumulate every target in a set instead of last-wins
+                # overwriting, so a later `doit()` over-approximates to both.
                 if alias_name and target_name in name_to_ids:
-                    aliases[alias_name] = target_name
+                    aliases.setdefault(alias_name, set()).add(target_name)
             # Struct field-init fn pointers: `const h = T{ .cb = knownFn };` binds
             # `h.cb` -> knownFn so a later `h.cb()` resolves. The first identifier
             # child is the bound variable; the struct type name is nested inside the
@@ -380,7 +389,11 @@ class CallGraphBuilder:
                 elif seen_eq and sub.type in ("identifier", "IDENTIFIER"):
                     target_name = self._get_node_text(sub, source)
             if field_name and target_name and target_name in name_to_ids:
-                aliases[f"{var_name}.{field_name}"] = target_name
+                # Same over-approximation as the plain-alias case: a dotted
+                # `<var>.<field>` alias can bind to different targets across
+                # control-flow paths, so accumulate targets in a set rather
+                # than last-wins overwriting.
+                aliases.setdefault(f"{var_name}.{field_name}", set()).add(target_name)
 
     def _find_calls_in_code(self, code: str, caller_file: str = "") -> Set[str]:
         """Find all function calls in a code snippet."""
@@ -501,26 +514,50 @@ class CallGraphBuilder:
         call_name: str,
         caller_file: str,
         name_to_ids: Dict[str, List[str]],
-        alias_to_target: Dict[str, Dict[str, Optional[str]]] | None = None,
+        alias_to_target: Dict[str, Dict[str, Set[str]]] | None = None,
         caller_id: Optional[str] = None,
     ) -> List[str]:
         """
-        Resolve a call name to function ID(s).
+        Resolve a call name to function ID(s), unioning over all alias targets.
+
+        A const fn-alias (`const f = handler; f()`) is expanded to its target
+        function name(s) before candidate lookup. Aliases are keyed by the
+        CALLER function (not the file) so a same-named alias in another function
+        in the same file cannot clobber this one. An alias may bind to MULTIPLE
+        targets across control-flow paths (`const doit = foo` in one branch,
+        `= bar` in another); over-approximate by resolving every target name and
+        unioning the resulting ids, so `doit()` yields caller->{foo, bar}.
+        """
+        names: List[str] = [call_name]
+        if alias_to_target is not None and caller_id is not None:
+            targets = alias_to_target.get(caller_id, {}).get(call_name)
+            if targets:
+                # Alias shadows the bare name (matching prior single-target
+                # behavior): resolve only the alias targets, deterministically
+                # ordered.
+                names = sorted(targets)
+
+        resolved: List[str] = []
+        for name in names:
+            for rid in self._resolve_name(name, caller_file, name_to_ids):
+                if rid not in resolved:
+                    resolved.append(rid)
+        return resolved
+
+    def _resolve_name(
+        self,
+        call_name: str,
+        caller_file: str,
+        name_to_ids: Dict[str, List[str]],
+    ) -> List[str]:
+        """
+        Resolve a single (already alias-expanded) name to function ID(s).
 
         Resolution order:
         1. Same file
         2. Imported files
         3. Unique name match
         """
-        # Resolve a const fn-alias (`const f = handler; f()`) to its target
-        # function name before looking up candidates. Aliases are keyed by the
-        # CALLER function (not the file) so a same-named alias in another
-        # function in the same file cannot clobber this one.
-        if alias_to_target is not None and caller_id is not None:
-            target = alias_to_target.get(caller_id, {}).get(call_name)
-            if target is not None:
-                call_name = target
-
         candidates = name_to_ids.get(call_name, [])
 
         if not candidates:

--- a/libs/openant-core/tests/parsers/zig/test_zig_alias_CORRECT_setunion.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_alias_CORRECT_setunion.py
@@ -1,0 +1,131 @@
+"""
+Edge-set conformance test for the zig const-fn-alias multi-target bug.
+
+Bug: parsers/zig/call_graph_builder.py `_collect_aliases_from_node` (and the
+struct-field sibling `_collect_field_fn_bindings`) recorded each alias with a
+last-wins overwrite `aliases[name] = target`, whose value type
+Dict[str, Optional[str]] cannot represent one alias name bound to MULTIPLE
+targets on different control-flow paths (`const doit = foo` in one branch,
+`const doit = bar` in another). One of the two caller->target edges was lost.
+
+Correct (over-approximating, SAFE) fix: alias value is a Set[str] populated via
+`aliases.setdefault(name, set()).add(target)`, and `_resolve_call` unions ids
+across every alias target so `doit()` yields caller -> {foo, bar}.
+
+This test asserts on the PUBLIC EDGE SET (builder.call_graph[caller]) -- the
+observable call-graph output -- NOT on the internal alias map. It CONTAINS-checks
+both targets so it stays valid regardless of edge ordering or extra edges.
+
+Run against a specific module file via env CGB_PATH (defaults to the repo file):
+    CGB_PATH=/path/to/call_graph_builder.py pytest test_zig_alias_multipath_edgeset.py
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+
+# openant-core root must be importable for the module's own imports
+# (`utilities.file_io`, `tree_sitter_zig`).
+_CORE_ROOT = os.environ.get(
+    "OPENANT_CORE_ROOT",
+    "/Users/gadievron/Documents/ClaudeNew/OpenAnt/new-bugs-2/OpenAnt/libs/openant-core",
+)
+if _CORE_ROOT not in sys.path:
+    sys.path.insert(0, _CORE_ROOT)
+
+_CGB_PATH = os.environ.get(
+    "CGB_PATH",
+    os.path.join(_CORE_ROOT, "parsers", "zig", "call_graph_builder.py"),
+)
+
+
+def _load_builder_class():
+    spec = importlib.util.spec_from_file_location("_cgb_under_test", _CGB_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.CallGraphBuilder
+
+
+FILE = "app.zig"
+
+# `doit` is bound to `foo` on the then-branch and to `bar` on the else-branch,
+# then called on each path. Both caller->foo and caller->bar are real edges.
+CALLER_CODE = """fn caller(cond: bool) void {
+    if (cond) {
+        const doit = foo;
+        doit();
+    } else {
+        const doit = bar;
+        doit();
+    }
+}"""
+
+# Struct-field variant: h.cb bound to foo on one path, bar on the other.
+CALLER_FIELD_CODE = """fn callerField(cond: bool) void {
+    if (cond) {
+        const h = T{ .cb = foo };
+        h.cb();
+    } else {
+        const h = T{ .cb = bar };
+        h.cb();
+    }
+}"""
+
+
+def _extractor_output(caller_name, caller_code):
+    def fn(name):
+        return {
+            "name": name,
+            "qualified_name": name,
+            "code": f"fn {name}() void {{}}",
+            "file_path": FILE,
+        }
+
+    return {
+        "repository": "fixture",
+        "functions": {
+            f"{FILE}:foo": fn("foo"),
+            f"{FILE}:bar": fn("bar"),
+            f"{FILE}:{caller_name}": {
+                "name": caller_name,
+                "qualified_name": caller_name,
+                "code": caller_code,
+                "file_path": FILE,
+            },
+        },
+        "classes": {},
+        "imports": {},
+    }
+
+
+@pytest.mark.parametrize(
+    "caller_name,caller_code",
+    [
+        ("caller", CALLER_CODE),
+        ("callerField", CALLER_FIELD_CODE),
+    ],
+)
+def test_multipath_alias_edge_set_contains_both_targets(caller_name, caller_code):
+    CallGraphBuilder = _load_builder_class()
+    builder = CallGraphBuilder(_extractor_output(caller_name, caller_code))
+    builder.build_call_graph()
+
+    caller_id = f"{FILE}:{caller_name}"
+    foo_id = f"{FILE}:foo"
+    bar_id = f"{FILE}:bar"
+
+    # Assert on the PUBLIC edge set, contains-both (order-independent).
+    edge_set = set(builder.call_graph.get(caller_id, []))
+    assert foo_id in edge_set, (
+        f"{caller_name}: missing caller->foo edge; got {sorted(edge_set)}"
+    )
+    assert bar_id in edge_set, (
+        f"{caller_name}: missing caller->bar edge (multi-path alias target dropped); "
+        f"got {sorted(edge_set)}"
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Verified fix from the new-bugs-2 investigation (base d993f07). Source-only, conformance test included. Review: 0 critical findings, base-feature-drop clean, prerequisite/U-class pass (see fixes/PR-REVIEW-RESULTS.md). Deploy order + collisions: fixes/DEPLOY-ORDER-AND-COLLISIONS.md.
Wave 2: land BEFORE #f1 (both touch zig call_graph_builder.py).