### PR TITLE
fix(callgraph): shared receiver-type resolution (go/js/ruby/zig)

### DIFF
--- a/libs/openant-core/parsers/go/go_parser/callgraph.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph.go
@@ -181,6 +181,12 @@ type CallInfo struct {
 	Package  string // Package alias for package.Func() calls
 	IsMethod bool   // True if this is a method call
 	IsSelf   bool   // True if receiver is "self" or matches current receiver
+	// ReceiverTypes is the STATIC type(s) the receiver variable holds, inferred
+	// from the enclosing function's signature and body (var-decl / composite
+	// literal / receiver / params). Method dispatch keys on the TYPE, not the
+	// receiver's variable name. A receiver whose type is unknown yields an empty
+	// slice (no edge); a reassigned receiver yields several types (UNION).
+	ReceiverTypes []string
 }
 
 func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
@@ -206,6 +212,12 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 	// reassignment (or a non-ident RHS) marks the name ambiguous so we emit
 	// no false edge — precision over recall.
 	aliases := c.collectFuncValueAliases(file)
+
+	// Per-body receiver-variable -> static-type model. Method calls are resolved
+	// against the receiver's TYPE (walking below), never its variable name, so a
+	// local `w := Widget{}` / a `var w Widget` / a parameter / the method's own
+	// receiver all dispatch to the right type's method.
+	varTypes := c.collectVarTypes(file)
 
 	// Walk the AST looking for call expressions
 	ast.Inspect(file, func(n ast.Node) bool {
@@ -239,6 +251,11 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 				callInfo.Name = target
 			}
 		}
+		// Attach the receiver's static type(s) for method-call dispatch. Package
+		// calls (Package != "") and non-method calls keep no receiver type.
+		if callInfo.IsMethod && callInfo.Package == "" && callInfo.Receiver != "" {
+			callInfo.ReceiverTypes = varTypes[callInfo.Receiver]
+		}
 		if callInfo.Name != "" && !c.builtins[callInfo.Name] && !c.builtins[callInfo.Package] {
 			calls = append(calls, callInfo)
 		}
@@ -246,6 +263,115 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 	})
 
 	return calls
+}
+
+// exprTypeName returns the simple type name of a type expression: the identifier
+// for `T`, and the pointee's name for `*T`. Anything more complex (qualified,
+// generic, slice, map, ...) is not a receiver type we can key on, so "".
+func exprTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return exprTypeName(t.X)
+	}
+	return ""
+}
+
+// compositeTypeName returns the type constructed by an RHS expression when it is
+// a composite literal `T{...}` or `&T{...}`, else "". This is the sound, local,
+// unambiguous ctor case; a plain call `NewT()` is deliberately NOT inferred (its
+// return type is not available here), so we never emit a wrong-type edge.
+func compositeTypeName(expr ast.Expr) string {
+	switch e := expr.(type) {
+	case *ast.CompositeLit:
+		return exprTypeName(e.Type)
+	case *ast.UnaryExpr:
+		if e.Op == token.AND {
+			return compositeTypeName(e.X)
+		}
+	}
+	return ""
+}
+
+// collectVarTypes builds a receiver-variable -> static-type-set model for a
+// parsed function body. Sources (all sound, static): the method's own receiver,
+// the function's parameters, `var x T` declarations, and `x := T{}` / `x := &T{}`
+// composite-literal assignments. A variable bound to several distinct types
+// keeps ALL of them (UNION) so a reassigned receiver never hides a reachable
+// method. Unknown / non-nameable types contribute nothing (no edge).
+func (c *CallGraphBuilder) collectVarTypes(file *ast.File) map[string][]string {
+	varTypes := make(map[string][]string)
+	add := func(name, typ string) {
+		if name == "" || name == "_" || typ == "" {
+			return
+		}
+		for _, existing := range varTypes[name] {
+			if existing == typ {
+				return
+			}
+		}
+		varTypes[name] = append(varTypes[name], typ)
+	}
+
+	// Method receiver + parameters, from each function signature.
+	for _, decl := range file.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fd.Recv != nil {
+			for _, field := range fd.Recv.List {
+				typ := exprTypeName(field.Type)
+				for _, n := range field.Names {
+					add(n.Name, typ)
+				}
+			}
+		}
+		if fd.Type != nil && fd.Type.Params != nil {
+			for _, field := range fd.Type.Params.List {
+				typ := exprTypeName(field.Type)
+				for _, n := range field.Names {
+					add(n.Name, typ)
+				}
+			}
+		}
+	}
+
+	// Local `var x T` declarations and `x := T{}` / `x := &T{}` bindings.
+	ast.Inspect(file, func(n ast.Node) bool {
+		switch stmt := n.(type) {
+		case *ast.AssignStmt:
+			if len(stmt.Lhs) == len(stmt.Rhs) {
+				for i, lhs := range stmt.Lhs {
+					if lid, ok := lhs.(*ast.Ident); ok {
+						add(lid.Name, compositeTypeName(stmt.Rhs[i]))
+					}
+				}
+			}
+		case *ast.DeclStmt:
+			gd, ok := stmt.Decl.(*ast.GenDecl)
+			if !ok || gd.Tok != token.VAR {
+				return true
+			}
+			for _, spec := range gd.Specs {
+				vs, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				declType := exprTypeName(vs.Type)
+				for i, name := range vs.Names {
+					typ := declType
+					if typ == "" && i < len(vs.Values) {
+						typ = compositeTypeName(vs.Values[i])
+					}
+					add(name.Name, typ)
+				}
+			}
+		}
+		return true
+	})
+	return varTypes
 }
 
 // collectFuncValueAliases scans a parsed function body for single, unconditional
@@ -356,29 +482,30 @@ func (c *CallGraphBuilder) resolveCalls(callerID string, callerInfo FunctionInfo
 	var resolved []string
 	seen := make(map[string]bool)
 
-	for _, call := range calls {
-		var targetID string
-
-		// Try different resolution strategies
-		if callerInfo.ClassName != "" && (call.IsSelf || call.Receiver == callerInfo.ClassName) {
-			// Self/receiver call - look in same type's methods. Guarded on ClassName != "" so a
-			// plain function (ClassName=="") making a simple call (Receiver=="") is NOT misrouted
-			// here via ""=="" and lost; it falls through to resolveSimpleCall below.
-			targetID = c.resolveMethodCall(call.Name, callerInfo.ClassName, callerInfo.FilePath)
-		} else if call.IsMethod && call.Receiver != "" {
-			// Method call on some object
-			targetID = c.resolveMethodCall(call.Name, call.Receiver, callerInfo.FilePath)
-		} else if call.Package != "" {
-			// Package-qualified call
-			targetID = c.resolvePackageCall(call.Name, call.Package, callerInfo.FilePath)
-		} else {
-			// Simple function call
-			targetID = c.resolveSimpleCall(call.Name, callerInfo.FilePath, callerInfo.Package)
-		}
-
+	appendTarget := func(targetID string) {
 		if targetID != "" && targetID != callerID && !seen[targetID] {
 			resolved = append(resolved, targetID)
 			seen[targetID] = true
+		}
+	}
+
+	for _, call := range calls {
+		switch {
+		case call.IsMethod && call.Package == "":
+			// Method call: dispatch on the receiver's static TYPE(S), never its
+			// variable name. An unknown/ambiguous receiver type resolves to
+			// nothing (no edge) rather than to an unrelated same-named method;
+			// several candidate types (a reassigned receiver) UNION their
+			// methods so no reachable method is hidden.
+			for _, rt := range call.ReceiverTypes {
+				appendTarget(c.resolveMethodCall(call.Name, rt, callerInfo.FilePath))
+			}
+		case call.Package != "":
+			// Package-qualified call
+			appendTarget(c.resolvePackageCall(call.Name, call.Package, callerInfo.FilePath))
+		default:
+			// Simple function call
+			appendTarget(c.resolveSimpleCall(call.Name, callerInfo.FilePath, callerInfo.Package))
 		}
 	}
 

--- a/libs/openant-core/parsers/javascript/dependency_resolver.js
+++ b/libs/openant-core/parsers/javascript/dependency_resolver.js
@@ -292,14 +292,6 @@ class DependencyResolver {
       return [];
     }
 
-    // 1. Exact class name match (existing behavior)
-    for (const funcId of candidates) {
-      const funcData = this.functions[funcId];
-      if (funcData && funcData.className === objectName) {
-        return [funcId];
-      }
-    }
-
     // Accumulate candidate edges across the local-var (1b) and DI (2) resolution
     // steps and return their UNION — neither step may REPLACE the other. A
     // receiver can be both locally reassigned (`this.svc = new FakeSvc()`) and
@@ -378,6 +370,23 @@ class DependencyResolver {
             });
             if (prefixMatches.length === 1) addMatch(prefixMatches[0]);
           }
+        }
+      }
+    }
+
+    // 3. Static-style receiver: objectName is itself a class name (`Klass.foo()`).
+    //    This is a FALLBACK, not an early-return: it runs ONLY when the receiver
+    //    had no local-var (1b) or DI (2) type binding. Otherwise a local var that
+    //    merely shadows a class name (`const B = new A(); B.foo()`) would wrongly
+    //    dispatch on the collided class name (B.foo) and HIDE its real type's
+    //    method (A.foo) — the exact reachability false-negative the receiver-type
+    //    contract forbids. With no type binding, the class-name reading is the
+    //    only sound interpretation, so it applies here.
+    if (matches.length === 0) {
+      for (const funcId of candidates) {
+        const funcData = this.functions[funcId];
+        if (funcData && funcData.className === objectName) {
+          addMatch(funcId);
         }
       }
     }

--- a/libs/openant-core/parsers/ruby/call_graph_builder.py
+++ b/libs/openant-core/parsers/ruby/call_graph_builder.py
@@ -230,6 +230,12 @@ class CallGraphBuilder:
             if assign_counts.get(name, 0) == 1
         }
 
+        # Receiver static types: `a = A.new` binds local `a` to type A, so a later
+        # `a.foo` dispatches to A#foo. Ambiguous vars (rebound to a different type)
+        # are dropped so an unknown/ambiguous receiver never binds to a same-named
+        # method on an unrelated type.
+        local_types = self._collect_receiver_types(tree.root_node, code_bytes)
+
         # Second pass: resolve calls and bare (parenless) identifier calls.
         stack = [tree.root_node]
         while stack:
@@ -237,7 +243,7 @@ class CallGraphBuilder:
             if node.type == 'call':
                 resolved = self._resolve_call_node(node, code_bytes, caller_file,
                                                    caller_class, caller_module, caller_method,
-                                                   method_object_bindings)
+                                                   method_object_bindings, local_types)
                 if resolved:
                     calls.add(resolved)
             elif node.type == 'identifier':
@@ -259,6 +265,69 @@ class CallGraphBuilder:
 
     def _node_str(self, node, source: bytes) -> str:
         return source[node.start_byte:node.end_byte].decode('utf-8', errors='replace')
+
+    def _collect_receiver_types(self, root, source: bytes) -> Dict[str, str]:
+        """Map local variable name -> class it is constructed from (`a = A.new`).
+
+        Only the unambiguous ctor case is recorded: the RHS is a `Const.new`
+        call. A variable rebound to a different type is dropped (treated as
+        ambiguous) so a typed-receiver dispatch never picks a wrong type. Mirrors
+        the Python gold sibling's `_collect_local_types` contract.
+        """
+        types: Dict[str, str] = {}
+        ambiguous: Set[str] = set()
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == 'assignment' and node.children:
+                lhs = node.children[0]
+                rhs = node.children[-1]
+                if lhs is not None and lhs.type == 'identifier':
+                    name = self._node_str(lhs, source)
+                    cls = self._ctor_class_of(rhs, source)
+                    if cls is not None:
+                        if name in ambiguous:
+                            pass
+                        elif name in types and types[name] != cls:
+                            ambiguous.add(name)
+                            types.pop(name, None)
+                        else:
+                            types[name] = cls
+            stack.extend(reversed(node.children))
+        return types
+
+    def _ctor_class_of(self, rhs, source: bytes) -> Optional[str]:
+        """Return the class name if `rhs` is a `Const.new(...)` call, else None."""
+        if rhs is None or rhs.type != 'call':
+            return None
+        recv = rhs.child_by_field_name('receiver')
+        meth = rhs.child_by_field_name('method')
+        if recv is None or meth is None:
+            return None
+        if self._node_str(meth, source) != 'new':
+            return None
+        cls = self._node_str(recv, source)
+        return cls if cls[0:1].isupper() else None
+
+    def _resolve_typed_receiver(self, class_name: str, method_name: str,
+                                caller_file: str) -> Optional[str]:
+        """Resolve `method_name` on the receiver's known TYPE (class_name).
+
+        Same-file class first, then a UNIQUE cross-file class of that name that
+        declares the method. Ambiguous (multiple) cross-file matches resolve to
+        nothing rather than binding to an unrelated same-named method.
+        """
+        hit = self._resolve_self_call(method_name, caller_file, class_name)
+        if hit:
+            return hit
+        matches: List[str] = []
+        for key, func_ids in self.methods_by_class.items():
+            if not key.endswith(f":{class_name}"):
+                continue
+            for func_id in func_ids:
+                if self.functions.get(func_id, {}).get('name') == method_name:
+                    matches.append(func_id)
+        return matches[0] if len(matches) == 1 else None
 
     @staticmethod
     def _is_top_level_statement(node) -> bool:
@@ -330,7 +399,8 @@ class CallGraphBuilder:
                            caller_class: Optional[str],
                            caller_module: Optional[str] = None,
                            caller_method: Optional[str] = None,
-                           method_object_bindings: Optional[Dict[str, str]] = None
+                           method_object_bindings: Optional[Dict[str, str]] = None,
+                           local_types: Optional[Dict[str, str]] = None
                            ) -> Optional[str]:
         """Resolve a tree-sitter call node to a function ID."""
         # `super(args)` is a call node whose head is a `super` node, not an
@@ -339,41 +409,26 @@ class CallGraphBuilder:
             return self._resolve_super_call(caller_file, caller_class, caller_method)
 
         method_object_bindings = method_object_bindings or {}
+        local_types = local_types or {}
 
-        # Method-object call: `m = method(:helper)` then `m.call` resolves to the
-        # bound target [BUG 31]. The positional heuristic below mis-parses a
-        # lowercase-variable receiver (it captures the var as the method name),
-        # so detect this precisely via tree-sitter's named receiver/method fields.
+        # Extract receiver and method via tree-sitter's NAMED fields, not a
+        # positional child scan. A `obj.foo` call lists the receiver identifier
+        # BEFORE the method identifier, so the old first-identifier heuristic
+        # captured the lowercase receiver var as the method name and dropped the
+        # real edge (or phantom-bound it). The receiver field is None for a bare
+        # `foo(args)` call.
         recv_field = node.child_by_field_name('receiver')
         meth_field = node.child_by_field_name('method')
-        if recv_field is not None and meth_field is not None:
-            recv_text = source[recv_field.start_byte:recv_field.end_byte].decode(
-                'utf-8', errors='replace')
-            meth_text = source[meth_field.start_byte:meth_field.end_byte].decode(
-                'utf-8', errors='replace')
-            if meth_text == 'call' and recv_text in method_object_bindings:
-                target_name = method_object_bindings[recv_text]
-                return self._resolve_simple_call(target_name, caller_file, caller_class)
+        args_node = node.child_by_field_name('arguments')
 
-        # Extract method name
-        method_name = None
-        receiver = None
-        args_node = None
+        receiver = self._node_str(recv_field, source) if recv_field is not None else None
+        method_name = self._node_str(meth_field, source) if meth_field is not None else None
 
-        for child in node.children:
-            if child.type == 'identifier' and method_name is None:
-                method_name = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
-            elif child.type == '.':
-                continue
-            elif child.type in ('argument_list', 'block', 'do_block'):
-                if child.type == 'argument_list' and args_node is None:
-                    args_node = child
-                continue
-            elif method_name is None and child.type not in ('identifier',):
-                # This might be the receiver
-                receiver_text = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
-                # The next identifier after '.' will be the method name
-                receiver = receiver_text
+        # Method-object call: `m = method(:helper)` then `m.call` resolves to the
+        # bound target [BUG 31].
+        if method_name == 'call' and receiver in method_object_bindings:
+            target_name = method_object_bindings[receiver]
+            return self._resolve_simple_call(target_name, caller_file, caller_class)
 
         if not method_name:
             return None
@@ -398,6 +453,17 @@ class CallGraphBuilder:
             if receiver[0:1].isupper():
                 return self._resolve_class_call(receiver, target, caller_file)
             return None
+
+        # Typed local receiver: `a = A.new; a.foo` dispatches to A#foo. Resolve on
+        # the receiver's known TYPE (walking same-class then a unique cross-file
+        # class of that name); an unknown/ambiguous receiver type resolves to
+        # nothing rather than binding to a same-named method on an unrelated type.
+        # Runs before the builtin filter so a typed call to a builtin-named method
+        # the type actually defines is not dropped.
+        if receiver is not None and receiver in local_types:
+            typed = self._resolve_typed_receiver(local_types[receiver], method_name, caller_file)
+            if typed:
+                return typed
 
         # A user method may share a name with a Ruby builtin (e.g. render, log,
         # open). Don't let the builtin filter drop a call that resolves to a

--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -160,11 +160,15 @@ class CallGraphBuilder:
             code = func_info.get("code", "")
             file_path = func_info.get("file_path", "")
 
+            # Per-body receiver-variable -> static-type model, so `var a = A{}; a.foo()`
+            # dispatches to A's foo, not to every same-named foo.
+            var_types = self._collect_var_types(code)
+
             calls = self._find_calls_in_code(code, file_path)
 
             for call_name in calls:
                 resolved_ids = self._resolve_call(
-                    call_name, file_path, name_to_ids, alias_to_target, func_id
+                    call_name, file_path, name_to_ids, alias_to_target, func_id, var_types
                 )
                 for resolved_id in resolved_ids:
                     if resolved_id != func_id:  # No self-calls
@@ -443,16 +447,15 @@ class CallGraphBuilder:
             if callee is not None and callee.type in ("identifier", "IDENTIFIER"):
                 calls.add(self._get_node_text(callee, source))
             elif callee is not None and callee.type in ("field_expression", "field_access"):
-                # The method name is the trailing identifier child. Prefer that
-                # over text-splitting, which is brittle when the receiver itself
-                # contains punctuation (e.g. `C{}.m`).
-                method_name = None
-                for sub in callee.children:
-                    if sub.type in ("identifier", "IDENTIFIER"):
-                        method_name = self._get_node_text(sub, source)
+                # Carry the RECEIVER by keeping only the full dotted form
+                # (`recv.method`); the resolver splits it and dispatches on the
+                # receiver's static TYPE. Adding the bare method name here would
+                # independently over-connect to EVERY same-named method (the
+                # namespace-leak FP), defeating type-based dispatch. An un-typed
+                # receiver still resolves by unique/same-file bare-name fallback
+                # inside _resolve_call, so recall is preserved.
                 text = self._get_node_text(callee, source)
-                calls.add(method_name if method_name else text.split(".")[-1])
-                calls.add(text)  # also the full dotted form
+                calls.add(text)  # full dotted `receiver.method`
         elif node.type == "builtin_function":
             # @call(.modifier, realFn, argsTuple): the wrapped function is the real call target;
             # other @builtins are filtered out downstream.
@@ -509,6 +512,97 @@ class CallGraphBuilder:
         """Get the source text for a node."""
         return source[node.start_byte : node.end_byte].decode("utf-8", errors="replace")
 
+    def _collect_var_types(self, code: str) -> Dict[str, str]:
+        """Map local variable name -> its declared struct type within one body.
+
+        Captures the two sound, static forms: `var a = A{};` / `const a = A{}`
+        (struct-initializer) and `var a: A = ...;` (type annotation). A variable
+        redeclared with a different type is dropped (ambiguous) so a typed member
+        dispatch never binds to a wrong type.
+        """
+        var_types: Dict[str, str] = {}
+        ambiguous: Set[str] = set()
+        if not code:
+            return var_types
+        try:
+            tree = self.parser.parse(code.encode("utf-8"))
+        except Exception:
+            return var_types
+        src = code.encode("utf-8")
+        stack = [tree.root_node]
+        while stack:
+            node = stack.pop()
+            if node.type in ("variable_declaration", "VarDecl"):
+                name, typ = self._var_decl_name_type(node, src)
+                if name and typ:
+                    if name in ambiguous:
+                        pass
+                    elif name in var_types and var_types[name] != typ:
+                        ambiguous.add(name)
+                        var_types.pop(name, None)
+                    else:
+                        var_types[name] = typ
+            stack.extend(node.children)
+        return var_types
+
+    def _var_decl_name_type(self, node: Node, src: bytes):
+        """Return (var_name, type_name) for a variable_declaration, or (name, None).
+
+        Recognizes `<name> = T{...}` (struct-initializer type) and `<name>: T = ...`
+        (type annotation). The bound variable is the first identifier child.
+        """
+        ident_children = [
+            c for c in node.children if c.type in ("identifier", "IDENTIFIER")
+        ]
+        if not ident_children:
+            return None, None
+        var_name = self._get_node_text(ident_children[0], src)
+        # struct-initializer form: `var a = A{};`
+        struct_init = next(
+            (c for c in node.children if c.type in ("struct_initializer", "StructInit")),
+            None,
+        )
+        if struct_init is not None:
+            for g in struct_init.children:
+                if g.type in ("identifier", "IDENTIFIER"):
+                    return var_name, self._get_node_text(g, src)
+        # type-annotation form: `var a: A = ...;`
+        seen_colon = False
+        for c in node.children:
+            if c.type == ":":
+                seen_colon = True
+                continue
+            if seen_colon and c.type == "=":
+                break
+            if seen_colon and c.type in ("identifier", "IDENTIFIER"):
+                return var_name, self._get_node_text(c, src)
+        return var_name, None
+
+    def _resolve_typed_member(
+        self,
+        recv_type: str,
+        method: str,
+        caller_file: str,
+        name_to_ids: Dict[str, List[str]],
+    ) -> List[str]:
+        """Resolve `method` to the method declared on `recv_type` only.
+
+        Filters the same-named candidates to those whose declaring struct is
+        recv_type; prefers same-file matches. Returns [] when the type declares
+        no such method (never over-connects to an unrelated type's method).
+        """
+        matches: List[str] = []
+        for cand in name_to_ids.get(method, []):
+            info = self.functions.get(cand, {})
+            if (
+                info.get("class_name") == recv_type
+                or info.get("qualified_name") == f"{recv_type}.{method}"
+            ):
+                if cand not in matches:
+                    matches.append(cand)
+        same_file = [c for c in matches if c.startswith(f"{caller_file}:")]
+        return same_file if same_file else matches
+
     def _resolve_call(
         self,
         call_name: str,
@@ -516,6 +610,7 @@ class CallGraphBuilder:
         name_to_ids: Dict[str, List[str]],
         alias_to_target: Dict[str, Dict[str, Set[str]]] | None = None,
         caller_id: Optional[str] = None,
+        var_types: Optional[Dict[str, str]] = None,
     ) -> List[str]:
         """
         Resolve a call name to function ID(s), unioning over all alias targets.
@@ -539,7 +634,7 @@ class CallGraphBuilder:
 
         resolved: List[str] = []
         for name in names:
-            for rid in self._resolve_name(name, caller_file, name_to_ids):
+            for rid in self._resolve_name(name, caller_file, name_to_ids, var_types):
                 if rid not in resolved:
                     resolved.append(rid)
         return resolved
@@ -549,6 +644,7 @@ class CallGraphBuilder:
         call_name: str,
         caller_file: str,
         name_to_ids: Dict[str, List[str]],
+        var_types: Optional[Dict[str, str]] = None,
     ) -> List[str]:
         """
         Resolve a single (already alias-expanded) name to function ID(s).
@@ -558,6 +654,24 @@ class CallGraphBuilder:
         2. Imported files
         3. Unique name match
         """
+        # Member call `receiver.method`: dispatch on the receiver's static TYPE.
+        # (Alias expansion already happened in _resolve_call; a directly-qualified
+        # `Type.method` whose full name is itself indexed -- e.g. a struct method's
+        # qualified_name -- is handled by the normal lookup below, so only names
+        # NOT in the index are treated as member calls.)
+        if "." in call_name and call_name not in name_to_ids:
+            receiver, _, method = call_name.rpartition(".")
+            recv_type = (var_types or {}).get(receiver)
+            if recv_type is not None:
+                # Known receiver type: resolve STRICTLY on that type -- return only
+                # its own method(s), never a same-named method on an unrelated
+                # type. Nothing if the type does not declare the method.
+                return self._resolve_typed_member(recv_type, method, caller_file, name_to_ids)
+            # Unknown receiver type: fall back to bare-name resolution of the
+            # method (unique/same-file/import), preserving recall for un-typed
+            # receivers (e.g. `obj.method()` with a single global `method`).
+            call_name = method
+
         candidates = name_to_ids.get(call_name, [])
 
         if not candidates:

--- a/libs/openant-core/tests/conformance/test_F1_receiver_type_contract.py
+++ b/libs/openant-core/tests/conformance/test_F1_receiver_type_contract.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""F1 general-case receiver-symmetry conformance test (one spec, six runtimes).
+
+Shared gold receiver-resolution contract: two methods with the SAME simple name
+live on two different types (A.foo and B.foo) in the same file; a receiver
+variable is typed to A (ctor / composite-literal / annotation). The call graph
+MUST contain the edge to A.foo (no reachability false-negative) AND MUST NOT
+contain the edge to B.foo (no same-name over-connection).
+
+Run against a core tree via the IMPL_CORE env var (default: the patched
+scratch copy). RED  when IMPL_CORE points at the pristine core (go self/var-name
+drop, js class-name early-return, ruby positional-drop, zig same-file fan-out);
+GREEN after the F1 patches are applied. The C and Python GOLD siblings pass in
+BOTH states -- that is the proof the test encodes the gold contract, not the fix.
+
+Usage:
+    IMPL_CORE=/path/to/openant-core python3 F1-receiver-type-contract.test.py
+    # or via pytest: IMPL_CORE=... python3 -m pytest F1-receiver-type-contract.test.py
+"""
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+IMPL_CORE = os.environ.get(
+    "IMPL_CORE",
+    "/private/tmp/claude-501/-Users-gadievron-Documents-ClaudeNew-OpenAnt-new-bugs-2/"
+    "e77a0496-1f59-4f65-80e9-fa508d40fa3c/scratchpad/impl-core",
+)
+
+
+def _load_builder(rel_path, uniq):
+    """Import a parser's call_graph_builder.py under a unique module name."""
+    if IMPL_CORE not in sys.path:
+        sys.path.insert(0, IMPL_CORE)
+    spec = importlib.util.spec_from_file_location(uniq, str(Path(IMPL_CORE) / rel_path))
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.CallGraphBuilder
+
+
+def _assert_symmetry(lang, edges, a_id, b_id):
+    edges = list(edges or [])
+    if a_id not in edges:
+        raise AssertionError(
+            f"[{lang}] expected edge to {a_id} (receiver typed A); got {edges} "
+            f"-- reachability false-negative (typed-receiver method dropped)")
+    if b_id in edges:
+        raise AssertionError(
+            f"[{lang}] did NOT expect edge to {b_id} (receiver is type A, not B); "
+            f"got {edges} -- same-name over-connection false-positive")
+
+
+# --------------------------------------------------------------------------- #
+# Python (GOLD) -- must pass in both pristine and patched states.
+# --------------------------------------------------------------------------- #
+def check_python():
+    CGB = _load_builder("parsers/python/call_graph_builder.py", "f1_py_cgb")
+    data = {
+        "repository": "/r",
+        "functions": {
+            "m.py:A.foo": {"name": "foo", "class_name": "A", "file_path": "m.py", "code": "def foo(self):\n    pass"},
+            "m.py:B.foo": {"name": "foo", "class_name": "B", "file_path": "m.py", "code": "def foo(self):\n    pass"},
+            "m.py:run": {"name": "run", "class_name": None, "file_path": "m.py",
+                          "code": "def run():\n    a = A()\n    a.foo()"},
+        },
+        "classes": {"m.py:A": {"name": "A", "bases": []}, "m.py:B": {"name": "B", "bases": []}},
+        "imports": {},
+    }
+    b = CGB(data)
+    b.build_call_graph()
+    _assert_symmetry("python(gold)", b.call_graph.get("m.py:run"), "m.py:A.foo", "m.py:B.foo")
+
+
+# --------------------------------------------------------------------------- #
+# C/C++ (GOLD) -- must pass in both pristine and patched states.
+# --------------------------------------------------------------------------- #
+def check_c():
+    CGB = _load_builder("parsers/c/call_graph_builder.py", "f1_c_cgb")
+    data = {
+        "repository": "/r",
+        "functions": {
+            "m.cpp:A::foo": {"name": "foo", "class_name": "A", "file_path": "m.cpp", "code": "void foo() {}"},
+            "m.cpp:B::foo": {"name": "foo", "class_name": "B", "file_path": "m.cpp", "code": "void foo() {}"},
+            "m.cpp:run": {"name": "run", "file_path": "m.cpp",
+                           "code": "void run() { A w; w.foo(); }"},
+        },
+        "class_bases": {"A": [], "B": []},
+        "includes": {}, "macros": {}, "macro_aliases": {}, "prototypes": {},
+    }
+    b = CGB(data)
+    b.build_call_graph()
+    _assert_symmetry("c(gold)", b.call_graph.get("m.cpp:run"), "m.cpp:A::foo", "m.cpp:B::foo")
+
+
+# --------------------------------------------------------------------------- #
+# Ruby (F1 target).
+# --------------------------------------------------------------------------- #
+def check_ruby():
+    CGB = _load_builder("parsers/ruby/call_graph_builder.py", "f1_rb_cgb")
+    data = {
+        "repository": "/r",
+        "functions": {
+            "m.rb:A#foo": {"name": "foo", "class_name": "A", "file_path": "m.rb", "code": "def foo\nend"},
+            "m.rb:B#foo": {"name": "foo", "class_name": "B", "file_path": "m.rb", "code": "def foo\nend"},
+            "m.rb:C#run": {"name": "run", "class_name": "C", "file_path": "m.rb",
+                            "code": "def run\n  a = A.new\n  a.foo\nend"},
+        },
+        "classes": {"m.rb:A": {"name": "A", "file_path": "m.rb"},
+                    "m.rb:B": {"name": "B", "file_path": "m.rb"},
+                    "m.rb:C": {"name": "C", "file_path": "m.rb"}},
+        "imports": {},
+    }
+    b = CGB(data)
+    b.build_call_graph()
+    _assert_symmetry("ruby", b.call_graph.get("m.rb:C#run"), "m.rb:A#foo", "m.rb:B#foo")
+
+
+# --------------------------------------------------------------------------- #
+# Zig (F1 target).
+# --------------------------------------------------------------------------- #
+def check_zig():
+    CGB = _load_builder("parsers/zig/call_graph_builder.py", "f1_zig_cgb")
+    data = {
+        "repository": "/r", "classes": {}, "imports": {},
+        "functions": {
+            "m.zig:A.foo": {"name": "foo", "qualified_name": "A.foo", "class_name": "A",
+                             "file_path": "m.zig", "code": "pub fn foo(self: A) void {}"},
+            "m.zig:B.foo": {"name": "foo", "qualified_name": "B.foo", "class_name": "B",
+                             "file_path": "m.zig", "code": "pub fn foo(self: B) void {}"},
+            "m.zig:run": {"name": "run", "qualified_name": "run", "class_name": None,
+                           "file_path": "m.zig", "code": "pub fn run() void { var a = A{}; a.foo(); }"},
+        },
+    }
+    b = CGB(data)
+    b.build_call_graph()
+    _assert_symmetry("zig", b.call_graph.get("m.zig:run"), "m.zig:A.foo", "m.zig:B.foo")
+
+
+# --------------------------------------------------------------------------- #
+# JavaScript (F1 target) -- driven through node against dependency_resolver.js.
+# --------------------------------------------------------------------------- #
+_JS_DRIVER = r"""
+const { DependencyResolver } = require(process.argv[2]);
+const out = {
+  functions: {
+    'm.js:A.foo': { name: 'foo', className: 'A', code: 'foo() {}' },
+    'm.js:B.foo': { name: 'foo', className: 'B', code: 'foo() {}' },
+    // Receiver var name collides with class B but is constructed `new A()`:
+    // it must dispatch on its real type A, not the collided class-name B.
+    'm.js:caller': { name: 'caller', className: null, code: 'function caller(){ const B = new A(); B.foo(); }' },
+  },
+  classes: { 'm.js:A': {}, 'm.js:B': {} },
+};
+const r = new DependencyResolver(out); r.buildCallGraph();
+process.stdout.write(JSON.stringify(r.callGraph['m.js:caller'] || []));
+"""
+
+
+def check_js():
+    resolver = str(Path(IMPL_CORE) / "parsers/javascript/dependency_resolver.js")
+    with tempfile.NamedTemporaryFile("w", suffix=".js", delete=False) as fh:
+        fh.write(_JS_DRIVER)
+        driver = fh.name
+    try:
+        res = subprocess.run(["node", driver, resolver], capture_output=True, text=True, timeout=60)
+        if res.returncode != 0:
+            raise AssertionError(f"[js] node driver failed: {res.stderr.strip()}")
+        edges = json.loads(res.stdout.strip() or "[]")
+    finally:
+        os.unlink(driver)
+    _assert_symmetry("js", edges, "m.js:A.foo", "m.js:B.foo")
+
+
+# --------------------------------------------------------------------------- #
+# Go (F1 target) -- driven through `go test` on a scratch copy of the package.
+# --------------------------------------------------------------------------- #
+_GO_TEST = r'''package main
+
+import "testing"
+
+func f1contains(xs []string, want string) bool {
+	for _, x := range xs {
+		if x == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestF1ReceiverTypeSymmetry(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	analyzer := &AnalyzerOutput{Functions: map[string]FunctionInfo{
+		"m.go:A.foo": {Name: "foo", ClassName: "A", FilePath: "m.go", Code: "func (a *A) foo() {}"},
+		"m.go:B.foo": {Name: "foo", ClassName: "B", FilePath: "m.go", Code: "func (b *B) foo() {}"},
+		"m.go:Run":   {Name: "Run", ClassName: "", FilePath: "m.go", Code: "func Run() { w := A{}; w.foo() }"},
+	}}
+	cg, err := c.BuildCallGraph(analyzer)
+	if err != nil {
+		t.Fatalf("BuildCallGraph error: %v", err)
+	}
+	edges := cg.CallGraph["m.go:Run"]
+	if !f1contains(edges, "m.go:A.foo") {
+		t.Errorf("expected edge to m.go:A.foo (receiver w typed A), got %v", edges)
+	}
+	if f1contains(edges, "m.go:B.foo") {
+		t.Errorf("did NOT expect edge to m.go:B.foo, got %v", edges)
+	}
+}
+'''
+
+
+def check_go():
+    src = Path(IMPL_CORE) / "parsers/go/go_parser"
+    tmp = tempfile.mkdtemp(prefix="f1-go-")
+    try:
+        dst = Path(tmp) / "go_parser"
+        # Copy only .go + go.mod (skip prebuilt artifacts); exclude *_test.go to
+        # avoid pulling unrelated tests, then drop in our symmetry test.
+        dst.mkdir(parents=True)
+        for p in src.iterdir():
+            if p.is_file() and p.suffix in (".go", ".mod", ".sum") and not p.name.endswith("_test.go"):
+                shutil.copy(p, dst / p.name)
+        (dst / "f1_symmetry_test.go").write_text(_GO_TEST)
+        res = subprocess.run(["go", "test", "-run", "TestF1ReceiverTypeSymmetry", "./..."],
+                             cwd=str(dst), capture_output=True, text=True, timeout=180)
+        if res.returncode != 0:
+            raise AssertionError(f"[go] go test failed:\n{res.stdout}\n{res.stderr}")
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+ALL_CHECKS = [
+    ("python(gold)", check_python),
+    ("c(gold)", check_c),
+    ("ruby", check_ruby),
+    ("zig", check_zig),
+    ("js", check_js),
+    ("go", check_go),
+]
+
+
+def _run_all():
+    failures = []
+    for name, fn in ALL_CHECKS:
+        try:
+            fn()
+            print(f"PASS  {name}")
+        except Exception as exc:  # noqa: BLE001 - report every lang, don't stop early
+            failures.append((name, exc))
+            print(f"FAIL  {name}: {exc}")
+    return failures
+
+
+# pytest entry points (each lang an independent test)
+def test_python_gold():
+    check_python()
+
+
+def test_c_gold():
+    check_c()
+
+
+def test_ruby():
+    check_ruby()
+
+
+def test_zig():
+    check_zig()
+
+
+def test_js():
+    check_js()
+
+
+def test_go():
+    check_go()
+
+
+if __name__ == "__main__":
+    print(f"IMPL_CORE = {IMPL_CORE}")
+    fails = _run_all()
+    if fails:
+        print(f"\n{len(fails)} FAILED")
+        sys.exit(1)
+    print("\nALL GREEN")


### PR DESCRIPTION
Verified fix from the new-bugs-2 investigation (base d993f07). Source-only, conformance test included. Review: 0 critical findings, base-feature-drop clean, prerequisite/U-class pass (see fixes/PR-REVIEW-RESULTS.md). Deploy order + collisions: fixes/DEPLOY-ORDER-AND-COLLISIONS.md.
Wave 2: rebase onto master AFTER zig-alias lands (real conflict in _resolve_call). Maintainer sign-off: cross-runtime recall shift.