### PR TITLE
fix: harden __init__.py, agent.py, context_enhancer.py (+4 more)

### DIFF
--- a/libs/openant-core/tests/test_agent_degenerate_exit.py
+++ b/libs/openant-core/tests/test_agent_degenerate_exit.py
@@ -1,0 +1,153 @@
+"""Regression tests for degenerate-exit classification in the agentic enhancer.
+
+Bug (agent-degenerate-exit-neutral-drop): when the tool-use loop ended without
+a completed ``finish`` tool call — the model emitted a bare ``end_turn``, made
+no tool calls, or hit MAX_ITERATIONS — ``analyze_unit`` stamped
+``security_classification="neutral"``. "neutral" is a *genuine* verdict ("no
+security relevance"), so an analysis that never completed was indistinguishable
+from a unit the agent inspected and cleared. Downstream (analyzer's
+exploitable-filter, CSV export, experiment reporting) silently bucketed the
+dropped unit as a real neutral finding.
+
+The three degenerate exits must carry a DISTINCT classification so the no-op /
+error state is recorded, not masqueraded as a neutral verdict.
+
+Pure/deterministic: a stub adapter drives the loop, no network.
+"""
+from utilities.llm.adapter import CompletionResult, TextBlock, ToolUseBlock
+from utilities.agentic_enhancer.agent import ContextAgent, INCOMPLETE_CLASSIFICATION
+from utilities.context_enhancer import ContextEnhancer
+
+
+class _StubIndex:
+    def get_function(self, name):
+        return None
+
+    def search_usages(self, *a, **kw):
+        return []
+
+    def search_definitions(self, *a, **kw):
+        return []
+
+    def list_functions(self, *a, **kw):
+        return []
+
+
+class _FakeAdapter:
+    name = "fake"
+    supports_tools = True
+
+    def __init__(self, results):
+        # results: a list consumed one per iteration (last repeats)
+        self._results = list(results)
+
+    def complete(self, **kw):
+        if len(self._results) > 1:
+            return self._results.pop(0)
+        return self._results[0]
+
+
+class _FakeBinding:
+    phase = "enhance"
+    model = "fake-model"
+
+    def __init__(self, adapter):
+        self.adapter = adapter
+
+
+class _FakeTracker:
+    def record_call(self, **kw):
+        return {"cost_usd": 0.0}
+
+
+def _agent(results):
+    binding = _FakeBinding(_FakeAdapter(results))
+    return ContextAgent(index=_StubIndex(), binding=binding, tracker=_FakeTracker())
+
+
+def _run(agent):
+    return agent.analyze_unit(
+        unit_id="test:fn",
+        unit_type="function",
+        primary_code="def fn():\n    return 1\n",
+        static_deps=[],
+        static_callers=[],
+    )
+
+
+def test_end_turn_without_finish_is_not_a_neutral_verdict():
+    """The anchor path: bare end_turn with no finish tool call."""
+    result = _run(_agent([
+        CompletionResult(
+            content=[TextBlock("I think I'm done.")],
+            input_tokens=1, output_tokens=1, stop_reason="end_turn",
+        )
+    ]))
+    assert result.security_classification != "neutral", (
+        "degenerate end_turn exit was stamped 'neutral' — indistinguishable "
+        "from a genuine no-security-relevance verdict"
+    )
+    assert result.security_classification == "incomplete"
+
+
+def test_no_tool_calls_is_not_a_neutral_verdict():
+    """Sibling path: model responded but made no tool calls."""
+    result = _run(_agent([
+        CompletionResult(
+            content=[TextBlock("hmm")],
+            input_tokens=1, output_tokens=1, stop_reason="tool_use",
+        )
+    ]))
+    assert result.security_classification != "neutral"
+    assert result.security_classification == "incomplete"
+
+
+def test_max_iterations_is_not_a_neutral_verdict():
+    """Sibling path: loop exhausts MAX_ITERATIONS without finishing."""
+    # Every iteration asks for a non-finish tool, so the loop never completes.
+    looping = CompletionResult(
+        content=[ToolUseBlock(id="t", name="search_usages", input={})],
+        input_tokens=1, output_tokens=1, stop_reason="tool_use",
+    )
+    agent = _agent([looping])
+    agent.tool_executor.execute = lambda name, inp: {"status": "ok", "result": {}}
+    result = _run(agent)
+    assert result.security_classification != "neutral"
+    assert result.security_classification == "incomplete"
+
+
+def test_incomplete_unit_is_reported_under_incomplete_not_neutral():
+    """Reporting residual (FA3): the enhance-phase summary must not mask a
+    degenerate-exit unit as a real neutral finding.
+
+    A unit that hit a degenerate exit carries security_classification=
+    'incomplete' and has NO 'error' field, so the error-continue guard in
+    _compute_agentic_stats does not skip it. Before the fix it fell through the
+    classification if/elif chain into the else -> neutral_found bucket (and the
+    'neutral' summary key), re-masquerading as neutral on the enhance summary.
+    It must instead be tallied under a distinct incomplete_found key.
+    """
+    units = [
+        {  # degenerate exit: incomplete classification, no error field
+            "agent_context": {
+                "security_classification": INCOMPLETE_CLASSIFICATION,
+                "include_functions": [],
+                "agent_metadata": {"iterations": 20},
+            }
+        },
+        {  # a genuine neutral verdict, for contrast
+            "agent_context": {
+                "security_classification": "neutral",
+                "include_functions": [],
+                "agent_metadata": {"iterations": 3},
+            }
+        },
+    ]
+    stats = ContextEnhancer._compute_agentic_stats(units)
+    assert stats["incomplete_found"] == 1, (
+        "degenerate-exit unit was not tallied under incomplete_found"
+    )
+    assert stats["neutral_found"] == 1, (
+        "only the genuine neutral verdict belongs in neutral_found; the "
+        "incomplete unit leaked into it"
+    )

--- a/libs/openant-core/tests/test_context_enhancer_diff_scope.py
+++ b/libs/openant-core/tests/test_context_enhancer_diff_scope.py
@@ -1,0 +1,66 @@
+"""Regression: single-shot enhance_dataset must keep the context-lookup dict
+scoped to ALL units, not the diff-selected subset.
+
+context_enhancer.enhance_dataset reassigns ``units`` to the diff-selected
+subset, then builds ``units_by_id`` from that filtered list. But the code's own
+comment promises ``units_by_id`` is kept over ALL units so that
+``enhance_unit``'s same-file cross-unit context lookup still resolves callers/
+callees that live outside the diff scope. The bug drops those non-diff units
+from the lookup dict, so a changed unit loses same-file context from unchanged
+siblings.
+
+This test overrides ``enhance_unit`` to record the ``all_units`` dict it is
+handed (no LLM call) and asserts an unchanged same-file sibling is still
+reachable through it.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utilities.context_enhancer import ContextEnhancer  # noqa: E402
+
+
+class _RecordingEnhancer(ContextEnhancer):
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self.seen_all_units = None
+
+    def enhance_unit(self, unit, all_units):
+        # Record the lookup dict handed to us; skip the real LLM call.
+        self.seen_all_units = dict(all_units)
+        unit["llm_context"] = {}
+        return unit
+
+
+def _unit(uid, file_path, diff_selected):
+    return {
+        "id": uid,
+        "diff_selected": diff_selected,
+        "unit_type": "function",
+        "code": {"primary_origin": {"file_path": file_path, "function_name": uid}},
+        "metadata": {"direct_calls": [], "direct_callers": []},
+    }
+
+
+def test_units_by_id_spans_all_units_not_diff_subset():
+    dataset = {
+        "units": [
+            _unit("a.py:changed", "a.py", True),
+            _unit("a.py:sibling", "a.py", False),  # unchanged same-file context
+        ]
+    }
+    binding = SimpleNamespace(provider_name="test", model="test")
+    enhancer = _RecordingEnhancer(binding)
+
+    enhancer.enhance_dataset(dataset, workers=1)
+
+    assert enhancer.seen_all_units is not None, "enhance_unit was never called"
+    # The changed unit is processed; the unchanged sibling must remain in the
+    # cross-unit lookup dict so same-file context resolution still works.
+    assert "a.py:changed" in enhancer.seen_all_units
+    assert "a.py:sibling" in enhancer.seen_all_units, (
+        "non-diff sibling dropped from units_by_id — cross-unit context lost"
+    )

--- a/libs/openant-core/tests/test_enhance_failed_context_error_key.py
+++ b/libs/openant-core/tests/test_enhance_failed_context_error_key.py
@@ -1,0 +1,95 @@
+"""Regression test for: single-shot enhance failed-context path sets no 'error' key.
+
+Bug (enhancer-failed-context-no-error-key):
+    ``core/enhancer.py`` counts enhancement failures with ``if ctx.get("error")``
+    (line ~151), mirroring the agentic path which sets a structured
+    ``agent_context["error"]`` on failure. But the single-shot failure path in
+    ``ContextEnhancer.enhance_unit`` writes ``_get_default_context()`` with NO
+    ``error`` key, so single-shot failures are never counted — they fall through
+    to the classification branch and are reported as if successfully enhanced
+    (error_count == 0, units_enhanced == all units).
+
+No network: ``simple_text`` is monkeypatched to raise / return junk.
+"""
+import pytest
+
+
+class _FakeAdapter:
+    name = "anthropic"
+    supports_tools = True
+
+    def complete(self, *, model, system, messages, max_tokens, tools=None):  # pragma: no cover
+        raise AssertionError("adapter must not be called")
+
+    def validate(self, model):  # pragma: no cover
+        pass
+
+
+def _fake_binding():
+    from utilities.llm import PhaseBinding
+
+    return PhaseBinding(
+        phase="enhance",
+        adapter=_FakeAdapter(),
+        model="claude-test",
+        provider_name="anthropic",
+    )
+
+
+def _make_enhancer():
+    from utilities.context_enhancer import ContextEnhancer
+
+    return ContextEnhancer(binding=_fake_binding(), tracker=None)
+
+
+def _unit():
+    return {"id": "u0", "code": {"primary_code": "def f(): pass"}, "unit_type": "function"}
+
+
+def test_exception_failure_sets_error_key(monkeypatch):
+    """When the LLM call raises, the failed llm_context must carry an 'error'
+    dict so enhancer.py's ``if ctx.get('error')`` counts the failure."""
+    import utilities.context_enhancer as ce
+
+    def boom(*a, **k):
+        raise RuntimeError("provider exploded")
+
+    monkeypatch.setattr(ce, "simple_text", boom)
+
+    enh = _make_enhancer()
+    unit = enh.enhance_unit(_unit(), {})
+    ctx = unit["llm_context"]
+
+    err = ctx.get("error")
+    assert err, "failed single-shot llm_context must set an 'error' key (enhancer.py counts on it)"
+    # enhancer.py does err.get("type") when err is a dict.
+    assert isinstance(err, dict) and err.get("type"), "error must be a structured dict with a 'type'"
+
+
+def test_parse_failure_sets_error_key(monkeypatch):
+    """When the response can't be parsed to JSON, the failed context is likewise
+    a failure and must carry an 'error' key."""
+    import utilities.context_enhancer as ce
+
+    monkeypatch.setattr(ce, "simple_text", lambda *a, **k: "not-json-at-all")
+
+    enh = _make_enhancer()
+    unit = enh.enhance_unit(_unit(), {})
+    ctx = unit["llm_context"]
+    assert ctx.get("error"), "unparseable-response failed context must set an 'error' key"
+
+
+def test_enhancer_counts_singleshot_failure_as_error(monkeypatch):
+    """End-to-end at the counting layer: a failed single-shot unit must be
+    tallied by enhancer.py's error loop, not reported as an enhanced unit."""
+    import utilities.context_enhancer as ce
+
+    monkeypatch.setattr(ce, "simple_text", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x")))
+
+    enh = _make_enhancer()
+    unit = enh.enhance_unit(_unit(), {})
+
+    # Reproduce enhancer.py's aggregation loop (mode != agentic -> llm_context).
+    ctx = unit.get("llm_context", {})
+    error_count = 1 if ctx.get("error") else 0
+    assert error_count == 1, "single-shot failure must be counted as an error by enhancer.py"

--- a/libs/openant-core/tests/test_enhance_resilience.py
+++ b/libs/openant-core/tests/test_enhance_resilience.py
@@ -171,6 +171,49 @@ class TestAgenticBoundedRetry:
 
 
 # --------------------------------------------------------------------------
+# an ERRORED unit must NOT masquerade as a genuine `neutral` verdict.
+# --------------------------------------------------------------------------
+class TestErroredUnitNotNeutral:
+    def test_exception_path_does_not_persist_neutral_classification(self, monkeypatch):
+        """When enhance_unit_with_agent raises, the except handler must persist a
+        NON-verdict security_classification (e.g. 'error'/'incomplete'), never
+        'neutral'. Otherwise the exploitable-filter / CSV read the errored unit as
+        a genuine benign result -- the same masquerade as the agent-degenerate exit.
+        """
+        from unittest.mock import MagicMock
+
+        from utilities import context_enhancer as ce
+
+        enh = _make_enhancer()
+        fake_index = MagicMock()
+        fake_index.get_statistics.return_value = {"total_functions": 0, "total_files": 0}
+        monkeypatch.setattr(ce, "load_index_from_file", lambda *a, **k: fake_index)
+
+        # A non-retryable failure so the post-loop retry does not re-run the unit.
+        def boom(unit, index, binding, tracker, verbose):
+            raise ValueError("agent blew up")
+
+        monkeypatch.setattr(ce, "enhance_unit_with_agent", boom)
+
+        result = enh.enhance_dataset_agentic(
+            dataset=_dataset(1), analyzer_output_path=None, repo_path=None, workers=1,
+        )
+
+        u0 = result["units"][0]
+        ctx = u0.get("agent_context", {})
+        # The error itself must be recorded (drives retry / stats tally).
+        assert ctx.get("error"), "errored unit lost its error record"
+        # The masquerade: an errored unit tagged 'neutral' is read as a real verdict.
+        assert ctx.get("security_classification") != "neutral", (
+            "errored unit persisted security_classification='neutral' -- masquerades "
+            "as a genuine benign verdict to the exploitable-filter/CSV"
+        )
+        assert ctx.get("security_classification") in ("error", "incomplete"), (
+            f"expected a non-verdict marker, got {ctx.get('security_classification')!r}"
+        )
+
+
+# --------------------------------------------------------------------------
 # single-shot enhance must support checkpoint/resume.
 # --------------------------------------------------------------------------
 class TestSingleShotCheckpoint:

--- a/libs/openant-core/tests/test_exploit_path_nondict.py
+++ b/libs/openant-core/tests/test_exploit_path_nondict.py
@@ -1,0 +1,41 @@
+"""Regression: _has_conclusive_exploit_path must not crash on a truthy
+non-dict ``exploit_path`` in model-supplied verification (finding
+findingverifier-862-869-exploitpath-nondict).
+
+A model can emit ``verification.exploit_path`` as a bare string (e.g.
+"reached") instead of the expected dict. The truthiness guard
+(``if not exploit_path``) lets a truthy non-dict through, and the
+subsequent ``exploit_path.get(...)`` raises AttributeError.
+
+``_has_conclusive_exploit_path(self, result)`` does not touch ``self``, so
+it is exercised unbound with ``None`` as the instance (avoids the heavy
+FindingVerifier constructor that requires a tool-supporting adapter).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from utilities.finding_verifier import FindingVerifier  # noqa: E402
+
+
+def _call(verification: object) -> bool:
+    return FindingVerifier._has_conclusive_exploit_path(None, {"verification": verification})
+
+
+def test_truthy_nondict_exploit_path_does_not_crash():
+    # Truthy non-dict exploit_path (a bare string) must be treated as
+    # not-conclusive, exactly like a missing exploit_path — never crash.
+    assert _call({"exploit_path": "reached"}) is False
+
+
+def test_missing_exploit_path_is_not_conclusive():
+    assert _call({}) is False
+
+
+def test_dict_exploit_path_sink_not_reached_is_conclusive():
+    # Preserve existing conclusive-path semantics for well-formed dicts.
+    assert _call({"exploit_path": {"sink_reached": False}}) is True

--- a/libs/openant-core/tests/test_json_corrector_output_cap.py
+++ b/libs/openant-core/tests/test_json_corrector_output_cap.py
@@ -1,0 +1,115 @@
+"""
+Conformance test for the json_corrector output-cap truncation bug.
+
+Bug (finding jsoncorrect-output-cap-2048): utilities/json_corrector.py
+``extract_json_with_llm`` capped the correction call at ``max_tokens=2048``.
+The correction has to reproduce the ENTIRE corrected verdict JSON (verdict +
+an array of vulnerabilities, each with 8 fields, + reasoning). A large but
+perfectly valid corrected JSON exceeds 2048 tokens, so the provider truncates
+the reply mid-structure. ``_parse_json_response`` then fails to parse the
+truncated (unbalanced-brace) JSON and returns ``None`` -- so a recoverable
+response is REJECTED and ``attempt_correction`` emits an ERROR verdict.
+
+The sibling module that GENERATES this exact schema, utilities/finding_verifier.py,
+uses ``MAX_TOKENS_PER_RESPONSE = 4096``; the ``simple_text`` helper defaults to
+8192. json_corrector alone under-capped at 2048.
+
+This test stubs ``simple_text`` with a fake provider that returns a large valid
+corrected JSON, TRUNCATED to whatever ``max_tokens`` budget it is handed
+(~4 chars/token) -- exactly how a real provider cuts a reply off at the cap.
+
+    RED  on pristine core: max_tokens=2048 -> reply truncated -> parse fails
+                           -> attempt_correction returns verdict ERROR.
+    GREEN on patched core:  raised cap -> full JSON fits -> parse succeeds
+                           -> verdict VULNERABLE preserved.
+
+Select the core under test with OPENANT_CORE_ROOT (defaults to pristine).
+"""
+
+import json
+import os
+import sys
+
+
+_CORE_ROOT = os.environ.get(
+    "OPENANT_CORE_ROOT",
+    "/Users/gadievron/Documents/ClaudeNew/OpenAnt/new-bugs-2/OpenAnt/libs/openant-core",
+)
+if _CORE_ROOT not in sys.path:
+    sys.path.insert(0, _CORE_ROOT)
+
+
+# A large but perfectly valid corrected JSON: many vulnerabilities, each with
+# the full 8-field schema. Serialized it is well over 2048 tokens (~8KB), so a
+# 2048-token cap truncates it; an un-capped/raised budget lets it through whole.
+def _build_large_valid_json() -> str:
+    vulns = []
+    for i in range(40):
+        vulns.append({
+            "type": "SQL Injection",
+            "severity": "CRITICAL",
+            "source": f"req.body.field_{i} entering handler number {i} of the route",
+            "sink": f"db.query() call site {i} in core/appHandler.js building raw SQL",
+            "flow": f"user input field_{i} -> string concatenation -> db.query -> database",
+            "evidence": f"var q = 'SELECT * FROM Users WHERE x=' + req.body.field_{i};",
+            "why_vulnerable": (
+                f"User-controlled field_{i} is concatenated directly into the SQL "
+                f"statement with no parameterization or escaping, allowing injection."
+            ),
+        })
+    doc = {
+        "verdict": "VULNERABLE",
+        "confidence": 0.95,
+        "vulnerabilities": vulns,
+        "reasoning": "Multiple injection sinks reached by untrusted request fields.",
+    }
+    return json.dumps(doc, indent=2)
+
+
+_LARGE_VALID_JSON = _build_large_valid_json()
+
+
+def _run():
+    import utilities.json_corrector as jc
+
+    captured = {}
+
+    # Fake provider: returns the large valid JSON, but truncated to the token
+    # budget it was given (~4 chars/token) -- i.e. it stops emitting at the cap.
+    def _fake_simple_text(binding, prompt, *, max_tokens=8192, **kwargs):
+        captured["max_tokens"] = max_tokens
+        char_budget = max_tokens * 4
+        return _LARGE_VALID_JSON[:char_budget]
+
+    original = jc.simple_text
+    jc.simple_text = _fake_simple_text
+    try:
+        result = jc.JSONCorrector(binding=None).attempt_correction(
+            "not json, please recover this large analysis result"
+        )
+    finally:
+        jc.simple_text = original
+
+    # Sanity: the full JSON really is big enough that a 2048-token cap truncates
+    # it (otherwise the test would not exercise the bug).
+    assert len(_LARGE_VALID_JSON) > 2048 * 4, (
+        "fixture JSON too small to exercise the 2048-token cap"
+    )
+
+    assert result.get("verdict") == "VULNERABLE", (
+        f"correction was rejected: verdict={result.get('verdict')!r} "
+        f"json_corrected={result.get('json_corrected')!r}; the output cap of "
+        f"max_tokens={captured.get('max_tokens')} truncated a valid corrected JSON"
+    )
+    assert result.get("json_corrected") is True, "expected a successful correction"
+    print(
+        f"PASS: large valid corrected JSON survives (cap={captured.get('max_tokens')})"
+    )
+
+
+def test_json_corrector_output_not_truncated_by_cap():
+    _run()
+
+
+if __name__ == "__main__":
+    _run()

--- a/libs/openant-core/tests/test_json_corrector_schema_shape.py
+++ b/libs/openant-core/tests/test_json_corrector_schema_shape.py
@@ -1,0 +1,100 @@
+"""
+Conformance test for jsoncorrect-schema-mismatch-enhance-review.
+
+Bug: utilities/json_corrector.py hardcodes the security-analysis extraction
+schema (verdict / vulnerabilities / reasoning) AND gates correction success on
+the presence of a ``verdict`` field. But it is also invoked by the enhance and
+review phases, whose valid output shapes have NO verdict:
+
+  * context_enhancer -> {missing_dependencies, additional_callers, data_flow,
+                         imports, reasoning, confidence}
+  * context_reviewer -> {context_complete, missing_items, confidence, reasoning}
+
+So a malformed-but-recoverable enhance/review response is (a) prompted with the
+WRONG schema (the LLM is told to emit verdict/vulnerabilities, destroying the
+enhance/review data) and (b) even a perfectly-extracted enhance/review dict is
+REJECTED by the verdict-only success gate and replaced with the ERROR sentinel.
+The enhancement/review is then silently dropped.
+
+The fix makes the corrector schema-aware: callers pass the expected ``schema``
+string (used to build the extraction prompt) and ``required_keys`` (used to
+validate the corrected shape).
+
+    RED  on pristine core: attempt_correction/get_json_extraction_prompt take no
+         schema kwarg -> TypeError; a valid enhance dict is dropped for ERROR.
+    GREEN on patched core: enhance-shaped extraction survives; prompt reflects
+         the requested schema; the default vuln path is unchanged.
+
+Select the core under test with OPENANT_CORE_ROOT (defaults to the worktree).
+"""
+
+import os
+import sys
+
+_CORE_ROOT = os.environ.get(
+    "OPENANT_CORE_ROOT",
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
+if _CORE_ROOT not in sys.path:
+    sys.path.insert(0, _CORE_ROOT)
+
+
+ENHANCE_SCHEMA = """{
+    "missing_dependencies": [],
+    "additional_callers": [],
+    "data_flow": {"inputs": [], "outputs": [], "tainted_variables": [], "security_relevant_flows": []},
+    "imports": [],
+    "reasoning": "analysis summary",
+    "confidence": 0.0
+}"""
+
+
+def test_json_corrector_schema_shape():
+    import utilities.json_corrector as jc
+    from utilities.json_corrector import JSONCorrector
+
+    # (1) The extraction prompt must reflect the requested (enhance) schema and
+    #     NOT force the vuln verdict schema onto an enhance/review response.
+    prompt = jc.get_json_extraction_prompt("some raw enhance response", schema=ENHANCE_SCHEMA)
+    assert "missing_dependencies" in prompt, "extraction prompt ignored the requested schema"
+
+    # This test stubs the module-global ``extract_json_with_llm``; snapshot and
+    # restore it so the stub does not leak into other test modules that patch
+    # ``simple_text`` instead (e.g. test_json_corrector_verify_schema).
+    _orig_extract = jc.extract_json_with_llm
+    try:
+        # (2) A perfectly-extracted enhance-shaped dict (no verdict) must SURVIVE the
+        #     correction gate rather than being replaced by the ERROR sentinel.
+        good_enhance = {
+            "missing_dependencies": [{"name": "authStrategy"}],
+            "additional_callers": [],
+            "data_flow": {"inputs": [], "outputs": [], "tainted_variables": [], "security_relevant_flows": []},
+            "imports": [],
+            "reasoning": "recovered",
+            "confidence": 0.8,
+        }
+        jc.extract_json_with_llm = lambda binding, raw, schema=None: dict(good_enhance)
+        corrected = JSONCorrector(binding=None).attempt_correction(
+            "{ malformed enhance", schema=ENHANCE_SCHEMA, required_keys=["missing_dependencies"]
+        )
+        assert corrected.get("verdict") != "ERROR", (
+            f"valid enhance response wrongly rejected as ERROR: {corrected!r}"
+        )
+        assert corrected.get("missing_dependencies") == [{"name": "authStrategy"}], (
+            f"enhance data lost by corrector: {corrected!r}"
+        )
+
+        # (3) Backward-compat: the default (vuln) path is unchanged.
+        jc.extract_json_with_llm = lambda binding, raw, schema=None: {
+            "verdict": "VULNERABLE", "confidence": 0.9, "vulnerabilities": [], "reasoning": "x",
+        }
+        vuln = JSONCorrector(binding=None).attempt_correction("{ malformed vuln")
+        assert vuln.get("verdict") == "VULNERABLE", f"vuln path regressed: {vuln!r}"
+    finally:
+        jc.extract_json_with_llm = _orig_extract
+
+    print("PASS: corrector is schema-aware; enhance/review shape survives; vuln path intact")
+
+
+if __name__ == "__main__":
+    test_json_corrector_schema_shape()

--- a/libs/openant-core/tests/test_json_corrector_sibling_callers.py
+++ b/libs/openant-core/tests/test_json_corrector_sibling_callers.py
@@ -1,0 +1,117 @@
+"""
+Sibling-caller conformance test for jsoncorrect-schema-mismatch-enhance-review.
+
+The base fix threaded the expected JSON ``schema`` / ``required_keys`` from
+context_enhancer and context_reviewer into JSONCorrector so a malformed-but-
+recoverable NON-verdict response isn't (a) prompted with the wrong vuln schema
+and (b) rejected by the verdict-only success gate.
+
+But the SAME ``json_corrector-called-with-non-verdict-shape`` pattern lives at
+two other call sites that the base fix did NOT thread:
+
+  * utilities/finding_verifier.py     _parse_json_from_text
+        shape: {agree, correct_finding, explanation, exploit_path, ...} -- no verdict
+  * utilities/ground_truth_challenger.py  _parse_json_response
+        shape: {arbitration_verdict, confidence, reasoning, recommendation} -- no verdict
+
+At both sites ``attempt_correction`` was called with the DEFAULT (vuln) schema
+and the DEFAULT required_keys=["verdict"]. A perfectly-extracted verifier /
+arbitration dict has no ``verdict`` key, so the corrector's success gate fails,
+returns the ERROR sentinel, the caller's ``verdict != "ERROR"`` check drops it,
+and the whole verification / challenge is silently lost.
+
+    RED  (un-threaded callers): a valid non-verdict dict extracted by the LLM
+         corrector is dropped -> _parse_* returns None.
+    GREEN (threaded callers): the non-verdict dict survives with json_corrected.
+
+Select the core under test with OPENANT_CORE_ROOT (defaults to the worktree).
+"""
+
+import os
+import sys
+
+_CORE_ROOT = os.environ.get(
+    "OPENANT_CORE_ROOT",
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)
+if _CORE_ROOT not in sys.path:
+    sys.path.insert(0, _CORE_ROOT)
+
+
+def test_finding_verifier_recovers_non_verdict_finish_shape():
+    """finding_verifier._parse_json_from_text must recover a `finish`-shaped
+    (agree/correct_finding/explanation) dict via the LLM corrector, not drop it
+    because the default corrector required a `verdict`."""
+    import utilities.json_corrector as jc
+    from utilities.finding_verifier import FindingVerifier
+
+    finish_shape = {
+        "agree": False,
+        "correct_finding": "vulnerable",
+        "explanation": "recovered exploit path",
+        "exploit_path": {"entry_point": "req.query.next", "sink_reached": True},
+        "security_weakness": None,
+    }
+    # The corrector's LLM extraction succeeds and returns the verifier shape.
+    # Snapshot/restore the module global so this stub does not leak into other
+    # test modules that patch ``simple_text`` instead.
+    _orig_extract = jc.extract_json_with_llm
+    try:
+        jc.extract_json_with_llm = lambda binding, raw, schema=None: dict(finish_shape)
+
+        # Build a verifier without running __init__ (only .binding is used here).
+        verifier = FindingVerifier.__new__(FindingVerifier)
+        verifier.binding = object()  # non-None so the correction path is taken
+
+        # Malformed text: has braces (so it reaches the corrector) but is not JSON.
+        recovered = verifier._parse_json_from_text("{ agree: false, correct_finding: vulnerable BROKEN")
+    finally:
+        jc.extract_json_with_llm = _orig_extract
+
+    assert recovered is not None, (
+        "verifier finish shape was dropped by the corrector (needs schema threading)"
+    )
+    assert recovered.get("agree") is False and recovered.get("correct_finding") == "vulnerable", (
+        f"verification data lost by corrector: {recovered!r}"
+    )
+    assert recovered.get("json_corrected") is True
+
+
+def test_ground_truth_challenger_recovers_arbitration_shape():
+    """ground_truth_challenger._parse_json_response must recover an arbitration-
+    shaped (arbitration_verdict/...) dict via the LLM corrector."""
+    import utilities.json_corrector as jc
+    from utilities.ground_truth_challenger import _parse_json_response
+
+    arbitration_shape = {
+        "arbitration_verdict": "MODEL_CORRECT",
+        "confidence": 0.9,
+        "reasoning": "recovered arbitration",
+        "recommendation": "VULNERABLE",
+    }
+    # Snapshot/restore the module global so this stub does not leak into other
+    # test modules that patch ``simple_text`` instead.
+    _orig_extract = jc.extract_json_with_llm
+    try:
+        jc.extract_json_with_llm = lambda binding, raw, schema=None: dict(arbitration_shape)
+
+        recovered = _parse_json_response(
+            "{ arbitration_verdict: MODEL_CORRECT confidence 0.9 BROKEN",
+            binding=object(),  # non-None so the correction path is taken
+        )
+    finally:
+        jc.extract_json_with_llm = _orig_extract
+
+    assert recovered is not None, (
+        "arbitration shape was dropped by the corrector (needs schema threading)"
+    )
+    assert recovered.get("arbitration_verdict") == "MODEL_CORRECT", (
+        f"arbitration data lost by corrector: {recovered!r}"
+    )
+    assert recovered.get("json_corrected") is True
+
+
+if __name__ == "__main__":
+    test_finding_verifier_recovers_non_verdict_finish_shape()
+    test_ground_truth_challenger_recovers_arbitration_shape()
+    print("PASS: sibling non-verdict callers (finding_verifier, ground_truth_challenger) recover their shape")

--- a/libs/openant-core/tests/test_json_corrector_verify_schema.py
+++ b/libs/openant-core/tests/test_json_corrector_verify_schema.py
@@ -1,0 +1,106 @@
+"""Regression test for finding verifier-jscorrect-prompt-stage1-schema-mismatch.
+
+The finding_verifier's Stage-2 (verify) response shape is
+``{agree, correct_finding, explanation, exploit_path, security_weakness}``
+(see VERIFICATION_TOOLS "finish" schema and ``_parse_finish_result``).
+
+Before the fix, ``FindingVerifier._parse_json_from_text`` fell back to
+``JSONCorrector.attempt_correction`` which ALWAYS used the Stage-1 (analyze)
+extraction prompt/schema (``verdict``/``vulnerabilities``/``reasoning``) and
+only accepted a ``verdict``/``finding`` key. A perfectly valid *verify*
+response therefore:
+  1. was asked for in the wrong schema, and
+  2. was rejected as ``verdict == "ERROR"`` (no ``verdict``/``finding`` key),
+so a real verification result was silently dropped (mis-corrected/rejected).
+"""
+import json
+
+import pytest
+
+from utilities.json_corrector import JSONCorrector
+
+
+class _ToolAdapter:
+    name = "anthropic"
+    supports_tools = True
+
+    def complete(self, **kwargs):  # pragma: no cover - never called
+        raise AssertionError("adapter.complete must not be called in this test")
+
+    def validate(self, model):  # pragma: no cover
+        pass
+
+
+def _tool_binding():
+    from utilities.llm import PhaseBinding
+
+    return PhaseBinding(
+        phase="verify",
+        adapter=_ToolAdapter(),
+        model="claude-test",
+        provider_name="anthropic",
+    )
+
+
+VERIFY_RESPONSE = {
+    "agree": False,
+    "correct_finding": "vulnerable",
+    "explanation": "attacker input reaches the sink unchanged",
+}
+
+
+def test_finding_verifier_correction_preserves_verify_schema(monkeypatch):
+    """End-to-end through the real anchor: a malformed verify text response
+    must be corrected into the VERIFY shape (agree/correct_finding/explanation),
+    not rejected, and the correction prompt must ask for the verify schema."""
+    import utilities.json_corrector as jc
+    from utilities.finding_verifier import FindingVerifier
+
+    captured = {}
+
+    def fake_simple_text(binding, prompt, **kwargs):
+        captured["prompt"] = prompt
+        return json.dumps(VERIFY_RESPONSE)
+
+    monkeypatch.setattr(jc, "simple_text", fake_simple_text)
+
+    fv = FindingVerifier(index=object(), binding=_tool_binding())
+
+    # Prose with no JSON braces -> forces the LLM-correction fallback path.
+    text = "Here is my verification analysis in plain prose with no json object at all"
+    out = fv._parse_json_from_text(text)
+
+    # (1) correction must NOT be rejected
+    assert out is not None, "valid verify response was rejected by JSON correction"
+    # (2) verify schema preserved for _parse_finish_result
+    assert out.get("correct_finding") == "vulnerable"
+    assert out.get("agree") is False
+    # (3) the correction prompt must describe the VERIFY schema, not analyze-only
+    assert "correct_finding" in captured["prompt"]
+    assert "agree" in captured["prompt"]
+
+
+def test_attempt_correction_accepts_verify_verdict(monkeypatch):
+    """Unit level: attempt_correction must surface a verify-shaped dict
+    (correct_finding present, no verdict field) instead of returning ERROR."""
+    import utilities.json_corrector as jc
+
+    monkeypatch.setattr(
+        jc, "simple_text", lambda binding, prompt, **k: json.dumps(VERIFY_RESPONSE)
+    )
+    out = JSONCorrector(_tool_binding()).attempt_correction(
+        "garbled prose then " + json.dumps(VERIFY_RESPONSE)
+    )
+    assert out.get("verdict") != "ERROR"
+    assert out.get("correct_finding") == "vulnerable"
+    assert out.get("agree") is False
+
+
+def test_verify_extraction_prompt_describes_verify_schema():
+    """The verify extraction prompt exists and asks for the verify fields."""
+    from utilities.json_corrector import get_verify_extraction_prompt
+
+    prompt = get_verify_extraction_prompt("some raw response")
+    assert "agree" in prompt
+    assert "correct_finding" in prompt
+    assert "explanation" in prompt

--- a/libs/openant-core/tests/test_parse_finish_result_nondict_exploit_path.py
+++ b/libs/openant-core/tests/test_parse_finish_result_nondict_exploit_path.py
@@ -1,0 +1,60 @@
+"""FAM-ROBUST: `_parse_finish_result` must not crash when a finish-tool call
+returns a non-dict `exploit_path`.
+
+finding_verifier.py:956-958 truthy-guards `finish_result["exploit_path"]` then
+calls `ep.get(...)`. `finish_result` is the RAW finish-tool arguments from an
+arbitrary (possibly non-Anthropic) model; a model that emits
+`exploit_path="src->sink"` (str) or a list instead of an object makes `ep.get`
+raise AttributeError, crashing the whole Stage-2 parse. The guard must only
+treat `exploit_path` as a dict when it actually is one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_CORE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from utilities.finding_verifier import FindingVerifier, VerificationResult
+
+
+def _bare_verifier() -> FindingVerifier:
+    # _parse_finish_result does not touch instance state, so bypass __init__
+    # (which needs a live tool-supporting adapter) and test the method directly.
+    return FindingVerifier.__new__(FindingVerifier)
+
+
+@pytest.mark.parametrize("bad_exploit_path", ["src -> sink", ["a", "b"], 42])
+def test_nondict_exploit_path_does_not_crash(bad_exploit_path):
+    v = _bare_verifier()
+    finish_result = {
+        "agree": True,
+        "correct_finding": "vulnerable",
+        "explanation": "e",
+        "exploit_path": bad_exploit_path,
+    }
+    result = v._parse_finish_result(
+        finish_result, original_finding="vulnerable", iterations=1, total_tokens=10
+    )
+    assert isinstance(result, VerificationResult)
+    # A non-dict exploit_path carries no structured path -> normalized to None.
+    assert result.exploit_path is None
+    assert result.agree is True
+
+
+def test_dict_exploit_path_still_parsed():
+    v = _bare_verifier()
+    finish_result = {
+        "agree": True,
+        "exploit_path": {"entry_point": "handler", "sink_reached": True},
+    }
+    result = v._parse_finish_result(
+        finish_result, original_finding="vulnerable", iterations=1, total_tokens=10
+    )
+    assert result.exploit_path is not None
+    assert result.exploit_path.entry_point == "handler"
+    assert result.exploit_path.sink_reached is True

--- a/libs/openant-core/tests/test_verdict_only_finding_resolution.py
+++ b/libs/openant-core/tests/test_verdict_only_finding_resolution.py
@@ -1,0 +1,27 @@
+"""Regression: a verdict-only Stage-1 result must not be downgraded to 'inconclusive'.
+
+Bug (finding_verifier.py :654 and :713): ``result.get("finding", "inconclusive")``
+defaulted a findingless verdict-only result (``{"verdict": "vulnerable"}``) to
+'inconclusive' instead of reading the raw ``verdict`` -> a real VULNERABLE was
+misclassified as inconclusive and dropped from the report.
+"""
+from __future__ import annotations
+
+from utilities.finding_verifier import _resolve_stage1_finding
+
+
+def test_verdict_only_vulnerable_reads_raw_verdict():
+    # No 'finding' key, only a raw 'verdict' -> must resolve to 'vulnerable'.
+    assert _resolve_stage1_finding({"verdict": "vulnerable"}) == "vulnerable"
+
+
+def test_finding_key_still_wins():
+    assert _resolve_stage1_finding({"finding": "safe", "verdict": "vulnerable"}) == "safe"
+
+
+def test_both_absent_defaults_inconclusive():
+    assert _resolve_stage1_finding({}) == "inconclusive"
+
+
+def test_uppercase_verdict_normalized():
+    assert _resolve_stage1_finding({"verdict": "VULNERABLE"}) == "vulnerable"

--- a/libs/openant-core/utilities/agentic_enhancer/__init__.py
+++ b/libs/openant-core/utilities/agentic_enhancer/__init__.py
@@ -16,7 +16,8 @@ from .agent import (
     ContextAgent,
     AgentResult,
     enhance_unit_with_agent,
-    create_reachability_context
+    create_reachability_context,
+    INCOMPLETE_CLASSIFICATION,
 )
 from .repository_index import RepositoryIndex, load_index_from_file
 from .tools import TOOL_DEFINITIONS, ToolExecutor
@@ -35,5 +36,6 @@ __all__ = [
     "EntryPointDetector",
     "blackout_warning",
     "library_seed_ids",
-    "ReachabilityAnalyzer"
+    "ReachabilityAnalyzer",
+    "INCOMPLETE_CLASSIFICATION",
 ]

--- a/libs/openant-core/utilities/agentic_enhancer/agent.py
+++ b/libs/openant-core/utilities/agentic_enhancer/agent.py
@@ -35,6 +35,13 @@ from .reachability_analyzer import ReachabilityAnalyzer
 MAX_ITERATIONS = 20
 MAX_TOKENS_PER_RESPONSE = 4096
 
+# Classification stamped on a degenerate exit (agent ended without a completed
+# `finish` tool call: bare end_turn, no tool calls, or MAX_ITERATIONS reached).
+# Distinct from "neutral" — a genuine "no security relevance" verdict — so
+# downstream (analyzer filter, CSV, reporting) records the no-op/error state
+# instead of silently bucketing an unanalyzed unit as a real neutral finding.
+INCOMPLETE_CLASSIFICATION = "incomplete"
+
 # Input budget.
 # The conversation input had no budget: primary_code was inlined verbatim and
 # raw tool results were appended every iteration, so input grew unbounded until
@@ -285,7 +292,7 @@ class ContextAgent:
                 return AgentResult(
                     include_functions=[],
                     usage_context="Agent did not complete analysis",
-                    security_classification="neutral",
+                    security_classification=INCOMPLETE_CLASSIFICATION,
                     classification_reasoning="Analysis incomplete",
                     confidence=0.3,
                     iterations=iterations,
@@ -381,7 +388,7 @@ class ContextAgent:
                 return AgentResult(
                     include_functions=[],
                     usage_context="Agent response had no tool calls",
-                    security_classification="neutral",
+                    security_classification=INCOMPLETE_CLASSIFICATION,
                     classification_reasoning="Analysis incomplete - no tool calls",
                     confidence=0.3,
                     iterations=iterations,
@@ -406,7 +413,7 @@ class ContextAgent:
         return AgentResult(
             include_functions=[],
             usage_context="Analysis terminated - max iterations reached",
-            security_classification="neutral",
+            security_classification=INCOMPLETE_CLASSIFICATION,
             classification_reasoning="Could not complete analysis within iteration limit",
             confidence=0.2,
             iterations=iterations,

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -35,7 +35,12 @@ from .llm import (
     PhaseBinding,
     simple_text,
 )
-from .agentic_enhancer import RepositoryIndex, enhance_unit_with_agent, load_index_from_file
+from .agentic_enhancer import (
+    RepositoryIndex,
+    enhance_unit_with_agent,
+    load_index_from_file,
+    INCOMPLETE_CLASSIFICATION,
+)
 from .rate_limiter import get_rate_limiter, is_rate_limit_error, is_retryable_error
 from .file_io import read_json, write_json
 
@@ -62,6 +67,18 @@ CONTEXT_ENHANCEMENT_MODEL_LEGACY = CLAUDE_SONNET_4_20250514
 # re-attempts units still carrying a retryable error; rounds stop early once
 # none remain or a round recovers nothing.
 MAX_RETRY_ROUNDS = 3
+
+# Expected JSON shape of an enhancer response — handed to JSONCorrector so a
+# malformed-but-recoverable enhancer reply is repaired into THIS shape (no
+# verdict) rather than the default vuln schema.
+_ENHANCE_JSON_SCHEMA = """{
+    "missing_dependencies": [{"name": "functionName", "reason": "why missed", "likely_location": "file or module"}],
+    "additional_callers": [{"name": "callerName", "reason": "why it likely calls the target"}],
+    "data_flow": {"inputs": [], "outputs": [], "tainted_variables": [], "security_relevant_flows": []},
+    "imports": [{"module": "name", "used_for": "purpose"}],
+    "reasoning": "Brief explanation of your analysis",
+    "confidence": 0.0
+}"""
 
 
 def _build_error_info(exc: Exception) -> dict:
@@ -336,12 +353,15 @@ class ContextEnhancer:
                     "confidence": analysis.get("confidence", 0.5)
                 }
             else:
-                unit["llm_context"] = self._get_default_context()
+                unit["llm_context"] = self._get_default_context(
+                    error={"type": "parse_error",
+                           "message": "LLM response could not be parsed as JSON"}
+                )
 
         except Exception as e:
             self.stats["errors"] += 1
             self._log("error", f"Error enhancing unit", unit_id=function_id, error=str(e))
-            unit["llm_context"] = self._get_default_context()
+            unit["llm_context"] = self._get_default_context(error=_build_error_info(e))
 
         return unit
 
@@ -377,9 +397,13 @@ class ContextEnhancer:
         """
         units = dataset.get("units", [])
 
-        # Diff filter: honor diff_selected when set by the parse step.
-        # Keep units_by_id scoped to the original so callers lookup still works
-        # for units outside the diff scope.
+        # Preserve the full unit list before diff filtering so units_by_id below
+        # can span ALL units — enhance_unit's same-file cross-unit context lookup
+        # must still resolve unchanged units outside the diff scope.
+        all_units = units
+
+        # Diff filter: honor diff_selected when set by the parse step. Only the
+        # diff-selected subset is *processed*, but context lookup uses all_units.
         if any("diff_selected" in u for u in units):
             _pre = len(units)
             units = [u for u in units if u.get("diff_selected")]
@@ -419,8 +443,9 @@ class ContextEnhancer:
         self._log("info", f"Mode: {mode}")
 
         # Build lookup dict for context gathering (over ALL units, so cross-unit
-        # context lookup still works even when some are restored/skipped).
-        units_by_id = {u.get("id"): u for u in units}
+        # context lookup still works even when some are restored/skipped or
+        # filtered out of the diff scope).
+        units_by_id = {u.get("id"): u for u in all_units}
         units_to_process = [u for u in units if u.get("id") not in processed_ids]
 
         def _process_one(unit):
@@ -683,7 +708,12 @@ class ContextEnhancer:
                           error_type=error_info.get("type", "unknown"))
                 unit["agent_context"] = {
                     "error": error_info,
-                    "security_classification": "neutral",
+                    # An errored unit has NO verdict. Tagging it "neutral" made the
+                    # exploitable-filter / CSV read the failure as a genuine benign
+                    # result (same masquerade as the agent-degenerate exit); "error"
+                    # is a non-verdict marker the filter never keeps and the CSV
+                    # shows honestly.
+                    "security_classification": "error",
                     "confidence": 0.0
                 }
 
@@ -848,6 +878,7 @@ class ContextEnhancer:
                       "exploitable": agentic_stats['exploitable_found'],
                       "vulnerable_internal": agentic_stats['vulnerable_found'],
                       "neutral": agentic_stats['neutral_found'],
+                      "incomplete": agentic_stats['incomplete_found'],
                       "errors": agentic_stats['errors']
                   })
         self._log("info", "Token usage",
@@ -940,6 +971,10 @@ class ContextEnhancer:
             "exploitable_found": 0,
             "vulnerable_found": 0,
             "neutral_found": 0,
+            # Degenerate-exit units (agent never completed a `finish` tool call).
+            # Tracked distinctly so an unanalyzed unit is not bucketed as a
+            # genuine "neutral" (no-security-relevance) verdict.
+            "incomplete_found": 0,
             "errors": 0,
             "error_summary": {},
         }
@@ -969,6 +1004,8 @@ class ContextEnhancer:
                 stats["exploitable_found"] += 1
             elif classification == "vulnerable_internal":
                 stats["vulnerable_found"] += 1
+            elif classification == INCOMPLETE_CLASSIFICATION:
+                stats["incomplete_found"] += 1
             else:
                 stats["neutral_found"] += 1
             stats["total_iterations"] += agent_ctx.get("agent_metadata", {}).get("iterations", 0)
@@ -996,9 +1033,15 @@ class ContextEnhancer:
         calls = summary.get("calls") or []
         return calls[-1] if calls else {}
 
-    def _get_default_context(self) -> dict:
-        """Return default context when LLM call fails."""
-        return {
+    def _get_default_context(self, error: dict | None = None) -> dict:
+        """Return default context when LLM call fails.
+
+        ``error`` carries a structured error dict so the failed context sets an
+        ``error`` key — mirroring the agentic path's ``agent_context["error"]``.
+        Without it, enhancer.py's ``if ctx.get("error")`` never counts single-shot
+        failures and they pass through reported as if successfully enhanced.
+        """
+        ctx = {
             "missing_dependencies": [],
             "additional_callers": [],
             "data_flow": {
@@ -1011,6 +1054,9 @@ class ContextEnhancer:
             "reasoning": "LLM analysis failed, using static analysis only",
             "confidence": 0.3
         }
+        if error is not None:
+            ctx["error"] = error
+        return ctx
 
     def _parse_json_response(self, response: str) -> Optional[dict]:
         """Parse JSON response from LLM, with LLM correction fallback."""
@@ -1039,12 +1085,18 @@ class ContextEnhancer:
                 except json.JSONDecodeError:
                     pass
 
-        # Fallback: use LLM to correct malformed JSON
+        # Fallback: use LLM to correct malformed JSON. Pass THIS phase's schema
+        # so the corrector recovers enhancer shape (no verdict) instead of
+        # rewriting it into the vuln verdict schema and dropping the context.
         if response.strip() and hasattr(self, 'binding') and self.binding:
             try:
                 from utilities.json_corrector import JSONCorrector
                 corrector = JSONCorrector(self.binding)
-                corrected = corrector.attempt_correction(response)
+                corrected = corrector.attempt_correction(
+                    response,
+                    schema=_ENHANCE_JSON_SCHEMA,
+                    required_keys=["missing_dependencies"],
+                )
                 if corrected.get("verdict") != "ERROR":
                     corrected["json_corrected"] = True
                     return corrected

--- a/libs/openant-core/utilities/context_reviewer.py
+++ b/libs/openant-core/utilities/context_reviewer.py
@@ -16,6 +16,17 @@ from .llm import PhaseBinding, simple_text
 from .context_corrector import gather_source_files, search_files_for_context
 
 
+# Expected JSON shape of a reviewer response — handed to JSONCorrector so a
+# malformed-but-recoverable reviewer reply is repaired into THIS shape (no
+# verdict) rather than the default vuln schema.
+_REVIEW_JSON_SCHEMA = """{
+    "context_complete": true,
+    "missing_items": [{"type": "utility", "description": "what is missing", "why_needed": "why", "hints": "clues"}],
+    "confidence": 0.0,
+    "reasoning": "Brief explanation of your assessment"
+}"""
+
+
 def get_context_review_prompt(code: str, route: str, handler: str, files_included: list[str]) -> str:
     """
     Generate a prompt for the LLM to review the assembled context
@@ -317,12 +328,18 @@ class ContextReviewer:
                 except json.JSONDecodeError:
                     pass
 
-        # Fallback: use LLM to correct malformed JSON
+        # Fallback: use LLM to correct malformed JSON. Pass THIS phase's schema
+        # so the corrector recovers reviewer shape (no verdict) instead of
+        # rewriting it into the vuln verdict schema and dropping the review.
         if response.strip() and hasattr(self, 'binding') and self.binding:
             try:
                 from utilities.json_corrector import JSONCorrector
                 corrector = JSONCorrector(self.binding)
-                corrected = corrector.attempt_correction(response)
+                corrected = corrector.attempt_correction(
+                    response,
+                    schema=_REVIEW_JSON_SCHEMA,
+                    required_keys=["context_complete"],
+                )
                 if corrected.get("verdict") != "ERROR":
                     corrected["json_corrected"] = True
                     return corrected

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -73,6 +73,19 @@ MAX_ITERATIONS = 20
 MAX_TOKENS_PER_RESPONSE = 4096
 
 
+# Expected JSON shape of a verifier `finish` response — handed to JSONCorrector
+# so a malformed-but-recoverable verifier reply is repaired into THIS shape (no
+# verdict) rather than the default vuln schema, and its success is gated on the
+# verifier's own required keys instead of a nonexistent ``verdict`` field.
+_VERIFY_JSON_SCHEMA = """{
+    "agree": true,
+    "correct_finding": "safe | protected | bypassable | vulnerable | inconclusive",
+    "exploit_path": {"entry_point": null, "data_flow": [], "sink_reached": false, "attacker_control_at_sink": "none", "path_broken_at": null},
+    "explanation": "Detailed explanation of your analysis",
+    "security_weakness": null
+}"""
+
+
 # Enhanced finish tool with exploit_path structure
 VERIFICATION_TOOLS = [
     {
@@ -187,6 +200,17 @@ VERIFICATION_TOOLS = [
         }
     }
 ]
+
+
+def _resolve_stage1_finding(result: dict) -> str:
+    """Resolve a Stage-1 result's classification for verification.
+
+    A verdict-only result (``{"verdict": "vulnerable"}`` with no ``finding``
+    key) must fall back to its raw ``verdict`` before the ``inconclusive``
+    default — otherwise a real VULNERABLE is silently downgraded to
+    ``inconclusive`` and dropped from the report.
+    """
+    return str(result.get("finding") or result.get("verdict") or "inconclusive").lower()
 
 
 @dataclass
@@ -651,7 +675,7 @@ class FindingVerifier:
         Mutates the result dict in-place (each result is unique, no contention).
         """
         route_key = result.get("route_key", "unknown")
-        stage1_finding = result.get("finding", "inconclusive")
+        stage1_finding = _resolve_stage1_finding(result)
         worker = threading.current_thread().name
 
         self.tracker.start_unit_tracking()
@@ -710,7 +734,7 @@ class FindingVerifier:
         try:
             for i, result in enumerate(results):
                 route_key = result.get("route_key", "unknown")
-                stage1_finding = result.get("finding", "inconclusive")
+                stage1_finding = _resolve_stage1_finding(result)
                 self._log("info", f"Verifying finding {i+1}/{len(results)}",
                           unit_id=route_key, classification=stage1_finding)
 
@@ -858,9 +882,12 @@ class FindingVerifier:
         if verification.get("explanation") == "Max iterations reached":
             return False
 
-        # Check for exploit path analysis
+        # Check for exploit path analysis. A model may emit ``exploit_path``
+        # as a truthy non-dict (e.g. the bare string "reached"); the ``.get``
+        # calls below would then raise AttributeError. Treat any non-dict as
+        # not-conclusive, matching a missing exploit_path.
         exploit_path = verification.get("exploit_path")
-        if not exploit_path:
+        if not isinstance(exploit_path, dict):
             return False
 
         # Check if the exploit path analysis shows the path is broken
@@ -953,8 +980,12 @@ class FindingVerifier:
         """Parse the finish tool result into VerificationResult."""
         # Parse exploit path if present
         exploit_path = None
-        if "exploit_path" in finish_result and finish_result["exploit_path"]:
-            ep = finish_result["exploit_path"]
+        # FAM-ROBUST: finish_result is raw model tool-args; only treat
+        # exploit_path as structured when it is actually a dict. A non-dict
+        # (str/list/int from a non-Anthropic model) has no path fields — skip
+        # it (normalized to None) instead of crashing on ep.get(...).
+        ep = finish_result.get("exploit_path")
+        if isinstance(ep, dict) and ep:
             exploit_path = ExploitPath(
                 entry_point=ep.get("entry_point"),
                 data_flow=ep.get("data_flow", []),
@@ -1022,12 +1053,20 @@ class FindingVerifier:
         except json.JSONDecodeError:
             pass
 
-        # Fallback: use LLM to correct malformed JSON
+        # Fallback: use LLM to correct malformed JSON. Pass the verifier's
+        # `finish` schema so the corrector recovers verifier shape (no verdict)
+        # instead of rewriting it into the vuln verdict schema — otherwise a
+        # perfectly-extractable verification is rejected by the verdict-only
+        # success gate and the finding is silently dropped.
         if text.strip():
             try:
                 from utilities.json_corrector import JSONCorrector
                 corrector = JSONCorrector(self.binding)
-                corrected = corrector.attempt_correction(text)
+                corrected = corrector.attempt_correction(
+                    text,
+                    schema=_VERIFY_JSON_SCHEMA,
+                    required_keys=["agree", "correct_finding", "explanation"],
+                )
                 if corrected.get("verdict") != "ERROR":
                     corrected["json_corrected"] = True
                     return corrected

--- a/libs/openant-core/utilities/ground_truth_challenger.py
+++ b/libs/openant-core/utilities/ground_truth_challenger.py
@@ -21,6 +21,18 @@ from dataclasses import dataclass
 from .llm import PhaseBinding, simple_text
 
 
+# Expected JSON shape of an arbitration response — handed to JSONCorrector so a
+# malformed-but-recoverable arbitration reply is repaired into THIS shape (no
+# verdict) rather than the default vuln schema, and its success is gated on the
+# arbitration's own key instead of a nonexistent ``verdict`` field.
+_ARBITRATION_JSON_SCHEMA = """{
+    "arbitration_verdict": "MODEL_CORRECT | GROUND_TRUTH_CORRECT | UNCERTAIN",
+    "confidence": 0.0,
+    "reasoning": "Detailed explanation of your analysis and conclusion",
+    "recommendation": "VULNERABLE or SAFE"
+}"""
+
+
 @dataclass
 class ChallengeResult:
     """Result of challenging a ground truth."""
@@ -186,12 +198,20 @@ def _parse_json_response(response: str, binding: Optional[PhaseBinding] = None) 
             except json.JSONDecodeError:
                 pass
 
-    # Fallback: use LLM to correct malformed JSON
+    # Fallback: use LLM to correct malformed JSON. Pass the arbitration schema
+    # so the corrector recovers arbitration shape (no verdict) instead of
+    # rewriting it into the vuln verdict schema — otherwise a perfectly-
+    # extractable arbitration is rejected by the verdict-only success gate and
+    # the challenge is silently dropped.
     if response.strip() and binding is not None:
         try:
             from utilities.json_corrector import JSONCorrector
             corrector = JSONCorrector(binding)
-            corrected = corrector.attempt_correction(response)
+            corrected = corrector.attempt_correction(
+                response,
+                schema=_ARBITRATION_JSON_SCHEMA,
+                required_keys=["arbitration_verdict"],
+            )
             if corrected.get("verdict") != "ERROR":
                 corrected["json_corrected"] = True
                 return corrected

--- a/libs/openant-core/utilities/json_corrector.py
+++ b/libs/openant-core/utilities/json_corrector.py
@@ -19,29 +19,19 @@ configurations where a "Sonnet" model may not even exist.
 
 import json
 import sys
-from typing import Optional
+from typing import List, Optional
 
 from .llm import PhaseBinding, simple_text
 
 
-def get_json_extraction_prompt(raw_response: str) -> str:
-    """
-    Generate a prompt to extract JSON from a malformed response.
-    """
-    # Truncate very long responses
-    if len(raw_response) > 8000:
-        raw_response = raw_response[:8000] + "\n... [truncated]"
-
-    return f"""The following is a response from a security analysis that should have been JSON but wasn't properly formatted.
-
-Your task is to extract the security analysis data and return it as valid JSON.
-
-The expected JSON schema is:
-{{
+# Default (analyze/verify) schema. The corrector is also called by the enhance
+# and review phases whose output shapes have NO verdict — those callers pass
+# their own ``schema`` so the extraction prompt asks for the correct shape.
+_VULN_SCHEMA = """{
     "verdict": "VULNERABLE" | "SAFE" | "INSUFFICIENT_CONTEXT",
     "confidence": 0.0-1.0,
     "vulnerabilities": [
-        {{
+        {
             "type": "SQL Injection | XSS | Command Injection | Path Traversal | Open Redirect | XXE | Insecure Deserialization | Broken Access Control | Other",
             "severity": "CRITICAL | HIGH | MEDIUM | LOW",
             "source": "description of where tainted data enters",
@@ -49,26 +39,86 @@ The expected JSON schema is:
             "flow": "data flow description",
             "evidence": "code snippet",
             "why_vulnerable": "explanation"
-        }}
+        }
     ],
     "reasoning": "analysis summary"
-}}
+}"""
+
+
+def get_json_extraction_prompt(raw_response: str, schema: Optional[str] = None) -> str:
+    """
+    Generate a prompt to extract JSON from a malformed response.
+
+    Args:
+        raw_response: The malformed response to recover structured data from.
+        schema: Expected JSON schema for the calling phase. Defaults to the
+            analyze/verify vuln schema; enhance/review callers pass their own
+            so a valid enhance/review response isn't rewritten into a verdict.
+    """
+    # Truncate very long responses
+    if len(raw_response) > 8000:
+        raw_response = raw_response[:8000] + "\n... [truncated]"
+
+    schema = schema or _VULN_SCHEMA
+
+    return f"""The following is a response from a security analysis pipeline that should have been JSON but wasn't properly formatted.
+
+Your task is to extract the structured data and return it as valid JSON.
+
+The expected JSON schema is:
+{schema}
 
 Raw response to extract from:
 ---
 {raw_response}
 ---
 
-Return ONLY valid JSON matching the schema above. If you cannot determine the verdict, use "INSUFFICIENT_CONTEXT".
-If the response indicates vulnerabilities were found, set verdict to "VULNERABLE" and populate the vulnerabilities array.
-If the response indicates the code is safe, set verdict to "SAFE" with an empty vulnerabilities array.
+Return ONLY valid JSON matching the schema above. Preserve every field that is present in the raw response; do not invent values. If a required field cannot be determined, use the most conservative default for that field.
 
 Respond with the JSON only, no markdown, no explanation:"""
+
+
+# Verify-stage (finding_verifier Stage 2) finish schema — agree/correct_finding/
+# explanation (+ optional exploit_path/security_weakness), NOT the Stage-1 vuln
+# schema. Exposed both as ``get_verify_extraction_prompt`` (used by verify-stage
+# callers that want a ready-made prompt) and reachable via ``schema=`` on the
+# generic corrector.
+_VERIFY_SCHEMA = """{
+    "agree": true | false,
+    "correct_finding": "safe" | "protected" | "bypassable" | "vulnerable" | "inconclusive",
+    "explanation": "detailed explanation of the analysis",
+    "exploit_path": {
+        "entry_point": "where attacker input enters (or null)",
+        "data_flow": ["step 1", "step 2"],
+        "sink_reached": true | false,
+        "attacker_control_at_sink": "full" | "partial" | "none",
+        "path_broken_at": "where/why the path breaks (or null)"
+    },
+    "security_weakness": "dangerous patterns that exist but aren't currently exploitable (or null)"
+}"""
+
+
+def get_verify_extraction_prompt(raw_response: str) -> str:
+    """
+    Generate a prompt to extract JSON from a malformed *verify-stage*
+    (finding_verifier Stage 2) response.
+
+    The verify stage's finish schema is agree/correct_finding/explanation
+    (+ optional exploit_path/security_weakness) — NOT the Stage-1 analyze
+    schema (verdict/vulnerabilities/reasoning). Using the analyze prompt here
+    would ask the model for the wrong shape and drop a valid verification.
+
+    This is a thin convenience wrapper over :func:`get_json_extraction_prompt`
+    with the verify schema pre-filled; the reconciled corrector reaches the
+    same shape when a caller passes ``schema=`` directly.
+    """
+    return get_json_extraction_prompt(raw_response, schema=_VERIFY_SCHEMA)
 
 
 def extract_json_with_llm(
     binding: PhaseBinding,
     raw_response: str,
+    schema: Optional[str] = None,
 ) -> Optional[dict]:
     """
     Use LLM to extract JSON from a malformed response.
@@ -78,6 +128,8 @@ def extract_json_with_llm(
             the binding of whatever phase received the malformed
             response in the first place (analyze, verify, etc.).
         raw_response: The raw response that failed to parse
+        schema: Expected JSON schema for the calling phase (see
+            ``get_json_extraction_prompt``). None => default vuln schema.
 
     Returns:
         Parsed JSON dict if successful, None otherwise
@@ -85,10 +137,16 @@ def extract_json_with_llm(
     if not raw_response or len(raw_response.strip()) < 10:
         return None
 
-    prompt = get_json_extraction_prompt(raw_response)
+    prompt = get_json_extraction_prompt(raw_response, schema=schema)
 
     try:
-        llm_response = simple_text(binding, prompt, max_tokens=2048)
+        # The correction must reproduce the FULL verdict JSON (verdict + an array
+        # of vulnerabilities + reasoning), which routinely exceeds 2048 tokens for
+        # a multi-finding response. A 2048-token cap truncated valid corrections
+        # mid-structure, so _parse_json_response rejected them. Match the schema's
+        # own producer (finding_verifier MAX_TOKENS_PER_RESPONSE) and simple_text's
+        # 8192 default so a large valid correction is never cut off.
+        llm_response = simple_text(binding, prompt, max_tokens=8192)
         return _parse_json_response(llm_response)
     except Exception as e:
         print(f"      JSON extraction failed: {e}", file=sys.stderr)
@@ -140,45 +198,82 @@ class JSONCorrector:
         """
         self.binding = binding
 
-    def attempt_correction(self, raw_response: str) -> dict:
+    def attempt_correction(
+        self,
+        raw_response: str,
+        schema: Optional[str] = None,
+        required_keys: Optional[List[str]] = None,
+    ) -> dict:
         """
         Attempt to correct a malformed JSON response.
 
         Args:
             raw_response: The raw response that failed to parse
+            schema: Expected JSON schema for the calling phase. None => the
+                default analyze/verify vuln schema. Enhance/review phases pass
+                their own shape so a valid non-verdict response is recovered
+                as-is instead of being rewritten into a vuln verdict.
+            required_keys: Keys that must be present for the correction to count
+                as successful. Defaults to ``["verdict"]`` (vuln shape). Callers
+                with a non-verdict shape pass their own required keys.
 
         Returns:
             Corrected result dict
         """
+        # Non-verdict schemas skip the vuln-specific finding->verdict
+        # normalization; their success gate is their own required_keys.
+        vuln_mode = schema is None
+        if required_keys is None:
+            required_keys = ["verdict"]
+
         print(f"      Attempting JSON correction with LLM...", file=sys.stderr)
 
-        extracted = extract_json_with_llm(self.binding, raw_response)
+        # Only forward ``schema`` when a caller supplied one, so pre-existing
+        # 2-arg stubs of extract_json_with_llm keep working on the default path.
+        if schema is None:
+            extracted = extract_json_with_llm(self.binding, raw_response)
+        else:
+            extracted = extract_json_with_llm(self.binding, raw_response, schema=schema)
 
         if extracted:
-            # Normalize the extracted finding casing so downstream lowercase
-            # gates (verifier/reporter) don't silently drop a capitalized
-            # "Vulnerable". Recover-only: lowercase, never invent a verdict.
-            if "finding" in extracted and isinstance(extracted["finding"], str):
-                extracted["finding"] = extracted["finding"].lower()
+            if vuln_mode:
+                # Normalize the extracted finding casing so downstream lowercase
+                # gates (verifier/reporter) don't silently drop a capitalized
+                # "Vulnerable". Recover-only: lowercase, never invent a verdict.
+                if "finding" in extracted and isinstance(extracted["finding"], str):
+                    extracted["finding"] = extracted["finding"].lower()
 
-            # Normalize finding -> verdict
-            if "verdict" not in extracted and "finding" in extracted:
-                finding = extracted["finding"]
-                mapping = {
-                    "vulnerable": "VULNERABLE", "safe": "SAFE",
-                    "protected": "PROTECTED", "bypassable": "BYPASSABLE",
-                    "inconclusive": "INCONCLUSIVE",
-                    "insufficient_context": "INSUFFICIENT_CONTEXT",
-                }
-                extracted["verdict"] = mapping.get(finding.lower(), finding.upper())
+                # Verify-stage shape recovery on the DEFAULT path: a verify finish
+                # dict carries the enum in ``correct_finding`` (lowercase) with no
+                # ``verdict`` key. Lowercase-normalize it and derive a ``verdict``
+                # so a default-args correction of a verify response passes the
+                # verdict-only success gate instead of being rejected as ERROR.
+                # (Verify callers that pass schema=/required_keys= skip this block
+                # entirely and are gated on their own keys.) Recover-only.
+                if "correct_finding" in extracted and isinstance(extracted["correct_finding"], str):
+                    extracted["correct_finding"] = extracted["correct_finding"].lower()
+                    if "verdict" not in extracted:
+                        extracted["verdict"] = extracted["correct_finding"].upper()
 
-            # Validate the extracted data has required fields
-            if "verdict" in extracted:
+                # Normalize finding -> verdict
+                if "verdict" not in extracted and "finding" in extracted:
+                    finding = extracted["finding"]
+                    mapping = {
+                        "vulnerable": "VULNERABLE", "safe": "SAFE",
+                        "protected": "PROTECTED", "bypassable": "BYPASSABLE",
+                        "inconclusive": "INCONCLUSIVE",
+                        "insufficient_context": "INSUFFICIENT_CONTEXT",
+                    }
+                    extracted["verdict"] = mapping.get(finding.lower(), finding.upper())
+
+            # Validate the extracted data has the caller's required fields
+            if all(k in extracted for k in required_keys):
                 extracted["json_corrected"] = True
-                print(f"      JSON correction successful! Verdict: {extracted.get('verdict')}", file=sys.stderr)
+                print(f"      JSON correction successful! keys={list(extracted.keys())}", file=sys.stderr)
                 return extracted
             else:
-                print(f"      JSON correction failed: missing verdict field", file=sys.stderr)
+                missing = [k for k in required_keys if k not in extracted]
+                print(f"      JSON correction failed: missing required fields {missing}", file=sys.stderr)
         else:
             print(f"      JSON correction failed: could not extract JSON", file=sys.stderr)
 


### PR DESCRIPTION
## What
Robustness/correctness hardening for `__init__.py, agent.py, context_enhancer.py, context_reviewer.py` (+3 more).

## Fixes in this PR (9)
- jsverif combined
- PR30 diff scope units filtered
- agent degenerate exit neutral drop
- enhancer failed context no error k
- jsoncorrect output cap 2048
- context enhancer exception persist
- findingverifier 654 713 verdictonl
- findingverifier 956 958 exploitpat
- findingverifier 862 869 exploitpat

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).