### PR TITLE
fix: harden function_extractor.py

### DIFF
--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -492,7 +492,15 @@ class FunctionExtractor:
         class_id, class_data, method_nodes = self.process_class(
             node, str(file_path), content, outer_qualifier=outer_qualifier
         )
-        self.classes[class_id] = class_data
+        existing = self.classes.get(class_id)
+        if existing is None:
+            self.classes[class_id] = class_data
+        else:
+            # Same-named class re-declared in one file (conditional/platform
+            # branch or a redefinition) collides on the `path:name` key. Merging
+            # rather than overwriting keeps every declaration's bases/methods so
+            # no inheritance edge is silently severed by last-write-wins.
+            self._merge_class_data(existing, class_data)
         self.stats['total_classes'] += 1
 
         qualified_class = f"{outer_qualifier}.{node.name}" if outer_qualifier else node.name
@@ -510,6 +518,23 @@ class FunctionExtractor:
         # class so a block-nested def stays a method of this class.
         self._descend_into_blocks(node.body, file_path, content,
                                   enclosing_class=qualified_class)
+
+    @staticmethod
+    def _merge_class_data(existing: Dict, new: Dict) -> None:
+        """Union a second declaration of a same-keyed class into the first.
+
+        Only additive: bases/methods/decorators are unioned (order-preserving),
+        the line range is widened, and a missing docstring is backfilled. Never
+        drops data the existing declaration already carried.
+        """
+        for key in ('bases', 'methods', 'decorators'):
+            for item in new.get(key, []):
+                if item not in existing[key]:
+                    existing[key].append(item)
+        existing['start_line'] = min(existing['start_line'], new['start_line'])
+        existing['end_line'] = max(existing['end_line'], new['end_line'])
+        if not existing.get('docstring'):
+            existing['docstring'] = new.get('docstring')
 
     def extract_assigned_lambdas(self, tree: ast.AST, file_path: Path, content: str) -> None:
         """Emit a function unit for each module-level `name = lambda ...`.

--- a/libs/openant-core/tests/parsers/python/test_function_extractor_class_dict_overwrite.py
+++ b/libs/openant-core/tests/parsers/python/test_function_extractor_class_dict_overwrite.py
@@ -1,0 +1,63 @@
+"""Regression lock: a class re-declared under the same name in one file must not be
+overwritten (last-write-wins) in `self.classes`, which would drop the first declaration's
+bases and methods and sever its inheritance edges.
+
+Pattern: a conditional / platform-branch / redefined class shares its `path:ClassName`
+key with the other declaration. The extractor keyed both on `f"{path}:{name}"` and did
+`self.classes[class_id] = class_data`, so the second declaration clobbered the first --
+its bases (used by super()/inheritance resolution in call_graph_builder) vanished.
+The fix merges same-key declarations (union of bases/methods/decorators).
+"""
+import tempfile
+from pathlib import Path
+
+from parsers.python.function_extractor import FunctionExtractor
+
+
+def _repo(files: dict) -> str:
+    d = Path(tempfile.mkdtemp())
+    for name, src in files.items():
+        (d / name).write_text(src)
+    return str(d)
+
+
+def test_redefined_class_does_not_drop_bases_and_methods():
+    repo = _repo({
+        "mod.py": (
+            "class Foo(BaseA):\n"
+            "    def a(self):\n"
+            "        return 1\n"
+            "\n"
+            "class Foo(BaseB):\n"
+            "    def b(self):\n"
+            "        return 2\n"
+        ),
+    })
+    res = FunctionExtractor(repo).extract_all(["mod.py"])
+    cls = res["classes"]["mod.py:Foo"]
+    # Both declarations' bases survive -- neither inheritance edge is severed.
+    assert "BaseA" in cls["bases"], f"BaseA dropped by overwrite: {cls['bases']}"
+    assert "BaseB" in cls["bases"], f"BaseB dropped: {cls['bases']}"
+    # Both declarations' methods survive.
+    assert "a" in cls["methods"], f"method a dropped by overwrite: {cls['methods']}"
+    assert "b" in cls["methods"], f"method b dropped: {cls['methods']}"
+
+
+def test_conditional_class_branches_merge():
+    repo = _repo({
+        "plat.py": (
+            "import sys\n"
+            "if sys.platform == 'win32':\n"
+            "    class Widget(WinBase):\n"
+            "        def win_only(self):\n"
+            "            return 1\n"
+            "else:\n"
+            "    class Widget(PosixBase):\n"
+            "        def posix_only(self):\n"
+            "            return 2\n"
+        ),
+    })
+    res = FunctionExtractor(repo).extract_all(["plat.py"])
+    cls = res["classes"]["plat.py:Widget"]
+    assert {"WinBase", "PosixBase"} <= set(cls["bases"]), cls["bases"]
+    assert {"win_only", "posix_only"} <= set(cls["methods"]), cls["methods"]


### PR DESCRIPTION
## What
Robustness/correctness hardening for `function_extractor.py`.

## Fixes in this PR (1)
- py class dict overwrite bases

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).