### PR TITLE
fix: harden callgraph.go

### DIFF
--- a/libs/openant-core/parsers/go/go_parser/callgraph.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph.go
@@ -219,6 +219,21 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 	// receiver all dispatch to the right type's method.
 	varTypes := c.collectVarTypes(file)
 
+	// A name is filtered as a builtin only when no user function of that name is
+	// visible from THIS caller's scope. A user func shadowing a builtin (e.g. a
+	// local `len`) is a real call target, so its edge must be kept. Go builtin
+	// shadowing is PACKAGE/BLOCK-scoped, NOT repo-global: a user `min` in one
+	// package does not disable the builtin `min` in another. So the bypass is
+	// scoped to the same file / same package (mirroring resolveSimpleCall's
+	// priorities 1 & 2, and the Python/C parsers' same-file scoping) and
+	// deliberately EXCLUDES the repo-global name index — using functionsByName
+	// here would let a genuine builtin call in an unrelated package survive the
+	// filter and then be mis-resolved to a cross-package user func via
+	// resolveSimpleCall's len(candidates)==1 uniqueness gate (a false edge).
+	isBuiltin := func(name string) bool {
+		return c.builtins[name] && !c.userFuncInScope(name, funcInfo.FilePath)
+	}
+
 	// Walk the AST looking for call expressions
 	ast.Inspect(file, func(n ast.Node) bool {
 		// Go 1.23 range-over-func: `for v := range seqFunc` invokes seqFunc as an
@@ -231,7 +246,7 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 				if target, ok := aliases[name]; ok {
 					name = target
 				}
-				if name != "" && !c.builtins[name] {
+				if name != "" && !isBuiltin(name) {
 					calls = append(calls, CallInfo{Name: name})
 				}
 			}
@@ -256,7 +271,7 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 		if callInfo.IsMethod && callInfo.Package == "" && callInfo.Receiver != "" {
 			callInfo.ReceiverTypes = varTypes[callInfo.Receiver]
 		}
-		if callInfo.Name != "" && !c.builtins[callInfo.Name] && !c.builtins[callInfo.Package] {
+		if callInfo.Name != "" && !isBuiltin(callInfo.Name) && !c.builtins[callInfo.Package] {
 			calls = append(calls, callInfo)
 		}
 		return true
@@ -266,13 +281,23 @@ func (c *CallGraphBuilder) extractCalls(funcInfo FunctionInfo) []CallInfo {
 }
 
 // exprTypeName returns the simple type name of a type expression: the identifier
-// for `T`, and the pointee's name for `*T`. Anything more complex (qualified,
-// generic, slice, map, ...) is not a receiver type we can key on, so "".
+// for `T`, the pointee's name for `*T`, and the bare base type for a generic
+// instantiation `T[A]` / `T[A, B]`. The base type is the key methodsByType uses
+// (extractor.go's typeToString collapses generics the same way), so a generic
+// receiver `*Stack[T]` must resolve to "Stack" — otherwise the receiver var gets
+// no static type and the self-call edge is dropped. Anything more complex
+// (qualified, slice, map, ...) is not a receiver type we can key on, so "".
 func exprTypeName(expr ast.Expr) string {
 	switch t := expr.(type) {
 	case *ast.Ident:
 		return t.Name
 	case *ast.StarExpr:
+		return exprTypeName(t.X)
+	case *ast.IndexExpr:
+		// Generic type with one type parameter, e.g. Stack[T]: drop the arg, key on the base.
+		return exprTypeName(t.X)
+	case *ast.IndexListExpr:
+		// Generic type with multiple type parameters, e.g. Pair[K, V]: same, key on the base.
 		return exprTypeName(t.X)
 	}
 	return ""
@@ -513,26 +538,41 @@ func (c *CallGraphBuilder) resolveCalls(callerID string, callerInfo FunctionInfo
 }
 
 func (c *CallGraphBuilder) resolveMethodCall(methodName, receiverType, currentFile string) string {
-	// Try to find method on the receiver type
-	if methods, ok := c.methodsByType[receiverType]; ok {
-		for _, funcID := range methods {
-			if strings.HasSuffix(funcID, "."+methodName) {
-				return funcID
-			}
+	// methodsByType is keyed by the BARE receiver type, so two packages that each define a type
+	// with the same name and method collide in one slice. Returning the first matching element made
+	// the winner depend on map-iteration order in buildIndexes -> nondeterministic/unstable edges.
+	// Instead pick deterministically: prefer a method in the caller's own package, then break ties
+	// by the lexicographically smallest funcID.
+	callerPkg := filepath.Dir(currentFile)
+	suffix := "." + methodName
+	best := ""
+	pick := func(funcID string) {
+		if !strings.HasSuffix(funcID, suffix) {
+			return
+		}
+		if best == "" {
+			best = funcID
+			return
+		}
+		candSame := filepath.Dir(funcID) == callerPkg
+		bestSame := filepath.Dir(best) == callerPkg
+		if (candSame && !bestSame) || (candSame == bestSame && funcID < best) {
+			best = funcID
 		}
 	}
 
-	// Also try without pointer
-	receiverType = strings.TrimPrefix(receiverType, "*")
-	if methods, ok := c.methodsByType[receiverType]; ok {
-		for _, funcID := range methods {
-			if strings.HasSuffix(funcID, "."+methodName) {
-				return funcID
-			}
+	// Try the exact receiver type first; only fall back to the pointer-stripped type if it yields
+	// no match (preserving the original exact-before-pointer preference).
+	for _, funcID := range c.methodsByType[receiverType] {
+		pick(funcID)
+	}
+	if best == "" {
+		for _, funcID := range c.methodsByType[strings.TrimPrefix(receiverType, "*")] {
+			pick(funcID)
 		}
 	}
 
-	return ""
+	return best
 }
 
 func (c *CallGraphBuilder) resolvePackageCall(funcName, pkgAlias, currentFile string) string {
@@ -564,6 +604,37 @@ func (c *CallGraphBuilder) resolvePackageCall(funcName, pkgAlias, currentFile st
 	}
 
 	return ""
+}
+
+// userFuncInScope reports whether the repo defines its own function of the given
+// simple name that is visible from currentFile's scope — the same file or the
+// same package (same directory). It intentionally mirrors resolveSimpleCall's
+// same-file + same-package priorities and EXCLUDES the repo-global unique-name
+// fallback: a user func in an unrelated package must not shadow a builtin call
+// here, otherwise a genuine builtin call would be kept and then mis-resolved to
+// that cross-package func. This is the Go analogue of the Python
+// (_resolve_local_function) and C (_resolve_same_file) parsers' same-file scoping.
+func (c *CallGraphBuilder) userFuncInScope(funcName, currentFile string) bool {
+	suffix := ":" + funcName
+	// Priority 1: same file.
+	for _, funcID := range c.functionsByFile[currentFile] {
+		if strings.HasSuffix(funcID, suffix) {
+			return true
+		}
+	}
+	// Priority 2: same package (a different file in the same directory).
+	currentDir := filepath.Dir(currentFile)
+	for file, funcs := range c.functionsByFile {
+		if filepath.Dir(file) != currentDir {
+			continue
+		}
+		for _, funcID := range funcs {
+			if strings.HasSuffix(funcID, suffix) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func (c *CallGraphBuilder) resolveSimpleCall(funcName, currentFile, currentPkg string) string {

--- a/libs/openant-core/parsers/go/go_parser/callgraph_builtinshadow_test.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph_builtinshadow_test.go
@@ -1,0 +1,96 @@
+package main
+
+// Regression tests for the builtin-shadow filter.
+//
+// The builtins skip-set is meant to drop calls to the LANGUAGE builtin (len,
+// make, min, ...). But when the repo defines its OWN function of that name a
+// bare call resolves to the user function and the edge is real, so the builtin
+// filter must be bypassed. Go builtin shadowing is PACKAGE/BLOCK-scoped, NOT
+// repo-global: a user `min` in one package does not disable the builtin `min`
+// in another. So the bypass is scoped to the caller's own file / package
+// (mirroring resolveSimpleCall's priorities 1 & 2 and the Python/C parsers'
+// same-file scoping) and must NOT consult the repo-global name index —
+// otherwise a genuine builtin call in an unrelated package survives the filter
+// and is then mis-resolved to a cross-package user func via
+// resolveSimpleCall's len(candidates)==1 uniqueness gate (a false edge that
+// poisons reachability). Sites covered: the plain call-expr filter
+// (callgraph.go) and the range-over-func filter.
+
+import "testing"
+
+func hasCall(calls []CallInfo, name string) bool {
+	for _, ci := range calls {
+		if ci.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// plain call: `len()` where the SAME FILE defines its own func named `len`.
+func TestExtractCalls_UserFuncShadowingBuiltinNotDropped(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.functionsByName["len"] = []string{"a/a.go:len"}
+	c.functionsByFile["a/a.go"] = []string{"a/a.go:len"} // same-file shadow
+	fi := FunctionInfo{Name: "F", FilePath: "a/a.go", Code: "func F(){ len() }"}
+
+	if !hasCall(c.extractCalls(fi), "len") {
+		t.Errorf("call to same-file user func 'len' (shadowing the builtin) was dropped by the builtins filter")
+	}
+}
+
+// range-over-func sibling site: `for range gen` where the same file shadows a
+// builtin name (`new`) with its own iterator func.
+func TestExtractCalls_RangeOverUserFuncShadowingBuiltinNotDropped(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.functionsByName["new"] = []string{"a/a.go:new"}
+	c.functionsByFile["a/a.go"] = []string{"a/a.go:new"} // same-file shadow
+	fi := FunctionInfo{Name: "F", FilePath: "a/a.go", Code: "func F(){ for range new {} }"}
+
+	if !hasCall(c.extractCalls(fi), "new") {
+		t.Errorf("range-over same-file user func 'new' (shadowing the builtin) was dropped by the builtins filter")
+	}
+}
+
+// same-PACKAGE (different file) shadow is also kept: Go shadowing is
+// package-scoped, so a user `len` in another file of the same dir shadows the
+// builtin for this caller too.
+func TestExtractCalls_SamePackageShadowNotDropped(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.functionsByName["len"] = []string{"pkg/other.go:len"}
+	c.functionsByFile["pkg/other.go"] = []string{"pkg/other.go:len"} // same dir as caller
+	fi := FunctionInfo{Name: "F", FilePath: "pkg/main.go", Code: "func F(){ len() }"}
+
+	if !hasCall(c.extractCalls(fi), "len") {
+		t.Errorf("call to same-package user func 'len' (shadowing the builtin) was dropped by the builtins filter")
+	}
+}
+
+// negative control: a genuine builtin call with NO user func of that name stays filtered.
+func TestExtractCalls_GenuineBuiltinStillFiltered(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	fi := FunctionInfo{Name: "F", FilePath: "a/a.go", Code: "func F(){ len([]int{}) }"}
+
+	if hasCall(c.extractCalls(fi), "len") {
+		t.Errorf("genuine builtin len() should stay filtered when no user func shadows it")
+	}
+}
+
+// CROSS-PACKAGE negative regression (the FA3 gap): a genuine builtin `min()` in
+// package a, plus an UNRELATED user func `min` in package b. Repo-global
+// shadowing (functionsByName) would KEEP this builtin call (because a `min`
+// exists SOMEWHERE), after which resolveSimpleCall's unique-name gate
+// (len(candidates)==1) mis-resolves it to b.min — a false cross-package edge.
+// Package-scoped shadowing must still FILTER the builtin here: package a defines
+// no `min`, so the call is the language builtin and must be dropped.
+func TestExtractCalls_CrossPackageBuiltinNotShadowed(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.functionsByName["min"] = []string{"b/b.go:min"}    // user min ONLY in pkg b
+	c.functionsByFile["b/b.go"] = []string{"b/b.go:min"} // unrelated package
+	// caller lives in pkg a and calls the genuine builtin min()
+	fi := FunctionInfo{Name: "F", FilePath: "a/a.go", Code: "func F(){ min(1, 2) }"}
+
+	if hasCall(c.extractCalls(fi), "min") {
+		t.Errorf("genuine builtin min() in pkg a must NOT be kept just because an unrelated user 'min' exists in pkg b (repo-global bypass would emit a false cross-package edge)")
+	}
+}

--- a/libs/openant-core/parsers/go/go_parser/callgraph_generic_receiver_test.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph_generic_receiver_test.go
@@ -1,0 +1,43 @@
+package main
+
+// Regression for go-self-deref-generic-receiver: a method whose receiver is a
+// generic type — func (s *Stack[T]) Push(){ s.grow() } (*ast.IndexExpr) or
+// func (p *Pair[K,V]) Set(){ p.norm() } (*ast.IndexListExpr) — must resolve the
+// self-call edge (Push -> grow). Pre-fix, exprTypeName handled *ast.Ident and
+// *ast.StarExpr (the deref) but had NO case for the type-parameter nodes, so the
+// receiver variable's static type collapsed to "", ReceiverTypes was empty, and
+// resolveCalls emitted no edge — the self-edge was silently dropped.
+
+import "testing"
+
+// Single type parameter: receiver *Stack[T] parses as *ast.StarExpr -> *ast.IndexExpr.
+func TestGenericReceiverSelfCallEdge_IndexExpr(t *testing.T) {
+	funcs := map[string]FunctionInfo{
+		"m.go:Stack.Push": {Name: "Push", FilePath: "m.go", Package: "main", ClassName: "Stack",
+			Receiver: "*Stack[T]",
+			Code:     "func (s *Stack[T]) Push(x int) {\n\ts.grow()\n}"},
+		"m.go:Stack.grow": {Name: "grow", FilePath: "m.go", Package: "main", ClassName: "Stack",
+			Receiver: "*Stack[T]",
+			Code:     "func (s *Stack[T]) grow() {}"},
+	}
+	cg := buildGraphForFuncs(t, funcs)
+	if !hasEdge(cg, "m.go:Stack.Push", "m.go:Stack.grow") {
+		t.Fatalf("expected self-edge m.go:Stack.Push -> m.go:Stack.grow, got %v", cg)
+	}
+}
+
+// Multiple type parameters: receiver *Pair[K,V] parses as *ast.StarExpr -> *ast.IndexListExpr.
+func TestGenericReceiverSelfCallEdge_IndexListExpr(t *testing.T) {
+	funcs := map[string]FunctionInfo{
+		"m.go:Pair.Set": {Name: "Set", FilePath: "m.go", Package: "main", ClassName: "Pair",
+			Receiver: "*Pair[K, V]",
+			Code:     "func (p *Pair[K, V]) Set(k int, v int) {\n\tp.norm()\n}"},
+		"m.go:Pair.norm": {Name: "norm", FilePath: "m.go", Package: "main", ClassName: "Pair",
+			Receiver: "*Pair[K, V]",
+			Code:     "func (p *Pair[K, V]) norm() {}"},
+	}
+	cg := buildGraphForFuncs(t, funcs)
+	if !hasEdge(cg, "m.go:Pair.Set", "m.go:Pair.norm") {
+		t.Fatalf("expected self-edge m.go:Pair.Set -> m.go:Pair.norm, got %v", cg)
+	}
+}

--- a/libs/openant-core/parsers/go/go_parser/callgraph_methcoll_test.go
+++ b/libs/openant-core/parsers/go/go_parser/callgraph_methcoll_test.go
@@ -1,0 +1,43 @@
+package main
+
+// Regression tests for cross-package method-collision resolution (callgraph.go:resolveMethodCall).
+//
+// methodsByType is keyed by the BARE receiver type name (funcInfo.ClassName), so two packages that
+// each define a type "Store" with a method "Get" land in the same slice. buildIndexes appends in
+// map-iteration order (`for _, funcInfo := range analyzer.Functions`), and the old resolveMethodCall
+// returned the FIRST slice element whose id ends in ".<method>" -- ignoring the currentFile param
+// entirely. The winning edge therefore depended on Go map-iteration order: nondeterministic and, on a
+// collision, frequently the wrong (other-package) method.
+//
+// These tests pin the deterministic behavior: prefer the caller's own package, and break any
+// remaining tie lexicographically. Both fail against the pre-fix source (which returns whichever
+// candidate is first in the slice).
+
+import "testing"
+
+// A collision must resolve to the method defined in the CALLER's package, not whichever candidate
+// happened to be indexed first.
+func TestResolveMethodCall_CrossPkgCollisionPrefersCallerPackage(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	// The wrong (other-package) candidate is deliberately FIRST, mimicking an unlucky map order.
+	c.methodsByType["Store"] = []string{"pkgb/b.go:Store.Get", "pkga/a.go:Store.Get"}
+
+	got := c.resolveMethodCall("Get", "Store", "pkga/a.go")
+	if got != "pkga/a.go:Store.Get" {
+		t.Errorf("cross-package method collision must resolve to the caller's own package, got %q "+
+			"(picking the first slice element depends on map-iteration order -> nondeterministic)", got)
+	}
+}
+
+// With no same-package candidate, the choice must still be deterministic (lexicographically smallest
+// funcID) rather than map-iteration-order dependent.
+func TestResolveMethodCall_CrossPkgCollisionDeterministicTieBreak(t *testing.T) {
+	c := NewCallGraphBuilder("/repo")
+	c.methodsByType["Store"] = []string{"z/z.go:Store.Get", "a/a.go:Store.Get"}
+
+	got := c.resolveMethodCall("Get", "Store", "other/o.go")
+	if got != "a/a.go:Store.Get" {
+		t.Errorf("cross-package collision with no same-package match must resolve deterministically "+
+			"(lexicographically smallest funcID), got %q", got)
+	}
+}


### PR DESCRIPTION
## What
Robustness/correctness hardening for `callgraph.go`.

## Fixes in this PR (3)
- go builtins name shadow drop
- go methcoll crosspkg nondeterminis
- go self deref generic receiver

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).