### PR TITLE
fix: harden application_context.py

### DIFF
--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -26,7 +26,7 @@ Usage:
 import json
 import re
 import sys
-from dataclasses import dataclass, asdict, field
+from dataclasses import dataclass, asdict, field, fields
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -166,6 +166,18 @@ class ApplicationContext:
             str(level).lower() == "untrusted"
             for level in (self.trust_boundaries or {}).values()
         )
+
+
+def _context_kwargs_from_dict(data: dict) -> dict:
+    """Allowlist-filter an untrusted dict to ApplicationContext dataclass fields.
+
+    LLM output and hand-edited JSON files can carry unknown/hallucinated keys;
+    passing them straight to ``ApplicationContext(**data)`` raises an uncaught
+    TypeError. Keep only keys that name a real dataclass field so construction
+    is robust to extra keys.
+    """
+    allowed = {f.name for f in fields(ApplicationContext)}
+    return {k: v for k, v in data.items() if k in allowed}
 
 
 # Files to check for manual override (in order of priority)
@@ -373,6 +385,32 @@ def detect_entry_points(repo_path: Path) -> str:
     return "\n".join(findings[:30])  # Limit output
 
 
+def _application_context_from_override(data: Any, filename: str) -> ApplicationContext:
+    """Build an ApplicationContext from operator override data, tolerating unknown keys.
+
+    An unknown/extra key makes ``ApplicationContext(**data)`` raise TypeError, which
+    the caller's broad ``except`` swallows -- silently dropping the whole override.
+    Filter to the dataclass's known fields (allowlist) and warn on the rest so the
+    known keys are still honored.
+
+    Raises ValueError when ``data`` is not a mapping (empty/list/scalar frontmatter),
+    so the caller's existing ``except`` handles it exactly like any other parse
+    failure -- falling through to the next MANUAL_OVERRIDE_FILES entry rather than
+    short-circuiting the precedence loop.
+    """
+    if not isinstance(data, dict):
+        raise ValueError(f"manual override is not a mapping (got {type(data).__name__})")
+    data = {**data, "source": "manual"}
+    known = {f.name for f in fields(ApplicationContext)}
+    unknown = [k for k in data if k not in known]
+    if unknown:
+        print(
+            f"Warning: ignoring unknown key(s) in {filename}: {', '.join(sorted(str(k) for k in unknown))}",
+            file=sys.stderr,
+        )
+    return ApplicationContext(**{k: v for k, v in data.items() if k in known})
+
+
 def check_manual_override(repo_path: Path) -> ApplicationContext | None:
     """Check for manual override file in the repository.
 
@@ -395,8 +433,7 @@ def check_manual_override(repo_path: Path) -> ApplicationContext | None:
             if filename.endswith('.json'):
                 # Direct JSON format
                 data = read_json(filepath)
-                data['source'] = 'manual'
-                return ApplicationContext(**data)
+                return _application_context_from_override(data, filename)
 
             # .md files need raw text so regex can extract the embedded JSON block.
             with open_utf8(filepath) as _f:
@@ -407,8 +444,7 @@ def check_manual_override(repo_path: Path) -> ApplicationContext | None:
                 json_match = re.search(r'```json\s*(.*?)\s*```', content, re.DOTALL)
                 if json_match:
                     data = json.loads(json_match.group(1))
-                    data['source'] = 'manual'
-                    return ApplicationContext(**data)
+                    return _application_context_from_override(data, filename)
 
                 # Check for YAML frontmatter
                 yaml_match = re.match(r'^---\s*\n(.*?)\n---', content, re.DOTALL)
@@ -416,8 +452,7 @@ def check_manual_override(repo_path: Path) -> ApplicationContext | None:
                     try:
                         import yaml
                         data = yaml.safe_load(yaml_match.group(1))
-                        data['source'] = 'manual'
-                        return ApplicationContext(**data)
+                        return _application_context_from_override(data, filename)
                     except ImportError:
                         print("Warning: PyYAML not installed, cannot parse YAML frontmatter", file=sys.stderr)
 
@@ -518,7 +553,7 @@ def generate_application_context(
     repo_path: Path,
     binding: PhaseBinding,
     force_regenerate: bool = False,
-) -> ApplicationContext:
+) -> ApplicationContext | None:
     """Generate application context using LLM analysis.
 
     Checks for manual override first, then falls back to LLM generation.
@@ -585,8 +620,29 @@ def generate_application_context(
 
     data['source'] = 'llm'
 
-    # Validate and create context (will raise UnsupportedApplicationTypeError if invalid)
-    return ApplicationContext(**data)
+    # Allowlist-filter to dataclass fields: the LLM can hallucinate unknown/extra
+    # keys, and a raw ApplicationContext(**data) would raise an uncaught TypeError
+    # ("unexpected keyword argument") that crashes context generation. Drop unknown
+    # keys so only recognized fields reach the constructor.
+    data = _context_kwargs_from_dict(data)
+
+    # Validate and create context (will raise UnsupportedApplicationTypeError if invalid).
+    # The allowlist filter above closes the UNKNOWN-key crash, but the LLM can also
+    # OMIT a required field (application_type / purpose); ApplicationContext(**data)
+    # then raises an uncaught TypeError ("missing required positional argument") that
+    # crashes generation — the exact class this hardening set out to kill. Untrusted
+    # LLM output: warn to stderr and fall back gracefully (return None; both callers —
+    # context/generate_context.py and core/scanner.py — wrap this call in a broad
+    # try/except and continue without a context).
+    try:
+        return ApplicationContext(**data)
+    except TypeError as e:
+        print(
+            f"WARNING: LLM returned an incomplete application context "
+            f"(missing required field): {e}. Skipping app context.",
+            file=sys.stderr,
+        )
+        return None
 
 
 def save_context(context: ApplicationContext, output_path: Path) -> None:
@@ -614,10 +670,22 @@ def load_context(input_path: Path) -> ApplicationContext:
         ApplicationContext loaded from file.
     """
     data = read_json(input_path)
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a JSON object in {input_path}, got {type(data).__name__}")
     # Mark as manual to skip validation (already validated when saved)
     original_source = data.get('source', 'llm')
     data['source'] = 'manual'  # Temporarily bypass validation
-    context = ApplicationContext(**data)
+    # Sibling of the LLM path: a hand-edited JSON file may carry unknown keys;
+    # allowlist-filter to dataclass fields so **data cannot raise TypeError.
+    data = _context_kwargs_from_dict(data)
+    # The filter drops unknown keys, but a saved/edited file can also be MISSING a
+    # required field (application_type / purpose); ApplicationContext(**data) then
+    # raises a raw, uninformative TypeError. This is a trusted-ish on-disk file, so
+    # surface a clear, actionable error naming the offending path instead of crashing.
+    try:
+        context = ApplicationContext(**data)
+    except TypeError as e:
+        raise ValueError(f"Invalid context in {input_path}: {e}")
     context.source = original_source  # Restore original source
     return context
 

--- a/libs/openant-core/tests/test_appcontext_llm_unknown_key.py
+++ b/libs/openant-core/tests/test_appcontext_llm_unknown_key.py
@@ -1,0 +1,124 @@
+"""Regression test for HUNT-sib-appcontext-man-5.
+
+generate_application_context() constructs ``ApplicationContext(**data)`` directly
+on JSON parsed from LLM output. An LLM that hallucinates an unknown/extra key
+(e.g. ``"threat_actors"``) makes ``**data`` pass an unexpected keyword argument to
+the dataclass __init__ -> uncaught TypeError, crashing context generation.
+
+The fix must allowlist-filter the LLM dict to the ApplicationContext dataclass
+fields before construction, so unknown keys are dropped rather than crashing.
+"""
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+import json  # noqa: E402
+
+import pytest  # noqa: E402
+
+from context import application_context as appctx  # noqa: E402
+from context.application_context import (  # noqa: E402
+    ApplicationContext,
+    generate_application_context,
+    load_context,
+)
+
+
+_LLM_JSON_WITH_HALLUCINATED_KEY = """```json
+{
+  "application_type": "cli_tool",
+  "purpose": "A command-line tool.",
+  "intended_behaviors": ["runs commands"],
+  "trust_boundaries": {"cli_args": "trusted"},
+  "requires_remote_trigger": false,
+  "confidence": 0.9,
+  "evidence": ["has a CLI entry point"],
+  "threat_actors": ["nation-state"],
+  "totally_made_up_field": 123
+}
+```"""
+
+
+def test_hallucinated_llm_key_does_not_crash(tmp_path, monkeypatch):
+    # A repo with at least one context source so gather_context_sources is non-empty.
+    (tmp_path / "README.md").write_text("# Demo\nA small CLI tool.\n")
+
+    monkeypatch.setattr(
+        appctx, "simple_text", lambda *a, **k: _LLM_JSON_WITH_HALLUCINATED_KEY
+    )
+    fake_binding = SimpleNamespace(provider_name="fake", model="fake-model")
+
+    # Pre-fix: raises TypeError (unexpected keyword argument 'threat_actors').
+    ctx = generate_application_context(
+        tmp_path, fake_binding, force_regenerate=True
+    )
+
+    assert isinstance(ctx, ApplicationContext)
+    assert ctx.application_type == "cli_tool"
+    assert ctx.source == "llm"
+    # The hallucinated keys must not have been set as attributes.
+    assert not hasattr(ctx, "threat_actors")
+    assert not hasattr(ctx, "totally_made_up_field")
+
+
+# --- FA3 same-mechanism residual: MISSING required field -------------------
+#
+# The allowlist filter closes the UNKNOWN-key crash, but if the LLM OMITS a
+# required field (application_type / purpose) then ApplicationContext(**data)
+# still raises an uncaught TypeError ("missing required positional argument") —
+# the exact crash class the fix set out to kill. generate_application_context
+# (untrusted LLM output) must fall back gracefully (return None); load_context
+# (a saved/edited file) must raise a clear ValueError, not a raw TypeError.
+
+# Exact repro from the audit finding: valid JSON, omits the required `purpose`.
+_LLM_JSON_MISSING_PURPOSE = """```json
+{
+  "application_type": "cli_tool",
+  "confidence": 0.9,
+  "threat_actors": ["x"]
+}
+```"""
+
+_LLM_JSON_EMPTY_OBJECT = """```json
+{}
+```"""
+
+_LLM_JSON_ONLY_UNKNOWN_KEYS = """```json
+{"threat_actors": ["x"], "totally_made_up_field": 123}
+```"""
+
+
+@pytest.mark.parametrize(
+    "llm_json",
+    [
+        _LLM_JSON_MISSING_PURPOSE,
+        _LLM_JSON_EMPTY_OBJECT,
+        _LLM_JSON_ONLY_UNKNOWN_KEYS,
+    ],
+)
+def test_missing_required_field_does_not_crash(tmp_path, monkeypatch, llm_json):
+    (tmp_path / "README.md").write_text("# Demo\nA small CLI tool.\n")
+    monkeypatch.setattr(appctx, "simple_text", lambda *a, **k: llm_json)
+    fake_binding = SimpleNamespace(provider_name="fake", model="fake-model")
+
+    # Pre-fix: raises TypeError (missing required positional argument 'purpose').
+    # Post-fix: graceful fallback to None so callers continue without a context.
+    ctx = generate_application_context(
+        tmp_path, fake_binding, force_regenerate=True
+    )
+    assert ctx is None
+
+
+def test_load_context_missing_required_field_raises_valueerror(tmp_path):
+    # A saved/hand-edited context file missing the required `purpose` field.
+    bad = tmp_path / "application_context.json"
+    bad.write_text(json.dumps({"application_type": "cli_tool", "confidence": 0.9}))
+
+    # Pre-fix: raw TypeError (missing required positional argument 'purpose').
+    # Post-fix: a clear ValueError naming the offending file.
+    with pytest.raises(ValueError) as excinfo:
+        load_context(bad)
+    assert str(bad) in str(excinfo.value)
+    assert not isinstance(excinfo.value, TypeError)

--- a/libs/openant-core/tests/test_appcontext_override_robust.py
+++ b/libs/openant-core/tests/test_appcontext_override_robust.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from context.application_context import check_manual_override
+
+
+def test_numeric_key_ok(tmp_path):
+    (tmp_path / "OPENANT.md").write_text(
+        "---\napplication_type: cli_tool\npurpose: p\n123: x\n---\n"
+    )
+    c = check_manual_override(tmp_path)
+    assert c and c.application_type == "cli_tool"
+
+
+def test_empty_yaml_single_file_no_crash(tmp_path):
+    (tmp_path / "OPENANT.md").write_text("---\n\n---\nbody\n")
+    # raise caught by the loop's except, no other override file -> None
+    assert check_manual_override(tmp_path) is None
+
+
+def test_list_yaml_single_file_no_crash(tmp_path):
+    (tmp_path / "OPENANT.md").write_text("---\n- a\n- b\n---\nbody\n")
+    assert check_manual_override(tmp_path) is None
+
+
+def test_precedence_malformed_high_priority_falls_through(tmp_path):
+    # OPENANT.md (highest priority) is malformed; OPENANT.json (lower) is valid.
+    # Regression: the helper must NOT short-circuit the loop -> the valid json wins.
+    (tmp_path / "OPENANT.md").write_text("---\n- not\n- a\n- map\n---\nbody\n")
+    (tmp_path / "OPENANT.json").write_text(
+        '{"application_type": "web_app", "purpose": "valid override"}'
+    )
+    c = check_manual_override(tmp_path)
+    assert c is not None, "malformed OPENANT.md short-circuited the precedence loop"
+    assert c.application_type == "web_app"
+
+
+def test_unknown_key_override_honored_not_dropped(tmp_path):
+    # the primary finding: an unknown key must not discard the whole override
+    (tmp_path / "OPENANT.json").write_text(
+        '{"application_type":"cli_tool","purpose":"p","bogus":1}'
+    )
+    c = check_manual_override(tmp_path)
+    assert c and c.application_type == "cli_tool"


### PR DESCRIPTION
## What
Robustness/correctness hardening for `application_context.py`.

## Fixes in this PR (1)
- appcontext combined

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).