### PR TITLE
fix: harden typescript_analyzer.js

### DIFF
--- a/libs/openant-core/parsers/javascript/typescript_analyzer.js
+++ b/libs/openant-core/parsers/javascript/typescript_analyzer.js
@@ -49,6 +49,41 @@ const PERMISSIVE_COMPILER_OPTIONS = {
   allowSyntheticDefaultImports: true,
 };
 
+// The source file plus every TypeScript namespace/module body (at any nesting
+// depth) that is NOT inside a function. Each is a StatementedNode whose
+// getClasses()/getVariableStatements() return its OWN direct members, so
+// iterating all of them extracts namespaced classes/arrows without double-
+// counting (each member belongs to exactly one direct container). Namespaces
+// nested inside a function are excluded — their text already rides inside the
+// enclosing unit, matching _moduleLevelFunctionNodes' isModuleLevel filter.
+// Module-level so the inventory builder, the call-graph builder, and the
+// single-function extractor all share one definition of the unit set.
+function statementedContainers(sourceFile) {
+  const FN_KINDS = new Set([
+    ts.SyntaxKind.FunctionDeclaration,
+    ts.SyntaxKind.FunctionExpression,
+    ts.SyntaxKind.ArrowFunction,
+    ts.SyntaxKind.MethodDeclaration,
+    ts.SyntaxKind.Constructor,
+    ts.SyntaxKind.GetAccessor,
+    ts.SyntaxKind.SetAccessor,
+    ts.SyntaxKind.ClassStaticBlockDeclaration,
+  ]);
+  const notInsideFunction = (node) => {
+    for (let p = node.getParent(); p; p = p.getParent()) {
+      if (FN_KINDS.has(p.getKind())) return false;
+    }
+    return true;
+  };
+  const containers = [sourceFile];
+  for (const mod of sourceFile.getDescendantsOfKind(
+    ts.SyntaxKind.ModuleDeclaration,
+  )) {
+    if (notInsideFunction(mod)) containers.push(mod);
+  }
+  return containers;
+}
+
 class TypeScriptAnalyzer {
   constructor(repoPath) {
     // Normalise immediately so all later path operations (path.relative,
@@ -235,6 +270,17 @@ class TypeScriptAnalyzer {
   // by the inventory builder, the call-graph builder, AND the resolver — all
   // three must see the same set so a block function is a unit, has its own
   // edges, and is resolvable as a call target.
+  // The source file plus every TypeScript namespace/module body (at any nesting
+  // depth) that is NOT inside a function. Each is a StatementedNode whose
+  // getClasses()/getVariableStatements() return its OWN direct members, so
+  // iterating all of them extracts namespaced classes/arrows without double-
+  // counting (each member belongs to exactly one direct container). Namespaces
+  // nested inside a function are excluded — their text already rides inside the
+  // enclosing unit, matching _moduleLevelFunctionNodes' isModuleLevel filter.
+  _statementedContainers(sourceFile) {
+    return statementedContainers(sourceFile);
+  }
+
   _moduleLevelFunctionNodes(sourceFile) {
     const STOP = new Set([
       ts.SyntaxKind.FunctionDeclaration,
@@ -289,6 +335,14 @@ class TypeScriptAnalyzer {
       path.relative(this.repoPath, sourceFile.getFilePath()),
     );
 
+    // TypeScript `namespace {}` / `module {}` bodies are their own statemented
+    // scopes: classes and `const fn = () =>` declared inside a namespace are NOT
+    // returned by sourceFile.getClasses()/getVariableStatements(), so their
+    // methods/arrows were silently dropped. Descend every namespace so members
+    // are extracted like top-level ones (function declarations already are, via
+    // _moduleLevelFunctionNodes' getDescendantsOfKind walk).
+    const containers = this._statementedContainers(sourceFile);
+
     // Extract function declarations (top-level + module-level block-scoped).
     for (const { node: func, id: functionId } of this._moduleLevelFunctionEntries(
       sourceFile,
@@ -311,7 +365,9 @@ class TypeScriptAnalyzer {
     // Also covers Higher-Order-Component wrappers whose initializer is a call
     // expression containing an inline function — `const X = memo(() => {})`,
     // `forwardRef((p, r) => {})`, `styled.div\`...\``.
-    for (const statement of sourceFile.getVariableStatements()) {
+    for (const statement of containers.flatMap((c) =>
+      c.getVariableStatements(),
+    )) {
       for (const declaration of statement.getDeclarations()) {
         const initializer = declaration.getInitializer();
         if (!initializer) continue;
@@ -347,7 +403,7 @@ class TypeScriptAnalyzer {
     }
 
     // Extract methods from classes
-    for (const classDecl of sourceFile.getClasses()) {
+    for (const classDecl of containers.flatMap((c) => c.getClasses())) {
       const className = classDecl.getName() || "AnonymousClass";
 
       // getMethods() excludes get/set accessors, so iterate the
@@ -362,6 +418,14 @@ class TypeScriptAnalyzer {
         const code = method.getFullText();
         const functionId = `${relativePath}:${className}.${methodName}`;
 
+        // First-wins: a namespace class and a top-level class can share a name
+        // (namespaces exist precisely to allow duplicate identifiers), producing
+        // the same `${className}.${methodName}` id. Since containers lists the
+        // source file before its namespaces, the top-level definition is emitted
+        // first; do not let a later namespace member overwrite it and silently
+        // drop the top-level unit. Matches the var-loop guard above.
+        if (this.functions[functionId]) continue;
+
         this.functions[functionId] = {
           name: `${className}.${methodName}`,
           code: code,
@@ -375,6 +439,38 @@ class TypeScriptAnalyzer {
         };
       }
 
+      // Emit class properties initialised with an arrow function / function
+      // expression as class-member units (NestJS/Angular `@Get() findAll = (req,
+      // res) => {...}`). getMethods() excludes these, so without this loop a
+      // decorated arrow-function handler is never seeded as a route_handler entry
+      // point. NOTE: this loop only makes the handler a UNIT; its outgoing edges
+      // (the transitive rescue of `this.svc.findAll()` from pruning) are filled
+      // by the matching getProperties() walk in buildCallGraphForFile — both
+      // sites are required for the callees to actually be reached.
+      for (const prop of classDecl.getProperties()) {
+        const init = prop.getInitializer();
+        if (!init) continue;
+        const ik = init.getKindName();
+        if (ik !== "ArrowFunction" && ik !== "FunctionExpression") continue;
+        const propName = prop.getName();
+        const code = prop.getFullText();
+        const functionId = `${relativePath}:${className}.${propName}`;
+        // First-wins: a real method of the same name already emitted above owns
+        // the id; do not overwrite it.
+        if (this.functions[functionId]) continue;
+        this.functions[functionId] = {
+          name: `${className}.${propName}`,
+          code: code,
+          isExported: classDecl.isExported(),
+          unitType: this.classifyFunction(propName, code, true, className),
+          startLine: prop.getStartLineNumber(),
+          endLine: prop.getEndLineNumber(),
+          className: className,
+          parameters: this._extractParameters(init),
+          decorators: this._decoratorTexts(classDecl, prop),
+        };
+      }
+
       // Emit the constructor as its own unit so `new X()` edges have a target and
       // its body's calls (this.foo()) are walked. A class has at most one
       // implemented constructor; overload signatures carry no body. The
@@ -383,9 +479,10 @@ class TypeScriptAnalyzer {
       const ctorDecl =
         classDecl.getConstructors().find((c) => c.getBody && c.getBody()) ||
         classDecl.getConstructors()[0];
-      if (ctorDecl) {
+      const ctorId = `${relativePath}:${className}.constructor`;
+      if (ctorDecl && !this.functions[ctorId]) {
         const ctorCode = ctorDecl.getFullText();
-        this.functions[`${relativePath}:${className}.constructor`] = {
+        this.functions[ctorId] = {
           name: `${className}.constructor`,
           code: ctorCode,
           isExported: classDecl.isExported(),
@@ -592,6 +689,40 @@ class TypeScriptAnalyzer {
         };
         this.callGraph[functionId] = this.extractCallsFromFunction(
           method,
+          relativePath,
+        );
+      }
+
+      // Sibling of the class-DECLARATION property path: a class *expression* can
+      // also carry decorated arrow-function / function-expression properties
+      // (`module.exports = class { @Get() findAll = (req, res) => {...} }`).
+      // getMethods() excludes them, so emit them as units here — and, because
+      // buildCallGraphForFile only walks getClasses() (declarations), populate
+      // their outgoing edges inline so the handler's callees are actually
+      // rescued from pruning.
+      const props = classExpr.getProperties ? classExpr.getProperties() : [];
+      for (const prop of props) {
+        const init = prop.getInitializer();
+        if (!init) continue;
+        const ik = init.getKindName();
+        if (ik !== "ArrowFunction" && ik !== "FunctionExpression") continue;
+        const propName = prop.getName();
+        const functionId = `${relativePath}:${className}.${propName}`;
+        if (this.functions[functionId]) continue;
+        const code = prop.getFullText();
+        this.functions[functionId] = {
+          name: `${className}.${propName}`,
+          code: code,
+          isExported: false,
+          unitType: this.classifyFunction(propName, code, true, className),
+          startLine: prop.getStartLineNumber(),
+          endLine: prop.getEndLineNumber(),
+          className: className,
+          parameters: this._extractParameters(init),
+          decorators: this._decoratorTexts(classExpr, prop),
+        };
+        this.callGraph[functionId] = this.extractCallsFromFunction(
+          init,
           relativePath,
         );
       }
@@ -1441,6 +1572,14 @@ class TypeScriptAnalyzer {
       path.relative(this.repoPath, sourceFile.getFilePath()),
     );
 
+    // Descend `namespace {}` / `module {}` bodies just like the inventory
+    // builder does: their arrows and class methods are their own StatementedNode
+    // scope, so sourceFile.getVariableStatements()/getClasses() do NOT return
+    // them. Without this the inventory emits those units but this arm never walks
+    // their bodies, so the Step-4 backstop stamps them with an empty edge list —
+    // silently dropping real outgoing edges (e.g. namespace Shape.render -> area).
+    const containers = statementedContainers(sourceFile);
+
     // Analyze function declarations (same enumeration + id scheme as the
     // inventory builder, so callGraph keys match functions keys exactly —
     // a block function must get its REAL outgoing edges, not a backstop []).
@@ -1455,7 +1594,9 @@ class TypeScriptAnalyzer {
     }
 
     // Analyze arrow functions
-    for (const statement of sourceFile.getVariableStatements()) {
+    for (const statement of containers.flatMap((c) =>
+      c.getVariableStatements(),
+    )) {
       for (const declaration of statement.getDeclarations()) {
         const initializer = declaration.getInitializer();
         if (
@@ -1465,6 +1606,11 @@ class TypeScriptAnalyzer {
         ) {
           const name = declaration.getName();
           const callerId = `${relativePath}:${name}`;
+          // First-wins, mirroring the inventory builder so callGraph picks the
+          // SAME unit as functions on an id collision (top-level vs namespace, or
+          // a same-name function declaration already walked above). Otherwise the
+          // kept unit would carry a dropped sibling's edges.
+          if (this.callGraph[callerId]) continue;
           this.callGraph[callerId] = this.extractCallsFromFunction(
             initializer,
             relativePath,
@@ -1474,7 +1620,7 @@ class TypeScriptAnalyzer {
     }
 
     // Analyze class methods
-    for (const classDecl of sourceFile.getClasses()) {
+    for (const classDecl of containers.flatMap((c) => c.getClasses())) {
       const className = classDecl.getName() || "AnonymousClass";
 
       // Mirror the inventory builder: include get/set accessors so
@@ -1487,6 +1633,10 @@ class TypeScriptAnalyzer {
       for (const method of classMembers) {
         const methodName = method.getName();
         const callerId = `${relativePath}:${className}.${methodName}`;
+        // First-wins, lockstep with the inventory class-method guard: a top-level
+        // and a namespace class can share `${className}.${methodName}`; keep the
+        // top-level unit's edges (it is walked first, containers = [file, ...ns]).
+        if (this.callGraph[callerId]) continue;
         this.callGraph[callerId] = this.extractCallsFromFunction(
           method,
           relativePath,
@@ -1499,10 +1649,31 @@ class TypeScriptAnalyzer {
       const ctorDecl =
         classDecl.getConstructors().find((c) => c.getBody && c.getBody()) ||
         classDecl.getConstructors()[0];
-      if (ctorDecl) {
-        const callerId = `${relativePath}:${className}.constructor`;
-        this.callGraph[callerId] = this.extractCallsFromFunction(
+      const ctorCallerId = `${relativePath}:${className}.constructor`;
+      if (ctorDecl && !this.callGraph[ctorCallerId]) {
+        this.callGraph[ctorCallerId] = this.extractCallsFromFunction(
           ctorDecl,
+          relativePath,
+        );
+      }
+
+      // Walk arrow-function / function-expression class properties too, so the
+      // property units emitted by the inventory builder get their REAL outgoing
+      // edges (e.g. `@Get() findAll = (req, res) => this.svc.findAll()`), not an
+      // empty Step-4 backstop. Without this the handler is seeded as an entry
+      // point but its callees are never reached through it and stay pruned.
+      // callGraph is already populated for methods/accessors/ctor above; the
+      // guard preserves a real method's edges when a property shares its name
+      // (mirrors the inventory builder's first-wins ownership of the id).
+      for (const prop of classDecl.getProperties()) {
+        const init = prop.getInitializer();
+        if (!init) continue;
+        const ik = init.getKindName();
+        if (ik !== "ArrowFunction" && ik !== "FunctionExpression") continue;
+        const callerId = `${relativePath}:${className}.${prop.getName()}`;
+        if (this.callGraph[callerId]) continue;
+        this.callGraph[callerId] = this.extractCallsFromFunction(
+          init,
           relativePath,
         );
       }
@@ -1569,11 +1740,14 @@ class TypeScriptAnalyzer {
   extractCallsFromFunction(funcNode, currentFile) {
     const calls = [];
     const seen = new Set();
-    const pushName = (name, dynamic) => {
+    // `member` marks a call through a receiver (`obj.foo()`, `this.foo()`); a
+    // bare `foo()` (member=false) can only target a free function in scope, never
+    // a sibling method, so the resolver must not match it to a `Class.foo` unit.
+    const pushName = (name, dynamic, member = false) => {
       const key = `${name} ${dynamic ? 1 : 0}`;
       if (seen.has(key)) return;
       seen.add(key);
-      calls.push({ resolved: false, name: name, dynamic: dynamic });
+      calls.push({ resolved: false, name: name, dynamic: dynamic, member: member });
     };
 
     const callExpressions = funcNode.getDescendantsOfKind(
@@ -1584,7 +1758,10 @@ class TypeScriptAnalyzer {
       const callee = callExpr.getExpression();
       const normalized = this._normalizeCallName(callee);
       if (normalized) {
-        pushName(normalized, false);
+        // A PropertyAccess callee (`obj.foo()`, `this.foo()`) is a receiver call.
+        const isMember =
+          !!callee && callee.getKindName() === "PropertyAccessExpression";
+        pushName(normalized, false, isMember);
       } else {
         // Dynamic / element-access callee — record the raw span trimmed to a
         // single line so node names never become multiline blobs.
@@ -1645,18 +1822,33 @@ class TypeScriptAnalyzer {
       (byName[simple] = byName[simple] || []).push(funcId);
     }
 
-    const resolveName = (name, callerFile) => {
-      // 1. Same-file simple-name match.
+    const resolveName = (name, callerFile, isMember) => {
+      // 1b. Same-file member/method-suffix match (`Class.foo` for `this.foo()` /
+      // `obj.foo()`). ONLY for receiver calls: a bare `foo()` never targets a
+      // sibling method, so gating this on `isMember` stops a same-named method
+      // from poisoning a bare call before the cross-file free function (step 2)
+      // is even considered. This runs BEFORE the exact 1a match: for a receiver
+      // call the sibling method is the correct target even when a same-name free
+      // function coexists in-file (an exact-first order would mis-route
+      // `this.foo()` to that free function).
+      if (isMember) {
+        for (const funcId of byFile[callerFile] || []) {
+          if ((this.functions[funcId].name || "").endsWith("." + name)) return funcId;
+        }
+      }
+      // 1a. Same-file EXACT simple-name match (a free function / top-level unit).
       for (const funcId of byFile[callerFile] || []) {
-        const fname = this.functions[funcId].name || "";
-        if (fname === name || fname.endsWith("." + name)) return funcId;
+        if ((this.functions[funcId].name || "") === name) return funcId;
       }
       // 2. Unique-name match across the repo. Exclude object-literal methods:
       // they are only ever invoked through a receiver (`ctrl.handler()`), so a bare
-      // cross-file same-name call must never resolve to one (no phantom). Same-file
-      // member calls still resolve via step 1's endsWith('.'+name) match.
+      // cross-file same-name call must never resolve to one (no phantom). For a bare
+      // call also exclude qualified/method units (`Class.foo`) — a bare call can only
+      // reach a free function — so a lone free function stays the unique target.
       const candidates = (byName[name] || []).filter(
-        (id) => !this.functions[id].localObjectLiteral,
+        (id) =>
+          !this.functions[id].localObjectLiteral &&
+          (isMember || !(this.functions[id].name || "").includes(".")),
       );
       if (candidates.length === 1) return candidates[0];
       return null;
@@ -1674,7 +1866,7 @@ class TypeScriptAnalyzer {
           if (!indirect.includes(name)) indirect.push(name);
           continue;
         }
-        const target = resolveName(name, callerFile);
+        const target = resolveName(name, callerFile, !!edge.member);
         if (target && target !== callerId) {
           if (!resolvedTargets.includes(target)) resolvedTargets.push(target);
         } else if (!target) {
@@ -1739,9 +1931,15 @@ function extractSingleFunction(filePath, functionRef) {
     // Search for the function
     let foundFunction = null;
 
-    // 1. Try class methods first if className specified
+    // 1. Try class methods first if className specified. Descend namespace/module
+    // bodies so a namespaced class member (e.g. `Shape.render` inside
+    // `namespace Geometry {}`) is findable — the inventory/call-graph builders
+    // enumerate the same descended set, so this must too or a namespace class is
+    // emitted as a unit yet its source can't be re-extracted on demand.
     if (className) {
-      for (const classDecl of sourceFile.getClasses()) {
+      for (const classDecl of statementedContainers(sourceFile).flatMap((c) =>
+        c.getClasses(),
+      )) {
         const classNameMatch = classDecl.getName();
         if (classNameMatch === className) {
           // getMethods() excludes get/set accessors, so search the
@@ -1771,7 +1969,12 @@ function extractSingleFunction(filePath, functionRef) {
     // 2. Try standalone function declarations (incl. module-level block-scoped,
     // so a call TO a function defined inside an if/try/for block resolves).
     if (!foundFunction) {
-      for (const func of this._moduleLevelFunctionNodes(sourceFile)) {
+      // extractSingleFunction is a standalone function (no analyzer `this`), so
+      // borrow the class's module-level enumeration via a throwaway instance —
+      // the method reads only `sourceFile`, never instance state. Calling it as
+      // `this._moduleLevelFunctionNodes` here threw a TypeError.
+      const analyzer = new TypeScriptAnalyzer(path.dirname(normalisedFilePath));
+      for (const func of analyzer._moduleLevelFunctionNodes(sourceFile)) {
         if (func.getName() === functionName) {
           foundFunction = {
             node: func,
@@ -1787,8 +1990,11 @@ function extractSingleFunction(filePath, functionRef) {
     }
 
     // 3. Try arrow functions / function expressions assigned to variables
+    // (including those declared inside a namespace/module body).
     if (!foundFunction) {
-      for (const statement of sourceFile.getVariableStatements()) {
+      for (const statement of statementedContainers(sourceFile).flatMap((c) =>
+        c.getVariableStatements(),
+      )) {
         for (const declaration of statement.getDeclarations()) {
           if (declaration.getName() === functionName) {
             const initializer = declaration.getInitializer();

--- a/libs/openant-core/tests/parsers/javascript/test_decorated_arrow_prop.py
+++ b/libs/openant-core/tests/parsers/javascript/test_decorated_arrow_prop.py
@@ -1,0 +1,196 @@
+"""Regression: decorated arrow-function class properties are seeded as units.
+
+PR #146 generalised decorator capture for class *methods*, but a decorated
+arrow-function class property (NestJS/Angular `@Get() findAll = (req, res) =>
+{...}`) is not returned by `getMethods()`, so it was never emitted as a unit —
+hence never seeded as a route_handler entry point and its callees were pruned
+as unreachable.
+
+Skips when Node.js or the parser's npm dependencies aren't installed.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def _write(tmp_path, name, content, filename="cats.controller.ts"):
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / filename
+    fp.write_text(content)
+    return repo, fp
+
+
+def test_decorated_arrow_property_seeded_as_route_handler(tmp_path):
+    repo, fp = _write(
+        tmp_path,
+        "pr146_arrow_prop",
+        "class CatsController {\n"
+        "  @Get()\n"
+        "  findAll = (req, res) => {\n"
+        "    return res.send('all cats');\n"
+        "  };\n"
+        "  ping() { return 'pong'; }\n"
+        "}\n",
+    )
+    out = _analyze(repo, fp)
+    fn = next(
+        (v for k, v in out["functions"].items() if k.endswith(":CatsController.findAll")),
+        None,
+    )
+    assert fn is not None, (
+        f"decorated arrow-function property must be emitted; got {list(out['functions'])}"
+    )
+    assert fn["decorators"] == ["@Get()"], fn["decorators"]
+    assert fn["unitType"] == "route_handler", fn["unitType"]
+    assert fn["className"] == "CatsController"
+
+
+def _callees(out, id_suffix):
+    """Callee names on the callGraph edge for the function whose id ends with
+    id_suffix. Empty list if the id has no edges / no entry."""
+    cg = out["callGraph"]
+    key = next((k for k in cg if k.endswith(id_suffix)), None)
+    if key is None:
+        return []
+    return [e.get("name") for e in cg[key]]
+
+
+def test_decorated_arrow_property_callees_get_edges(tmp_path):
+    """The transitive rescue: the handler's body call must produce a REAL
+    outgoing callGraph edge, not an empty Step-4 backstop. buildCallGraphForFile
+    must walk getProperties() arrow initializers, else the callee stays pruned."""
+    repo, fp = _write(
+        tmp_path,
+        "pr146_arrow_prop_edges",
+        "class CatsController {\n"
+        "  @Get()\n"
+        "  findAll = (req, res) => {\n"
+        "    return this.svc.rescueMe();\n"
+        "  };\n"
+        "}\n",
+    )
+    out = _analyze(repo, fp)
+    callees = _callees(out, ":CatsController.findAll")
+    assert "rescueMe" in callees, (
+        f"handler's body callee must get a callGraph edge (transitive rescue); "
+        f"got {callees}"
+    )
+
+
+def test_class_expression_decorated_arrow_property(tmp_path):
+    """A-class sibling: class *expressions* (module.exports = class {...}) carry
+    the same property-arrow gap. The property must be a unit AND its callee must
+    get an edge."""
+    repo, fp = _write(
+        tmp_path,
+        "pr146_arrow_prop_classexpr",
+        "module.exports = class CatsController {\n"
+        "  @Get()\n"
+        "  findAll = (req, res) => {\n"
+        "    return this.svc.rescueMe();\n"
+        "  };\n"
+        "};\n",
+    )
+    out = _analyze(repo, fp)
+    fn = next(
+        (v for k, v in out["functions"].items() if k.endswith(":CatsController.findAll")),
+        None,
+    )
+    assert fn is not None, (
+        f"class-expression decorated arrow property must be emitted; "
+        f"got {list(out['functions'])}"
+    )
+    assert fn["decorators"] == ["@Get()"], fn["decorators"]
+    assert fn["className"] == "CatsController"
+    callees = _callees(out, ":CatsController.findAll")
+    assert "rescueMe" in callees, (
+        f"class-expression handler's callee must get a callGraph edge; got {callees}"
+    )
+
+
+def test_class_decorated_controller_arrow_property_carries_class_decorator(tmp_path):
+    """A-class completeness (FA3): the arrow-property unit must bundle the
+    CLASS-level decorator too, exactly as the sibling METHOD paths do via the
+    variadic `_decoratorTexts(classDecl, member)`. A NestJS `@Controller('cats')`
+    on the class is what makes the route prefix / entry-point classification
+    correct; if the property emission passes only the member node it silently
+    drops the class decorator and the handler loses its controller context."""
+    repo, fp = _write(
+        tmp_path,
+        "pr146_class_decorated_arrow_prop",
+        "@Controller('cats')\n"
+        "class CatsController {\n"
+        "  @Get()\n"
+        "  findAll = (req, res) => {\n"
+        "    return res.send('all cats');\n"
+        "  };\n"
+        "}\n",
+    )
+    out = _analyze(repo, fp)
+    fn = next(
+        (v for k, v in out["functions"].items() if k.endswith(":CatsController.findAll")),
+        None,
+    )
+    assert fn is not None, (
+        f"decorated arrow-function property must be emitted; got {list(out['functions'])}"
+    )
+    # Both the class-level and the member-level decorators, mirroring methods.
+    assert "@Controller('cats')" in fn["decorators"], (
+        f"class-level decorator must be bundled onto the property unit "
+        f"(mirrors method paths); got {fn['decorators']}"
+    )
+    assert "@Get()" in fn["decorators"], fn["decorators"]
+
+
+def test_class_expression_decorated_controller_arrow_property_carries_class_decorator(
+    tmp_path,
+):
+    """A-class completeness (FA3), class-EXPRESSION sibling: the class-expression
+    property path must bundle the class decorator via `_decoratorTexts(classExpr,
+    prop)`, matching its method sibling."""
+    repo, fp = _write(
+        tmp_path,
+        "pr146_classexpr_decorated_arrow_prop",
+        "module.exports = @Controller('cats') class CatsController {\n"
+        "  @Get()\n"
+        "  findAll = (req, res) => {\n"
+        "    return res.send('all cats');\n"
+        "  };\n"
+        "};\n",
+    )
+    out = _analyze(repo, fp)
+    fn = next(
+        (v for k, v in out["functions"].items() if k.endswith(":CatsController.findAll")),
+        None,
+    )
+    assert fn is not None, (
+        f"class-expression decorated arrow property must be emitted; "
+        f"got {list(out['functions'])}"
+    )
+    assert "@Controller('cats')" in fn["decorators"], (
+        f"class-expression class-level decorator must be bundled onto the property "
+        f"unit; got {fn['decorators']}"
+    )
+    assert "@Get()" in fn["decorators"], fn["decorators"]

--- a/libs/openant-core/tests/parsers/javascript/test_extract_single_function_this.py
+++ b/libs/openant-core/tests/parsers/javascript/test_extract_single_function_this.py
@@ -1,0 +1,36 @@
+"""Regression (PR134): single-function mode crashed on a standalone function.
+
+`extractSingleFunction` is a top-level function (no analyzer `this`), but its
+path-2 standalone-function lookup called `this._moduleLevelFunctionNodes(...)`.
+For a bare function ref (no class) path 1 is skipped and control reaches path 2,
+where `this` is undefined -> `TypeError`, so `node typescript_analyzer.js <file>
+<func>` exited non-zero and emitted no function.
+"""
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _extract_single(tmp_path, source, func_ref, filename="a.js"):
+    fp = tmp_path / filename
+    fp.write_text(source)
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(fp), func_ref]
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=60)
+
+
+def test_single_function_module_level_block_scoped(tmp_path):
+    # a module-level block-scoped function requested by bare name -> path 2
+    src = "if (globalThis.flag) {\n  function target() { return 42; }\n}\n"
+    res = _extract_single(tmp_path, src, "target")
+    assert res.returncode == 0, f"single-function mode crashed:\n{res.stderr}"
+    assert "target" in res.stdout

--- a/libs/openant-core/tests/parsers/javascript/test_namespace_body_descended.py
+++ b/libs/openant-core/tests/parsers/javascript/test_namespace_body_descended.py
@@ -1,0 +1,182 @@
+"""Bug: TypeScript `namespace {}` / `module {}` bodies are not descended, so
+classes and arrow/const functions declared inside a namespace are never
+extracted.
+
+`extractFunctionsFromFile` enumerated classes via `sourceFile.getClasses()` and
+const-arrow functions via `sourceFile.getVariableStatements()`. Both return only
+the source file's OWN top-level statements — a namespace body is its own
+StatementedNode scope, so `class Shape {}` and `const f = () =>` declared inside
+`namespace X {}` were invisible: never a unit, never a call-graph node, never an
+entry point. (Plain `function` declarations inside a namespace were already
+surfaced, because _moduleLevelFunctionNodes walks getDescendantsOfKind.)
+
+Fix: descend every namespace/module body (at any nesting depth) that is not
+inside a function, and extract its classes + variable statements too. Namespaces
+nested inside a function stay omitted (their text rides inside the enclosing
+unit), matching the existing block-scoped-function scope decision.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(tmp_path, source, filename="a.ts"):
+    repo = tmp_path / "r"
+    repo.mkdir(exist_ok=True)
+    fp = repo / filename
+    fp.write_text(source)
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo), str(fp)]
+    res = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert res.returncode == 0, f"analyzer failed:\n{res.stderr}"
+    return json.loads(res.stdout)
+
+
+def _names(out):
+    return sorted(k.split(":", 1)[1] for k in out["functions"])
+
+
+NAMESPACE_SRC = (
+    "namespace Geometry {\n"
+    "  export function area(r: number): number { return circ(r); }\n"
+    "  function circ(r: number): number { return 2 * Math.PI * r; }\n"
+    "  export class Shape { render(): void { area(1); } }\n"
+    "  export const scale = (x: number) => x * 2;\n"
+    "}\n"
+)
+
+
+def test_namespace_class_method_is_extracted(tmp_path):
+    out = _analyze(tmp_path, NAMESPACE_SRC)
+    assert "Shape.render" in _names(out), (
+        f"class method inside namespace dropped: {_names(out)}"
+    )
+
+
+def test_namespace_arrow_const_is_extracted(tmp_path):
+    out = _analyze(tmp_path, NAMESPACE_SRC)
+    assert "scale" in _names(out), (
+        f"const-arrow inside namespace dropped: {_names(out)}"
+    )
+
+
+def test_namespace_function_declarations_still_extracted(tmp_path):
+    # regression: the paths that already worked must keep working.
+    out = _analyze(tmp_path, NAMESPACE_SRC)
+    names = _names(out)
+    assert "area" in names and "circ" in names, names
+
+
+def test_nested_namespace_members_extracted(tmp_path):
+    src = (
+        "namespace Outer {\n"
+        "  export namespace Inner {\n"
+        "    export class Deep { go(): void {} }\n"
+        "    export const helper = () => 1;\n"
+        "  }\n"
+        "}\n"
+    )
+    out = _analyze(tmp_path, src)
+    names = _names(out)
+    assert "Deep.go" in names, f"nested-namespace class method dropped: {names}"
+    assert "helper" in names, f"nested-namespace arrow dropped: {names}"
+
+
+def test_namespace_inside_function_stays_omitted(tmp_path):
+    # A namespace declared inside a function is not module-level; its members'
+    # text rides inside the enclosing unit and must NOT be double-extracted.
+    src = (
+        "function outer() {\n"
+        "  namespace Local { export class C { m(): void {} } }\n"
+        "  return 1;\n"
+        "}\n"
+    )
+    out = _analyze(tmp_path, src)
+    names = _names(out)
+    assert "C.m" not in names, f"function-nested namespace over-extracted: {names}"
+    assert "outer" in names, names
+
+
+def test_top_level_class_unchanged(tmp_path):
+    # regression: a top-level class + arrow must still be extracted exactly once.
+    src = "class Top { run(): void {} }\nconst top = () => 1;\n"
+    out = _analyze(tmp_path, src)
+    names = _names(out)
+    assert "Top.run" in names and "top" in names, names
+    assert names.count("Top.run") == 1
+
+
+# --- FA3 revision: the inventory arm alone is a partial fix. A namespace member
+# must also get its REAL outgoing edges in callGraph (buildCallGraphForFile must
+# descend namespaces too), and a top-level unit must win over a same-name
+# namespace member on id collision (first-wins). These tests assert the OUTGOING
+# EDGE, not mere membership — the membership-only tests above were false-green.
+
+def _edges(out, caller_id):
+    """Outgoing edge target names for a callGraph key, or None if key absent."""
+    cg = out.get("callGraph", {})
+    if caller_id not in cg:
+        return None
+    return sorted(e["name"] for e in cg[caller_id] if e.get("name"))
+
+
+EDGE_SRC = (
+    "namespace Geometry {\n"
+    "  function area(r: number): number { return 2 * Math.PI * r; }\n"
+    "  export class Shape { render(): void { area(1); } }\n"
+    "  export const scale = (x: number) => area(x);\n"
+    "}\n"
+)
+
+
+def test_namespace_class_method_has_outgoing_edge(tmp_path):
+    # Shape.render() calls area(). Before the callGraph arm descended namespaces,
+    # this key existed (Step-4 backstop) but its edge list was empty [].
+    out = _analyze(tmp_path, EDGE_SRC)
+    edges = _edges(out, "a.ts:Shape.render")
+    assert edges is not None, f"Shape.render missing from callGraph: {sorted(out.get('callGraph', {}))}"
+    assert "area" in edges, f"Shape.render -> area edge dropped (empty backstop?): {edges}"
+
+
+def test_namespace_arrow_has_outgoing_edge(tmp_path):
+    # const scale = (x) => area(x); its outgoing edge to area must be walked.
+    out = _analyze(tmp_path, EDGE_SRC)
+    edges = _edges(out, "a.ts:scale")
+    assert edges is not None, f"scale missing from callGraph: {sorted(out.get('callGraph', {}))}"
+    assert "area" in edges, f"scale -> area edge dropped (empty backstop?): {edges}"
+
+
+COLLISION_SRC = (
+    "class Shape { render(): void { topHelper(); } }\n"
+    "function topHelper(): void {}\n"
+    "namespace NS {\n"
+    "  export class Shape { render(): void { nsHelper(); } }\n"
+    "  function nsHelper(): void {}\n"
+    "}\n"
+)
+
+
+def test_top_level_wins_over_namespace_on_id_collision(tmp_path):
+    # A top-level `class Shape` and a namespace `class Shape` both produce the id
+    # `Shape.render`. Without a first-wins guard the later namespace member
+    # OVERWROTE the top-level unit (and its edges). Top-level must be kept.
+    out = _analyze(tmp_path, COLLISION_SRC)
+    unit = out["functions"].get("a.ts:Shape.render")
+    assert unit is not None, "Shape.render unit missing"
+    assert unit.get("startLine") == 1, (
+        f"namespace Shape.render (line 4) overwrote top-level (line 1): startLine={unit.get('startLine')}"
+    )
+    edges = _edges(out, "a.ts:Shape.render")
+    assert edges == ["topHelper"], (
+        f"callGraph for kept unit must be the top-level's edges, got {edges}"
+    )

--- a/libs/openant-core/tests/parsers/javascript/test_resolvename_barecall_classmethod_poison.py
+++ b/libs/openant-core/tests/parsers/javascript/test_resolvename_barecall_classmethod_poison.py
@@ -1,0 +1,90 @@
+"""Regression: a bare call inside a class method must resolve to a same-named
+free FUNCTION, not to a same-named sibling class METHOD.
+
+A bare `run()` (no `this.`/receiver) can only target a free function in scope;
+a sibling method requires a receiver. The same-file resolver scanned exact and
+member ('Class.run') matches in one pass, so declaration order let the method
+poison the edge (FAM-A misdirection).
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    return json.loads(result.stdout)
+
+
+def _analyze_multi(repo_path, *file_paths):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"), str(repo_path)]
+    cmd += [str(p) for p in file_paths]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    return json.loads(result.stdout)
+
+
+def test_barecall_not_poisoned_by_sibling_method_crossfile(tmp_path):
+    """The live manifestation: the free function lives in another file, so the
+    same-file sibling method is the only same-name unit in the caller's file.
+
+    A bare `run()` must resolve to the cross-file free function, NOT the
+    same-file `Runner.run` sibling method it can never actually invoke.
+    """
+    repo = tmp_path / "poison"
+    repo.mkdir()
+    a = repo / "a.js"
+    b = repo / "b.js"
+    a.write_text(
+        "class Runner {\n"
+        "  start() { return run(); }\n"   # bare call
+        "  run() { return 1; }\n"          # sibling method -> the poison
+        "}\n"
+    )
+    b.write_text("function run() { return 2; }\n")  # free function -> correct target
+
+    out = _analyze_multi(repo, a, b)
+    targets = out["call_graph"].get("a.js:Runner.start", [])
+    assert "a.js:Runner.run" not in targets, f"bare run() poisoned to sibling method; got {targets}"
+    assert "b.js:run" in targets, f"bare run() must resolve to cross-file free function; got {targets}"
+
+
+def test_member_call_still_resolves_sibling_method(tmp_path):
+    """Guardrail: a receiver call `this.run()` must STILL reach the same-file
+    sibling method (the member path is only gated, not removed).
+
+    A same-name free FUNCTION coexists in the SAME file. This exercises the
+    1a/1b ordering: the exact 1a match would grab the free `run()` first, so the
+    resolver must run the member-suffix (1b) match BEFORE 1a for receiver calls.
+    Without the coexisting free function this test is false-green (nothing forces
+    1b to precede 1a)."""
+    repo = tmp_path / "member"
+    repo.mkdir()
+    fp = repo / "file.js"
+    fp.write_text(
+        "function run() { return 9; }\n"          # coexisting free function (1a bait)
+        "class Runner {\n"
+        "  start() { return this.run(); }\n"       # receiver call -> must hit method
+        "  run() { return 1; }\n"                  # sibling method -> correct target
+        "}\n"
+    )
+    out = _analyze(repo, fp)
+    targets = out["call_graph"].get("file.js:Runner.start", [])
+    assert "file.js:Runner.run" in targets, f"this.run() must reach sibling method; got {targets}"
+    assert "file.js:run" not in targets, (
+        f"this.run() must NOT resolve to coexisting free function; got {targets}"
+    )


### PR DESCRIPTION
## What
Robustness/correctness hardening for `typescript_analyzer.js`.

## Fixes in this PR (4)
- PR146 js decorated arrow prop unse
- js namespace body not descended
- js resolvename barecall classmetho
- PR134 js extractsingle this cr

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).