### PR TITLE
fix: harden call_graph_builder.py, function_extractor.py (+1 more)

### DIFF
--- a/libs/openant-core/parsers/c/function_extractor.py
+++ b/libs/openant-core/parsers/c/function_extractor.py
@@ -253,7 +253,7 @@ class FunctionExtractor:
         """
         return a.get('parameters', []) == b.get('parameters', [])
 
-    def _store_function(self, func_id: str, func_data: dict) -> None:
+    def _store_function(self, func_id: str, func_data: dict) -> str:
         """Store a function, disambiguating same-(file,name) collisions instead
         of silently overwriting (Bug 1: #ifdef/#else stubs and C++ overloads
         collapsed onto one node — see reachability-bugs.md / bug-3482.md).
@@ -272,19 +272,28 @@ class FunctionExtractor:
             so both overloads stay findable. (Contrast bug [39], which folds the
             template-arg discriminator into the NAME — correct there because a
             template call is written `g<int>`; an overload call is written bare.)
+
+        Returns the func_id the node was actually stored under: the plain
+        `func_id` when there was no collision or a same-signature merge, and the
+        overload-disambiguated `overload_id` when a genuine overload minted a new
+        key. Callers building an enclosing-function scope for GNU nested
+        functions / lambdas MUST use this returned key (not the bare full_name)
+        so nested callables inside two same-named OVERLOADED enclosers stay
+        distinct instead of colliding (PR150-c-nested-fn-collision, FA3).
         """
         existing = self.functions.get(func_id)
         if existing is None:
             self.functions[func_id] = func_data
-            return
+            return func_id
         if self._same_signature(existing, func_data):
             if len(func_data.get('code', '')) > len(existing.get('code', '')):
                 self.functions[func_id] = func_data
-            return
+            return func_id
         overload_id = f"{func_id}({self._signature_discriminator(func_data.get('parameters', []))})"
         prior = self.functions.get(overload_id)
         if prior is None or len(func_data.get('code', '')) > len(prior.get('code', '')):
             self.functions[overload_id] = func_data
+        return overload_id
 
     def _find_function_declarator(self, node):
         """Find the function_declarator within a declarator tree."""
@@ -450,43 +459,51 @@ class FunctionExtractor:
         is_header = os.path.splitext(file_path)[1].lower() in ('.h', '.hpp', '.hxx', '.hh')
 
         # Iterative traversal with explicit stack carrying
-        # (node, namespace_prefix, class_context). namespace_prefix is the
-        # qualified prefix used to build the func_id; class_context is the
-        # enclosing class/struct/union name (or None) used for metadata so a
-        # namespace qualifier is never mistaken for a class qualifier.
-        stack = [(tree.root_node, '', None)]
+        # (node, namespace_prefix, class_context, enclosing_prefix).
+        # namespace_prefix is the qualified prefix used to build the func_id;
+        # class_context is the enclosing class/struct/union name (or None) used
+        # for metadata so a namespace qualifier is never mistaken for a class
+        # qualifier. enclosing_prefix is the dotted chain of enclosing FUNCTION
+        # names (empty at top level) folded into the func_id so two GNU nested
+        # functions of the same name in different enclosers don't collide
+        # (PR150-c-nested-fn-collision).
+        stack = [(tree.root_node, '', None, '')]
 
         # struct/union member functions are C++ methods exactly like class
         # members; only `class_specifier` was special-cased originally.
         record_specifiers = ('class_specifier', 'struct_specifier', 'union_specifier')
 
         while stack:
-            node, namespace_prefix, class_context = stack.pop()
+            node, namespace_prefix, class_context, enclosing_prefix = stack.pop()
 
             if node.type == 'function_definition':
-                self._process_function_node(node, source, relative_path,
-                                            is_cpp, is_header, namespace_prefix,
-                                            class_context)
+                # scope_chain already includes enclosing_prefix AND any overload
+                # discriminator _store_function appended, so it is NOT re-prefixed.
+                scope_chain = self._process_function_node(
+                    node, source, relative_path, is_cpp, is_header,
+                    namespace_prefix, class_context, enclosing_prefix)
                 # Descend into the body: GNU nested functions (a GCC extension) are
                 # `function_definition` nodes inside the compound_statement and would
                 # otherwise never be visited. A nested definition is processed on a
-                # later iteration with the same namespace/class context.
+                # later iteration with the same namespace/class context, but under a
+                # deeper enclosing_prefix so its func_id carries this function's scope.
+                child_prefix = f"{scope_chain}." if scope_chain else enclosing_prefix
                 for child in reversed(node.children):
-                    stack.append((child, namespace_prefix, class_context))
+                    stack.append((child, namespace_prefix, class_context, child_prefix))
 
             elif node.type == 'declaration' and not is_header:
                 # Standalone declarations in .c/.cpp files are prototypes, EXCEPT
                 # a declaration whose initializer is a lambda — a named callable.
                 if is_cpp:
                     self._process_lambda_declaration(node, source, relative_path,
-                                                     namespace_prefix)
+                                                     namespace_prefix, enclosing_prefix)
 
             elif node.type == 'declaration' and is_header:
                 # In headers, track prototypes for call resolution
                 self._process_declaration_node(node, source, relative_path)
                 if is_cpp:
                     self._process_lambda_declaration(node, source, relative_path,
-                                                     namespace_prefix)
+                                                     namespace_prefix, enclosing_prefix)
 
             elif node.type == 'namespace_definition' and is_cpp:
                 ns_name_node = node.child_by_field_name('name')
@@ -496,7 +513,7 @@ class FunctionExtractor:
                 if body_node:
                     for child in reversed(body_node.children):
                         # class_context unchanged: a namespace is NOT a class.
-                        stack.append((child, new_prefix, class_context))
+                        stack.append((child, new_prefix, class_context, enclosing_prefix))
                 continue  # Don't walk children again
 
             elif node.type in record_specifiers and is_cpp:
@@ -524,21 +541,28 @@ class FunctionExtractor:
                             elif child.type == 'access_specifier':
                                 pass
                             else:
-                                stack.append((child, new_prefix, class_name))
+                                stack.append((child, new_prefix, class_name, enclosing_prefix))
                 continue
 
             else:
                 for child in reversed(node.children):
-                    stack.append((child, namespace_prefix, class_context))
+                    stack.append((child, namespace_prefix, class_context, enclosing_prefix))
 
     def _process_function_node(self, node, source: bytes, relative_path: str,
                                 is_cpp: bool, is_header: bool,
                                 namespace_prefix: str = '',
-                                class_context: Optional[str] = None) -> None:
-        """Process a single function_definition node."""
+                                class_context: Optional[str] = None,
+                                enclosing_prefix: str = '') -> Optional[str]:
+        """Process a single function_definition node. Returns the enclosing-function
+        SCOPE CHAIN (or None if the node has no name) so the caller can build the
+        scope for any GNU nested functions/lambdas in its body. The scope is the
+        stored func_id minus the ``relative_path:`` prefix — i.e. it carries the
+        overload disambiguator that ``_store_function`` may have appended, so two
+        same-named OVERLOADED enclosers yield DISTINCT nested scopes
+        (PR150-c-nested-fn-collision, FA3)."""
         name = self._get_function_name(node, source)
         if not name:
-            return
+            return None
 
         full_name = namespace_prefix + name if namespace_prefix and '::' not in name else name
         # class_name comes from the lexical enclosing class/struct/union
@@ -565,7 +589,13 @@ class FunctionExtractor:
             name, relative_path, is_static, code, is_cpp, class_name
         )
 
-        func_id = f"{relative_path}:{full_name}"
+        # enclosing_prefix is empty for top-level/method functions (id stays the
+        # plain `path:name` the suite's hardcoded id literals depend on) and the
+        # dotted enclosing-function chain for a GNU nested function, so two
+        # same-named nested fns in different enclosers stay distinct. The `name`
+        # field is left bare (unscoped) so the call-graph builder still resolves
+        # the bare nested call.
+        func_id = f"{relative_path}:{enclosing_prefix}{full_name}"
 
         func_data = {
             'name': full_name,
@@ -582,7 +612,7 @@ class FunctionExtractor:
             'class_name': class_name,
         }
 
-        self._store_function(func_id, func_data)
+        stored_id = self._store_function(func_id, func_data)
         self.stats['total_functions'] += 1
 
         if is_static:
@@ -592,13 +622,27 @@ class FunctionExtractor:
 
         self.stats['by_type'][unit_type] = self.stats['by_type'].get(unit_type, 0) + 1
 
+        # Return the scope chain (stored id minus the `relative_path:` prefix)
+        # rather than the bare full_name: `_store_function` may have appended an
+        # overload discriminator (e.g. `outer(double x)`), and nested callables
+        # must inherit THAT disambiguated scope so two same-named overloaded
+        # enclosers don't hand their nested fns/lambdas an identical prefix
+        # (PR150-c-nested-fn-collision, FA3).
+        return stored_id[len(relative_path) + 1:]
+
     def _process_lambda_declaration(self, node, source: bytes, relative_path: str,
-                                    namespace_prefix: str = '') -> None:
+                                    namespace_prefix: str = '',
+                                    enclosing_prefix: str = '') -> None:
         """Extract a named lambda from a declaration (auto f = [](){...};).
 
         A lambda is a `lambda_expression` initializer inside an
         `init_declarator`; the declaration node is otherwise skipped by the
         traversal, so the callable would never be recorded as a unit.
+
+        ``enclosing_prefix`` is the dotted enclosing-function scope (empty at
+        top level) folded into the func_id so two same-named lambdas declared in
+        different enclosing functions don't collide/overwrite
+        (PR150-c-nested-fn-collision).
         """
         # A declaration may declare several init_declarators.
         stack = list(node.children)
@@ -620,7 +664,11 @@ class FunctionExtractor:
 
             full_name = (namespace_prefix + name
                          if namespace_prefix and '::' not in name else name)
-            func_id = f"{relative_path}:{full_name}"
+            # enclosing_prefix is empty for top-level lambdas (id stays the plain
+            # `path:name`) and the dotted enclosing-function chain for a lambda
+            # declared inside a function body, so two same-named lambdas in
+            # different enclosers stay distinct (PR150-c-nested-fn-collision).
+            func_id = f"{relative_path}:{enclosing_prefix}{full_name}"
             self._store_function(func_id, {
                 'name': full_name,
                 'file_path': relative_path,
@@ -678,8 +726,6 @@ class FunctionExtractor:
             self.stats['files_with_errors'] += 1
             return
 
-        self.stats['files_processed'] += 1
-
         # Extract includes
         self.includes[relative_path] = self._extract_includes(tree, source)
 
@@ -692,11 +738,27 @@ class FunctionExtractor:
         self._extract_functions_from_tree(tree, source, str(file_path),
                                            relative_path, is_cpp)
 
+        # Count as processed only after extraction fully succeeds, so a file that crashes
+        # mid-extraction (caught by _process_file_guarded) is counted once as an error and
+        # never as processed.
+        self.stats['files_processed'] += 1
+
+    def _process_file_guarded(self, file_path: Path) -> None:
+        """Process one file, isolating any failure so a single pathological file cannot abort the
+        whole repo's extraction (mirrors the Python/Zig/Go per-file loop guard from PR #136).
+        Parse errors are already handled inside process_file; this backstops the rest
+        (RecursionError/MemoryError from deep nesting, extractor bugs)."""
+        try:
+            self.process_file(file_path)
+        except Exception as e:
+            print(f"Warning: failed to process {file_path}: {type(e).__name__}: {e}", file=sys.stderr)
+            self.stats['files_with_errors'] += 1
+
     def extract_from_scan(self, scan_result: Dict) -> Dict:
         """Extract functions from files listed in a scan result."""
         for file_info in scan_result.get('files', []):
             file_path = self.repo_path / file_info['path']
-            self.process_file(file_path)
+            self._process_file_guarded(file_path)
 
         return self.export()
 
@@ -706,7 +768,7 @@ class FunctionExtractor:
             for file_rel_path in files:
                 file_path = self.repo_path / file_rel_path
                 if file_path.exists():
-                    self.process_file(file_path)
+                    self._process_file_guarded(file_path)
         else:
             all_extensions = C_EXTENSIONS | CPP_EXTENSIONS
             for ext in all_extensions:
@@ -717,7 +779,7 @@ class FunctionExtractor:
                     # ancestor of repo_path contains one (a checkout under '/home/tester/' excludes all).
                     if {'.git', 'build', 'test', 'node_modules'} & set(file_path.relative_to(self.repo_path).parts):
                         continue
-                    self.process_file(file_path)
+                    self._process_file_guarded(file_path)
 
         return self.export()
 

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -294,7 +294,13 @@ class CallGraphBuilder:
         if fw_idx is not None and func_name not in self.functions_by_name:
             return self._resolve_callback_arg(node, source, caller_file, caller_class, fw_idx)
 
-        return self._resolve_simple_call(func_name, caller_file, caller_class, caller_namespace)
+        # A bare function call -- `foo()`, incl. a framework-callback dispatcher that is
+        # shadowed by a same-named user function and so lands here -- is resolved by PHP in
+        # the (namespaced/global) FUNCTION namespace, never as a method of the enclosing
+        # class. Pass caller_class=None so _resolve_simple_call's implicit-$this step does
+        # not poison the edge with a coincidentally same-named enclosing method (mirrors the
+        # string-callback fix in _resolve_callback_name). Namespace resolution is preserved.
+        return self._resolve_simple_call(func_name, caller_file, None, caller_namespace)
 
     def _resolve_callback_arg(self, node, source: bytes, caller_file: str,
                               caller_class: Optional[str], idx: int) -> Optional[str]:
@@ -310,8 +316,11 @@ class CallGraphBuilder:
         if idx >= len(arg_nodes) or not arg_nodes[idx].children:
             return None
         value = arg_nodes[idx].children[0]
-        if value.type == 'string':
-            name = source[value.start_byte:value.end_byte].decode('utf-8', errors='replace').strip('\'"')
+        # A callback name may be single-quoted (`string`) or double-quoted (`encapsed_string`);
+        # route both through _string_literal_value so `"cb"` / escaped names aren't dropped
+        # (PR#147 added encapsed_string support there but this resolver only saw `string`).
+        name = self._string_literal_value(value, source)
+        if name is not None:
             return self._resolve_callback_name(name, caller_file, caller_class)
         if value.type == 'array_creation_expression':
             # ['ClassName', 'method'] static callback (instance [$obj,'m'] needs a type we don't track).
@@ -319,11 +328,14 @@ class CallGraphBuilder:
             stack = [value]
             while stack:
                 n = stack.pop()
-                if n.type == 'string':
-                    strings.append(source[n.start_byte:n.end_byte].decode('utf-8', errors='replace').strip('\'"'))
+                lit = self._string_literal_value(n, source)
+                if lit is not None:
+                    strings.append(lit)
                 stack.extend(reversed(n.children))
             if len(strings) >= 2:
-                return self._resolve_class_call(strings[0], strings[1], caller_file)
+                # ['App\\Loader', 'load'] -- reduce the (possibly namespaced) class to its
+                # bare name so the array-form callback resolves like the string form.
+                return self._resolve_class_call(self._strip_namespace(strings[0]), strings[1], caller_file)
         return None
 
     def _resolve_callback_name(self, name: str, caller_file: str,
@@ -331,10 +343,16 @@ class CallGraphBuilder:
         """Resolve a string callback: 'Class::method' (static) or a plain function name."""
         if '::' in name:
             cls, _, method = name.partition('::')
-            return self._resolve_class_call(cls, method, caller_file)
+            # A namespaced callable ('App\\Sanitizer::run', either quote style) names a real
+            # class indexed by its bare name; reduce the qualified class to its last segment
+            # so it resolves like a plain callback instead of leaving an unmatched prefix.
+            return self._resolve_class_call(self._strip_namespace(cls), method, caller_file)
         if self._is_builtin(name):
             return None
-        return self._resolve_simple_call(name, caller_file, caller_class)
+        # A bare string callable ('name') is resolved by PHP as a GLOBAL function, never a
+        # method of the class the registration sits in. Pass caller_class=None so the implicit
+        # $this self-call step does not poison the edge with a same-named enclosing method.
+        return self._resolve_simple_call(name, caller_file, None)
 
     def _resolve_new(self, node, source: bytes, caller_file: str,
                      caller_class: Optional[str]) -> Optional[str]:
@@ -388,36 +406,58 @@ class CallGraphBuilder:
             return None
         return next(iter(literal_names))
 
+    # Double-quoted single-char PHP escapes. Octal (\0..\777), hex (\x..) and
+    # unicode (\u{..}) sequences are left literal: they are irrelevant to callable
+    # names and keeping them raw never drops a namespace segment.
+    _DQ_SIMPLE_ESCAPES = {
+        '\\\\': '\\', '\\"': '"', '\\$': '$', '\\n': '\n', '\\r': '\r',
+        '\\t': '\t', '\\v': '\v', '\\f': '\f', '\\e': '\x1b',
+    }
+
+    @staticmethod
+    def _unescape_php(seq: str, single_quoted: bool) -> str:
+        """Translate one tree-sitter `escape_sequence` to its runtime value.
+
+        PHP single-quoted strings escape ONLY `\\` and `\'`; every other backslash
+        pair is literal. Double-quoted strings recognise the C-style set above.
+        """
+        if single_quoted:
+            if seq == '\\\\':
+                return '\\'
+            if seq == "\\'":
+                return "'"
+            return seq
+        return CallGraphBuilder._DQ_SIMPLE_ESCAPES.get(seq, seq)
+
     @staticmethod
     def _string_literal_value(node, source: bytes) -> Optional[str]:
-        """Return the content of a string-literal node, else None.
+        """Return the runtime value of a string-literal node, else None.
 
         Single-quoted strings parse as `string`; double-quoted as `encapsed_string`.
-        An `encapsed_string` is accepted only when it has NO interpolation (its only
-        meaningful child is a single `string_content`), so `"dang$p"` is not treated
-        as a static literal.
+        tree-sitter splits EITHER into `string_content` + `escape_sequence` chunks when
+        the literal contains an escape (e.g. the `\\` namespace separator in the callable
+        'App\\Sanitizer::run'). We concatenate every chunk and unescape the sequences so the
+        result is the real PHP value -- never the first chunk truncated at the first
+        backslash, and never dropped just because an escape is present. An `encapsed_string`
+        carrying interpolation (a `variable_name` / embedded-expression child) is still
+        declined, so `"dang$p"` is not treated as a static literal.
         """
-        if node.type == 'string':
-            for child in node.children:
-                if child.type == 'string_content':
-                    return source[child.start_byte:child.end_byte].decode(
-                        'utf-8', errors='replace')
-            # Empty string literal ('') has no string_content child.
-            return ''
-        if node.type == 'encapsed_string':
-            content = None
-            for child in node.children:
-                if child.type == '"':
-                    continue
-                if child.type == 'string_content':
-                    if content is not None:
-                        return None  # multiple chunks -> unusual, decline
-                    content = source[child.start_byte:child.end_byte].decode(
-                        'utf-8', errors='replace')
-                else:
-                    return None  # interpolation / embedded expression -> not static
-            return content if content is not None else ''
-        return None
+        if node.type not in ('string', 'encapsed_string'):
+            return None
+        single_quoted = node.type == 'string'
+        parts = []
+        for child in node.children:
+            if child.type in ('"', "'"):
+                continue
+            raw = source[child.start_byte:child.end_byte].decode('utf-8', errors='replace')
+            if child.type == 'string_content':
+                parts.append(raw)
+            elif child.type == 'escape_sequence':
+                parts.append(CallGraphBuilder._unescape_php(raw, single_quoted))
+            else:
+                return None  # interpolation / embedded expression -> not static
+        # Empty literal ('' / "") has no content children -> ''.
+        return ''.join(parts)
 
     def _resolve_member_call(self, node, source: bytes, caller_file: str,
                               caller_class: Optional[str], root=None) -> Optional[str]:
@@ -503,20 +543,19 @@ class CallGraphBuilder:
                              caller_class: Optional[str],
                              caller_namespace: Optional[str] = None) -> Optional[str]:
         """Resolve a simple (unqualified) function call to a function ID."""
-        # 1. Check same class first (implicit $this)
-        if caller_class:
-            result = self._resolve_self_call(func_name, caller_file, caller_class)
-            if result:
-                return result
+        # NB: a bare unqualified call `foo()` has NO implicit `$this->` in PHP -- it
+        # resolves to a FUNCTION (current namespace, then global), never to a same-named
+        # method. Preferring a same-class method here misdirected the edge; a method is
+        # reachable only via $this->/self::/static:: (handled by _resolve_method_call).
 
-        # 2. Check same file
+        # 1. Check same file
         same_file_funcs = self.functions_by_file.get(caller_file, [])
         for func_id in same_file_funcs:
             func_data = self.functions.get(func_id, {})
             if func_data.get('name') == func_name and not func_data.get('class_name'):
                 return func_id
 
-        # 3. Check use/require-resolved files
+        # 2. Check use/require-resolved files
         file_imports = self.imports.get(caller_file, {})
         for import_name, import_type in file_imports.items():
             if import_type in ('require', 'require_once', 'include', 'include_once', 'use'):
@@ -533,7 +572,7 @@ class CallGraphBuilder:
                             if func_data.get('name') == func_name:
                                 return func_id
 
-        # 4. Unqualified call resolution across files. PHP resolves an unqualified
+        # 3. Unqualified call resolution across files. PHP resolves an unqualified
         #    function call within the caller's own namespace FIRST; if there is no such
         #    function it FALLS BACK to the global namespace. A same-named function in an
         #    unrelated namespace is never reachable this way, so it must not leak an edge.
@@ -637,6 +676,19 @@ class CallGraphBuilder:
     def _resolve_class_call(self, class_name: str, method_name: str,
                             caller_file: str) -> Optional[str]:
         """Resolve a ClassName::method() call."""
+        # Translate an import alias to its real class so `Bar::run()` / `new Bar()` resolves to
+        # the aliased target instead of dropping the edge. Every alias sibling form
+        # (`use App\Service\Foo as Bar;` and grouped `use App\{Foo as Bar};`) is recorded by the
+        # extractor as `imports[alias] = 'use_alias:<Target>'`; this is the single chokepoint
+        # through which `new`, `Class::method`, and string-callback resolution all pass.
+        import_entry = self.imports.get(caller_file, {}).get(class_name)
+        if isinstance(import_entry, str) and import_entry.startswith('use_alias:'):
+            class_name = import_entry[len('use_alias:'):]
+        # methods_by_class is keyed by BARE class name, so a namespace-qualified target
+        # ('App\Sanitizer' from a string/array callback) must be reduced to its last segment
+        # or the lookup misses and the handler+sink go unreachable. (No-op after alias
+        # translation, whose stored target is already a bare last segment.)
+        class_name = self._strip_namespace(class_name)
         # Check same file first
         class_key = f"{caller_file}:{class_name}"
         if class_key in self.methods_by_class:

--- a/libs/openant-core/parsers/php/function_extractor.py
+++ b/libs/openant-core/parsers/php/function_extractor.py
@@ -208,6 +208,41 @@ class FunctionExtractor:
                 aliases[alias] = [trait_name, method_name]
         return aliases
 
+    def _register_class(self, class_id: str, entry: Dict) -> None:
+        """Register a class/interface/trait/enum entry, MERGING on id collision.
+
+        A PHP name may be (re)declared in mutually-exclusive/guarded branches
+        (`if (...) { class Foo {..} } else { class Foo {..} }`, or a double
+        `!class_exists()` guard). All such branches share id `<file>:<name>`, so
+        a plain `self.classes[id] = entry` was last-write-wins and silently
+        dropped the earlier branch's methods/bases -- a false negative for the
+        call graph. Merge instead: union the list fields and keep the first
+        non-empty base. Only fields already present on the stored entry are
+        touched, so the (name-keyed, hence same-kind) schema is preserved.
+        """
+        existing = self.classes.get(class_id)
+        if existing is None:
+            self.classes[class_id] = entry
+            self.stats['total_classes'] += 1
+            return
+
+        def _union(a, b):
+            out = list(a or [])
+            for x in (b or []):
+                if x not in out:
+                    out.append(x)
+            return out
+
+        for key in ('methods', 'traits', 'interfaces'):
+            if key in existing:
+                existing[key] = _union(existing[key], entry.get(key))
+        if 'superclass' in existing and not existing.get('superclass'):
+            existing['superclass'] = entry.get('superclass')
+        if 'trait_aliases' in existing:
+            merged = dict(existing['trait_aliases'])
+            merged.update(entry.get('trait_aliases') or {})
+            existing['trait_aliases'] = merged
+
     def _get_visibility(self, node, source: bytes) -> Optional[str]:
         """Extract visibility modifier from a method_declaration node."""
         for child in node.children:
@@ -258,7 +293,16 @@ class FunctionExtractor:
         return 'function'
 
     def _extract_imports(self, tree, source: bytes) -> Dict[str, str]:
-        """Extract use declarations, namespace definitions, and include/require from a file."""
+        """Extract use declarations, namespace definitions, and include/require from a file.
+
+        An import alias is recorded as a distinct entry ``imports[alias] = 'use_alias:<Target>'``
+        (``<Target>`` is the target class's last segment), covering every sibling form:
+        ``use App\\Service\\Foo as Bar;`` at namespace scope AND grouped
+        ``use App\\Service\\{Foo as Bar, Baz};``. Downstream call resolution translates the alias
+        so `Bar::run()` / `new Bar()` resolves to the real class instead of dropping the edge. The
+        alias lives in the per-file ``imports`` map (not a separate top-level key) so it needs no
+        change to the process-file / export path. The ``use_alias:`` type is ignored by the
+        file-name import matcher, so it never leaks a spurious function edge."""
         imports = {}
         stack = [tree.root_node]
 
@@ -274,14 +318,22 @@ class FunctionExtractor:
                 if cleaned.startswith('use '):
                     cleaned = cleaned[4:]
                 cleaned = cleaned.rstrip(';').strip()
-                # Handle grouped `use A\B, C\D;` and drop trailing `as Alias` so the stored import is
-                # the namespace path (matched by file name downstream).
-                for part in cleaned.split(','):
-                    entry = part.strip()
-                    if not entry:
-                        continue
-                    path = entry.split(' as ')[0].strip() if ' as ' in entry else entry
-                    imports[path] = 'use'
+                # Expand both a flat `use A\B, C\D;` list and a grouped `use A\B\{C, D as E};`
+                # declaration into individual `path[ as alias]` entries, then record each.
+                for entry in self._expand_use_entries(cleaned):
+                    if ' as ' in entry:
+                        path, _, alias = entry.partition(' as ')
+                        path = path.strip()
+                        alias = alias.strip()
+                        # Map the alias to the target class's last segment so `Bar::run()`
+                        # / `new Bar()` resolves to the aliased class rather than dropping.
+                        if alias:
+                            target = path.replace('\\', '/').rsplit('/', 1)[-1]
+                            imports[alias] = f'use_alias:{target}'
+                    else:
+                        path = entry.strip()
+                    if path:
+                        imports[path] = 'use'
 
             elif node.type == 'namespace_definition':
                 # Extract namespace name
@@ -301,6 +353,25 @@ class FunctionExtractor:
             stack.extend(reversed(node.children))
 
         return imports
+
+    @staticmethod
+    def _expand_use_entries(cleaned: str) -> List[str]:
+        """Expand a cleaned `use` body into individual `path[ as alias]` entries.
+
+        Handles the grouped form `App\\Service\\{Foo as Bar, Baz}` by distributing the prefix
+        over every brace item, and the flat form `A\\B, C\\D` by splitting on commas. Returns
+        one string per imported name so the caller can uniformly detect a trailing `as` alias."""
+        if '{' in cleaned and '}' in cleaned:
+            prefix, _, rest = cleaned.partition('{')
+            prefix = prefix.strip().rstrip('\\')
+            inner = rest.split('}', 1)[0]
+            entries = []
+            for item in inner.split(','):
+                item = item.strip()
+                if item:
+                    entries.append(f'{prefix}\\{item}' if prefix else item)
+            return entries
+        return [p.strip() for p in cleaned.split(',') if p.strip()]
 
     def _extract_functions_from_tree(self, tree, source: bytes, file_path: Path,
                                      relative_path: str) -> None:
@@ -408,7 +479,7 @@ class FunctionExtractor:
                                 trait_aliases.update(
                                     self._extract_trait_aliases(child, source))
 
-                    self.classes[class_id] = {
+                    self._register_class(class_id, {
                         'name': new_class_name,
                         'file_path': relative_path,
                         'start_line': node.start_point[0] + 1,
@@ -419,8 +490,7 @@ class FunctionExtractor:
                         'superclass': superclass,
                         'interfaces': interfaces,
                         'namespace_name': namespace_name,
-                    }
-                    self.stats['total_classes'] += 1
+                    })
 
                 # Recurse into class body with updated class_name
                 if body_node:
@@ -450,7 +520,7 @@ class FunctionExtractor:
                                 if mname:
                                     methods.append(mname)
 
-                    self.classes[class_id] = {
+                    self._register_class(class_id, {
                         'name': new_iface_name,
                         'file_path': relative_path,
                         'start_line': node.start_point[0] + 1,
@@ -459,8 +529,7 @@ class FunctionExtractor:
                         'superclass': None,
                         'interfaces': [],
                         'namespace_name': namespace_name,
-                    }
-                    self.stats['total_classes'] += 1
+                    })
 
                 if body_node:
                     for child in reversed(body_node.children):
@@ -489,7 +558,7 @@ class FunctionExtractor:
                                 if mname:
                                     methods.append(mname)
 
-                    self.classes[class_id] = {
+                    self._register_class(class_id, {
                         'name': new_trait_name,
                         'file_path': relative_path,
                         'start_line': node.start_point[0] + 1,
@@ -498,8 +567,7 @@ class FunctionExtractor:
                         'superclass': None,
                         'interfaces': [],
                         'namespace_name': namespace_name,
-                    }
-                    self.stats['total_classes'] += 1
+                    })
 
                 if body_node:
                     for child in reversed(body_node.children):
@@ -533,7 +601,7 @@ class FunctionExtractor:
                                     else:
                                         methods.append(mname)
 
-                    self.classes[class_id] = {
+                    self._register_class(class_id, {
                         'name': new_enum_name,
                         'file_path': relative_path,
                         'start_line': node.start_point[0] + 1,
@@ -542,8 +610,7 @@ class FunctionExtractor:
                         'superclass': None,
                         'interfaces': [],
                         'namespace_name': namespace_name,
-                    }
-                    self.stats['total_classes'] += 1
+                    })
 
                 if body_node:
                     for child in reversed(body_node.children):
@@ -600,7 +667,7 @@ class FunctionExtractor:
                                 else:
                                     methods.append(mname)
 
-                    self.classes[f"{relative_path}:{anon_name}"] = {
+                    self._register_class(f"{relative_path}:{anon_name}", {
                         'name': anon_name,
                         'file_path': relative_path,
                         'start_line': node.start_point[0] + 1,
@@ -609,8 +676,7 @@ class FunctionExtractor:
                         'superclass': None,
                         'interfaces': [],
                         'namespace_name': namespace_name,
-                    }
-                    self.stats['total_classes'] += 1
+                    })
 
                     for child in reversed(body_node.children):
                         stack.append((child, anon_name, namespace_name))
@@ -795,31 +861,41 @@ class FunctionExtractor:
             'comment', 'declare_statement', '{', '}',
         }
 
-        def program_statements(node):
-            """Yield file-scope statement nodes.
+        def program_statements(node, ns_name=None):
+            """Yield ``(statement_node, enclosing_namespace)`` pairs.
 
             A braceless `namespace App;` is a self-contained node whose following
             statements are program-level SIBLINGS (tree-sitter-php does not nest
-            them), so we simply skip the namespace token-node. A braced
-            `namespace App { ... }` wraps its statements in a body, so we descend
-            into that body.
+            them), so we skip the namespace token-node but carry its name forward
+            to the siblings it governs. A braced `namespace App { ... }` wraps its
+            statements in a body, so we descend into that body with the name.
+            The namespace must ride along so the synthetic module unit is keyed to
+            its namespace rather than to a null one (which mis-keys it against the
+            file's other App\\ symbols).
             """
             for child in node.children:
                 if child.type == 'namespace_definition':
+                    name_node = child.child_by_field_name('name')
+                    child_ns = self._node_text(name_node, source) if name_node else ns_name
                     body = child.child_by_field_name('body')
                     if body is not None:
-                        yield from program_statements(body)
-                    # braceless: its real statements are program-level siblings,
-                    # reached later in this same loop; the namespace node itself
-                    # contributes no executable code.
+                        yield from program_statements(body, child_ns)
+                    else:
+                        # braceless: its real statements are program-level siblings,
+                        # reached later in this same loop; propagate the namespace
+                        # to them. The namespace node itself is not executable code.
+                        ns_name = child_ns
                     continue
                 if child.type in skip_types:
                     continue
-                yield child
+                yield child, ns_name
 
-        statements = list(program_statements(root))
-        if not statements:
+        pairs = list(program_statements(root))
+        if not pairs:
             return
+        statements = [stmt for stmt, _ in pairs]
+        # Key the unit to the namespace governing its statements (first non-null).
+        namespace_name = next((ns for _, ns in pairs if ns), None)
 
         code = '\n'.join(self._node_text(s, source) for s in statements).strip()
         if not code:
@@ -829,15 +905,16 @@ class FunctionExtractor:
         end_line = statements[-1].end_point[0] + 1
 
         func_id = f"{relative_path}:__module__"
+        qualified_name = f"{namespace_name}\\__module__" if namespace_name else '__module__'
         self.functions[func_id] = {
             'name': '__module__',
-            'qualified_name': '__module__',
+            'qualified_name': qualified_name,
             'file_path': relative_path,
             'start_line': start_line,
             'end_line': end_line,
             'code': code,
             'class_name': None,
-            'namespace_name': None,
+            'namespace_name': namespace_name,
             'parameters': [],
             'is_static': False,
             'unit_type': 'module_level',
@@ -864,8 +941,6 @@ class FunctionExtractor:
             self.stats['files_with_errors'] += 1
             return
 
-        self.stats['files_processed'] += 1
-
         # Extract imports
         self.imports[relative_path] = self._extract_imports(tree, source)
 
@@ -875,11 +950,27 @@ class FunctionExtractor:
         # Synthesise a module_level unit for any top-level procedural statements
         self._extract_module_level_unit(tree, source, relative_path)
 
+        # Count as processed only after extraction fully succeeds, so a file that crashes
+        # mid-extraction (caught by _process_file_guarded) is counted once as an error and
+        # never as processed.
+        self.stats['files_processed'] += 1
+
+    def _process_file_guarded(self, file_path: Path) -> None:
+        """Process one file, isolating any failure so a single pathological file cannot abort the
+        whole repo's extraction (mirrors the Python/Zig/Go per-file loop guard from PR #136).
+        Parse errors are already handled inside process_file; this backstops the rest
+        (RecursionError/MemoryError from deep nesting, extractor bugs)."""
+        try:
+            self.process_file(file_path)
+        except Exception as e:
+            print(f"Warning: failed to process {file_path}: {type(e).__name__}: {e}", file=sys.stderr)
+            self.stats['files_with_errors'] += 1
+
     def extract_from_scan(self, scan_result: Dict) -> Dict:
         """Extract functions from files listed in a scan result."""
         for file_info in scan_result.get('files', []):
             file_path = self.repo_path / file_info['path']
-            self.process_file(file_path)
+            self._process_file_guarded(file_path)
 
         return self.export()
 
@@ -889,7 +980,7 @@ class FunctionExtractor:
             for file_rel_path in files:
                 file_path = self.repo_path / file_rel_path
                 if file_path.exists():
-                    self.process_file(file_path)
+                    self._process_file_guarded(file_path)
         else:
             for ext in ('.php', '.phtml'):
                 for file_path in self.repo_path.rglob(f'*{ext}'):
@@ -899,7 +990,7 @@ class FunctionExtractor:
                     rel_parts = file_path.relative_to(self.repo_path).parts
                     if any(excl in rel_parts for excl in ('.git', 'vendor', 'node_modules', 'tmp', '.cache')):
                         continue
-                    self.process_file(file_path)
+                    self._process_file_guarded(file_path)
 
         return self.export()
 

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -283,7 +283,22 @@ class FunctionExtractor:
         """True if the call node carries a do..end or { } block."""
         return any(c.type in ('do_block', 'block') for c in node.children)
 
-    def _is_sinatra_class(self, relative_path: str, class_name: Optional[str]) -> bool:
+    @staticmethod
+    def _class_key(relative_path: str, class_name: Optional[str],
+                   module_name: Optional[str]) -> str:
+        """The self.classes key for a class, folding in its enclosing module.
+
+        The module namespace is part of a class's identity: `module A; class Foo`
+        and `module B; class Foo` are DISTINCT classes and must NOT share a key.
+        Every read of self.classes must build the key through here so it agrees
+        with the write site.
+        """
+        if module_name:
+            return f"{relative_path}:{module_name}::{class_name}"
+        return f"{relative_path}:{class_name}"
+
+    def _is_sinatra_class(self, relative_path: str, class_name: Optional[str],
+                          module_name: Optional[str] = None) -> bool:
         """True if `class_name` extends Sinatra::Base/Application (modular Sinatra).
 
         The class was registered in self.classes (with its superclass) before its
@@ -291,7 +306,7 @@ class FunctionExtractor:
         """
         if not class_name:
             return False
-        cls = self.classes.get(f"{relative_path}:{class_name}", {})
+        cls = self.classes.get(self._class_key(relative_path, class_name, module_name), {})
         superclass = cls.get('superclass') or ''
         return 'Sinatra::Base' in superclass or 'Sinatra::Application' in superclass
 
@@ -437,7 +452,7 @@ class FunctionExtractor:
                 elif (method_name in self._SINATRA_VERBS
                       and self._has_block(node) and args
                       and ((class_name is None and module_name is None)
-                           or self._is_sinatra_class(relative_path, class_name))):
+                           or self._is_sinatra_class(relative_path, class_name, module_name))):
                     # `get '/path' do..end` -- a Sinatra route, either classic
                     # top-level style or MODULAR style inside a `< Sinatra::Base`
                     # subclass. The class case is gated on the class actually
@@ -487,20 +502,41 @@ class FunctionExtractor:
                             break
 
                 if new_class_name:
-                    class_id = f"{relative_path}:{new_class_name}"
+                    # Fold the enclosing module into the class_id key. Two
+                    # GENUINELY-DISTINCT same-name classes in DIFFERENT modules
+                    # (`module A; class Foo` vs `module B; class Foo`) must get
+                    # DISTINCT ids -- they are distinct classes -- so the reopen
+                    # MERGE below does not wrongly union their methods and
+                    # superclass. A same-module reopen still collides -> merges.
+                    class_id = self._class_key(relative_path, new_class_name, module_name)
                     body_node = node.child_by_field_name('body')
                     methods = self._collect_class_method_names(body_node, source)
 
-                    self.classes[class_id] = {
-                        'name': new_class_name,
-                        'file_path': relative_path,
-                        'start_line': node.start_point[0] + 1,
-                        'end_line': node.end_point[0] + 1,
-                        'methods': methods,
-                        'superclass': superclass,
-                        'module_name': module_name,
-                    }
-                    self.stats['total_classes'] += 1
+                    # Ruby class reopening is idiomatic: a later `class X` block
+                    # augments the earlier one. MERGE rather than last-write-wins
+                    # so an earlier superclass (often omitted on reopen) and the
+                    # earlier methods are not dropped.
+                    existing = self.classes.get(class_id)
+                    if existing is None:
+                        self.classes[class_id] = {
+                            'name': new_class_name,
+                            'file_path': relative_path,
+                            'start_line': node.start_point[0] + 1,
+                            'end_line': node.end_point[0] + 1,
+                            'methods': methods,
+                            'superclass': superclass,
+                            'module_name': module_name,
+                        }
+                        self.stats['total_classes'] += 1
+                    else:
+                        if not existing.get('superclass') and superclass:
+                            existing['superclass'] = superclass
+                        seen = set(existing['methods'])
+                        existing['methods'].extend(
+                            m for m in methods if not (m in seen or seen.add(m))
+                        )
+                        existing['end_line'] = max(existing['end_line'],
+                                                   node.end_point[0] + 1)
 
                 # Recurse into class body with updated class_name and a FRESH
                 # per-body visibility state (defaults to public).
@@ -741,8 +777,6 @@ class FunctionExtractor:
             self.stats['files_with_errors'] += 1
             return
 
-        self.stats['files_processed'] += 1
-
         # Extract imports
         self.imports[relative_path] = self._extract_imports(tree, source)
 
@@ -751,6 +785,11 @@ class FunctionExtractor:
 
         # Extract file-scope top-level script code
         self._extract_module_level_code(tree, source, relative_path)
+
+        # Count as processed only after extraction fully succeeds, so a file that crashes
+        # mid-extraction (caught by _process_file_guarded) is counted once as an error and
+        # never as processed.
+        self.stats['files_processed'] += 1
 
     # Top-level program children that are NOT file-scope script statements:
     # definitions (their bodies are their own units) and comments.
@@ -817,11 +856,22 @@ class FunctionExtractor:
         self.stats['standalone_functions'] += 1
         self.stats['by_type']['module_level'] = self.stats['by_type'].get('module_level', 0) + 1
 
+    def _process_file_guarded(self, file_path: Path) -> None:
+        """Process one file, isolating any failure so a single pathological file cannot abort the
+        whole repo's extraction (mirrors the Python/Zig/Go per-file loop guard from PR #136).
+        Parse errors are already handled inside process_file; this backstops the rest
+        (RecursionError/MemoryError from deep nesting, extractor bugs)."""
+        try:
+            self.process_file(file_path)
+        except Exception as e:
+            print(f"Warning: failed to process {file_path}: {type(e).__name__}: {e}", file=sys.stderr)
+            self.stats['files_with_errors'] += 1
+
     def extract_from_scan(self, scan_result: Dict) -> Dict:
         """Extract functions from files listed in a scan result."""
         for file_info in scan_result.get('files', []):
             file_path = self.repo_path / file_info['path']
-            self.process_file(file_path)
+            self._process_file_guarded(file_path)
 
         return self.export()
 
@@ -831,15 +881,20 @@ class FunctionExtractor:
             for file_rel_path in files:
                 file_path = self.repo_path / file_rel_path
                 if file_path.exists():
-                    self.process_file(file_path)
+                    self._process_file_guarded(file_path)
         else:
             for ext in ('.rb', '.rake'):
                 for file_path in self.repo_path.rglob(f'*{ext}'):
+                    # Exclude on the REPO-RELATIVE path: should_exclude_directory tests every
+                    # segment, so passing the absolute path would let an ancestor named like an
+                    # excluded token (e.g. a repo under /private/tmp) drop the entire scan. rglob
+                    # yields paths under repo_path, so relative_to never raises.
                     if should_exclude_directory(
-                        file_path, ['.git', 'vendor', '.bundle', 'tmp', 'node_modules']
+                        file_path.relative_to(self.repo_path),
+                        ['.git', 'vendor', '.bundle', 'tmp', 'node_modules'],
                     ):
                         continue
-                    self.process_file(file_path)
+                    self._process_file_guarded(file_path)
 
         return self.export()
 

--- a/libs/openant-core/tests/parsers/c/test_c_nested_fn_collision.py
+++ b/libs/openant-core/tests/parsers/c/test_c_nested_fn_collision.py
@@ -1,0 +1,138 @@
+"""GNU nested functions with the same name in different enclosing functions
+must NOT collide (PR150-c-nested-fn-collision).
+
+PR #150 descends into function bodies to extract GNU nested functions but built
+their func_id as `path:name` without the enclosing-function scope. Two enclosing
+functions that each define a same-named nested helper therefore minted the SAME
+func_id (`t.c:helper`); `_store_function` treated the second as an ODR-duplicate
+(same signature) and dropped it, so one of the two distinct nested definitions was
+silently overwritten. The fix qualifies a nested function's func_id with its
+enclosing-function scope (`t.c:outer_a.helper`).
+"""
+import os
+import tempfile
+
+from parsers.c.function_extractor import FunctionExtractor
+
+
+def _extract(filename: str, src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    with open(os.path.join(repo, filename), "w") as fh:
+        fh.write(src)
+    return FunctionExtractor(repo).extract_all(files=[filename])["functions"]
+
+
+def test_same_named_nested_functions_do_not_collide():
+    fns = _extract(
+        "t.c",
+        "int outer_a(int x){\n"
+        "    int helper(int y){ return y + 1; }\n"
+        "    return helper(x);\n"
+        "}\n"
+        "int outer_b(int x){\n"
+        "    int helper(int y){ return y + 2; }\n"
+        "    return helper(x);\n"
+        "}\n"
+        "int main(){ return outer_a(1) + outer_b(2); }\n",
+    )
+    helpers = [v for v in fns.values() if v["name"] == "helper"]
+    # Both nested helpers must survive as distinct nodes (not collapsed to one).
+    assert len(helpers) == 2, (
+        f"both nested helper() definitions must be extracted, got {len(helpers)}; keys={list(fns)}"
+    )
+    # And they must be the two genuinely-different bodies (+1 vs +2), proving no overwrite.
+    assert len({h["code"] for h in helpers}) == 2, (
+        f"the two nested helpers must keep distinct bodies; keys={list(fns)}"
+    )
+    # func_ids are scoped by the enclosing function, so both are addressable.
+    assert "t.c:outer_a.helper" in fns and "t.c:outer_b.helper" in fns, (
+        f"nested func_ids must carry enclosing-function scope; keys={list(fns)}"
+    )
+
+
+def test_same_named_nested_lambdas_do_not_collide():
+    """A-class sibling: named lambdas (`auto f = [](){...};`) declared inside two
+    different enclosing functions must not collide either. Before the extension,
+    `_process_lambda_declaration` built `func_id = path:name` with no enclosing
+    scope, so `outer_a`'s and `outer_b`'s same-named lambda minted the SAME
+    func_id and one was overwritten."""
+    fns = _extract(
+        "t.cpp",
+        "int outer_a(int x){\n"
+        "    auto lam = [](int y){ return y + 1; };\n"
+        "    return lam(x);\n"
+        "}\n"
+        "int outer_b(int x){\n"
+        "    auto lam = [](int y){ return y + 2; };\n"
+        "    return lam(x);\n"
+        "}\n"
+        "int main(){ return outer_a(1) + outer_b(2); }\n",
+    )
+    lams = [v for v in fns.values() if v["name"] == "lam"]
+    # Both lambdas must survive as distinct nodes (not collapsed to one).
+    assert len(lams) == 2, (
+        f"both nested lambda lam definitions must be extracted, got {len(lams)}; keys={list(fns)}"
+    )
+    # And they must keep the two genuinely-different bodies (+1 vs +2), proving no overwrite.
+    assert len({l["code"] for l in lams}) == 2, (
+        f"the two nested lambdas must keep distinct bodies; keys={list(fns)}"
+    )
+    # func_ids are scoped by the enclosing function, so both are addressable.
+    assert "t.cpp:outer_a.lam" in fns and "t.cpp:outer_b.lam" in fns, (
+        f"lambda func_ids must carry enclosing-function scope; keys={list(fns)}"
+    )
+
+
+def test_nested_lambdas_in_overloaded_enclosers_do_not_collide():
+    """FA3: the two enclosing functions have the SAME BARE NAME (`outer`) and
+    differ only by overload signature (`int outer(int)` vs `int outer(double)`).
+    `_store_function` disambiguates the enclosers themselves, but if the nested
+    scope is built from the enclosing function's BARE full_name (`outer`) instead
+    of its DISAMBIGUATED id, both same-named nested lambdas mint the identical
+    `t.cpp:outer.lam` and one is silently overwritten. The scope must be built
+    from the disambiguated enclosing id so the nested lambdas stay distinct."""
+    fns = _extract(
+        "t.cpp",
+        "int outer(int x){\n"
+        "    auto lam = [](int y){ return y + 1; };\n"
+        "    return lam(x);\n"
+        "}\n"
+        "int outer(double x){\n"
+        "    auto lam = [](int y){ return y + 2; };\n"
+        "    return lam((int)x);\n"
+        "}\n"
+        "int main(){ return outer(1) + outer(2.0); }\n",
+    )
+    lams = [v for v in fns.values() if v["name"] == "lam"]
+    assert len(lams) == 2, (
+        f"both nested lambdas inside the overloaded enclosers must survive, "
+        f"got {len(lams)}; keys={list(fns)}"
+    )
+    assert len({l["code"] for l in lams}) == 2, (
+        f"the two nested lambdas must keep distinct bodies (+1 vs +2); keys={list(fns)}"
+    )
+
+
+def test_nested_functions_in_overloaded_enclosers_do_not_collide():
+    """FA3 sibling: GNU nested functions (not lambdas) inside two overloaded
+    enclosers must not collide either — same root cause, same fix path."""
+    fns = _extract(
+        "t.cpp",
+        "int outer(int x){\n"
+        "    int helper(int y){ return y + 1; }\n"
+        "    return helper(x);\n"
+        "}\n"
+        "int outer(double x){\n"
+        "    int helper(int y){ return y + 2; }\n"
+        "    return helper((int)x);\n"
+        "}\n"
+        "int main(){ return outer(1) + outer(2.0); }\n",
+    )
+    helpers = [v for v in fns.values() if v["name"] == "helper"]
+    assert len(helpers) == 2, (
+        f"both nested helpers inside the overloaded enclosers must survive, "
+        f"got {len(helpers)}; keys={list(fns)}"
+    )
+    assert len({h["code"] for h in helpers}) == 2, (
+        f"the two nested helpers must keep distinct bodies (+1 vs +2); keys={list(fns)}"
+    )

--- a/libs/openant-core/tests/parsers/c/test_callgraph_gnu_nested_fn.py
+++ b/libs/openant-core/tests/parsers/c/test_callgraph_gnu_nested_fn.py
@@ -26,7 +26,10 @@ def test_gnu_nested_function_extracted():
         "}\n"
         "int main(){ return outer(1); }\n",
     )
-    assert any(k.endswith(":inner") for k in fns), (
+    # The nested func_id is scoped by its enclosing function
+    # (`n.c:outer.inner`), so it ends with `.inner`, not `:inner`
+    # (PR150-c-nested-fn-collision).
+    assert any(k.endswith(":inner") or k.endswith(".inner") for k in fns), (
         f"GNU nested function inner() must be extracted; funcs={list(fns)}"
     )
     # sanity: the outer functions are still present (no regression to normal extraction)

--- a/libs/openant-core/tests/parsers/c/test_function_extractor_robustness.py
+++ b/libs/openant-core/tests/parsers/c/test_function_extractor_robustness.py
@@ -1,0 +1,72 @@
+"""Regression lock: one pathological C/C++ file must not abort the whole repo's extraction.
+
+PR #136 added a per-file loop guard (`_process_file_guarded`) to the PYTHON extractor only.
+The C extractor's caller loops (`extract_from_scan`, `extract_all`) still called
+`self.process_file(file_path)` directly, so a single file raising a non-parse error propagated
+out of the file loop and aborted the entire parse, losing ALL units collected so far. The fix
+mirrors Python/Zig/Go: wrap each file in `_process_file_guarded`.
+
+NOTE: requires the optional `tree_sitter_c` dependency; skipped where it is not installed.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tree_sitter_c")
+
+from parsers.c.function_extractor import FunctionExtractor  # noqa: E402
+
+
+def _repo(files: dict) -> str:
+    d = Path(os.path.realpath(tempfile.mkdtemp()))  # macOS /var -> /private/var so repo_path.resolve() matches
+    for name, src in files.items():
+        (d / name).write_text(src)
+    return str(d)
+
+
+def _wrap_boom(ex: FunctionExtractor, bad_name: str) -> None:
+    """Simulate a REAL mid-extraction crash: raise INSIDE the extraction body
+    (`_extract_functions_from_tree`), AFTER the point where the old buggy ordering had
+    already incremented files_processed. Patching process_file itself (raising before the
+    increment) would be FALSE-GREEN — it never exercises the increment ordering."""
+    orig = ex._extract_functions_from_tree
+
+    def boom(*args, **kwargs):
+        if any(bad_name in str(a) for a in args):
+            raise RecursionError("simulated deep extraction recursion")
+        return orig(*args, **kwargs)
+
+    ex._extract_functions_from_tree = boom
+
+
+_GOOD = "int alpha(void) { return 1; }\n"
+_BAD = "int beta(void) { return 2; }\n"
+
+
+def test_pathological_file_does_not_abort_extract_from_scan():
+    repo = _repo({"good.c": _GOOD, "bad.c": _BAD})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.c")
+    res = ex.extract_from_scan({"files": [{"path": "good.c"}, {"path": "bad.c"}]})
+    assert "good.c:alpha" in res["functions"], "good file's units lost — a bad file aborted the parse"
+    assert res["statistics"]["files_with_errors"] >= 1
+
+
+def test_pathological_file_does_not_abort_extract_all():
+    repo = _repo({"good.c": _GOOD, "bad.c": _BAD})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.c")
+    res = ex.extract_all(["good.c", "bad.c"])
+    assert "good.c:alpha" in res["functions"], "post-parse crash in one file aborted the batch"
+    assert res["statistics"]["files_with_errors"] >= 1
+
+
+def test_stats_not_double_counted():
+    repo = _repo({"good.c": _GOOD, "bad.c": _BAD})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.c")
+    st = ex.extract_all(["good.c", "bad.c"])["statistics"]
+    assert st["files_processed"] == 1, "a crashed file must not be counted as processed"
+    assert st["files_with_errors"] == 1

--- a/libs/openant-core/tests/parsers/php/test_callgraph_barecall_self_precedence.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_barecall_self_precedence.py
@@ -1,0 +1,54 @@
+"""PHP bare (unqualified) call must NOT bind to a same-named class METHOD.
+
+In PHP a bare `foo()` inside a method has NO implicit `$this->` -- it resolves to a
+function (current namespace, then the global namespace). To call a method you must
+write `$this->foo()`, `self::foo()`, or `static::foo()`. The call-graph builder's
+step-1 ("check same class first (implicit $this)") wrongly preferred a same-named
+METHOD over the free function, MISDIRECTING the edge to the method.
+
+RED before the fix: the bare `helper()` edge points at the same-class method
+Svc.helper instead of the free function helper (the true system() sink).
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    paths = []
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+        paths.append(p)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all(paths))
+    b.build_call_graph()
+    return b
+
+
+def _edges(b, caller_suffix):
+    keys = [k for k in b.call_graph if k.endswith(caller_suffix)]
+    return [e for k in keys for e in b.call_graph[k]]
+
+
+def test_barecall_binds_free_function_not_same_class_method():
+    b = _build({
+        "src/a.php": "<?php\n"
+                     "class Svc {\n"
+                     "  public function run($x){ helper($x); }\n"   # bare call -> free function
+                     "  public function helper($x){ echo $x; }\n"   # same-named METHOD (misdirect risk)
+                     "}\n",
+        "src/b.php": "<?php\nfunction helper($x){ system($x); }\n",  # free function (true sink)
+    })
+    edges = _edges(b, ":Svc.run")
+    assert any(e.endswith("b.php:helper") for e in edges), (
+        f"bare helper() must bind the FREE function (the system() sink), not the "
+        f"same-class method; got edges: {edges}"
+    )
+    assert not any(e.endswith(":Svc.helper") for e in edges), (
+        f"MISDIRECT: bare helper() bound the same-class method Svc.helper; got {edges}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_callback_double_quoted.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_callback_double_quoted.py
@@ -1,0 +1,63 @@
+"""Double-quoted (encapsed_string) callback targets must resolve (PR#147 FN).
+
+_resolve_callback_arg only recognized single-quoted `string` nodes, so a double-quoted
+callback -- `add_action('init', "handler")`, `spl_autoload_register(["Loader", "load"])`,
+`call_user_func("Cls::m")` -- parsed as `encapsed_string` and was dropped, leaving the
+registered handler (and its sink) unreachable. PR#147 already added encapsed_string support
+in _string_literal_value; the callback resolver just did not use it.
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "plugin.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _all_edges(b):
+    return [e for edges in b.call_graph.values() for e in edges]
+
+
+def test_framework_callback_double_quoted_name():
+    b = _build(
+        '<?php\n'
+        'add_action("init", "cleanup");\n'
+        'function cleanup(){ system("x"); }\n'
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith(":cleanup") for e in edges), (
+        f"double-quoted framework callback not registered as an edge; edges={edges}"
+    )
+
+
+def test_builtin_callback_double_quoted_scoped():
+    b = _build(
+        '<?php\n'
+        'call_user_func("Loader::load");\n'
+        'class Loader { static function load(){ system("x"); } }\n'
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith(":Loader.load") for e in edges), (
+        f"double-quoted Class::method callback not resolved; edges={edges}"
+    )
+
+
+def test_framework_callback_array_double_quoted():
+    b = _build(
+        '<?php\n'
+        'spl_autoload_register(["Loader", "load"]);\n'
+        'class Loader { static function load(){ system("x"); } }\n'
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith(":Loader.load") for e in edges), (
+        f"double-quoted array callback not resolved; edges={edges}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_callback_namespaced_escape.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_callback_namespaced_escape.py
@@ -1,0 +1,89 @@
+r"""Namespaced string callbacks must resolve to the real class method, not a truncated/false target.
+
+PR#147 rerouted the callback resolver through `_string_literal_value`, which returned only the
+FIRST `string_content` child of a string literal. tree-sitter splits an escaped literal like the
+idiomatic `'App\\Sanitizer::run'` (double-backslash namespace separator) into
+`string_content('App') + escape_sequence('\\') + string_content('Sanitizer::run')`, so the resolver
+saw only `App` -- truncating the class/method away (a dropped or false edge). The double-quoted
+variant fared worse: any `escape_sequence` child made `_string_literal_value` decline outright, so
+the callback (and its sink) vanished entirely.
+
+The fix concatenates + unescapes every chunk (so the name is the real PHP value `App\Sanitizer::run`)
+and reduces the qualified class to its bare name so it resolves exactly like a plain callback.
+Covers both quote styles and both single- and double-backslash source spellings.
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+BS = chr(92)  # a single backslash
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "plugin.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _all_edges(b):
+    return [e for edges in b.call_graph.values() for e in edges]
+
+
+def _assert_resolves(callback_literal: str):
+    # `Sanitizer::run` is the real sink; class lives under namespace App.
+    src = (
+        "<?php\n"
+        "namespace App;\n"
+        "class Sanitizer { static function run(){ system('x'); } }\n"
+        f"add_action('init', {callback_literal});\n"
+    )
+    b = _build(src)
+    edges = _all_edges(b)
+    assert any(e.endswith(":Sanitizer.run") for e in edges), (
+        f"namespaced callback {callback_literal} did not resolve to the real class method; edges={edges}"
+    )
+    # Must NOT produce the truncated / false `App` target.
+    assert not any(e.endswith(":App") or e.endswith(".App") for e in edges), (
+        f"namespaced callback {callback_literal} produced a truncated `App` target; edges={edges}"
+    )
+
+
+def test_single_quoted_double_backslash():
+    # Idiomatic PHP: 'App\\Sanitizer::run' -> tree-sitter escape_sequence -> was truncated to `App`.
+    _assert_resolves("'App" + BS + BS + "Sanitizer::run'")
+
+
+def test_double_quoted_double_backslash():
+    # "App\\Sanitizer::run" -> escape_sequence made _string_literal_value decline -> dropped edge.
+    _assert_resolves('"App' + BS + BS + 'Sanitizer::run"')
+
+
+def test_single_quoted_single_backslash():
+    # 'App\Sanitizer::run' -> single string_content, but namespace prefix never matched the index.
+    _assert_resolves("'App" + BS + "Sanitizer::run'")
+
+
+def test_double_quoted_single_backslash():
+    # "App\Sanitizer::run" -> single string_content, same namespace-prefix miss.
+    _assert_resolves('"App' + BS + 'Sanitizer::run"')
+
+
+def test_array_form_namespaced():
+    # spl_autoload_register(['App\\Sanitizer', 'run']) -- array-form namespaced callback.
+    src = (
+        "<?php\n"
+        "namespace App;\n"
+        "class Sanitizer { static function run(){ system('x'); } }\n"
+        "spl_autoload_register(['App" + BS + BS + "Sanitizer', 'run']);\n"
+    )
+    b = _build(src)
+    edges = _all_edges(b)
+    assert any(e.endswith(":Sanitizer.run") for e in edges), (
+        f"array-form namespaced callback did not resolve; edges={edges}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_encapsed_callback.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_encapsed_callback.py
@@ -1,0 +1,64 @@
+"""Double-quoted (encapsed_string) callback arguments must resolve to an edge (#147 sibling gap).
+
+PR #147 taught `_string_literal_value` that double-quoted strings parse as `encapsed_string`,
+but `_resolve_callback_arg` still only matched `value.type == 'string'` (single-quoted). So a
+double-quoted callback -- array_map("cb", ...), add_action('h', "cb") -- was dropped from the
+call graph, making the handler (and its sink) unreachable.
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "plugin.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _all_edges(b):
+    return [e for edges in b.call_graph.values() for e in edges]
+
+
+def test_double_quoted_builtin_callback_resolved():
+    # array_map is a PHP builtin higher-order call; its callback here is double-quoted.
+    b = _build(
+        "<?php\n"
+        'array_map("cleanse", [1,2,3]);\n'
+        "function cleanse($x){ system($x); return $x; }\n"
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith(":cleanse") for e in edges), (
+        f"double-quoted array_map callback must register an edge; edges={edges}"
+    )
+
+
+def test_double_quoted_framework_callback_resolved():
+    b = _build(
+        "<?php\n"
+        'add_action("init", "cleanup");\n'
+        "function cleanup(){ system('x'); }\n"
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith(":cleanup") for e in edges), (
+        f"double-quoted framework callback must register an edge; edges={edges}"
+    )
+
+
+def test_double_quoted_static_array_callback_resolved():
+    # ['Class', 'method'] array callback with double-quoted members.
+    b = _build(
+        "<?php\n"
+        'array_map(["Sanitizer", "run"], [1]);\n'
+        "class Sanitizer { static function run($x){ system($x); return $x; } }\n"
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith("Sanitizer.run") for e in edges), (
+        f"double-quoted array static callback must register an edge; edges={edges}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_framework_callback_method_poison.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_framework_callback_method_poison.py
@@ -1,0 +1,118 @@
+"""A bare string callback is a GLOBAL function, never a method of the enclosing class.
+
+`add_action('save_post', 'save_post')` (or call_user_func('foo')) uses the PHP callable
+string form 'name', which PHP resolves in the global function namespace only -- it can never
+name a method of the class the registration happens to sit in. The callback resolver routed
+the bare name through _resolve_simple_call WITH the enclosing caller_class, so its implicit
+$this self-call step matched a same-named method of that class and poisoned the edge, pointing
+the callback at the wrong target (and hiding the real global sink).
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "plugin.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _all_edges(b):
+    return [e for edges in b.call_graph.values() for e in edges]
+
+
+def test_framework_callback_string_binds_global_not_enclosing_method():
+    # add_action sits inside Handler::register; the class ALSO defines a save_post method.
+    # The string callback 'save_post' must bind the GLOBAL function (the real sink), not the
+    # coincidentally same-named class method.
+    b = _build(
+        "<?php\n"
+        "class Handler {\n"
+        "  public function register(){ add_action('save_post', 'save_post'); }\n"
+        "  public function save_post(){ echo 'inert method'; }\n"
+        "}\n"
+        "function save_post(){ system('rm -rf /'); }\n"
+    )
+    edges = _all_edges(b)
+    global_id = next(fid for fid, fd in b.functions.items()
+                     if fd.get('name') == 'save_post' and not fd.get('class_name'))
+    method_id = next(fid for fid, fd in b.functions.items()
+                     if fd.get('name') == 'save_post' and fd.get('class_name'))
+    assert global_id in edges, (
+        f"string callback 'save_post' must bind the GLOBAL function {global_id}; edges={edges}")
+    assert method_id not in edges, (
+        f"string callback 'save_post' must NOT bind enclosing class method {method_id}; edges={edges}")
+
+
+def test_call_user_func_string_binds_global_not_enclosing_method():
+    # Same poison via the builtin higher-order path (call_user_func).
+    b = _build(
+        "<?php\n"
+        "class C {\n"
+        "  public function go(){ call_user_func('handle'); }\n"
+        "  public function handle(){ echo 'inert method'; }\n"
+        "}\n"
+        "function handle(){ exec('danger'); }\n"
+    )
+    edges = _all_edges(b)
+    global_id = next(fid for fid, fd in b.functions.items()
+                     if fd.get('name') == 'handle' and not fd.get('class_name'))
+    method_id = next(fid for fid, fd in b.functions.items()
+                     if fd.get('name') == 'handle' and fd.get('class_name'))
+    assert global_id in edges, f"'handle' must bind GLOBAL {global_id}; edges={edges}"
+    assert method_id not in edges, f"'handle' must NOT bind method {method_id}; edges={edges}"
+
+
+def test_bare_call_binds_global_not_enclosing_method():
+    # A-class sibling of the string-callback poison, via the DIRECT-call fallthrough
+    # (_resolve_function_call -> _resolve_simple_call at :297). A bare `notify()` inside a
+    # class is a GLOBAL function call in PHP, never `$this->notify()`. The implicit-$this
+    # step-1 must not poison the edge with the same-named enclosing method (which would hide
+    # the real global sink).
+    b = _build(
+        "<?php\n"
+        "class Handler {\n"
+        "  public function register(){ notify(); }\n"
+        "  public function notify(){ echo 'inert method'; }\n"
+        "}\n"
+        "function notify(){ system('rm -rf /'); }\n"
+    )
+    edges = _all_edges(b)
+    global_id = next(fid for fid, fd in b.functions.items()
+                     if fd.get('name') == 'notify' and not fd.get('class_name'))
+    method_id = next(fid for fid, fd in b.functions.items()
+                     if fd.get('name') == 'notify' and fd.get('class_name'))
+    assert global_id in edges, (
+        f"bare call 'notify()' must bind the GLOBAL function {global_id}; edges={edges}")
+    assert method_id not in edges, (
+        f"bare call 'notify()' must NOT bind enclosing method {method_id}; edges={edges}")
+
+
+def test_shadowed_framework_dispatcher_binds_global_not_enclosing_method():
+    # A framework dispatcher name (add_action) that is SHADOWED by a user-defined global
+    # function is treated as a real call and also lands at the :297 fallthrough. It must
+    # bind that global user function, not a coincidentally same-named enclosing method.
+    b = _build(
+        "<?php\n"
+        "class Plugin {\n"
+        "  public function boot(){ add_action('init', 'x'); }\n"
+        "  public function add_action($h, $c){ echo 'inert method'; }\n"
+        "}\n"
+        "function add_action($h, $c){ system('danger'); }\n"
+    )
+    edges = _all_edges(b)
+    global_id = next(fid for fid, fd in b.functions.items()
+                     if fd.get('name') == 'add_action' and not fd.get('class_name'))
+    method_id = next(fid for fid, fd in b.functions.items()
+                     if fd.get('name') == 'add_action' and fd.get('class_name'))
+    assert global_id in edges, (
+        f"shadowed 'add_action()' must bind the GLOBAL function {global_id}; edges={edges}")
+    assert method_id not in edges, (
+        f"shadowed 'add_action()' must NOT bind enclosing method {method_id}; edges={edges}")

--- a/libs/openant-core/tests/parsers/php/test_callgraph_namespaced_static_callback.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_namespaced_static_callback.py
@@ -1,0 +1,59 @@
+"""Namespaced static-method string callback must resolve to its target (reachability FN fix).
+
+A single-quoted callback like 'App\\Sanitizer::run' carries a namespace-qualified class name,
+but the class index (methods_by_class) is keyed by BARE class name. The callback resolver funneled
+the qualified name straight into _resolve_class_call without stripping the namespace prefix, so the
+lookup missed -> the handler (and its sink) was unreachable. Sibling call sites (_resolve_new,
+_resolve_scoped_call) already stripped the prefix; the callback path did not.
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "app.php")
+    with open(p, "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all([p]))
+    b.build_call_graph()
+    return b
+
+
+def _all_edges(b):
+    return [e for edges in b.call_graph.values() for e in edges]
+
+
+def test_namespaced_static_string_callback_resolves():
+    # 'App\Sanitizer::run' passed to a builtin higher-order call.
+    b = _build(
+        "<?php\n"
+        "namespace App;\n"
+        "class Sanitizer {\n"
+        "  public static function run($v){ system($v); return $v; }\n"
+        "}\n"
+        "call_user_func('App\\\\Sanitizer::run', $_GET['x']);\n"
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith("Sanitizer.run") for e in edges), (
+        f"namespaced static callback 'App\\Sanitizer::run' dropped; edges={edges}"
+    )
+
+
+def test_namespaced_static_array_callback_resolves():
+    # ['App\Sanitizer', 'run'] array-form static callback also carries the namespace prefix.
+    b = _build(
+        "<?php\n"
+        "namespace App;\n"
+        "class Sanitizer {\n"
+        "  public static function run($v){ system($v); return $v; }\n"
+        "}\n"
+        "array_map(['App\\\\Sanitizer', 'run'], $items);\n"
+    )
+    edges = _all_edges(b)
+    assert any(e.endswith("Sanitizer.run") for e in edges), (
+        f"namespaced array static callback ['App\\Sanitizer','run'] dropped; edges={edges}"
+    )

--- a/libs/openant-core/tests/parsers/php/test_callgraph_use_alias.py
+++ b/libs/openant-core/tests/parsers/php/test_callgraph_use_alias.py
@@ -1,0 +1,106 @@
+r"""Aliased `use` imports resolve calls made via the alias (reachability FN).
+
+`_extract_imports` used to drop the trailing `as Bar`, so a `Bar::run()` / `new Bar()` call
+named the alias `Bar`, which never matched the real class `Foo`, and the edge (potentially to a
+sink) was lost. The extractor now records the alias as `imports[alias] = 'use_alias:<Target>'`
+and `_resolve_class_call` translates it before resolving.
+
+Covered sibling forms (all must resolve to the real target, never to an unrelated same-named
+symbol):
+  * `use App\Service\Foo as Bar;`      -- plain, namespace-scope alias (static call + `new`)
+  * `use App\Service\{Foo as Bar};`    -- GROUPED-use alias  (the previously-uncovered form)
+"""
+import os
+import tempfile
+
+from parsers.php.function_extractor import FunctionExtractor
+from parsers.php.call_graph_builder import CallGraphBuilder
+
+
+def _build(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    paths = []
+    for rel, src in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(src)
+        paths.append(p)
+    b = CallGraphBuilder(FunctionExtractor(repo).extract_all(paths))
+    b.build_call_graph()
+    return b
+
+
+def _edges(b, caller_suffix):
+    keys = [k for k in b.call_graph if k.endswith(caller_suffix)]
+    return [e for k in keys for e in b.call_graph[k]]
+
+
+def test_use_alias_static_call_resolves_to_target_class():
+    b = _build({
+        "svc.php": (
+            "<?php\n"
+            "namespace App\\Service;\n"
+            "class Foo { public static function run(){ system('x'); } }\n"
+        ),
+        "app.php": (
+            "<?php\n"
+            "use App\\Service\\Foo as Bar;\n"
+            "class Ctrl { public function go(){ return Bar::run(); } }\n"
+        ),
+    })
+    assert any(e.endswith(":Foo.run") for e in _edges(b, ":Ctrl.go")), (
+        f"Bar::run() (alias of App\\Service\\Foo) must resolve to Foo.run; "
+        f"got {_edges(b, ':Ctrl.go')}"
+    )
+
+
+def test_use_alias_new_resolves_to_target_constructor():
+    b = _build({
+        "svc.php": (
+            "<?php\n"
+            "namespace App\\Service;\n"
+            "class Foo { public function __construct(){ system('x'); } }\n"
+        ),
+        "app.php": (
+            "<?php\n"
+            "use App\\Service\\Foo as Bar;\n"
+            "class Ctrl { public function go(){ return new Bar(); } }\n"
+        ),
+    })
+    assert any(e.endswith(":Foo.__construct") for e in _edges(b, ":Ctrl.go")), (
+        f"new Bar() (alias of App\\Service\\Foo) must resolve to Foo.__construct; "
+        f"got {_edges(b, ':Ctrl.go')}"
+    )
+
+
+def test_grouped_use_alias_static_call_resolves_to_target_class():
+    # GROUPED-use alias `use App\Service\{Foo as Bar};` -- the sibling form the narrow fix missed.
+    b = _build({
+        "svc.php": (
+            "<?php\n"
+            "namespace App\\Service;\n"
+            "class Foo { public static function run(){ system('x'); } }\n"
+        ),
+        "app.php": (
+            "<?php\n"
+            "use App\\Service\\{Foo as Bar};\n"
+            "class Ctrl { public function go(){ return Bar::run(); } }\n"
+        ),
+    })
+    assert any(e.endswith(":Foo.run") for e in _edges(b, ":Ctrl.go")), (
+        f"grouped-use alias Bar::run() must resolve to Foo.run; got {_edges(b, ':Ctrl.go')}"
+    )
+
+
+def test_grouped_use_alias_extractor_records_target():
+    # The grouped form must distribute the `App\Service\` prefix over each brace item and record
+    # both the alias entry and the resolved path.
+    repo = os.path.realpath(tempfile.mkdtemp())
+    p = os.path.join(repo, "app.php")
+    with open(p, "w") as fh:
+        fh.write("<?php use App\\Service\\{Foo as Bar, Baz};")
+    out = FunctionExtractor(repo).extract_all([p])
+    imports = out["imports"]["app.php"]
+    assert imports.get("Bar") == "use_alias:Foo", imports  # grouped alias Bar -> class Foo
+    assert "App\\Service\\Baz" in imports, imports         # non-aliased grouped member resolved

--- a/libs/openant-core/tests/parsers/php/test_function_extractor_robustness.py
+++ b/libs/openant-core/tests/parsers/php/test_function_extractor_robustness.py
@@ -1,0 +1,66 @@
+"""Regression lock: one pathological PHP file must not abort the whole repo's extraction.
+
+PR #136 added a per-file loop guard (`_process_file_guarded`) to the PYTHON extractor only.
+The PHP extractor's caller loops (`extract_from_scan`, `extract_all`) still called
+`self.process_file(file_path)` directly, so a single file raising a non-parse error propagated
+out of the file loop and aborted the entire parse, losing ALL units collected so far. The fix
+mirrors Python/Zig/Go: wrap each file in `_process_file_guarded`.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+from parsers.php.function_extractor import FunctionExtractor
+
+
+def _repo(files: dict) -> str:
+    d = Path(os.path.realpath(tempfile.mkdtemp()))  # macOS /var -> /private/var so repo_path.resolve() matches
+    for name, src in files.items():
+        (d / name).write_text(src)
+    return str(d)
+
+
+def _wrap_boom(ex: FunctionExtractor, bad_name: str) -> None:
+    """Simulate a REAL mid-extraction crash: raise INSIDE the extraction body
+    (`_extract_functions_from_tree`), AFTER the point where the old buggy ordering had
+    already incremented files_processed. Patching process_file itself (raising before the
+    increment) would be FALSE-GREEN — it never exercises the increment ordering."""
+    orig = ex._extract_functions_from_tree
+
+    def boom(*args, **kwargs):
+        if any(bad_name in str(a) for a in args):
+            raise RecursionError("simulated deep extraction recursion")
+        return orig(*args, **kwargs)
+
+    ex._extract_functions_from_tree = boom
+
+
+_GOOD = "<?php\nfunction alpha() { return 1; }\n"
+_BAD = "<?php\nfunction beta() { return 2; }\n"
+
+
+def test_pathological_file_does_not_abort_extract_from_scan():
+    repo = _repo({"good.php": _GOOD, "bad.php": _BAD})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.php")
+    res = ex.extract_from_scan({"files": [{"path": "good.php"}, {"path": "bad.php"}]})
+    assert "good.php:alpha" in res["functions"], "good file's units lost — a bad file aborted the parse"
+    assert res["statistics"]["files_with_errors"] >= 1
+
+
+def test_pathological_file_does_not_abort_extract_all():
+    repo = _repo({"good.php": _GOOD, "bad.php": _BAD})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.php")
+    res = ex.extract_all(["good.php", "bad.php"])
+    assert "good.php:alpha" in res["functions"], "post-parse crash in one file aborted the batch"
+    assert res["statistics"]["files_with_errors"] >= 1
+
+
+def test_stats_not_double_counted():
+    repo = _repo({"good.php": _GOOD, "bad.php": _BAD})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.php")
+    st = ex.extract_all(["good.php", "bad.php"])["statistics"]
+    assert st["files_processed"] == 1, "a crashed file must not be counted as processed"
+    assert st["files_with_errors"] == 1

--- a/libs/openant-core/tests/parsers/php/test_php_class_dict_collision.py
+++ b/libs/openant-core/tests/parsers/php/test_php_class_dict_collision.py
@@ -1,0 +1,79 @@
+"""PHP classes dict last-write-wins: a same-name class redefined in a
+mutually-exclusive/guarded branch must NOT silently drop the earlier
+definition's methods/bases.
+
+Sibling of py-class-dict-overwrite-bases. PHP allows a class to be defined in
+conditional branches, e.g.
+    if (PHP_VERSION_ID >= 80000) { class Widget extends ModernBase { newFeature() } }
+    else                         { class Widget extends LegacyBase { oldFeature() } }
+Both branches share class_id `<file>:Widget`, so `self.classes[class_id] = {...}`
+overwrote the first with the last-in-source one -- a silent false negative for a
+SAST call-graph (methods on the dropped branch become unreachable). The fix
+merges same-id registrations (union methods/traits/interfaces, keep first base).
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.php.function_extractor import FunctionExtractor
+
+
+def _extract(php_source: str, filename: str = "cls.php") -> dict:
+    repo = tempfile.mkdtemp()
+    Path(repo, filename).write_text(php_source)
+    return FunctionExtractor(repo).extract_all([filename])
+
+
+def test_conditional_same_name_class_keeps_both_branch_methods():
+    src = (
+        "<?php\n"
+        "if (PHP_VERSION_ID >= 80000) {\n"
+        "    class Widget extends ModernBase {\n"
+        "        public function render() {}\n"
+        "        public function newFeature() {}\n"
+        "    }\n"
+        "} else {\n"
+        "    class Widget extends LegacyBase {\n"
+        "        public function render() {}\n"
+        "        public function oldFeature() {}\n"
+        "    }\n"
+        "}\n"
+    )
+    out = _extract(src)
+    widget_ids = [cid for cid, d in out["classes"].items() if d.get("name") == "Widget"]
+    assert len(widget_ids) == 1, f"same-name class stays one id; got {widget_ids}"
+    methods = set(out["classes"][widget_ids[0]]["methods"])
+    # Both env-dependently-reachable branches must survive the merge.
+    assert "newFeature" in methods and "oldFeature" in methods, (
+        f"a conditional branch's methods were dropped: {sorted(methods)}"
+    )
+    # An earlier branch's base must not be lost when the later branch declares one.
+    assert out["classes"][widget_ids[0]]["superclass"] in ("ModernBase", "LegacyBase")
+
+
+def test_guarded_same_name_trait_keeps_both_branch_methods():
+    # Traits carry a different entry schema (no 'traits'/'trait_aliases' keys);
+    # the merge must handle it without KeyError.
+    src = (
+        "<?php\n"
+        "if (!trait_exists('Helper')) {\n"
+        "    trait Helper { public function a() {} }\n"
+        "}\n"
+        "if (!trait_exists('Helper')) {\n"
+        "    trait Helper { public function b() {} }\n"
+        "}\n"
+    )
+    out = _extract(src)
+    ids = [cid for cid, d in out["classes"].items() if d.get("name") == "Helper"]
+    assert len(ids) == 1, f"same-name trait stays one id; got {ids}"
+    methods = set(out["classes"][ids[0]]["methods"])
+    assert "a" in methods and "b" in methods, f"a guarded trait def was dropped: {sorted(methods)}"
+
+
+def test_unique_name_class_id_unchanged():
+    out = _extract("<?php\nclass Solo { public function go() {} }\n", filename="u.php")
+    ids = [cid for cid, d in out["classes"].items() if d.get("name") == "Solo"]
+    assert ids == ["u.php:Solo"], f"unique-name class id must stay byte-identical; got {ids}"

--- a/libs/openant-core/tests/parsers/php/test_php_extractor.py
+++ b/libs/openant-core/tests/parsers/php/test_php_extractor.py
@@ -159,6 +159,54 @@ def test_class_only_file_has_no_module_level_unit(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# A namespaced module-level unit must carry its enclosing namespace
+# ---------------------------------------------------------------------------
+
+NAMESPACED_PROCEDURAL = """<?php
+namespace App;
+
+$config = $_GET['mode'];
+add_action('wp_ajax_x', 'handler');
+"""
+
+BRACED_NAMESPACED_PROCEDURAL = """<?php
+namespace App\\Web {
+    $config = $_GET['mode'];
+    add_action('wp_ajax_x', 'handler');
+}
+"""
+
+
+def test_braceless_namespaced_module_unit_carries_namespace(tmp_path):
+    """A module_level unit under `namespace App;` must be keyed to that namespace,
+    not to a null namespace (which mis-keys it against other App\\ symbols)."""
+    result = _extract(tmp_path, "plugin.php", NAMESPACED_PROCEDURAL)
+    units = result["functions"]
+    module_units = [
+        fd for fd in units.values() if fd.get("unit_type") == "module_level"
+    ]
+    assert module_units, "expected a module_level unit for the namespaced code"
+    assert module_units[0]["namespace_name"] == "App", (
+        "namespaced module_level unit must carry namespace 'App'; got "
+        f"{module_units[0]['namespace_name']!r}"
+    )
+
+
+def test_braced_namespaced_module_unit_carries_namespace(tmp_path):
+    """Same requirement for a braced `namespace App\\Web { ... }` block."""
+    result = _extract(tmp_path, "plugin.php", BRACED_NAMESPACED_PROCEDURAL)
+    units = result["functions"]
+    module_units = [
+        fd for fd in units.values() if fd.get("unit_type") == "module_level"
+    ]
+    assert module_units, "expected a module_level unit for the namespaced code"
+    assert module_units[0]["namespace_name"] == "App\\Web", (
+        "braced-namespaced module_level unit must carry namespace 'App\\\\Web'; got "
+        f"{module_units[0]['namespace_name']!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # PHP superglobals must seed entry points
 # ---------------------------------------------------------------------------
 

--- a/libs/openant-core/tests/parsers/ruby/test_class_reopen_merge.py
+++ b/libs/openant-core/tests/parsers/ruby/test_class_reopen_merge.py
@@ -1,0 +1,73 @@
+"""Regression test: Ruby class reopening must MERGE, not last-write-wins.
+
+Reopening a class is idiomatic Ruby. The FunctionExtractor keyed each class
+definition on ``<file>:<qualified_name>`` and did a plain dict assignment, so a
+later ``class Widget ... end`` block silently overwrote the earlier one --
+dropping the original superclass (breaking super-call and Sinatra::Base
+resolution) and the earlier method list.
+"""
+
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.ruby.function_extractor import FunctionExtractor
+
+
+def _extract(tmp_path: Path, filename: str, source: str) -> dict:
+    (tmp_path / filename).write_text(source)
+    return FunctionExtractor(str(tmp_path)).extract_all([filename])
+
+
+def test_reopen_preserves_superclass_and_merges_methods(tmp_path):
+    result = _extract(
+        tmp_path,
+        "reopen.rb",
+        "class Widget < Base\n"
+        "  def foo; end\n"
+        "end\n"
+        "\n"
+        "class Widget\n"          # reopened WITHOUT restating the superclass
+        "  def bar; end\n"
+        "end\n",
+    )
+    cls = result["classes"]["reopen.rb:Widget"]
+    # Superclass from the first opening must survive the reopen.
+    assert cls["superclass"] == "Base", cls
+    # Both definitions' methods must be present (union, not overwrite).
+    assert set(cls["methods"]) >= {"foo", "bar"}, cls
+
+
+def test_distinct_module_same_name_classes_are_not_merged(tmp_path):
+    """`module A; class Foo` and `module B; class Foo` are DISTINCT classes.
+
+    The reopen-merge keys on class_id. If class_id omits the module namespace
+    the two Foos collide and get wrongly merged (methods + superclass unioned).
+    They must stay separate: A::Foo has only `a`, B::Foo has only `b`.
+    """
+    result = _extract(
+        tmp_path,
+        "modns.rb",
+        "module A\n"
+        "  class Foo\n"
+        "    def a; end\n"
+        "  end\n"
+        "end\n"
+        "\n"
+        "module B\n"
+        "  class Foo\n"
+        "    def b; end\n"
+        "  end\n"
+        "end\n",
+    )
+    classes = result["classes"]
+    a_foo = classes["modns.rb:A::Foo"]
+    b_foo = classes["modns.rb:B::Foo"]
+    # Two distinct entries, no cross-contamination of methods.
+    assert set(a_foo["methods"]) == {"a"}, a_foo
+    assert set(b_foo["methods"]) == {"b"}, b_foo
+    assert a_foo["module_name"] == "A"
+    assert b_foo["module_name"] == "B"

--- a/libs/openant-core/tests/parsers/ruby/test_extract_all_abspath_wholerepo.py
+++ b/libs/openant-core/tests/parsers/ruby/test_extract_all_abspath_wholerepo.py
@@ -1,0 +1,46 @@
+"""Regression: extract_all must exclude by REPO-RELATIVE segments, not the
+absolute path.
+
+Defect (PR164-ruby-abspath-wholerepo-drop): ``extract_all`` walked
+``self.repo_path.rglob(...)`` and passed the ABSOLUTE ``file_path`` to
+``should_exclude_directory(file_path, [... 'tmp' ...])``. That helper tests
+every path *segment*, so a repository located under an ancestor named like an
+excluded token (``/private/tmp/repo``, ``.../vendor/checkout``) had EVERY file
+excluded -> zero functions extracted. The sibling Python extractor already
+guards on ``file_path.relative_to(self.repo_path).parts``.
+
+The module-basename ``function_extractor.py`` recurs across parsers, so the
+import is package-qualified to load the Ruby one unambiguously.
+"""
+
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.ruby.function_extractor import FunctionExtractor
+
+_SOURCE = "def greet\n  puts 'hi'\nend\n"
+
+
+def test_extract_all_walks_repo_under_excluded_ancestor(tmp_path: Path) -> None:
+    """A repo whose ANCESTOR dir is named 'tmp' must still be scanned.
+
+    The excluded token ('tmp') appears only ABOVE repo_path, so no file inside
+    the repo is genuinely in an excluded directory. With the abspath bug every
+    file is dropped; with the fix (relative-path exclusion) the method extracts.
+    """
+    repo = tmp_path / "tmp" / "repo"
+    repo.mkdir(parents=True)
+    (repo / "app.rb").write_text(_SOURCE)
+
+    extractor = FunctionExtractor(str(repo))
+    result = extractor.extract_all()  # no explicit file list -> rglob branch
+
+    names = {fd["name"] for fd in result["functions"].values()}
+    assert "greet" in names, (
+        "extract_all dropped every file because an ancestor segment matched an "
+        f"exclude token; extracted names={names}"
+    )

--- a/libs/openant-core/tests/parsers/ruby/test_function_extractor_robustness.py
+++ b/libs/openant-core/tests/parsers/ruby/test_function_extractor_robustness.py
@@ -1,0 +1,67 @@
+"""Regression lock: one pathological Ruby file must not abort the whole repo's extraction.
+
+PR #136 added a per-file loop guard (`_process_file_guarded`) to the PYTHON extractor only.
+The Ruby extractor's caller loops (`extract_from_scan`, `extract_all`) still called
+`self.process_file(file_path)` directly, so a single file raising a non-parse error (e.g. a
+`RecursionError` from a deeply-nested tree, or any bug in the extraction body) propagated out of
+the file loop and aborted the entire parse, losing ALL units collected so far. The fix mirrors
+Python/Zig/Go: wrap each file in `_process_file_guarded`.
+
+These tests drive the real extractor entry points, not hand-constructed dicts.
+"""
+import os
+import tempfile
+from pathlib import Path
+
+from parsers.ruby.function_extractor import FunctionExtractor
+
+
+def _repo(files: dict) -> str:
+    d = Path(os.path.realpath(tempfile.mkdtemp()))  # macOS /var -> /private/var so repo_path.resolve() matches
+    for name, src in files.items():
+        (d / name).write_text(src)
+    return str(d)
+
+
+def _wrap_boom(ex: FunctionExtractor, bad_name: str) -> None:
+    """Simulate a REAL mid-extraction crash: raise INSIDE the extraction body
+    (`_extract_functions_from_tree`), AFTER the point where the old buggy ordering had
+    already incremented files_processed. This is what distinguishes the fix: with the
+    increment moved to the END of process_file, a file crashing here is counted once as an
+    error and never as processed. Patching process_file itself (raising before the increment)
+    would be FALSE-GREEN — it never exercises the increment ordering."""
+    orig = ex._extract_functions_from_tree
+
+    def boom(*args, **kwargs):
+        if any(bad_name in str(a) for a in args):
+            raise RecursionError("simulated deep extraction recursion")
+        return orig(*args, **kwargs)
+
+    ex._extract_functions_from_tree = boom
+
+
+def test_pathological_file_does_not_abort_extract_from_scan():
+    repo = _repo({"good.rb": "def alpha\n  1\nend\n", "bad.rb": "def beta\n  2\nend\n"})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.rb")
+    res = ex.extract_from_scan({"files": [{"path": "good.rb"}, {"path": "bad.rb"}]})
+    assert "good.rb:alpha" in res["functions"], "good file's units lost — a bad file aborted the parse"
+    assert res["statistics"]["files_with_errors"] >= 1
+
+
+def test_pathological_file_does_not_abort_extract_all():
+    repo = _repo({"good.rb": "def alpha\n  1\nend\n", "bad.rb": "def beta\n  2\nend\n"})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.rb")
+    res = ex.extract_all(["good.rb", "bad.rb"])
+    assert "good.rb:alpha" in res["functions"], "post-parse crash in one file aborted the batch"
+    assert res["statistics"]["files_with_errors"] >= 1
+
+
+def test_stats_not_double_counted():
+    repo = _repo({"good.rb": "def alpha\n  1\nend\n", "bad.rb": "def beta\n  2\nend\n"})
+    ex = FunctionExtractor(repo)
+    _wrap_boom(ex, "bad.rb")
+    st = ex.extract_all(["good.rb", "bad.rb"])["statistics"]
+    assert st["files_processed"] == 1, "a crashed file must not be counted as processed"
+    assert st["files_with_errors"] == 1

--- a/libs/openant-core/tests/test_php_call_graph.py
+++ b/libs/openant-core/tests/test_php_call_graph.py
@@ -131,4 +131,6 @@ def test_extract_imports_namespace_use_declaration():
     tree = parser.parse(src)
     imports = FunctionExtractor("/r")._extract_imports(tree, src)
     assert "App\\Service\\Foo" in imports, imports
-    assert "App\\Bar" in imports, imports  # alias stripped to the namespace path
+    assert "App\\Bar" in imports, imports  # namespace path recorded for file-name matching
+    # The alias is recorded as its own entry pointing at the target class's last segment.
+    assert imports.get("B") == "use_alias:Bar", imports  # alias B -> class Bar


### PR DESCRIPTION
## What
Robustness/correctness hardening for `call_graph_builder.py, function_extractor.py`.

## Fixes in this PR (7)
- php callgraph combined
- PR136 perfile loopguard missing
- PR150 c nested fn collision
- php module unit namespace null
- ruby class reopen superclass lastw
- php classes dict last write overwr
- PR164 ruby abspath wholerepo d

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).