### PR TITLE
fix: harden context_corrector.py

### DIFF
--- a/libs/openant-core/tests/test_context_corrector_exclude_dirs.py
+++ b/libs/openant-core/tests/test_context_corrector_exclude_dirs.py
@@ -1,0 +1,61 @@
+"""Regression: gather_source_files must mirror the parsers' canonical skip dirs.
+
+The default extension list of gather_source_files was broadened from JS-only to
+every language OpenAnt parses (go/python/ruby/rust/php/zig/c). That broadened
+walk now descends into dependency/build/VCS trees the JS-only default never
+reached -- Python __pycache__/.venv, Ruby .bundle/tmp, a top-level .git, etc.
+If exclude_dirs is not extended to mirror the canonical skip set
+(config/languages.json -> skip_dirs, unioned with the extractors' skips), the
+corrector "corrects" security context against vendored/generated code.
+
+This test drives the real gather_source_files with DEFAULT extensions over a
+repo that places source files BOTH at the top level (must be gathered) and
+inside canonical skip dirs (must be excluded).
+"""
+from pathlib import Path
+
+from utilities.context_corrector import gather_source_files
+
+# Top-level source that MUST be gathered.
+INCLUDED = {
+    "handler.js",
+    "app.py",
+    "server.rb",
+    "index.ts",
+}
+
+# (skip_dir, filename) source that MUST be excluded because it lives under a
+# canonical non-source directory. Covers the dirs the pre-fix JS-only default
+# already excluded (node_modules) AND the ones only reachable once the walk
+# went multi-language (__pycache__, .venv, .bundle, tmp, vendor, .git).
+EXCLUDED = {
+    ("node_modules", "lib.ts"),   # audit-named case (already excluded pre-fix)
+    ("__pycache__", "mod.py"),    # python build cache
+    (".venv", "site.py"),         # python virtualenv
+    (".bundle", "gem.rb"),        # ruby bundler
+    ("tmp", "scratch.rb"),        # ruby tmp
+    ("vendor", "vend.go"),        # vendored deps
+    (".git", "hook.py"),          # VCS internals
+}
+
+
+def test_gather_source_files_excludes_canonical_skip_dirs(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    for fname in INCLUDED:
+        (repo / fname).write_text(f"// top-level {fname}\n", encoding="utf-8")
+
+    for skip_dir, fname in EXCLUDED:
+        d = repo / skip_dir
+        d.mkdir(parents=True, exist_ok=True)
+        (d / fname).write_text(f"// vendored/generated {fname}\n", encoding="utf-8")
+
+    gathered = gather_source_files(str(repo))  # DEFAULT extensions (what every caller uses)
+    gathered_names = {Path(f["relative_path"]).name for f in gathered}
+
+    missing = INCLUDED - gathered_names
+    assert not missing, f"top-level source was dropped: {missing}"
+
+    leaked = {f"{d}/{fn}" for d, fn in EXCLUDED if fn in gathered_names}
+    assert not leaked, f"gather_source_files walked into canonical skip dirs: {sorted(leaked)}"

--- a/libs/openant-core/tests/test_context_corrector_language_coverage.py
+++ b/libs/openant-core/tests/test_context_corrector_language_coverage.py
@@ -1,0 +1,39 @@
+"""Regression: context_corrector.gather_source_files must cover every language OpenAnt parses.
+
+When the LLM returns INSUFFICIENT_CONTEXT, ContextCorrector.gather_source_files() walks the repo to
+feed candidate source files to the LLM-based semantic search. Its default extension list historically
+covered only the JS/TS family (.js/.ts/.jsx/.tsx/.ejs/.pug/.hbs/.json). OpenAnt, however, parses
+c, go, php, python, ruby, rust and zig. For a repo in any of those languages the default glob gathers
+NO source files, so context correction is silently skipped for every non-JS project.
+
+This test drives the real gather_source_files with its DEFAULT extensions (all three call sites pass no
+extensions arg) over a mixed-language repo and asserts each supported language's source is discovered.
+"""
+from pathlib import Path
+
+from utilities.context_corrector import gather_source_files
+
+# language -> a representative source filename that must be discoverable by default
+LANG_FILES = {
+    "go": "main.go",
+    "python": "app.py",
+    "ruby": "server.rb",
+    "rust": "lib.rs",
+    "php": "index.php",
+    "zig": "build.zig",
+    "c": "parser.c",
+    "javascript": "handler.js",  # baseline that already worked
+}
+
+
+def test_gather_source_files_covers_all_parsed_languages(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    for fname in LANG_FILES.values():
+        (repo / fname).write_text(f"// content of {fname}\n", encoding="utf-8")
+
+    gathered = gather_source_files(str(repo))  # DEFAULT extensions (what every caller uses)
+    gathered_names = {Path(f["relative_path"]).name for f in gathered}
+
+    missing = {lang: fname for lang, fname in LANG_FILES.items() if fname not in gathered_names}
+    assert not missing, f"gather_source_files skipped source for languages OpenAnt parses: {missing}"

--- a/libs/openant-core/utilities/context_corrector.py
+++ b/libs/openant-core/utilities/context_corrector.py
@@ -14,6 +14,7 @@ import json
 import os
 import subprocess
 import sys
+from pathlib import Path
 from typing import Optional
 
 from .llm_client import TokenTracker, get_global_tracker
@@ -22,6 +23,51 @@ from .llm import PhaseBinding, simple_text
 
 # Maximum characters per batch (leaving room for prompt overhead)
 MAX_BATCH_SIZE = 150000  # ~37k tokens for Sonnet
+
+
+# Canonical non-source directories the parsers skip when walking a repo.
+#
+# The single source of truth for language detection is config/languages.json
+# -> "skip_dirs" (see core/parser_adapter.detect_language). The per-language
+# extractors add a few more (e.g. parsers/ruby/repository_scanner.py excludes
+# .bundle/tmp/log/pkg/.cache/doc). gather_source_files() below must mirror
+# these: its extension list was broadened from JS-only to every parsed
+# language, so the walk now descends into dependency/build/VCS trees that the
+# JS-only default never reached (Python __pycache__/.venv, Ruby .bundle/tmp,
+# a top-level .git, ...). Correcting context against vendored/generated code
+# is wrong, so we exclude the union of the canonical skip sets.
+#
+# This literal is the always-available fallback + extractor-specific extras;
+# _canonical_skip_dirs() unions in config/languages.json at runtime so the
+# two never silently drift.
+_FALLBACK_SKIP_DIRS = frozenset({
+    # config/languages.json -> skip_dirs
+    'node_modules', '__pycache__', 'venv', '.venv', 'dist', 'build',
+    '.git', 'vendor',
+    # extractor-specific skips (parsers/ruby/repository_scanner.py) + JS extras
+    '.bundle', 'tmp', 'log', 'coverage', 'pkg', '.cache', 'doc', 'docs',
+    '.next',
+})
+
+
+def _canonical_skip_dirs() -> set[str]:
+    """Union of the parsers' canonical skip dirs.
+
+    Loads config/languages.json -> "skip_dirs" (the same single source of truth
+    core/parser_adapter.detect_language reads) and unions it with the literal
+    fallback so the corrector's exclusions stay in sync with the parsers even
+    if the config gains new entries. Never raises: on any load failure it
+    degrades to the fallback set.
+    """
+    skip = set(_FALLBACK_SKIP_DIRS)
+    try:
+        # utilities/context_corrector.py -> utilities -> openant-core -> libs -> repo root
+        cfg = Path(__file__).resolve().parent.parent.parent.parent / "config" / "languages.json"
+        with open(cfg, 'r', encoding='utf-8') as fh:
+            skip |= set(json.load(fh).get("skip_dirs", ()))
+    except Exception:
+        pass
+    return skip
 
 
 def get_missing_context_prompt(reasoning: str) -> str:
@@ -120,16 +166,29 @@ def gather_source_files(repo_path: str, extensions: list[str] = None) -> list[di
 
     Args:
         repo_path: Path to the repository root
-        extensions: File extensions to include (default: js, ts, jsx, tsx, ejs, pug, hbs)
+        extensions: File extensions to include (default: source files for every language
+            OpenAnt parses -- js/ts family plus c, go, php, python, ruby, rust, zig)
 
     Returns:
         List of dicts with file_path, relative_path, and content
     """
     if extensions is None:
-        extensions = ['.js', '.ts', '.jsx', '.tsx', '.ejs', '.pug', '.hbs', '.json']
+        # Cover every language the parsers/ directory supports, not just JS/TS: a default
+        # of JS-only extensions silently gathered zero source files for c/go/php/python/
+        # ruby/rust/zig repos, so context correction was skipped for every non-JS project.
+        extensions = [
+            # JS / TS family + templates
+            '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.ejs', '.pug', '.hbs', '.json',
+            # other parsed languages
+            '.go', '.py', '.rb', '.rake', '.php', '.rs', '.zig',
+            '.c', '.h', '.cpp', '.hpp', '.cc', '.cxx', '.hxx', '.hh',
+        ]
 
-    # Directories to exclude
-    exclude_dirs = {'node_modules', '.git', 'dist', 'build', 'coverage', 'vendor', '.next'}
+    # Directories to exclude. Mirror the parsers' canonical skip set (see
+    # _canonical_skip_dirs) so the broadened multi-language extension walk does
+    # not descend into dependency/build/VCS trees and correct context against
+    # vendored or generated code.
+    exclude_dirs = _canonical_skip_dirs()
 
     # File patterns to exclude
     exclude_patterns = {'.min.js', '.min.css', '.bundle.js', '.chunk.js', 'package-lock.json'}


### PR DESCRIPTION
## What
Robustness/correctness hardening for `context_corrector.py`.

## Fixes in this PR (1)
- context corrector js only extensio

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).