### PR TITLE
fix: harden __init__.py, __main__.py, cli.py (+7 more)

### DIFF
--- a/libs/openant-core/core/dynamic_tester.py
+++ b/libs/openant-core/core/dynamic_tester.py
@@ -13,7 +13,7 @@ import sys
 from core.schemas import DynamicTestStepResult, UsageInfo
 from core.verdict_taxonomy import DYNAMIC_TESTABLE
 from core import tracking
-from utilities.file_io import read_json, write_json
+from utilities.file_io import normalize_results, read_json, write_json
 
 
 def run_tests(
@@ -59,6 +59,10 @@ def run_tests(
 
     # Check how many findings to test
     pipeline_data = read_json(pipeline_output_path)
+    # fa18 TRUST BOUNDARY: normalize model `findings` to dicts-only at load
+    # (presence-guarded) so the testability filter's `f.get(...)` is safe.
+    if "findings" in pipeline_data:
+        normalize_results(pipeline_data, "findings")
     findings = pipeline_data.get("findings", [])
     testable = [
         f for f in findings

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from core.schemas import ReportResult
 from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
-from utilities.file_io import open_utf8, read_json, write_json
+from utilities.file_io import normalize_results, open_utf8, read_json, write_json
 
 # Root of openant-core
 _CORE_ROOT = Path(__file__).parent.parent
@@ -153,6 +153,13 @@ def _dedup_caller_callee(
     because CWE is stable across runs while attack_vector varies.
     CWE-0 (unknown) never matches — two unknowns shouldn't collapse.
     """
+    # FAM-ROBUST: `confirmed` and `all_results` are model-supplied lists. A
+    # non-Anthropic model can emit a bare string/number where a finding dict
+    # is expected; drop non-dict elements up front so every `.get()` below —
+    # and this helper when called standalone — is safe.
+    confirmed = [f for f in confirmed if isinstance(f, dict)]
+    all_results = [r for r in all_results if isinstance(r, dict)]
+
     if not os.path.isfile(call_graph_path):
         return confirmed
 
@@ -241,7 +248,25 @@ def build_pipeline_output(
     print(f"[Report] Building pipeline_output.json...", file=sys.stderr)
 
     experiment = read_json(results_path)
-    all_results = experiment.get("results", [])
+    # fa17 TRUST BOUNDARY: normalize model-supplied `results` to dicts-only once
+    # at load so every downstream count/iterator sees the same filtered list.
+    normalize_results(experiment)
+    # fa18 TRUST BOUNDARY: `confirmed_findings` shares this same
+    # results_verified.json trust boundary and is iterated with `finding.get(...)`
+    # below (and inside _dedup_caller_callee). Normalize it to dicts-only at the
+    # same load point so a non-list value (which fa15's `[c for c in confirmed]`
+    # guard would raise TypeError on) or non-dict elements can't crash the build.
+    # Guard on presence: an ABSENT key must stay absent so the `confirmed is None`
+    # fallback below (manual filter from `results`) still fires -- materializing
+    # it to [] would silently skip that fallback.
+    if "confirmed_findings" in experiment:
+        normalize_results(experiment, "confirmed_findings")
+    # FAM-ROBUST (fa15/fa16, kept as defense-in-depth): `results` is
+    # model-supplied; a non-Anthropic model can emit a bare string/number where a
+    # result dict is expected. Drop non-dict elements once at the entry so the
+    # confirmed filter and the full_result `next(...)` lookup below never call
+    # `.get()` on a non-dict.
+    all_results = [r for r in experiment.get("results", []) if isinstance(r, dict)]
     code_by_route = experiment.get("code_by_route", {})
     metrics = experiment.get("metrics", {})
 
@@ -256,6 +281,11 @@ def build_pipeline_output(
             r for r in all_results
             if str(r.get("finding") or r.get("verdict", "")).lower() in ("vulnerable", "bypassable")
         ]
+
+    # FAM-ROBUST: the `confirmed_findings` (verified-results) path comes straight
+    # from model output and may contain non-dict elements; drop them before the
+    # top-level `for finding in confirmed` loop `.get()`s each element.
+    confirmed = [c for c in confirmed if isinstance(c, dict)]
 
     # ---------------------------------------------------------------
     # Dedup: collapse caller/callee pairs that share the same attack
@@ -281,7 +311,11 @@ def build_pipeline_output(
 
         # Extract vulnerability details from nested structure if present
         vulns = finding.get("vulnerabilities", [])
-        vuln = vulns[0] if vulns else {}
+        # Truthiness only proves the list is non-empty, not that its first
+        # element is a dict. A model can return vulnerabilities=["str"]; guard
+        # the element with isinstance so the vuln.get(...) reads below can't
+        # raise AttributeError. Same defensive-coercion class as _coerce_to_str.
+        vuln = vulns[0] if vulns and isinstance(vulns[0], dict) else {}
 
         description = (
             vuln.get("description")
@@ -308,7 +342,12 @@ def build_pipeline_output(
             parts = []
             if finding.get("attack_vector"):
                 parts.append(_coerce_to_str(finding["attack_vector"]))
-            exploit_path = finding.get("exploit_path") or {}
+            # ``or {}`` only substitutes for FALSY values; a truthy non-dict
+            # exploit_path (a string/list, which non-Anthropic models emit)
+            # would slip through and crash ``.get``. Guard the type too.
+            exploit_path = finding.get("exploit_path")
+            if not isinstance(exploit_path, dict):
+                exploit_path = {}
             data_flow = exploit_path.get("data_flow")
             if data_flow:
                 # ``data_flow`` is meant to be ``list[str]`` (verify
@@ -339,6 +378,12 @@ def build_pipeline_output(
         # Map incomplete → "unverified" so it renders distinctly and stays
         # disclosure-eligible (surfaced for manual review).
         verification = finding.get("verification", {})
+        # A non-Anthropic model can return ``verification`` as a truthy
+        # non-dict (e.g. the string "agreed"); the ``.get`` calls below
+        # would raise AttributeError and crash report generation. Coerce
+        # to an empty dict — same read-side guard as exploit_path / M3.
+        if not isinstance(verification, dict):
+            verification = {}
         if verification.get("agree", False):
             stage2_verdict = "confirmed" if finding.get("exploit_path") else "agreed"
         elif verification.get("incomplete"):
@@ -532,6 +577,14 @@ def generate_summary_report(
     print("[Report] Generating summary report (LLM)...", file=sys.stderr)
 
     pipeline_data = read_json(results_path)
+    # fa18 TRUST BOUNDARY: `findings` is a model array-of-dict read back from
+    # pipeline_output.json; merge_dynamic_results (below) and the summary
+    # compaction iterate it with `finding.get(...)`. Normalize to dicts-only
+    # once at this load, BEFORE the merge, so a non-dict element can't crash.
+    # Guard on presence so an absent `findings` still trips validation's
+    # "missing required field" check rather than silently validating as empty.
+    if "findings" in pipeline_data:
+        normalize_results(pipeline_data, "findings")
     # Merge dynamic test results if available
     pipeline_data = merge_dynamic_results(pipeline_data, results_path)
 
@@ -595,6 +648,12 @@ def generate_disclosure_docs(
     print("[Report] Generating disclosure documents (LLM)...", file=sys.stderr)
 
     pipeline_data = read_json(results_path)
+    # fa18 TRUST BOUNDARY: normalize model `findings` to dicts-only at load,
+    # BEFORE merge_dynamic_results / the disclosure-eligibility enumerate below,
+    # so a non-dict element can't crash `finding.get("stage2_verdict")`.
+    # Presence-guarded (see generate_summary_report for rationale).
+    if "findings" in pipeline_data:
+        normalize_results(pipeline_data, "findings")
     # Merge dynamic test results if available
     pipeline_data = merge_dynamic_results(pipeline_data, results_path)
 

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -26,7 +26,7 @@ from utilities.llm import (
     load_config_file,
     resolve_llm_config,
 )
-from utilities.file_io import read_json, write_json
+from utilities.file_io import normalize_results, read_json, write_json
 from utilities.finding_verifier import FindingVerifier
 from utilities.agentic_enhancer.repository_index import load_index_from_file
 
@@ -90,6 +90,11 @@ def run_verification(
     # Load Stage 1 results
     print(f"[Verify] Loading results: {results_path}", file=sys.stderr)
     experiment = read_json(results_path)
+    # fa17 TRUST BOUNDARY: `results` is model-supplied; drop non-dict elements
+    # once here so the vulnerable_results filter below (and every downstream
+    # r.get()) is safe. Verify runs BEFORE report, so this is the first place a
+    # poisoned result would crash — normalizing per-loop missed it (fa15/fa16).
+    normalize_results(experiment)
     all_results = experiment.get("results", [])
     code_by_route = experiment.get("code_by_route", {})
 
@@ -278,11 +283,26 @@ def _count_verification_outcomes(verified_results: list) -> dict:
             continue
         if verification.get("agree", False):
             counts["agreed"] += 1
-            finding = r.get("finding", "").lower()
+            # Canonical read (matches :99 input filter): fall back to `verdict`
+            # so a verdict-only VULNERABLE result is not silently dropped.
+            finding = str(r.get("finding") or r.get("verdict", "")).lower()
             if finding in ("vulnerable", "bypassable"):
                 counts["confirmed_vulnerabilities"] += 1
         else:
-            counts["disagreed"] += 1
+            # Stage 2 disagreed. finding_verifier has already written the
+            # corrected verdict onto ``r["finding"]`` (= correct_finding). A
+            # disagreement only folds into ``safe`` (``safe += disagreed``) when
+            # that corrected verdict is itself non-vulnerable. If the verifier
+            # disagreed but the finding is STILL vulnerable/bypassable (e.g.
+            # vulnerable -> bypassable), it is a confirmed vulnerability, NOT
+            # safe — counting it as ``disagreed`` would under-report the vuln.
+            # Canonical read (matches :99 input filter): fall back to `verdict`
+            # so a verdict-only VULNERABLE disagreement is not silently dropped.
+            finding = str(r.get("finding") or r.get("verdict", "")).lower()
+            if finding in ("vulnerable", "bypassable"):
+                counts["confirmed_vulnerabilities"] += 1
+            else:
+                counts["disagreed"] += 1
     return counts
 
 
@@ -306,7 +326,9 @@ def _write_verified_results(
         # must not be dropped.
         "confirmed_findings": [
             r for r in verified_only
-            if r.get("finding", "").lower() in ("vulnerable", "bypassable")
+            # Canonical read (matches :99 input filter): fall back to `verdict`.
+            if str(r.get("finding") or r.get("verdict", "")).lower()
+            in ("vulnerable", "bypassable")
         ],
     }
 
@@ -316,7 +338,9 @@ def _write_verified_results(
         "protected": 0, "safe": 0, "errors": 0,
     }
     for r in merged_results:
-        finding = r.get("finding", r.get("verdict", "error").lower())
+        # Canonical read: lowercase a PRESENT finding too (not only the
+        # verdict/default), so a verdict-only result is classified correctly.
+        finding = str(r.get("finding") or r.get("verdict") or "error").lower()
         if finding in counts:
             counts[finding] += 1
         elif r.get("verdict") == "ERROR":

--- a/libs/openant-core/export_csv.py
+++ b/libs/openant-core/export_csv.py
@@ -29,7 +29,7 @@ import csv
 import json
 import os
 import sys
-from utilities.file_io import read_json
+from utilities.file_io import normalize_results, read_json
 
 # Characters that make a spreadsheet treat a cell as a formula on open (CSV / formula
 # injection, CWE-1236 / OWASP). Cells written from scanned source or LLM text must be
@@ -105,13 +105,14 @@ def get_stage1_verdict(result: dict) -> str:
                 return parts[i + 1]
 
     # If Stage 2 agreed, current finding is Stage 1's finding
+    # Fall back to 'verdict' so a verdict-only result exports its verdict, not blank.
     if verification.get('agree', True):
-        return result.get('finding', '')
+        return result.get('finding') or result.get('verdict', '')
 
     # If disagreed but no note, try to infer
     # The verification.correct_finding is Stage 2's, so current finding should be Stage 2's
     # This is a fallback - ideally verification_note should exist
-    return result.get('finding', '')
+    return result.get('finding') or result.get('verdict', '')
 
 
 def export_csv(experiment_path: str, dataset_path: str, output_path: str):
@@ -125,6 +126,10 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
     """
     # Load data
     experiment = load_json(experiment_path)
+    # fa17 TRUST BOUNDARY: normalize model-supplied `results` to dicts-only once
+    # at load so the CSV row loop below is safe (fa15/fa16 per-loop filter kept
+    # as defense-in-depth).
+    normalize_results(experiment)
     dataset = load_json(dataset_path)
 
     # Build unit lookup by ID
@@ -135,7 +140,11 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
 
     # Prepare CSV rows
     rows = []
-    for result in experiment.get('results', []):
+    # FAM-ROBUST (fa16): `results` is model-supplied; a non-Anthropic model can
+    # emit a bare string/number where a result dict is expected. Drop non-dict
+    # elements at loop entry so every `.get()` below is safe (mirrors the fa15
+    # guard in core/reporter.py).
+    for result in [r for r in experiment.get('results', []) if isinstance(r, dict)]:
         route_key = result.get('route_key', '')
 
         # Get unit data from dataset
@@ -158,7 +167,8 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
         stage1_verdict = get_stage1_verdict(result)
 
         # Stage 2 verdict is the final finding
-        stage2_verdict = result.get('finding', '')
+        # Fall back to 'verdict' so a verdict-only result exports its verdict, not blank.
+        stage2_verdict = result.get('finding') or result.get('verdict', '')
 
         # Build row
         row = {

--- a/libs/openant-core/generate_report.py
+++ b/libs/openant-core/generate_report.py
@@ -31,7 +31,7 @@ from datetime import datetime
 
 from dotenv import load_dotenv
 from core.verdict_taxonomy import FINDING_VERDICT_ORDER
-from utilities.file_io import read_json
+from utilities.file_io import normalize_results, read_json
 from utilities.llm import (
     build_phase_registry,
     load_config_file,
@@ -147,7 +147,11 @@ def prepare_findings_summary(experiment: dict, dataset: dict) -> list:
     units_by_id = {u['id']: u for u in dataset.get('units', [])}
 
     findings = []
-    for result in experiment.get('results', []):
+    # FAM-ROBUST (fa16): `results` is model-supplied; a non-Anthropic model can
+    # emit a bare string/number where a result dict is expected. Drop non-dict
+    # elements at loop entry so every `.get()` below is safe (mirrors the fa15
+    # guard in core/reporter.py).
+    for result in [r for r in experiment.get('results', []) if isinstance(r, dict)]:
         route_key = result.get('route_key', '')
         unit = units_by_id.get(route_key, {})
         llm_context = unit.get('llm_context') or {}
@@ -156,7 +160,9 @@ def prepare_findings_summary(experiment: dict, dataset: dict) -> list:
         findings.append({
             'file': extract_file(route_key),
             'unit_id': route_key,
-            'verdict': result.get('finding', ''),
+            # Fall back to raw ``verdict`` when ``finding`` is absent (see
+            # verdict-count site below); keeps finding-less vulns actionable.
+            'verdict': str(result.get('finding') or result.get('verdict', '')).lower(),
             'attack_vector': result.get('attack_vector', ''),
             'stage1_reasoning': result.get('reasoning', ''),
             'stage2_explanation': verification.get('explanation', ''),
@@ -303,9 +309,16 @@ def generate_html_report(
     file_verdicts = {}  # file -> worst verdict
     findings_data = []
 
-    for result in experiment.get('results', []):
+    # FAM-ROBUST (fa16): `results` is model-supplied; a non-Anthropic model can
+    # emit a bare string/number where a result dict is expected. Drop non-dict
+    # elements at loop entry so every `.get()` below is safe (mirrors the fa15
+    # guard in core/reporter.py).
+    for result in [r for r in experiment.get('results', []) if isinstance(r, dict)]:
         route_key = result.get('route_key', '')
-        verdict = result.get('finding', '')
+        # Fall back to the raw ``verdict`` field when a result has no normalized
+        # ``finding`` key, else finding-less vulnerable results are dropped from
+        # the count. Mirrors the canonical read in reporter.py / verifier.py.
+        verdict = str(result.get('finding') or result.get('verdict', '')).lower()
         file_path = extract_file(route_key)
         unit = units_by_id.get(route_key, {})
         llm_context = unit.get('llm_context') or {}
@@ -822,6 +835,10 @@ def main():
 
     print("Loading data...")
     experiment = load_json(args.experiment)
+    # fa17 TRUST BOUNDARY: normalize model-supplied `results` to dicts-only once
+    # at load. `experiment` is passed by reference into prepare_findings_summary
+    # and generate_html_report, so both iterators see the filtered list.
+    normalize_results(experiment)
     dataset = load_json(args.dataset)
 
     # Load step reports if available

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -23,7 +23,7 @@ import sys
 import tempfile
 
 from core.verdict_taxonomy import FINDING_VERDICT_ORDER
-from utilities.file_io import read_json
+from utilities.file_io import normalize_results, read_json
 
 
 def _output_json(data: dict):
@@ -290,6 +290,9 @@ def cmd_analyze(args):
                         repo_path=args.repo_path,
                         workers=args.workers,
                         backoff_seconds=args.backoff,
+                        # Propagate --llm-config so the chained verify stage
+                        # uses the same configured model as analyze, not the default.
+                        llm_config_name=args.llm_config,
                     )
 
                     vctx.summary = {
@@ -630,6 +633,11 @@ def cmd_report_data(args):
         }) as ctx:
             # Load data
             experiment = read_json(results_path)
+            # fa17 TRUST BOUNDARY: normalize model-supplied `results` to dicts-only
+            # once at load. This also fixes the total_units stat below —
+            # `len(experiment.get("results", []))` now counts the filtered list
+            # (matching len(findings)) instead of the raw, poisoned array.
+            normalize_results(experiment)
             dataset = read_json(dataset_path)
 
             # --- Load dynamic test results if available ---
@@ -641,7 +649,16 @@ def cmd_report_data(args):
             po_path = os.path.join(results_dir, "pipeline_output.json")
             if os.path.exists(dt_path) and os.path.exists(po_path):
                 dt_data = read_json(dt_path)
+                # fa17 TRUST BOUNDARY: dynamic_test_results.json is a separate
+                # model-supplied schema; normalize its `results` to dicts-only so
+                # the `for dr in dt_data.get("results", [])` loop below is safe.
+                normalize_results(dt_data)
                 po_data = read_json(po_path)
+                # fa18 TRUST BOUNDARY: normalize model `findings` from
+                # pipeline_output.json to dicts-only at load (presence-guarded)
+                # so the `finding.get("id")` mapping loop below is safe.
+                if "findings" in po_data:
+                    normalize_results(po_data, "findings")
 
                 # Map VULN-ID → route_key from pipeline_output
                 vuln_id_to_route = {}
@@ -679,9 +696,16 @@ def cmd_report_data(args):
             file_verdicts = {}
             findings = []
 
-            for result in experiment.get("results", []):
+            # FAM-ROBUST (fa16): `results` is model-supplied; a non-Anthropic
+            # model can emit a bare string/number where a result dict is
+            # expected. Drop non-dict elements at loop entry so every `.get()`
+            # below is safe (mirrors the fa15 guard in core/reporter.py).
+            for result in [r for r in experiment.get("results", []) if isinstance(r, dict)]:
                 route_key = result.get("route_key", "")
-                verdict = result.get("finding", "")
+                # Fall back to the raw ``verdict`` field when ``finding`` is
+                # absent, else finding-less vulnerable results are dropped from
+                # the count. Mirrors the canonical read in reporter.py.
+                verdict = str(result.get("finding") or result.get("verdict", "")).lower()
                 file_path = route_key.rsplit(":", 1)[0] if ":" in route_key else route_key
                 unit = units_by_id.get(route_key, {})
                 llm_context = unit.get("llm_context") or {}

--- a/libs/openant-core/report/__main__.py
+++ b/libs/openant-core/report/__main__.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
 from .generator import generate_summary_report, generate_disclosure, generate_all
 from .schema import validate_pipeline_output, ValidationError
-from utilities.file_io import open_utf8, read_json
+from utilities.file_io import normalize_results, open_utf8, read_json
 from utilities.llm import (
     PhaseBinding,
     build_phase_registry,
@@ -44,6 +44,10 @@ def _build_report_binding(llm_config_name: str | None = None) -> PhaseBinding:
 def cmd_summary(args):
     """Generate summary report."""
     pipeline_data = read_json(args.input)
+    # fa18 TRUST BOUNDARY: normalize model `findings` to dicts-only at load
+    # (presence-guarded) before validation / iteration.
+    if "findings" in pipeline_data:
+        normalize_results(pipeline_data, "findings")
 
     try:
         validate_pipeline_output(pipeline_data)
@@ -67,6 +71,10 @@ def cmd_summary(args):
 def cmd_disclosures(args):
     """Generate disclosure documents."""
     pipeline_data = read_json(args.input)
+    # fa18 TRUST BOUNDARY: normalize model `findings` to dicts-only at load
+    # (presence-guarded) before validation / the disclosure enumerate.
+    if "findings" in pipeline_data:
+        normalize_results(pipeline_data, "findings")
 
     try:
         validate_pipeline_output(pipeline_data)

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -13,7 +13,7 @@ from dotenv import load_dotenv
 
 from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
 from .schema import validate_pipeline_output, ValidationError
-from utilities.file_io import open_utf8, read_json
+from utilities.file_io import normalize_results, open_utf8, read_json
 from utilities.llm import (
     PhaseBinding,
     PhaseRegistry,
@@ -93,6 +93,10 @@ def merge_dynamic_results(pipeline_data: dict, pipeline_path: str) -> dict:
         return pipeline_data
 
     dynamic_data = read_json(dynamic_path)
+    # fa17 TRUST BOUNDARY: dynamic_test_results.json `results` is model-supplied;
+    # normalize to dicts-only once so the `result.get("finding_id")` loop below
+    # never calls `.get()` on a bare string/number.
+    normalize_results(dynamic_data)
     results_by_id = {}
     for result in dynamic_data.get("results", []):
         fid = result.get("finding_id")
@@ -284,6 +288,12 @@ def generate_all(
 ) -> None:
     """Generate all reports from a pipeline output file."""
     pipeline_data = read_json(pipeline_path)
+    # fa18 TRUST BOUNDARY: normalize model `findings` to dicts-only once at load
+    # so the summary compaction and the disclosure enumerate below iterate
+    # dicts-only. Presence-guarded so an absent `findings` still fails
+    # validate_pipeline_output's "missing required field" check.
+    if "findings" in pipeline_data:
+        normalize_results(pipeline_data, "findings")
 
     try:
         validate_pipeline_output(pipeline_data)

--- a/libs/openant-core/tests/report/test_poisoned_confirmed_findings_and_findings_fa18.py
+++ b/libs/openant-core/tests/report/test_poisoned_confirmed_findings_and_findings_fa18.py
@@ -1,0 +1,229 @@
+"""fa18 POISONED-SUBSTRATE: normalize `confirmed_findings` and `findings` at load.
+
+fa17 normalized the model `results` array at 7 load boundaries. An adversarial
+enumeration of EVERY model-JSON array-of-dict key iterated with `element.get()`
+at a disk-load boundary found two more keys fa17 did NOT cover:
+
+  * ``confirmed_findings`` -- reporter.build_pipeline_output reads it from the
+    SAME results_verified.json trust boundary as ``results``. fa15 added a
+    LIST-element guard (``[c for c in confirmed if isinstance(c, dict)]``), but
+    that guard itself iterates ``confirmed``: a NON-LIST value (e.g. an int) a
+    non-Anthropic model can emit raises ``TypeError`` at the guard. fa18
+    normalizes the container at load so a non-list becomes ``[]``.
+  * ``findings`` -- pipeline_output.json is our own generated output, but it is
+    read back from disk (read_json) and iterated with ``finding.get(...)`` at
+    every report/dynamic-test boundary (defense-in-depth boundary). A non-dict
+    element raises ``AttributeError`` at the first ``.get()``.
+
+RED (against the 63-set base, WITHOUT fa18):
+  * reporter.build_pipeline_output(confirmed_findings=<int>) -> TypeError at the
+    fa15 ``[c for c in confirmed]`` guard.
+  * cli.cmd_report_data (dynamic path, poisoned pipeline_output findings) ->
+    AttributeError at ``finding.get("id")`` -> rc == 2.
+  * dynamic_tester.run_dynamic_tests(poisoned findings) -> AttributeError at the
+    DYNAMIC_TESTABLE filter ``f.get("stage2_verdict")``.
+  * reporter.generate_disclosure_docs(poisoned findings) -> AttributeError in
+    merge_dynamic_results at ``finding.get("id")`` (runs before validation).
+GREEN (with fa18): all pass -- non-dict elements dropped, non-list -> [].
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from utilities.file_io import normalize_results, write_json
+
+
+# ---------------------------------------------------------------------------
+# 0. Helper-level: the existing normalize_results(obj, key) generalizes to the
+#    two new keys (container-level filtering + non-list -> []).
+# ---------------------------------------------------------------------------
+def test_normalize_confirmed_findings_non_list_becomes_empty():
+    obj = {"confirmed_findings": 12345}
+    normalize_results(obj, "confirmed_findings")
+    assert obj["confirmed_findings"] == []
+
+
+def test_normalize_findings_filters_non_dicts():
+    obj = {"findings": [{"id": "A"}, "bare string", 7, None, ["x"]]}
+    normalize_results(obj, "findings")
+    assert obj["findings"] == [{"id": "A"}]
+
+
+# ---------------------------------------------------------------------------
+# 1. confirmed_findings boundary: reporter.build_pipeline_output.
+#    RED at base: confirmed_findings is a non-list int -> the fa15
+#    `[c for c in confirmed]` guard raises TypeError.
+# ---------------------------------------------------------------------------
+def _experiment_with_confirmed(confirmed) -> dict:
+    return {
+        "dataset": "fa18",
+        "code_by_route": {"app.py:foo": "def foo(): ..."},
+        "metrics": {},
+        "results": [],
+        "confirmed_findings": confirmed,
+    }
+
+
+def test_build_pipeline_output_non_list_confirmed_findings(tmp_path: Path):
+    from core.reporter import build_pipeline_output
+
+    exp = tmp_path / "results.json"
+    write_json(exp, _experiment_with_confirmed(12345))  # non-list -> TypeError at base
+    out = tmp_path / "pipeline_output.json"
+
+    out_path, count = build_pipeline_output(str(exp), str(out))
+    # Poisoned container dropped to [] -> zero confirmed findings, no crash.
+    assert count == 0
+    data = json.loads(Path(out_path).read_text())
+    assert data["findings"] == []
+
+
+def test_build_pipeline_output_list_confirmed_findings_with_non_dicts(tmp_path: Path):
+    """Defense-in-depth / no-regression: a LIST with non-dict elements (fa15's
+    class) still yields exactly the valid dict."""
+    from core.reporter import build_pipeline_output
+
+    exp = tmp_path / "results.json"
+    valid = {"route_key": "app.py:foo", "unit_id": "app.py:foo",
+             "verdict": "vulnerable", "finding": "vulnerable"}
+    write_json(exp, _experiment_with_confirmed([valid, "bare string", 99]))
+    out = tmp_path / "pipeline_output.json"
+
+    out_path, count = build_pipeline_output(str(exp), str(out))
+    assert count == 1
+    assert len(json.loads(Path(out_path).read_text())["findings"]) == 1
+
+
+def test_build_pipeline_output_absent_confirmed_findings_uses_manual_filter(tmp_path: Path):
+    """Regression guard for the presence-check: ABSENT confirmed_findings must
+    keep falling through to the manual verdict filter over `results`."""
+    from core.reporter import build_pipeline_output
+
+    exp = tmp_path / "results.json"
+    write_json(exp, {
+        "dataset": "fa18",
+        "code_by_route": {"app.py:foo": "def foo(): ..."},
+        "metrics": {},
+        "results": [{"route_key": "app.py:foo", "unit_id": "app.py:foo",
+                     "verdict": "vulnerable", "finding": "vulnerable"}],
+        # NO confirmed_findings key -> manual filter must run.
+    })
+    out = tmp_path / "pipeline_output.json"
+    out_path, count = build_pipeline_output(str(exp), str(out))
+    assert count == 1  # manual filter recovered the one vulnerable result
+
+
+# ---------------------------------------------------------------------------
+# 2. findings boundary: cli.cmd_report_data dynamic path (po_data findings).
+#    RED at base: finding.get("id") on a bare string -> AttributeError -> rc 2.
+# ---------------------------------------------------------------------------
+_DATASET = {"units": [{"id": "app/api.py:handler",
+                       "code": {"primary_code": "def handler(): ..."},
+                       "llm_context": {"reasoning": "ctx"}}]}
+
+
+def _safe_experiment() -> dict:
+    return {
+        "dataset": "fa18",
+        "code_by_route": {"app/api.py:handler": "def handler(): ..."},
+        "metrics": {},
+        "results": [{"route_key": "app/api.py:handler", "unit_id": "app/api.py:handler",
+                     "finding": "safe", "verdict": "safe",
+                     "verification": {"correct_finding": "safe"}}],
+    }
+
+
+def test_cli_report_data_survives_poisoned_pipeline_findings(tmp_path: Path, capsys):
+    from openant import cli
+
+    exp = tmp_path / "results.json"
+    ds = tmp_path / "dataset.json"
+    exp.write_text(json.dumps(_safe_experiment()))
+    ds.write_text(json.dumps(_DATASET))
+    # Both files present -> cmd_report_data enters the dynamic branch.
+    (tmp_path / "dynamic_test_results.json").write_text(
+        json.dumps({"results": [{"finding_id": "VULN-001", "status": "CONFIRMED"}]}))
+    (tmp_path / "pipeline_output.json").write_text(json.dumps({
+        "repository": {"name": "poison/repo"},
+        "findings": [
+            "a bare string the model emitted",   # non-dict -> AttributeError at base
+            {"id": "VULN-001", "location": {"function": "app/api.py:handler"}},
+        ],
+    }))
+
+    args = types.SimpleNamespace(results=str(exp), dataset=str(ds))
+    rc = cli.cmd_report_data(args)
+    assert rc == 0  # RED at base: rc == 2 (AttributeError in the po_data findings loop)
+
+
+# ---------------------------------------------------------------------------
+# 3. findings boundary: utilities.dynamic_tester.run_dynamic_tests.
+#    Driven hermetically with a dummy registry (skips probe/Docker). The one
+#    valid dict is non-DYNAMIC_TESTABLE, so after filtering findings is empty
+#    -> early return, no Docker. RED at base: f.get() on the bare string.
+# ---------------------------------------------------------------------------
+def test_run_dynamic_tests_survives_poisoned_findings(tmp_path: Path):
+    from utilities.dynamic_tester import run_dynamic_tests
+
+    pipeline = tmp_path / "pipeline_output.json"
+    pipeline.write_text(json.dumps({
+        "repository": {"name": "poison/repo", "language": "Python"},
+        "application_type": "web_app",
+        "findings": [
+            "a bare string the model emitted",         # non-dict -> AttributeError at base
+            {"id": "V1", "stage2_verdict": "safe"},    # dict, NOT dynamic-testable
+        ],
+    }))
+
+    # Dict registry -> `registry.get("dynamic_test")` works, skips probe/Docker.
+    out = run_dynamic_tests(str(pipeline), output_dir=str(tmp_path),
+                            registry={"dynamic_test": None})
+    assert out == []  # non-dict dropped; the safe dict filtered out -> early return
+
+
+# ---------------------------------------------------------------------------
+# 4. findings boundary: reporter.generate_disclosure_docs.
+#    RED at base: merge_dynamic_results (runs BEFORE validation) does
+#    finding.get("id") on the bare string -> AttributeError. GREEN: fa18
+#    normalizes findings at load, before merge; the registry build is
+#    monkeypatched so the no-eligible-findings path returns hermetically.
+# ---------------------------------------------------------------------------
+def test_generate_disclosure_docs_survives_poisoned_findings(tmp_path: Path, monkeypatch):
+    import utilities.llm as _llm
+    monkeypatch.setattr(_llm, "load_config_file", lambda *a, **k: {}, raising=False)
+    monkeypatch.setattr(_llm, "resolve_llm_config", lambda *a, **k: None, raising=False)
+    monkeypatch.setattr(_llm, "build_phase_registry", lambda *a, **k: {"report": None}, raising=False)
+    monkeypatch.setattr(_llm, "probe_registry_or_raise", lambda *a, **k: None, raising=False)
+
+    from core.reporter import generate_disclosure_docs
+
+    results_path = tmp_path / "pipeline_output.json"
+    results_path.write_text(json.dumps({
+        "repository": {"name": "poison/repo"},
+        "analysis_date": "2026-01-01",
+        "application_type": "web_app",
+        "pipeline_stats": {},
+        "results": {"vulnerable": 0, "safe": 1},
+        "findings": [
+            "a bare string the model emitted",   # non-dict -> AttributeError at base (in merge)
+            {   # fully schema-valid but NOT disclosure-eligible ("safe")
+                "id": "VULN-001", "name": "n", "short_name": "sn",
+                "location": {"file": "app.py", "function": "app.py:foo"},
+                "cwe_id": 0, "cwe_name": "unknown",
+                "stage1_verdict": "safe", "stage2_verdict": "safe",
+            },
+        ],
+    }))
+    # Present so merge_dynamic_results iterates findings (results_by_id non-empty).
+    (tmp_path / "dynamic_test_results.json").write_text(
+        json.dumps({"results": [{"finding_id": "VULN-001", "status": "CONFIRMED",
+                                 "details": "d", "evidence": []}]}))
+
+    res = generate_disclosure_docs(str(results_path), str(tmp_path / "disclosures"))
+    # No eligible ("safe") -> no disclosures generated, but NO crash.
+    assert res.format == "disclosure"

--- a/libs/openant-core/tests/report/test_poisoned_results_substrate.py
+++ b/libs/openant-core/tests/report/test_poisoned_results_substrate.py
@@ -1,0 +1,280 @@
+"""fa17 POISONED-SUBSTRATE E2E: normalize model-supplied `results` at TRUST BOUNDARIES.
+
+OpenAnt reads model-produced JSON (experiment_results.json, dynamic_test_results.json)
+and iterates the `results` array in ~20 places doing bare `r.get(...)`. A non-Anthropic
+model can emit a NON-DICT element (bare string / number / None / nested list) — or a
+non-list value for `results` itself — and the first `.get()` raises AttributeError,
+aborting verify / report / CSV.
+
+Per-loop `isinstance` guards (fa15 in reporter.py, fa16 in the 4 sibling emitters) did
+NOT converge: they missed the upstream verifier (verify runs BEFORE report, so it
+crashes first), the cli dynamic-test path, and report/generator's dynamic merge.
+
+fa17's design: normalize ONCE at each load boundary via
+`utilities.file_io.normalize_results(obj)`, mutating `obj["results"]` in place to a
+list of dicts-only. Every downstream count AND iterator then sees the same filtered
+list. This test drives EVERY public entry point that loads such JSON with a poisoned
+substrate and asserts (a) no crash, (b) only valid dicts propagate, (c) counts match
+the valid-dict count.
+
+RED (against the 62-set base, without fa17):
+  * core.verifier.run_verification    -> AttributeError at the vulnerable-filter (FIRST crash)
+  * report.generator.merge_dynamic_results -> AttributeError at result.get("finding_id")
+  * cli.cmd_report_data (dynamic path) -> AttributeError at dr.get("finding_id")
+  * cli.cmd_report_data (experiment)   -> stats.total_units counts the RAW poisoned list
+                                          (== 5) instead of the valid-dict count (== 1)
+GREEN (with fa17): all pass.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+from utilities.file_io import normalize_results
+
+
+# ---------------------------------------------------------------------------
+# Poisoned substrates. One valid dict + the full non-dict zoo the task names:
+# bare string, number, None, nested list.
+# ---------------------------------------------------------------------------
+def _valid_result(verdict: str) -> dict:
+    return {
+        "route_key": "app/api.py:handler",
+        "unit_id": "app/api.py:handler",
+        "finding": verdict,
+        "verdict": verdict,
+        "attack_vector": "prompt-injection",
+        "reasoning": "r",
+        "verification": {"correct_finding": verdict},
+    }
+
+
+def _poison_results(verdict: str) -> list:
+    return [
+        _valid_result(verdict),
+        "a bare string a non-Anthropic model emitted",
+        123,
+        None,
+        ["a", "nested", "list"],
+    ]
+
+
+def _experiment(verdict: str) -> dict:
+    return {
+        "dataset": "poison-substrate",
+        "code_by_route": {"app/api.py:handler": "def handler(): ..."},
+        "metrics": {},
+        "results": _poison_results(verdict),
+    }
+
+
+DATASET = {
+    "units": [
+        {
+            "id": "app/api.py:handler",
+            "code": {"primary_code": "def handler(): ..."},
+            "llm_context": {"reasoning": "context"},
+        }
+    ]
+}
+
+# Dynamic-test schema (separate schema, same `results` key + same poison).
+DYNAMIC_POISON = {
+    "results": [
+        {
+            "finding_id": "VULN-001",
+            "status": "CONFIRMED",
+            "details": "reproduced",
+            "evidence": ["step-1"],
+        },
+        "bare string in dynamic results",
+        456,
+        None,
+        ["nested"],
+    ]
+}
+
+PIPELINE_OUTPUT = {
+    "repository": {"name": "poison/repo"},
+    "findings": [
+        {"id": "VULN-001", "location": {"function": "app/api.py:handler"}}
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# 0. The helper itself, incl. the malformed top-level (non-list) results.
+# ---------------------------------------------------------------------------
+def test_normalize_results_filters_non_dicts():
+    obj = _experiment("vulnerable")
+    normalize_results(obj)
+    assert obj["results"] == [_valid_result("vulnerable")]
+    assert all(isinstance(r, dict) for r in obj["results"])
+
+
+def test_normalize_results_non_list_becomes_empty():
+    obj = {"results": "not a list at all"}
+    normalize_results(obj)
+    assert obj["results"] == []
+
+
+def test_normalize_results_missing_key_and_non_dict_obj():
+    obj = {}
+    normalize_results(obj)
+    assert obj["results"] == []
+    # A non-dict container is returned untouched (nothing to normalize).
+    assert normalize_results("not even a dict") == "not even a dict"
+
+
+# ---------------------------------------------------------------------------
+# 1. EXPERIMENT boundary: core.verifier.run_verification (verify path).
+#    The valid dict is `safe` so `findings_input == 0` and run_verification
+#    early-returns BEFORE any LLM/registry/index work — hermetic.
+#    RED at base: AttributeError at the vulnerable/bypassable filter.
+# ---------------------------------------------------------------------------
+def test_verifier_verify_path_survives_poison(tmp_path: Path):
+    from core.verifier import run_verification
+
+    exp = tmp_path / "results.json"
+    exp.write_text(json.dumps(_experiment("safe")))
+    out_dir = tmp_path / "verify_out"
+
+    result = run_verification(
+        results_path=str(exp),
+        output_dir=str(out_dir),
+        analyzer_output_path=str(tmp_path / "analyzer_output.json"),  # unused on early-return
+    )
+    assert result.findings_input == 0  # no vulnerable/bypassable -> hermetic early return
+
+    written = json.loads((out_dir / "results_verified.json").read_text())
+    assert all(isinstance(r, dict) for r in written["results"])
+    assert len(written["results"]) == 1  # only the one valid dict survived
+
+
+# ---------------------------------------------------------------------------
+# 2. EXPERIMENT boundary: reporter.build_pipeline_output.
+# ---------------------------------------------------------------------------
+def test_reporter_build_pipeline_output_survives_poison(tmp_path: Path):
+    from core.reporter import build_pipeline_output
+
+    exp = tmp_path / "results.json"
+    exp.write_text(json.dumps(_experiment("vulnerable")))
+    out = tmp_path / "pipeline_output.json"
+
+    out_path, findings_count = build_pipeline_output(str(exp), str(out))
+    assert findings_count == 1  # exactly the one valid vulnerable dict
+    data = json.loads(Path(out_path).read_text())
+    assert len(data["findings"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 3. EXPERIMENT boundary: export_csv.export_csv.
+# ---------------------------------------------------------------------------
+def test_export_csv_survives_poison(tmp_path: Path):
+    import export_csv
+
+    exp = tmp_path / "results.json"
+    ds = tmp_path / "dataset.json"
+    out = tmp_path / "out.csv"
+    exp.write_text(json.dumps(_experiment("vulnerable")))
+    ds.write_text(json.dumps(DATASET))
+
+    export_csv.export_csv(str(exp), str(ds), str(out))
+    lines = [ln for ln in out.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 2  # header + exactly one data row (4 poison elements dropped)
+
+
+# ---------------------------------------------------------------------------
+# 4. EXPERIMENT boundary: generate_report.main (drives load boundary at :824).
+#    Remediation is the only LLM call -> monkeypatched so the test is hermetic.
+# ---------------------------------------------------------------------------
+def test_generate_report_main_survives_poison(tmp_path: Path, monkeypatch, capsys):
+    import generate_report
+
+    exp = tmp_path / "results.json"
+    ds = tmp_path / "dataset.json"
+    out = tmp_path / "report.html"
+    exp.write_text(json.dumps(_experiment("vulnerable")))
+    ds.write_text(json.dumps(DATASET))
+
+    monkeypatch.setattr(generate_report, "generate_remediation_guidance", lambda findings: "")
+    monkeypatch.setattr("sys.argv", ["generate_report", str(exp), str(ds), str(out)])
+
+    generate_report.main()
+    assert out.exists()
+
+    # main() prints "Summary: {<verdict counts>}" — parse it and assert the
+    # count reflects only the 1 valid dict, never the 5 raw elements.
+    summary_line = next(
+        ln for ln in capsys.readouterr().out.splitlines() if ln.startswith("Summary:")
+    )
+    counts = ast.literal_eval(summary_line.split("Summary:", 1)[1].strip())
+    assert counts == {"vulnerable": 1}
+
+
+# ---------------------------------------------------------------------------
+# 5. EXPERIMENT boundary + STAT FIX: cli.cmd_report_data.
+#    Valid dict is `safe` -> non-actionable -> no LLM. RED at base: total_units
+#    counts the raw poisoned list (5) instead of the valid-dict count (1).
+# ---------------------------------------------------------------------------
+def test_cli_report_data_stat_matches_valid_count(tmp_path: Path, capsys):
+    from openant import cli
+
+    exp = tmp_path / "results.json"
+    ds = tmp_path / "dataset.json"
+    exp.write_text(json.dumps(_experiment("safe")))
+    ds.write_text(json.dumps(DATASET))
+
+    args = types.SimpleNamespace(results=str(exp), dataset=str(ds))
+    rc = cli.cmd_report_data(args)
+    assert rc == 0
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    stats = payload["data"]["stats"]
+    findings = payload["data"]["findings"]
+    assert stats["total_units"] == 1  # RED at base == 5 (counts poison)
+    assert stats["total_units"] == len(findings)  # count invariant restored
+
+
+# ---------------------------------------------------------------------------
+# 6. DYNAMIC boundary: report.generator.merge_dynamic_results.
+#    RED at base: AttributeError at result.get("finding_id") on the bare string.
+# ---------------------------------------------------------------------------
+def test_report_generator_dynamic_path_survives_poison(tmp_path: Path):
+    from report.generator import merge_dynamic_results
+
+    pipeline_path = tmp_path / "pipeline_output.json"
+    pipeline_path.write_text(json.dumps(PIPELINE_OUTPUT))
+    (tmp_path / "dynamic_test_results.json").write_text(json.dumps(DYNAMIC_POISON))
+
+    merged = merge_dynamic_results(json.loads(json.dumps(PIPELINE_OUTPUT)), str(pipeline_path))
+    finding = merged["findings"][0]
+    assert finding["dynamic_testing"]["status"] == "CONFIRMED"  # only valid dynamic dict merged
+
+
+# ---------------------------------------------------------------------------
+# 7. DYNAMIC boundary: cli.cmd_report_data dynamic path (dt_data loop).
+#    Both dynamic_test_results.json AND pipeline_output.json present triggers it.
+#    RED at base: AttributeError at dr.get("finding_id") on the bare string.
+# ---------------------------------------------------------------------------
+def test_cli_report_data_dynamic_path_survives_poison(tmp_path: Path, capsys):
+    from openant import cli
+
+    exp = tmp_path / "results.json"
+    ds = tmp_path / "dataset.json"
+    exp.write_text(json.dumps(_experiment("safe")))
+    ds.write_text(json.dumps(DATASET))
+    (tmp_path / "dynamic_test_results.json").write_text(json.dumps(DYNAMIC_POISON))
+    (tmp_path / "pipeline_output.json").write_text(json.dumps(PIPELINE_OUTPUT))
+
+    args = types.SimpleNamespace(results=str(exp), dataset=str(ds))
+    rc = cli.cmd_report_data(args)
+    assert rc == 0  # RED at base: crashes in the dt_data loop -> rc == 2
+
+    payload = json.loads(capsys.readouterr().out.strip())
+    assert payload["data"]["stats"]["total_units"] == 1

--- a/libs/openant-core/tests/report/test_sibling_result_iteration_guard_fa16.py
+++ b/libs/openant-core/tests/report/test_sibling_result_iteration_guard_fa16.py
@@ -1,0 +1,99 @@
+"""FAM-ROBUST (fa16 siblings): unguarded iteration over model-supplied `results`.
+
+fa15 guarded `core/reporter.py`, but four sibling emitters iterate the SAME
+model-supplied `experiment["results"]` list and call `result.get(...)` on each
+element with NO `isinstance(result, dict)` guard. A non-Anthropic model can emit
+a bare string / number where a result dict is expected; the first `.get()` then
+raises `AttributeError: 'str' object has no attribute 'get'` and aborts the
+report / CSV.
+
+Sites:
+  * generate_report.prepare_findings_summary  (generate_report.py:150)
+  * generate_report.generate_html_report      (generate_report.py:306)
+  * export_csv.export_csv                      (export_csv.py:138)
+  * openant.cli.cmd_report_data               (cli.py:682) — the LIVE report-data path
+
+The `cmd_report_data` case is driven end-to-end through the real CLI entrypoint
+(`cli.cmd_report_data(args)`) reading on-disk results/dataset JSON. The single
+real finding is verdict ``safe`` so the post-loop remediation branch is
+non-actionable and makes no LLM/network call — the test stays hermetic.
+"""
+
+from __future__ import annotations
+
+import json
+import types
+from pathlib import Path
+
+import pytest
+
+import generate_report
+import export_csv
+from openant import cli
+
+
+# One bare-string element (would crash `.get()`) + one real finding.
+# The real finding is ``safe`` so cmd_report_data's remediation stays offline.
+DIRTY_RESULTS = {
+    "dataset": "fam-robust",
+    "code_by_route": {},
+    "metrics": {},
+    "results": [
+        "a bare string a non-Anthropic model emitted",  # non-dict -> would crash result.get()
+        {
+            "route_key": "app.py:foo",
+            "unit_id": "app.py:foo",
+            "verdict": "safe",
+            "finding": "safe",
+            "attack_vector": "",
+            "reasoning": "r",
+        },
+    ],
+}
+DATASET = {"units": [{"id": "app.py:foo", "code": {"primary_code": "def foo(): pass"}, "llm_context": {}}]}
+
+
+def test_prepare_findings_summary_skips_non_dict():
+    """SITE generate_report.py:150."""
+    findings = generate_report.prepare_findings_summary(DIRTY_RESULTS, DATASET)
+    assert len(findings) == 1
+    assert findings[0]["unit_id"] == "app.py:foo"
+
+
+def test_generate_html_report_skips_non_dict(tmp_path: Path):
+    """SITE generate_report.py:306."""
+    out = tmp_path / "report.html"
+    generate_report.generate_html_report(
+        experiment=DIRTY_RESULTS,
+        dataset=DATASET,
+        remediation_html="",
+        output_path=str(out),
+    )
+    assert out.exists()
+
+
+def test_export_csv_skips_non_dict(tmp_path: Path):
+    """SITE export_csv.py:138."""
+    exp = tmp_path / "results.json"
+    ds = tmp_path / "dataset.json"
+    out = tmp_path / "out.csv"
+    exp.write_text(json.dumps(DIRTY_RESULTS))
+    ds.write_text(json.dumps(DATASET))
+    export_csv.export_csv(str(exp), str(ds), str(out))
+    assert out.exists()
+    # header + exactly one data row (bare string skipped)
+    lines = [ln for ln in out.read_text().splitlines() if ln.strip()]
+    assert len(lines) == 2
+
+
+def test_cli_report_data_skips_non_dict(tmp_path: Path):
+    """SITE cli.py:682 — driven through the real cmd_report_data entrypoint."""
+    exp = tmp_path / "results.json"
+    ds = tmp_path / "dataset.json"
+    exp.write_text(json.dumps(DIRTY_RESULTS))
+    ds.write_text(json.dumps(DATASET))
+    args = types.SimpleNamespace(results=str(exp), dataset=str(ds))
+    rc = cli.cmd_report_data(args)
+    # HEAD: the bare string crashes result.get() -> caught -> rc == 2.
+    # Fixed: the non-dict is skipped -> the report builds -> rc == 0.
+    assert rc == 0

--- a/libs/openant-core/tests/report/test_unguarded_iteration_fam_robust.py
+++ b/libs/openant-core/tests/report/test_unguarded_iteration_fam_robust.py
@@ -1,0 +1,168 @@
+"""FAM-ROBUST regression: unguarded iteration over model-supplied lists.
+
+Distinct from the already-fixed *guarded-then-.get* class (a ``.get()`` on a
+value returned with a default, e.g. ``finding.get("verification", {}).get(...)``).
+
+This class is: ``core.reporter`` iterates a **model-supplied list**
+(``results`` / ``confirmed_findings``) and calls ``.get()`` on **each element**
+with no ``isinstance(el, dict)`` guard. A non-Anthropic model can emit a bare
+string / number where a finding dict is expected (the same provider-fidelity
+gap that motivated ``_coerce_to_str``). The first ``.get()`` then raises
+``AttributeError: 'str' object has no attribute 'get'`` and report generation
+crashes instead of skipping the malformed element.
+
+Enumerated sites exercised here:
+  * D — the manual ``confirmed`` filter over ``all_results``
+        (``str(r.get("finding") ...)``), no-confirmed_findings path.
+  * E — the top-level ``for finding in confirmed`` loop (``finding.get(...)``).
+  * F — the ``full_result = next((r for r in all_results ...))`` lookup.
+  * A/B/C — ``_dedup_caller_callee`` iterating ``confirmed`` / ``all_results``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.reporter import _dedup_caller_callee, build_pipeline_output
+from utilities.file_io import write_json
+
+
+def _write_results(tmp_path: Path, results: dict) -> Path:
+    p = tmp_path / "results.json"
+    write_json(p, results)
+    return p
+
+
+def test_bare_string_in_results_no_confirmed_findings(tmp_path: Path):
+    """SITE D: manual confirmed-filter over ``results`` skips non-dict elements."""
+    results = {
+        "dataset": "fam-robust",
+        "code_by_route": {},
+        "metrics": {},
+        # No confirmed_findings -> the manual filter iterates `results`.
+        "results": [
+            "a bare string a non-Anthropic model emitted",  # non-dict -> would crash r.get()
+            {
+                "route_key": "app.py:foo",
+                "unit_id": "app.py:foo",
+                "verdict": "vulnerable",
+                "finding": "vulnerable",
+            },
+        ],
+    }
+    results_path = _write_results(tmp_path, results)
+    out_path = tmp_path / "pipeline_output.json"
+
+    out, count = build_pipeline_output(
+        results_path=str(results_path),
+        output_path=str(out_path),
+        language="python",
+        repo_name="test/repo",
+    )
+    data = json.loads(Path(out).read_text())
+    # The one real dict finding survives; the bare string is skipped.
+    assert count == 1
+    assert len(data["findings"]) == 1
+
+
+def test_bare_string_in_confirmed_findings(tmp_path: Path):
+    """SITE E: the top-level ``for finding in confirmed`` loop skips non-dicts."""
+    results = {
+        "dataset": "fam-robust",
+        "code_by_route": {"app.py:foo": "def foo(): pass"},
+        "metrics": {},
+        "results": [],
+        "confirmed_findings": [
+            12345,  # non-dict -> would crash finding.get()
+            {
+                "route_key": "app.py:foo",
+                "unit_id": "app.py:foo",
+                "verdict": "vulnerable",
+                "finding": "vulnerable",
+            },
+        ],
+    }
+    results_path = _write_results(tmp_path, results)
+    out_path = tmp_path / "pipeline_output.json"
+
+    out, count = build_pipeline_output(
+        results_path=str(results_path),
+        output_path=str(out_path),
+        language="python",
+        repo_name="test/repo",
+    )
+    data = json.loads(Path(out).read_text())
+    assert count == 1
+    assert len(data["findings"]) == 1
+
+
+def test_bare_string_in_results_during_full_result_lookup(tmp_path: Path):
+    """SITE F: ``full_result = next((r for r in all_results ...))`` skips non-dicts."""
+    results = {
+        "dataset": "fam-robust",
+        "code_by_route": {},
+        "metrics": {},
+        "results": [
+            ["not", "a", "dict"],  # non-dict list element -> would crash r.get()
+            {
+                "route_key": "app.py:foo",
+                "unit_id": "app.py:foo",
+                "verdict": "vulnerable",
+                "finding": "vulnerable",
+                "cwe_id": 89,
+            },
+        ],
+        # confirmed_findings present so the main loop's full_result lookup
+        # iterates the (dirty) all_results list.
+        "confirmed_findings": [
+            {
+                "route_key": "app.py:foo",
+                "unit_id": "app.py:foo",
+                "verdict": "vulnerable",
+                "finding": "vulnerable",
+            }
+        ],
+    }
+    results_path = _write_results(tmp_path, results)
+    out_path = tmp_path / "pipeline_output.json"
+
+    out, count = build_pipeline_output(
+        results_path=str(results_path),
+        output_path=str(out_path),
+        language="python",
+        repo_name="test/repo",
+    )
+    data = json.loads(Path(out).read_text())
+    assert count == 1
+    assert data["findings"][0]["cwe_id"] == 89
+
+
+def test_dedup_helper_standalone_with_non_dict_elements(tmp_path: Path):
+    """SITES A/B/C: ``_dedup_caller_callee`` is self-defensive against non-dicts."""
+    call_graph = {
+        "reverse_call_graph": {
+            "app.py:run_query": ["app.py:get_user"],
+        }
+    }
+    cg_path = tmp_path / "call_graph.json"
+    cg_path.write_text(json.dumps(call_graph))
+
+    confirmed = [
+        "bare string in confirmed",  # non-dict -> would crash f.get()
+        {"route_key": "app.py:get_user", "unit_id": "app.py:get_user", "cwe_id": 89},
+        {"route_key": "app.py:run_query", "unit_id": "app.py:run_query", "cwe_id": 89},
+    ]
+    all_results = [
+        None,  # non-dict -> would crash r.get() in the cwe-lookup generator
+        {"route_key": "app.py:get_user", "unit_id": "app.py:get_user", "cwe_id": 89},
+        {"route_key": "app.py:run_query", "unit_id": "app.py:run_query", "cwe_id": 89},
+    ]
+
+    # Must not raise; the callee (run_query) is collapsed into its caller.
+    deduped = _dedup_caller_callee(confirmed, all_results, str(cg_path))
+    keys = {d.get("route_key") for d in deduped}
+    assert "app.py:get_user" in keys
+    assert "app.py:run_query" not in keys  # collapsed

--- a/libs/openant-core/tests/test_analyze_verify_chain_llm_config.py
+++ b/libs/openant-core/tests/test_analyze_verify_chain_llm_config.py
@@ -1,0 +1,63 @@
+"""Regression test for cli-analyze-verify-chain-drops-llm-config.
+
+``cmd_analyze --verify`` chains Stage 1 detection into Stage 2 verification.
+The chained ``run_verification`` call must propagate the user's
+``--llm-config`` so the verify stage runs with the SAME configured model as
+the analyze stage — not the built-in default. This pins that contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from openant.cli import cmd_analyze
+
+
+def _make_args() -> argparse.Namespace:
+    return argparse.Namespace(
+        dataset="dataset.json",
+        output="/tmp/out_dir_does_not_matter",
+        exploitable_all=False,
+        exploitable_only=False,
+        analyzer_output="analyzer_output.json",
+        app_context=None,
+        repo_path=None,
+        limit=None,
+        llm_config="my-custom-config",
+        workers=8,
+        checkpoint=None,
+        backoff=30,
+        verify=True,
+    )
+
+
+@contextmanager
+def _fake_step_context(*_args, **_kwargs):
+    yield MagicMock()
+
+
+def test_verify_chain_propagates_llm_config():
+    args = _make_args()
+
+    analyze_result = MagicMock()
+    analyze_result.results_path = "/tmp/out_dir_does_not_matter/results.json"
+
+    verify_result = MagicMock()
+    verify_result.confirmed_vulnerabilities = 0
+    verify_result.to_dict.return_value = {}
+
+    with patch("core.analyzer.run_analysis", return_value=analyze_result), \
+         patch("core.verifier.run_verification", return_value=verify_result) as mock_verify, \
+         patch("core.step_report.step_context", _fake_step_context), \
+         patch("openant.cli._output_json"):
+        cmd_analyze(args)
+
+    assert mock_verify.called, "run_verification was never invoked by --verify chain"
+    _, kwargs = mock_verify.call_args
+    assert kwargs.get("llm_config_name") == "my-custom-config", (
+        "verify chain dropped --llm-config: run_verification was called with "
+        f"llm_config_name={kwargs.get('llm_config_name')!r} instead of the "
+        "configured 'my-custom-config' (verify would run on the default model)"
+    )

--- a/libs/openant-core/tests/test_dynamic_testable_filter.py
+++ b/libs/openant-core/tests/test_dynamic_testable_filter.py
@@ -1,0 +1,116 @@
+"""Regression: run_dynamic_tests must enforce the DYNAMIC_TESTABLE filter.
+
+core/dynamic_tester.py computes a DYNAMIC_TESTABLE filter for reporting, but
+the actual per-finding loop lives in utilities/dynamic_tester/run_dynamic_tests.
+Without enforcement AT that loop, findings whose stage2_verdict is NOT in
+DYNAMIC_TESTABLE (e.g. "rejected") get a Docker reproduction attempt anyway.
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_CORE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_CORE_ROOT))
+
+if "anthropic" not in sys.modules:
+    _stub = types.ModuleType("anthropic")
+    _stub.Anthropic = MagicMock()
+    _stub.RateLimitError = type("RateLimitError", (Exception,), {})
+    _stub.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    sys.modules["anthropic"] = _stub
+
+
+def _fake_registry():
+    from utilities.llm import PhaseBinding, PhaseRegistry
+
+    class _NoopAdapter:
+        name = "anthropic"
+        supports_tools = True
+
+        def complete(self, **kwargs):  # pragma: no cover - mocked away
+            raise AssertionError("should not reach the adapter")
+
+        def validate(self, model):
+            pass
+
+    adapter = _NoopAdapter()
+    bindings = {
+        phase: PhaseBinding(
+            phase=phase, adapter=adapter, model="test-model",
+            provider_name="anthropic",
+        )
+        for phase in ("analyze", "enhance", "verify", "report",
+                      "dynamic_test", "llm_reach", "app_context")
+    }
+    return PhaseRegistry(bindings=bindings, config_name="filter-test-config")
+
+
+def test_non_testable_finding_is_not_dynamically_tested(tmp_path, monkeypatch):
+    """A finding whose stage2_verdict is not in DYNAMIC_TESTABLE must be
+    skipped by the execution loop, not handed to generate_test/Docker."""
+    po = {
+        "repository": {"name": "test", "language": "python"},
+        "application_type": "web_app",
+        "findings": [
+            {
+                "id": "TESTABLE-1",
+                "name": "confirmed vuln",
+                "short_name": "vuln",
+                "location": {"file": "app.py", "function": "app.py:vuln"},
+                "cwe_id": 79,
+                "cwe_name": "XSS",
+                "stage1_verdict": "vulnerable",
+                "stage2_verdict": "confirmed",   # in DYNAMIC_TESTABLE
+            },
+            {
+                "id": "NOT-TESTABLE-1",
+                "name": "rejected finding",
+                "short_name": "rej",
+                "location": {"file": "app.py", "function": "app.py:safe"},
+                "cwe_id": 79,
+                "cwe_name": "XSS",
+                "stage1_verdict": "vulnerable",
+                "stage2_verdict": "rejected",    # NOT in DYNAMIC_TESTABLE
+            },
+        ],
+    }
+    po_path = tmp_path / "pipeline_output.json"
+    po_path.write_text(json.dumps(po))
+
+    tested_ids = []
+
+    def mock_generate_test(finding, repo_info, binding, tracker):
+        tested_ids.append(finding.get("id"))
+        return {
+            "dockerfile": "FROM python:3.11\nCMD echo hi",
+            "test_script": "print('ok')",
+            "test_filename": "test_exploit.py",
+        }
+
+    def mock_run_single_container(generation, finding_id, source_file=None, **kwargs):
+        from utilities.dynamic_tester.docker_executor import DockerExecutionResult
+        result = DockerExecutionResult()
+        result.stdout = '{"status": "CONFIRMED", "details": "t", "evidence": []}'
+        result.exit_code = 0
+        return result
+
+    monkeypatch.setattr("utilities.dynamic_tester.generate_test", mock_generate_test)
+    monkeypatch.setattr("utilities.dynamic_tester.run_single_container",
+                        mock_run_single_container)
+
+    from utilities.dynamic_tester import run_dynamic_tests
+    results = run_dynamic_tests(
+        pipeline_output_path=str(po_path),
+        output_dir=str(tmp_path / "out"),
+        max_retries=0,
+        registry=_fake_registry(),
+    )
+
+    assert tested_ids == ["TESTABLE-1"], (
+        "non-testable finding must NOT be handed to the dynamic tester; "
+        f"generate_test was called for {tested_ids}"
+    )
+    assert {r.finding_id for r in results} == {"TESTABLE-1"}

--- a/libs/openant-core/tests/test_export_csv_verdictonly.py
+++ b/libs/openant-core/tests/test_export_csv_verdictonly.py
@@ -1,0 +1,48 @@
+"""Regression test: a verdict-only result must not export a BLANK finding column.
+
+export_csv reads result.get('finding', '') at three sites — the agree branch and the
+disagree fallback of get_stage1_verdict(), and stage2_verdict in export_csv(). A result
+that carries a 'verdict' key but no 'finding' key (a verdict-only result) therefore
+exports an empty finding column instead of its verdict. Fix: fall back to
+result.get('verdict', '') at all three sites, preserving the raw casing for display.
+"""
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+import export_csv as ec  # noqa: E402
+
+
+def test_get_stage1_verdict_falls_back_to_verdict_agree_branch():
+    """agree branch (:109): verdict-only result returns its verdict, not ''."""
+    assert ec.get_stage1_verdict({'verdict': 'VULNERABLE', 'verification': {'agree': True}}) == 'VULNERABLE'
+
+
+def test_get_stage1_verdict_falls_back_to_verdict_disagree_fallback():
+    """disagree fallback (:114): verdict-only result with no note returns its verdict, not ''."""
+    result = {'verdict': 'SAFE', 'verification': {'agree': False}}
+    assert ec.get_stage1_verdict(result) == 'SAFE'
+
+
+def test_export_csv_verdict_only_result_exports_verdict(tmp_path):
+    """Integration (:161 + get_stage1_verdict): a verdict-only result exports 'VULNERABLE', not blank."""
+    ds = tmp_path / "dataset.json"
+    exp = tmp_path / "experiment.json"
+    out = tmp_path / "out.csv"
+    ds.write_text(
+        '{"units": [{"id": "f.py:foo", "code": {"primary_code": "x = 1"},'
+        ' "llm_context": {"reasoning": "r", "security_classification": "c"}}]}'
+    )
+    # verdict-only result: has 'verdict' but NO 'finding' key
+    exp.write_text(
+        '{"results": [{"route_key": "f.py:foo", "verification": {"agree": true, "explanation": "e"},'
+        ' "verdict": "VULNERABLE", "reasoning": "r1", "confidence": "high"}]}'
+    )
+    ec.export_csv(str(exp), str(ds), str(out))
+    with open(out, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows, "no rows exported"
+    assert rows[0]["stage2_verdict"] == "VULNERABLE", f"blank/wrong stage2_verdict: {rows[0]['stage2_verdict']!r}"
+    assert rows[0]["stage1_verdict"] == "VULNERABLE", f"blank/wrong stage1_verdict: {rows[0]['stage1_verdict']!r}"

--- a/libs/openant-core/tests/test_famreport_disagreed_vuln_counted_safe.py
+++ b/libs/openant-core/tests/test_famreport_disagreed_vuln_counted_safe.py
@@ -1,0 +1,80 @@
+"""FAM-REPORT: a disagreement whose corrected verdict is still vulnerable must
+not be folded into ``safe``.
+
+Bug (core/verifier.py:_count_verification_outcomes): the ``else`` (agree=False)
+branch bucketed EVERY disagreement as ``disagreed``, which the scanner folds
+into ``safe`` (scanner.py: ``safe += verify_result.disagreed``). But
+finding_verifier sets ``result["finding"] = correct_finding`` on disagree, and
+``correct_finding`` may still be ``vulnerable``/``bypassable`` (e.g. Stage 1
+"vulnerable" -> Stage 2 disagrees and says "bypassable"). Such a finding is a
+confirmed vulnerability, yet it was counted as safe -> under-reports vulns.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.verifier import _count_verification_outcomes
+
+
+def test_disagreed_but_still_vulnerable_is_confirmed_not_safe():
+    verified_results = [
+        {  # Stage 2 disagreed on classification but it is STILL a vuln
+            "route_key": "a:1", "finding": "bypassable",
+            "verification": {"agree": False, "correct_finding": "bypassable",
+                             "incomplete": False},
+        },
+        {  # disagreed and re-classified vulnerable (still a vuln)
+            "route_key": "a:2", "finding": "vulnerable",
+            "verification": {"agree": False, "correct_finding": "vulnerable",
+                             "incomplete": False},
+        },
+        {  # genuine downgrade to safe — the only true "disagreed" (folds to safe)
+            "route_key": "c:3", "finding": "safe",
+            "verification": {"agree": False, "correct_finding": "safe",
+                             "incomplete": False},
+        },
+    ]
+    counts = _count_verification_outcomes(verified_results)
+
+    # The two still-vulnerable disagreements must be confirmed vulnerabilities.
+    assert counts["confirmed_vulnerabilities"] == 2, (
+        f"still-vulnerable disagreements must count as confirmed vulns, "
+        f"got {counts['confirmed_vulnerabilities']}"
+    )
+    # Only the genuine downgrade-to-safe may fold into safe via ``disagreed``.
+    assert counts["disagreed"] == 1, (
+        f"only the downgrade-to-safe is 'disagreed'; a still-vulnerable "
+        f"disagreement must NOT be (it folds into safe), got {counts['disagreed']}"
+    )
+
+
+def test_verdictonly_disagreed_still_vulnerable_is_confirmed():
+    """fa2-alone defect: fa2's disagreed-branch read was ``r.get("finding","")
+    .lower()`` — it OMITS the ``or r.get("verdict")`` fallback. So a verdict-only
+    DISAGREED-still-vulnerable result {"verdict": "VULNERABLE", verification=
+    {agree:False, correct_finding:"VULNERABLE"}} reads finding="" and is bucketed
+    as ``disagreed`` (folds into safe) instead of ``confirmed_vulnerabilities``.
+    RED on pristine (no disagreed-branch promotion at all) AND on fa2-alone;
+    GREEN only on the canonical read.
+    """
+    verified_results = [
+        {
+            "route_key": "a:1", "verdict": "VULNERABLE",
+            "verification": {"agree": False, "correct_finding": "VULNERABLE",
+                             "incomplete": False},
+        },
+    ]
+    counts = _count_verification_outcomes(verified_results)
+    assert counts["confirmed_vulnerabilities"] == 1, (
+        f"verdict-only disagreed-still-vulnerable must be a confirmed vuln, "
+        f"got {counts['confirmed_vulnerabilities']}"
+    )
+    assert counts["disagreed"] == 0, (
+        f"verdict-only disagreed-still-vulnerable must NOT fold into safe, "
+        f"got disagreed={counts['disagreed']}"
+    )

--- a/libs/openant-core/tests/test_normalize_quarantine.py
+++ b/libs/openant-core/tests/test_normalize_quarantine.py
@@ -1,0 +1,13 @@
+"""fa17 quarantine-not-drop: dropped non-dict elements are COUNTED + SURFACED + logged."""
+import logging
+from utilities.file_io import normalize_results
+def test_dropped_counted_surfaced():
+    obj={"results":[{"a":1},"poison",123,None,["x"]]}; normalize_results(obj)
+    assert obj["results"]==[{"a":1}] and obj["_results_invalid_dropped"]==4
+def test_clean_no_marker():
+    obj={"results":[{"a":1}]}; normalize_results(obj); assert "_results_invalid_dropped" not in obj
+def test_logged(caplog):
+    with caplog.at_level(logging.WARNING, logger="openant.normalize"): normalize_results({"results":["bad"]})
+    assert any("dropped" in r.message for r in caplog.records)
+def test_non_list_marked():
+    obj={"results":{"x":1}}; normalize_results(obj); assert obj["results"]==[] and obj["_results_invalid_dropped"]==1

--- a/libs/openant-core/tests/test_report_verdict_findingless.py
+++ b/libs/openant-core/tests/test_report_verdict_findingless.py
@@ -1,0 +1,40 @@
+"""Regression test for finding: report-verdict-count-findingless-vuln-dropped.
+
+A result whose verdict lives only in the raw ``verdict`` field (no normalized
+``finding`` key) must still be counted. The canonical verdict-read pattern used
+elsewhere in the core (reporter.py, verifier.py, analyzer.py) is
+``str(r.get("finding") or r.get("verdict", "")).lower()``. The report paths
+previously read only ``result.get("finding", "")``, so a finding-less
+vulnerable result was silently dropped from the verdict count -> under-reports.
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import generate_report  # noqa: E402
+
+
+def test_findingless_vulnerable_counted_in_html_report(tmp_path):
+    # Result carries only the raw uppercase ``verdict`` field, no ``finding``.
+    experiment = {"results": [{"route_key": "app/x.py:foo", "verdict": "VULNERABLE"}]}
+    dataset = {"units": []}
+    out = tmp_path / "report.html"
+
+    generate_report.generate_html_report(experiment, dataset, "", str(out))
+    html_text = out.read_text(encoding="utf-8")
+
+    m = re.search(r'#dc3545">(\d+)</div>\s*<div class="stat-label">Vulnerable', html_text)
+    assert m, "Vulnerable stat card not found in rendered report"
+    assert m.group(1) == "1", f"expected Vulnerable count 1, got {m.group(1)}"
+
+
+def test_findingless_vulnerable_counted_in_findings_summary():
+    experiment = {"results": [{"route_key": "app/x.py:foo", "verdict": "VULNERABLE"}]}
+    dataset = {"units": []}
+
+    findings = generate_report.prepare_findings_summary(experiment, dataset)
+    assert findings[0]["verdict"] == "vulnerable", findings[0]["verdict"]

--- a/libs/openant-core/tests/test_reporter_coercion.py
+++ b/libs/openant-core/tests/test_reporter_coercion.py
@@ -177,6 +177,23 @@ class TestBuildPipelineOutputCoercion:
         steps = out["findings"][0]["steps_to_reproduce"] or ""
         assert "no input validation" in steps
 
+    def test_truthy_nondict_verification_does_not_crash(self, tmp_path):
+        # A non-Anthropic model can return ``verification`` as a bare
+        # string (e.g. "agreed") where the schema expects a dict. The
+        # verdict block did ``verification.get("agree")`` unguarded,
+        # which raised AttributeError on any truthy non-dict and crashed
+        # build_pipeline_output. Same read-side coercion concern as the
+        # exploit_path / M3 fixes in this file.
+        out = _run_build(tmp_path, finding={
+            "attack_vector": "GET /user?id=evil",
+            "verification": "agreed",
+        })
+        assert len(out["findings"]) == 1
+        # A non-dict verification coerces to ``{}`` (falsy), carrying no
+        # ``agree``/``incomplete`` flag, so the verdict falls through to
+        # the Stage-1 default rather than crashing.
+        assert out["findings"][0]["stage2_verdict"] == "vulnerable"
+
     def test_string_fields_unchanged_after_fix(self, tmp_path):
         # Anthropic still returns clean strings; coercion must be
         # a no-op for the common case (no spurious quoting / wrapping).

--- a/libs/openant-core/tests/test_reporter_exploit_path_shape.py
+++ b/libs/openant-core/tests/test_reporter_exploit_path_shape.py
@@ -1,0 +1,67 @@
+"""Regression: a truthy non-dict ``exploit_path`` must not crash reporting.
+
+``build_pipeline_output`` reads ``exploit_path.get("data_flow")`` after
+``exploit_path = finding.get("exploit_path") or {}``. The ``or {}`` only
+substitutes a dict for *falsy* values (None / {}); a *truthy* non-dict —
+a string or list, which non-Anthropic models can emit for this field —
+passes straight through, and ``.get`` then raises ``AttributeError``,
+aborting report generation for the whole scan.
+
+The sibling ``data_flow`` container is already defensively coerced; these
+tests pin the same defensiveness for ``exploit_path`` itself.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.reporter import build_pipeline_output
+from utilities.file_io import write_json
+
+
+def _run_build(tmp_path: Path, finding: dict) -> dict:
+    results = {
+        "dataset": "test",
+        "code_by_route": {"app.py:foo": "def foo(): pass"},
+        "metrics": {},
+        "confirmed_findings": [{
+            "route_key": "app.py:foo",
+            "unit_id": "app.py:foo",
+            "verdict": "VULNERABLE",
+            "finding": "vulnerable",
+            **finding,
+        }],
+    }
+    results_path = tmp_path / "results.json"
+    write_json(results_path, results)
+    out_path = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(results_path),
+        output_path=str(out_path),
+        language="python",
+        repo_name="test/repo",
+    )
+    return json.loads(out_path.read_text())
+
+
+def test_string_exploit_path_does_not_crash(tmp_path):
+    # Truthy non-dict exploit_path: a bare string. Used to raise
+    # ``AttributeError: 'str' object has no attribute 'get'``.
+    out = _run_build(tmp_path, finding={
+        "attack_vector": "GET /user?id=evil",
+        "exploit_path": "source -> sink",
+    })
+    steps = out["findings"][0]["steps_to_reproduce"] or ""
+    # The other part still renders; we only skipped the malformed field.
+    assert "GET /user?id=evil" in steps
+
+
+def test_list_exploit_path_does_not_crash(tmp_path):
+    # Truthy non-dict exploit_path: a list.
+    out = _run_build(tmp_path, finding={
+        "attack_vector": "GET /user?id=evil",
+        "exploit_path": ["source", "sink"],
+    })
+    steps = out["findings"][0]["steps_to_reproduce"] or ""
+    assert "GET /user?id=evil" in steps

--- a/libs/openant-core/tests/test_reporter_nondict_vuln.py
+++ b/libs/openant-core/tests/test_reporter_nondict_vuln.py
@@ -1,0 +1,67 @@
+"""Regression: a non-dict element in a finding's ``vulnerabilities`` list
+must not crash ``build_pipeline_output``.
+
+``reporter.py`` did ``vuln = vulns[0] if vulns else {}`` and then called
+``vuln.get(...)``. The truthiness guard only proves the list is non-empty —
+it does NOT prove ``vulns[0]`` is a dict. A model that returns
+``vulnerabilities: ["some string"]`` (schema violation) made the first
+``vuln.get("description")`` raise ``AttributeError: 'str' object has no
+attribute 'get'`` and killed report generation.
+
+Same defensive-coercion class as ``test_reporter_coercion.py`` (issue #65
+follow-up); this pins the list-element isinstance guard at :283-284.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.reporter import build_pipeline_output
+from utilities.file_io import write_json
+
+
+def _run_build(tmp_path: Path, finding: dict) -> dict:
+    results = {
+        "dataset": "test",
+        "code_by_route": {"app.py:foo": "def foo(): pass"},
+        "metrics": {},
+        "confirmed_findings": [{
+            "route_key": "app.py:foo",
+            "unit_id": "app.py:foo",
+            "verdict": "VULNERABLE",
+            "finding": "vulnerable",
+            **finding,
+        }],
+    }
+    results_path = tmp_path / "results.json"
+    write_json(results_path, results)
+    out_path = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(results_path),
+        output_path=str(out_path),
+        language="python",
+        repo_name="test/repo",
+    )
+    return json.loads(out_path.read_text())
+
+
+def test_non_dict_vulnerabilities_element_does_not_crash(tmp_path):
+    # vulnerabilities is truthy (non-empty) but vulns[0] is a bare string.
+    # Old code: vuln = "not-a-dict"; vuln.get(...) -> AttributeError.
+    out = _run_build(tmp_path, finding={
+        "vulnerabilities": ["not-a-dict"],
+        "reasoning": "fallback reasoning",
+    })
+    assert len(out["findings"]) == 1
+    # The non-dict vuln is ignored; downstream falls back to finding fields.
+    assert out["findings"][0]["description"] == "fallback reasoning"
+
+
+def test_dict_vulnerabilities_element_still_read(tmp_path):
+    # Well-formed dict element must still be consumed (no regression).
+    out = _run_build(tmp_path, finding={
+        "vulnerabilities": [{"description": "real vuln desc", "impact": "RCE"}],
+    })
+    assert out["findings"][0]["description"] == "real vuln desc"
+    assert out["findings"][0]["impact"] == "RCE"

--- a/libs/openant-core/tests/test_verifier_verdictonly_confirmed_drop.py
+++ b/libs/openant-core/tests/test_verifier_verdictonly_confirmed_drop.py
@@ -1,0 +1,98 @@
+"""
+Conformance test for finding verifier-309-verdictonly-vuln-dropped.
+
+Bug: the Stage-2 INPUT gate at core/verifier.py:99 admits a result on the
+canonical read ``str(r.get("finding") or r.get("verdict", "")).lower()`` -- so
+a verdict-only result ``{"verdict": "VULNERABLE"}`` (no ``finding`` key) passes.
+But the downstream count/classify sites omit the ``or r.get("verdict")``
+fallback:
+
+  * :281 ``_count_verification_outcomes`` -> confirmed_vulnerabilities count
+  * :309 ``_write_verified_results``       -> confirmed_findings list
+  * :319 ``_write_verified_results``       -> metrics recount (does not lowercase
+                                             a present finding)
+
+so a verdict-only VULNERABLE result that the :99 filter admitted is silently
+DROPPED from confirmed_findings / confirmed_vulnerabilities.
+
+RED  on pristine core: verdict-only result absent from confirmed sets.
+GREEN on patched core: verdict-only result counted / kept.
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+
+_CORE_ROOT = os.environ.get(
+    "OPENANT_CORE_ROOT",
+    os.path.join(os.path.dirname(__file__), ".."),
+)
+_CORE_ROOT = os.path.abspath(_CORE_ROOT)
+if _CORE_ROOT not in sys.path:
+    sys.path.insert(0, _CORE_ROOT)
+
+
+def test_verdictonly_vulnerable_counted_as_confirmed():
+    from core.verifier import _count_verification_outcomes
+
+    # A verdict-only result the :99 input filter admits (agree=True Stage 2).
+    verified = [
+        {"verdict": "VULNERABLE", "verification": {"agree": True}},
+    ]
+    counts = _count_verification_outcomes(verified)
+    assert counts["confirmed_vulnerabilities"] == 1, (
+        f"verdict-only VULNERABLE dropped from confirmed_vulnerabilities: {counts}"
+    )
+
+
+def test_verdictonly_vulnerable_kept_in_confirmed_findings():
+    from core.verifier import _write_verified_results
+
+    verdict_only = {"verdict": "VULNERABLE", "verification": {"agree": True}}
+    experiment = {"dataset": "d", "model": "m", "timestamp": "t"}
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "results_verified.json")
+        _write_verified_results(path, experiment, [verdict_only], [verdict_only])
+        with open(path) as fh:
+            out = json.load(fh)
+    confirmed = out["confirmed_findings"]
+    assert len(confirmed) == 1, (
+        f"verdict-only VULNERABLE dropped from confirmed_findings: {confirmed}"
+    )
+    # :319 metrics recount must also lowercase/classify the verdict.
+    assert out["metrics"]["vulnerable"] == 1, (
+        f"verdict-only VULNERABLE miscounted in metrics: {out['metrics']}"
+    )
+
+
+def test_present_uppercase_finding_counted_in_metrics():
+    """Real :319 defect (the case fa11's own metrics assertion was false-green
+    on): a PRESENT but UPPERCASE finding {"finding": "VULNERABLE"} with NO
+    verdict. On pristine, :319's ``r.get("finding", r.get("verdict","error")
+    .lower())`` takes the present-key branch and returns "VULNERABLE"
+    UN-lowercased -> not in the counts dict -> dropped. Also RED on fa2-alone,
+    which never touched :319. GREEN only on the canonical read that lowercases a
+    present finding too.
+    """
+    from core.verifier import _write_verified_results
+
+    present_upper = {"finding": "VULNERABLE", "verification": {"agree": True}}
+    experiment = {"dataset": "d", "model": "m", "timestamp": "t"}
+    with tempfile.TemporaryDirectory() as td:
+        path = os.path.join(td, "results_verified.json")
+        _write_verified_results(path, experiment, [present_upper], [present_upper])
+        with open(path) as fh:
+            out = json.load(fh)
+    assert out["metrics"]["vulnerable"] == 1, (
+        f"present-uppercase VULNERABLE dropped from :319 metrics recount: "
+        f"{out['metrics']}"
+    )
+
+
+if __name__ == "__main__":
+    test_verdictonly_vulnerable_counted_as_confirmed()
+    test_verdictonly_vulnerable_kept_in_confirmed_findings()
+    test_present_uppercase_finding_counted_in_metrics()
+    print("PASS")

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -26,7 +26,7 @@ from utilities.llm import (
     load_config_file,
     resolve_llm_config,
 )
-from utilities.file_io import read_json, write_json, open_utf8
+from utilities.file_io import normalize_results, read_json, write_json, open_utf8
 
 
 def run_dynamic_tests(
@@ -66,7 +66,19 @@ def run_dynamic_tests(
 
     # Load pipeline output
     pipeline = read_json(pipeline_output_path)
+    # fa18 TRUST BOUNDARY: normalize model `findings` to dicts-only at load
+    # (presence-guarded) so the DYNAMIC_TESTABLE filter's `f.get(...)` is safe.
+    if "findings" in pipeline:
+        normalize_results(pipeline, "findings")
     findings = pipeline.get("findings", [])
+    # Enforce the dynamic-testability filter at the execution site. Only
+    # findings asserted vulnerable are worth an active Docker reproduction;
+    # core/dynamic_tester.py computes the same filter for reporting, but the
+    # per-finding loop lives here, so without this every finding (regardless
+    # of stage2_verdict) was dynamically tested anyway.
+    from core.verdict_taxonomy import DYNAMIC_TESTABLE
+    findings = [f for f in findings
+                if f.get("stage2_verdict") in DYNAMIC_TESTABLE]
     repo_info = {
         "name": pipeline.get("repository", {}).get("name", "unknown"),
         "language": pipeline.get("repository", {}).get("language", "Python"),

--- a/libs/openant-core/utilities/file_io.py
+++ b/libs/openant-core/utilities/file_io.py
@@ -7,6 +7,7 @@ explicitly, preventing ``'charmap' codec can't decode byte ...`` errors.
 """
 
 import json
+import logging
 import os
 import subprocess
 import tempfile
@@ -32,6 +33,48 @@ def read_json(path: PathLike) -> Any:
     """Read and parse a JSON file using UTF-8 encoding."""
     with open_utf8(path, "r") as f:
         return json.load(f)
+
+
+def normalize_results(obj: Any, key: str = "results") -> Any:
+    """Normalize a model-produced results container at the trust boundary.
+
+    OpenAnt reads JSON emitted by an LLM (experiment_results.json,
+    dynamic_test_results.json). A non-Anthropic model can emit a NON-DICT
+    element (bare string/number/None/list) inside the ``results`` array, or a
+    non-list value for ``results`` itself. Downstream code iterates that array
+    doing ``r.get(...)`` in ~20 places; a non-dict element raises
+    ``AttributeError`` and aborts verify/report/CSV.
+
+    Rather than guard every per-loop read (which was tried in fa15/fa16 and
+    missed the upstream verifier and dynamic paths — per-loop guards do not
+    converge), normalize ONCE at each load boundary: mutate ``obj[key]`` in
+    place so it is always a list containing only dicts. Every downstream
+    iterator AND count (e.g. ``len(obj["results"])``) then sees the same
+    filtered list. fa15/fa16 per-loop guards become harmless defense-in-depth.
+
+    Mutates ``obj`` in place and also returns it for convenience.
+    """
+    raw = obj.get(key, []) if isinstance(obj, dict) else []
+    if isinstance(obj, dict):
+        if isinstance(raw, list):
+            kept = [r for r in raw if isinstance(r, dict)]
+            dropped = len(raw) - len(kept)
+        else:
+            kept = []
+            dropped = 0 if raw in (None, [], {}, "") else 1
+        obj[key] = kept
+        if dropped:
+            # QUARANTINE-NOT-DROP (recall safety — a SAST tool must never silently
+            # lose a finding): a dropped non-dict element could be a half-emitted
+            # sink. Surface the count on the object AND log fail-LOUD so malformed
+            # model output is visible, never a silent false-negative.
+            obj[f"_{key}_invalid_dropped"] = obj.get(f"_{key}_invalid_dropped", 0) + dropped
+            logging.getLogger("openant.normalize").warning(
+                "normalize_results: dropped %d non-dict element(s) from %r — "
+                "malformed model output (surfaced as _%s_invalid_dropped)",
+                dropped, key, key,
+            )
+    return obj
 
 
 def write_json(path: PathLike, data: Any, **kwargs) -> None:


### PR DESCRIPTION
## What
Robustness/correctness hardening for `__init__.py, __main__.py, cli.py, dynamic_tester.py` (+6 more).

## Fixes in this PR (12)
- dynamic tester testable filter not
- cli analyze verify chain drops llm
- report verdict count findingless v
- verifier COMBINED supersedes fa2
- export csv verdictonly blank
- reporter 341 342 verification trut
- reporter 283 284 vuln nondict list
- reporter unguarded iteration
- exploit path
- sibling result iteration guard
- results trust boundary normalize
- boundary normalize complete

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).