### PR TITLE
fix: harden extractor.go

### DIFF
--- a/libs/openant-core/parsers/go/go_parser/extractor.go
+++ b/libs/openant-core/parsers/go/go_parser/extractor.go
@@ -133,6 +133,20 @@ func (e *Extractor) extractVarFuncLit(lit *ast.FuncLit, name, filePath, pkgName 
 		}
 	}
 
+	var returns []string
+	if lit.Type.Results != nil {
+		for _, field := range lit.Type.Results.List {
+			returnType := e.typeToString(field.Type)
+			if len(field.Names) > 0 {
+				for _, n := range field.Names {
+					returns = append(returns, fmt.Sprintf("%s %s", n.Name, returnType))
+				}
+			} else {
+				returns = append(returns, returnType)
+			}
+		}
+	}
+
 	litSrc := ""
 	if so, eo := startPos.Offset, endPos.Offset; so >= 0 && eo <= len(content) && so < eo {
 		litSrc = string(content[so:eo])
@@ -140,15 +154,19 @@ func (e *Extractor) extractVarFuncLit(lit *ast.FuncLit, name, filePath, pkgName 
 	code := "var " + name + " = " + litSrc
 
 	return FunctionInfo{
-		Name:       name,
-		Code:       code,
-		StartLine:  startPos.Line,
-		EndLine:    endPos.Line,
-		UnitType:   UnitTypeFunction,
+		Name:      name,
+		Code:      code,
+		StartLine: startPos.Line,
+		EndLine:   endPos.Line,
+		// A func-valued var is still a function unit: classify it like any other
+		// (http_handler/cli_handler/middleware/…) instead of hardcoding "function",
+		// so handlers assigned to package-level vars are seeded as entry points.
+		UnitType:   e.classifyUnitType(name, "", params, returns, code, filePath),
 		IsExported: len(name) > 0 && unicode.IsUpper(rune(name[0])),
 		Package:    pkgName,
 		FilePath:   filePath,
 		Parameters: params,
+		Returns:    returns,
 	}
 }
 
@@ -446,6 +464,13 @@ func duplicateIDWarning(fns map[string]FunctionInfo, funcID string, incoming Fun
 func (e *Extractor) makeFunctionID(filePath string, info FunctionInfo) string {
 	if info.ClassName != "" {
 		return fmt.Sprintf("%s:%s.%s", filePath, info.ClassName, info.Name)
+	}
+	// Go permits several `init` (and blank `_`) functions per file/package, so the name
+	// alone is not a unique id: without disambiguation they collapse onto one key and all
+	// but the last are silently overwritten in output.Functions (data loss). Neither is a
+	// callable target, so suffixing the start line cannot break call-edge resolution.
+	if info.Name == "init" || info.Name == "_" {
+		return fmt.Sprintf("%s:%s#L%d", filePath, info.Name, info.StartLine)
 	}
 	return fmt.Sprintf("%s:%s", filePath, info.Name)
 }

--- a/libs/openant-core/parsers/go/go_parser/extractor_initcollision_test.go
+++ b/libs/openant-core/parsers/go/go_parser/extractor_initcollision_test.go
@@ -1,0 +1,43 @@
+package main
+
+// Go permits several `init()` functions in a single file/package. makeFunctionID
+// keyed a top-level func solely on `filePath:Name`, so every `init` in one file
+// collapsed to the same unit id and all but the last were overwritten in
+// output.Functions (data loss -> their bodies were never scanned for the call graph).
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtract_MultipleInitFuncsNotDropped(t *testing.T) {
+	dir := t.TempDir()
+	src := "package main\n" +
+		"func a(){ _ = 1 }\n" +
+		"func b(){ _ = 1 }\n" +
+		"func init(){ a() }\n" +
+		"func init(){ b() }\n" +
+		"func main(){}\n"
+	path := filepath.Join(dir, "m.go")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := NewExtractor(dir).Extract([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	initCount := 0
+	ids := make([]string, 0, len(out.Functions))
+	for id, fi := range out.Functions {
+		ids = append(ids, id)
+		if fi.Name == "init" {
+			initCount++
+		}
+	}
+	if initCount != 2 {
+		t.Fatalf("both init() functions must be extracted as distinct units; got %d init units, all ids: %v", initCount, ids)
+	}
+}

--- a/libs/openant-core/parsers/go/go_parser/extractor_varfunclit_unittype_test.go
+++ b/libs/openant-core/parsers/go/go_parser/extractor_varfunclit_unittype_test.go
@@ -1,0 +1,45 @@
+package main
+
+// A package-level `var Handler = func(w http.ResponseWriter, r *http.Request){...}`
+// is a func-valued var whose unit_type must be classified like any other function
+// (here: http_handler). extractVarFuncLit hardcoded UnitTypeFunction, bypassing
+// classifyUnitType, so such a var was mis-tagged "function" and never seeded as an
+// HTTP entry point downstream.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExtract_VarFuncLit_ClassifiedAsHTTPHandler(t *testing.T) {
+	dir := t.TempDir()
+	src := "package main\n" +
+		"import \"net/http\"\n" +
+		"var Handler = func(w http.ResponseWriter, r *http.Request){ w.Write([]byte(\"ok\")) }\n" +
+		"func main(){ _ = Handler }\n"
+	path := filepath.Join(dir, "m.go")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := NewExtractor(dir).Extract([]string{path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var handler *FunctionInfo
+	for _, fi := range out.Functions {
+		if fi.Name == "Handler" {
+			f := fi
+			handler = &f
+		}
+	}
+	if handler == nil {
+		t.Fatalf("var func literal `Handler` must be extracted as a unit")
+	}
+	if handler.UnitType != UnitTypeHTTPHandler {
+		t.Fatalf("var func literal HTTP handler misclassified: got unit_type %q, want %q",
+			handler.UnitType, UnitTypeHTTPHandler)
+	}
+}


### PR DESCRIPTION
## What
Robustness/correctness hardening for `extractor.go`.

## Fixes in this PR (2)
- go init collision drop
- go varfunclit unittype misclassify

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).