### PR TITLE
fix: harden call_graph_builder.py

### DIFF
--- a/libs/openant-core/parsers/c/call_graph_builder.py
+++ b/libs/openant-core/parsers/c/call_graph_builder.py
@@ -349,7 +349,12 @@ class CallGraphBuilder:
             return None
 
         if node.type == 'qualified_identifier':
-            return text
+            # A qualified TEMPLATE call (ns::foo<int>()) parses as a
+            # qualified_identifier whose leaf `name` is a template_function, so the
+            # raw text carries the `<...>` argument list (ns::foo<int>) and never
+            # matches the ns::foo definition -> the specialized function is
+            # unreachable. Rebuild the name with template argument lists dropped.
+            return self._qualified_name_without_template_args(node, source) or text
 
         if node.type == 'template_function':
             name_node = node.child_by_field_name('name')
@@ -361,6 +366,54 @@ class CallGraphBuilder:
             return None
 
         return text if text.isidentifier() else None
+
+    def _qualified_name_without_template_args(self, node, source: bytes) -> Optional[str]:
+        """Reconstruct a (possibly nested) qualified call name, dropping any
+        template argument list so ns::foo<int> normalises to ns::foo.
+
+        Handles the shapes tree-sitter-cpp produces for a qualified name:
+        namespace/identifier leaves, a template_function leaf (returns just its
+        `name`, i.e. no `<...>`), and a nested qualified_identifier (recurses on
+        the scope and name fields).
+
+        CONSERVATIVE by design: this returns None whenever ANY present segment is
+        a node shape it does not cleanly model (e.g. a decltype scope, or a
+        destructor_name / operator_name / conversion name leaf). It must NEVER
+        drop an unmodelled segment and emit a bare/partial name — doing so would
+        fabricate a name (``ns::~Widget`` -> ``ns``, ``decltype(x)::foo`` ->
+        ``foo``) that resolves to an unrelated function, creating a FALSE
+        call-graph edge HEAD never emitted. On None the caller falls back to the
+        raw node text (which resolves to nothing, exactly like prior behaviour).
+        Only ``ns::foo<int>`` -> ``ns::foo`` (every segment modelled) normalises.
+        """
+        if node.type in ('identifier', 'namespace_identifier', 'type_identifier'):
+            return source[node.start_byte:node.end_byte].decode('utf-8', errors='replace')
+        if node.type == 'template_function':
+            name_node = node.child_by_field_name('name')
+            if name_node is not None:
+                return source[name_node.start_byte:name_node.end_byte].decode('utf-8', errors='replace')
+            return None
+        if node.type == 'qualified_identifier':
+            scope = node.child_by_field_name('scope')
+            name = node.child_by_field_name('name')
+            # The name segment is required and must be cleanly modelled; an exotic
+            # leaf (destructor_name / operator_name / ...) -> None -> fallback.
+            if name is None:
+                return None
+            name_txt = self._qualified_name_without_template_args(name, source)
+            if name_txt is None:
+                return None
+            # Scope absent (global-scope ``::foo``): the only present segment is
+            # the modelled name, so normalise to it.
+            if scope is None:
+                return name_txt
+            # Scope present: it too must be cleanly modelled, else fall back so we
+            # never emit a partial name with an unmodelled scope silently dropped.
+            scope_txt = self._qualified_name_without_template_args(scope, source)
+            if scope_txt is None:
+                return None
+            return f"{scope_txt}::{name_txt}"
+        return None
 
     def _is_visible_from(self, func_id: str, caller_file: str) -> bool:
         """Whether a candidate definition is linkable from caller_file.

--- a/libs/openant-core/tests/parsers/c/test_c_template_specialization_reachable.py
+++ b/libs/openant-core/tests/parsers/c/test_c_template_specialization_reachable.py
@@ -1,0 +1,132 @@
+"""Regression: a qualified C++ template call must resolve to its definition.
+
+Bug (c-template-specialization-unreachable, FAM-A): a qualified template call
+like ``ns::foo<int>()`` parses as a ``qualified_identifier`` whose leaf ``name``
+is a ``template_function`` (``foo<int>``). ``_extract_call_name`` returned the
+raw node text ``ns::foo<int>`` — with the ``<int>`` template argument list still
+attached — which never matches a definition named ``ns::foo``. The specialized/
+template function was therefore unreachable in the call graph. The bare
+(non-qualified) case ``foo<int>()`` was already handled at the ``template_function``
+branch; only the qualified case leaked the argument list.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = Path(__file__).resolve().parents[3]  # libs/openant-core (test is at tests/parsers/c/)
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+pytest.importorskip("tree_sitter_cpp")  # qualified template calls need the C++ grammar
+
+from parsers.c.call_graph_builder import CallGraphBuilder  # noqa: E402
+
+
+def test_qualified_template_call_resolves_to_specialized_function():
+    """ns::foo<int>() must produce an edge to the ns::foo definition."""
+    code = "void caller(){ ns::foo<int>(1); }"
+    eo = {
+        "functions": {
+            "app.cpp:caller": {"name": "caller", "file_path": "app.cpp", "code": code},
+            "app.cpp:ns::foo": {"name": "ns::foo", "file_path": "app.cpp",
+                                "code": "template<typename T> void foo(T x){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(code, "app.cpp:caller")
+    assert "app.cpp:ns::foo" in edges, (
+        f"qualified template call ns::foo<int>() did not resolve; edges={sorted(edges)}"
+    )
+
+
+def test_nested_namespace_template_call_resolves():
+    """a::b::bar<T,U>() (nested qualified_identifier) must resolve to a::b::bar."""
+    code = "void caller(){ a::b::bar<int,long>(1); }"
+    eo = {
+        "functions": {
+            "app.cpp:caller": {"name": "caller", "file_path": "app.cpp", "code": code},
+            "app.cpp:a::b::bar": {"name": "a::b::bar", "file_path": "app.cpp",
+                                  "code": "template<class T,class U> void bar(T x){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(code, "app.cpp:caller")
+    assert "app.cpp:a::b::bar" in edges, (
+        f"nested qualified template call did not resolve; edges={sorted(edges)}"
+    )
+
+
+def test_plain_qualified_call_still_resolves():
+    """Guard: a non-template qualified call ns::foo() must keep resolving."""
+    code = "void caller(){ ns::foo(1); }"
+    eo = {
+        "functions": {
+            "app.cpp:caller": {"name": "caller", "file_path": "app.cpp", "code": code},
+            "app.cpp:ns::foo": {"name": "ns::foo", "file_path": "app.cpp",
+                                "code": "void foo(int x){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(code, "app.cpp:caller")
+    assert "app.cpp:ns::foo" in edges, (
+        f"plain qualified call regressed; edges={sorted(edges)}"
+    )
+
+
+# --- FA3 completeness: the template-arg-stripping helper must be CONSERVATIVE ---
+# An exotic qualified form whose scope OR name is a node shape the helper does not
+# cleanly model (decltype scope, destructor_name / operator_name / conversion
+# name) must NOT be normalised into a bare/partial name. Dropping the unmodelled
+# segment fabricates a name (e.g. "foo" or "ns") that resolves to an unrelated
+# function — a FALSE call-graph edge HEAD never emitted. The helper must return
+# None so the qualified branch falls back to the raw node text (which resolves to
+# nothing, exactly like HEAD).
+
+def test_exotic_decltype_scope_does_not_fabricate_edge():
+    """decltype(x)::compute() must NOT resolve to the unrelated global compute()."""
+    code = "void caller(){ decltype(x)::compute(1); }"
+    eo = {
+        "functions": {
+            "app.cpp:caller": {"name": "caller", "file_path": "app.cpp", "code": code},
+            "app.cpp:compute": {"name": "compute", "file_path": "app.cpp",
+                                "code": "void compute(int x){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(code, "app.cpp:caller")
+    assert "app.cpp:compute" not in edges, (
+        f"exotic decltype-scoped call fabricated a false edge; edges={sorted(edges)}"
+    )
+
+
+def test_exotic_destructor_name_does_not_fabricate_edge():
+    """ns::~Widget() (destructor_name leaf) must NOT resolve to a function named ns."""
+    code = "void caller(){ ns::~Widget(); }"
+    eo = {
+        "functions": {
+            "app.cpp:caller": {"name": "caller", "file_path": "app.cpp", "code": code},
+            "app.cpp:ns": {"name": "ns", "file_path": "app.cpp", "code": "void ns(){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(code, "app.cpp:caller")
+    assert "app.cpp:ns" not in edges, (
+        f"exotic destructor-name call fabricated a false edge; edges={sorted(edges)}"
+    )
+
+
+def test_exotic_operator_name_does_not_fabricate_edge():
+    """ns::operator+() (operator_name leaf) must NOT resolve to a function named ns."""
+    code = "void caller(){ ns::operator+(a, b); }"
+    eo = {
+        "functions": {
+            "app.cpp:caller": {"name": "caller", "file_path": "app.cpp", "code": code},
+            "app.cpp:ns": {"name": "ns", "file_path": "app.cpp", "code": "void ns(){}"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    edges = b._extract_calls_from_code(code, "app.cpp:caller")
+    assert "app.cpp:ns" not in edges, (
+        f"exotic operator-name call fabricated a false edge; edges={sorted(edges)}"
+    )


### PR DESCRIPTION
## What
Robustness/correctness hardening for `call_graph_builder.py`.

## Fixes in this PR (1)
- c template specialization unreacha

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).