### PR TITLE
fix: harden call_graph_builder.py

### DIFF
--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -209,6 +209,32 @@ class CallGraphBuilder:
 
         return calls
 
+    # Nodes that open a new lexical scope; their local names are separate bindings.
+    _SCOPE_NODES = (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+
+    def _walk_current_scope(self, tree: ast.AST):
+        """Yield nodes in the caller's own scope, NOT descending into nested scopes.
+
+        ``tree`` is the parsed caller source: ``Module([FunctionDef(caller)])`` for a
+        function (enter that def's frame) or bare module statements. We walk the caller's
+        frame but stop at any further nested function/lambda/class, whose locals are
+        distinct variables that must not leak into (or out of) the caller's frame.
+        """
+        stack: List[ast.AST] = []
+        for child in ast.iter_child_nodes(tree):
+            if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                stack.extend(child.body)  # enter the top-level caller's own frame
+            elif isinstance(child, ast.ClassDef):
+                continue                  # a class body is its own scope, not the caller's
+            else:
+                stack.append(child)       # module-level statement in the caller's frame
+        while stack:
+            node = stack.pop()
+            yield node
+            if isinstance(node, self._SCOPE_NODES):
+                continue                  # do not cross into a nested scope
+            stack.extend(ast.iter_child_nodes(node))
+
     def _collect_local_types(self, tree: ast.AST) -> Dict[str, str]:
         """Map local variable names to the class name they are constructed from.
 
@@ -216,10 +242,15 @@ class CallGraphBuilder:
         right-hand side is a direct call of a bare Name (the constructor). Used to resolve
         ``var.method()`` against the constructed type. If the same
         name is rebound to different types, it is treated as ambiguous and dropped.
+
+        Collection is scoped to the caller's OWN lexical frame: a same-named variable
+        constructed in a nested function/lambda/class is a DIFFERENT binding, so
+        descending into those scopes (as a flat ast.walk would) leaks an inner type onto
+        the outer same-named var and misdirects its method-call edges.
         """
         types: Dict[str, str] = {}
         ambiguous: Set[str] = set()
-        for node in ast.walk(tree):
+        for node in self._walk_current_scope(tree):
             if not isinstance(node, ast.Assign):
                 continue
             value = node.value
@@ -407,7 +438,24 @@ class CallGraphBuilder:
                 return local
             if self._is_builtin(func_name):
                 return None
-            return self._resolve_simple_call(func_name, caller_file)
+            resolved = self._resolve_simple_call(func_name, caller_file)
+            if resolved:
+                return resolved
+            # Constructor call FALLBACK: `ClassName(...)` is a real call to that
+            # class's __init__. This runs ONLY AFTER _resolve_simple_call (which
+            # consults same-file functions, the import map, and the cross-file
+            # function index) returns None, so a genuine import/function binding
+            # always wins. Ordering matters: an imported FACTORY FUNCTION named
+            # like a class (e.g. `from b import Widget` where b.Widget is a
+            # function, while some other file has `class Widget`) must resolve to
+            # the function, NOT to the class's __init__ -- running ctor first
+            # PREEMPTED import resolution and dropped the true edge (S2:
+            # additive emission that lowers reachability via preemption). An
+            # imported CLASS ctor still resolves here, because _resolve_simple_call
+            # returns None for a name that isn't a function. Without this fallback
+            # the constructor call resolved to no function at all and the
+            # __init__ edge was dropped from reachability entirely.
+            return self._resolve_class_method(func_name, '__init__', caller_file)
 
         # Method call: obj.method(...)
         elif isinstance(func, ast.Attribute):
@@ -464,8 +512,13 @@ class CallGraphBuilder:
 
         # 3. Check by simple name across files (single match only)
         candidates = self.functions_by_name.get(func_name, [])
-        # Filter to non-method functions
-        candidates = [c for c in candidates if not self.functions.get(c, {}).get('class_name')]
+        # Filter to non-method functions. Also exclude module-level lambdas
+        # (`name = lambda ...`): a lambda binding is module-LOCAL, reachable only
+        # same-file (step 1) or via explicit import (step 2), so a bare cross-file
+        # name must not resolve to it here or the uniqueness gate poisons the edge.
+        candidates = [c for c in candidates
+                      if not self.functions.get(c, {}).get('class_name')
+                      and not self.functions.get(c, {}).get('is_lambda')]
         if len(candidates) == 1:
             return candidates[0]
 

--- a/libs/openant-core/tests/parsers/python/test_call_graph_ctor_init_edge.py
+++ b/libs/openant-core/tests/parsers/python/test_call_graph_ctor_init_edge.py
@@ -1,0 +1,140 @@
+"""Regression test for the constructor -> __init__ call-graph edge.
+
+Bug (py-ctor-init-edge-drop, FAM-A):
+    A bare Name call that names a repo class -- `Thing()` -- is a real call to
+    that class's `__init__`, but `_resolve_call_node`'s ast.Name branch only
+    tried function resolution (_resolve_local_function / _resolve_simple_call),
+    both of which filter OUT methods (`class_name` set). A constructor call
+    therefore resolved to None and the edge to `Thing.__init__` was dropped
+    from reachability entirely -- `__init__` (and everything only it reaches)
+    looked unreachable.
+
+Fixing ADDS the missing edge; it never removes one (raises reachability).
+"""
+
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.python.call_graph_builder import CallGraphBuilder
+
+
+def _ctor_extractor_output() -> dict:
+    """A module-level factory function that constructs `Thing`, plus the class."""
+    file_path = "m.py"
+    return {
+        "repository": "/tmp/fake",
+        "imports": {file_path: {}},
+        "classes": {f"{file_path}:Thing": {"name": "Thing", "file_path": file_path}},
+        "functions": {
+            f"{file_path}:make_thing": {
+                "name": "make_thing",
+                "qualified_name": "make_thing",
+                "file_path": file_path,
+                "unit_type": "function",
+                "code": (
+                    "def make_thing():\n"
+                    "    return Thing()\n"
+                ),
+            },
+            f"{file_path}:Thing.__init__": {
+                "name": "__init__",
+                "qualified_name": "Thing.__init__",
+                "file_path": file_path,
+                "class_name": "Thing",
+                "unit_type": "method",
+                "code": (
+                    "    def __init__(self):\n"
+                    "        self.x = 1\n"
+                ),
+            },
+        },
+    }
+
+
+def test_constructor_call_emits_init_edge():
+    builder = CallGraphBuilder(_ctor_extractor_output())
+    builder.build_call_graph()
+
+    caller = "m.py:make_thing"
+    callee = "m.py:Thing.__init__"
+
+    assert callee in builder.call_graph.get(caller, []), (
+        f"Constructor call Thing() did not emit an edge to {callee}.\n"
+        f"  caller edges: {builder.call_graph.get(caller)}"
+    )
+    assert caller in builder.reverse_call_graph.get(callee, []), (
+        f"Reverse edge missing: {callee} does not list caller {caller}."
+    )
+
+
+def _collision_extractor_output() -> dict:
+    """Import/ctor NAME COLLISION.
+
+    a.py:  `from b import Widget` (b.Widget is a FUNCTION), `def caller(): return Widget()`
+    b.py:  `def Widget(): ...`    (a module-level factory function)
+    c.py:  `class Widget` with `__init__`
+
+    `Widget()` in a.py is a call to the IMPORTED FUNCTION b.Widget, NOT to the
+    unrelated class c.Widget's `__init__`. The true edge is a.py:caller ->
+    b.py:Widget; the ctor resolver must NOT preempt it.
+    """
+    return {
+        "repository": "/tmp/fake",
+        # `from b import Widget` -> {name: module.name}
+        "imports": {"a.py": {"Widget": "b.Widget"}, "b.py": {}, "c.py": {}},
+        "classes": {"c.py:Widget": {"name": "Widget", "file_path": "c.py"}},
+        "functions": {
+            "a.py:caller": {
+                "name": "caller",
+                "qualified_name": "caller",
+                "file_path": "a.py",
+                "unit_type": "function",
+                "code": "def caller():\n    return Widget()\n",
+            },
+            "b.py:Widget": {
+                "name": "Widget",
+                "qualified_name": "Widget",
+                "file_path": "b.py",
+                "unit_type": "function",
+                "code": "def Widget():\n    return object()\n",
+            },
+            "c.py:Widget.__init__": {
+                "name": "__init__",
+                "qualified_name": "Widget.__init__",
+                "file_path": "c.py",
+                "class_name": "Widget",
+                "unit_type": "method",
+                "code": "    def __init__(self):\n        self.x = 1\n",
+            },
+        },
+    }
+
+
+def test_imported_factory_function_wins_over_same_named_class_ctor():
+    """RED without the fallback-ordering fix.
+
+    With the buggy order (ctor resolved BEFORE _resolve_simple_call), `Widget()`
+    binds to c.py:Widget.__init__ (the unique cross-file class) and the true
+    import edge to b.py:Widget is DROPPED -- an additive branch LOWERING recall
+    via preemption (memory S2). The fix makes ctor a FALLBACK, so real import
+    resolution wins.
+    """
+    builder = CallGraphBuilder(_collision_extractor_output())
+    builder.build_call_graph()
+
+    caller = "a.py:caller"
+    true_edge = "b.py:Widget"           # the imported factory FUNCTION
+    wrong_edge = "c.py:Widget.__init__"  # the same-named class ctor
+
+    edges = builder.call_graph.get(caller, [])
+    assert true_edge in edges, (
+        f"true import edge {true_edge} was DROPPED (ctor preempted import "
+        f"resolution). caller edges: {edges}"
+    )
+    assert wrong_edge not in edges, (
+        f"ctor edge {wrong_edge} wrongly preempted the imported function. "
+        f"caller edges: {edges}"
+    )

--- a/libs/openant-core/tests/parsers/python/test_callgraph_nested_scope_poison.py
+++ b/libs/openant-core/tests/parsers/python/test_callgraph_nested_scope_poison.py
@@ -1,0 +1,67 @@
+"""Local-type inference must not leak across nested scopes (poison FP fix).
+
+`_collect_local_types` used `ast.walk(tree)` over the WHOLE caller source, flattening
+every nested function/lambda/class scope into ONE variable->type map. A same-named
+variable constructed in an INNER scope (`def inner(): x = Danger()`) then leaked its
+type onto the OUTER scope's same-named variable, so a bare `x.run()` in the outer
+frame -- where `x` is really an untyped parameter -- was misdirected to Danger.run.
+That fabricates a phantom reachability edge (here: a path to an os.system sink).
+"""
+import os
+import tempfile
+
+from parsers.python.function_extractor import FunctionExtractor
+from parsers.python.call_graph_builder import CallGraphBuilder
+
+
+def _build(src: str):
+    d = os.path.realpath(tempfile.mkdtemp())
+    with open(os.path.join(d, "m.py"), "w") as fh:
+        fh.write(src)
+    b = CallGraphBuilder(FunctionExtractor(d).extract_all())
+    b.build_call_graph()
+    return b
+
+
+def _edges(b, caller_suffix):
+    keys = [k for k in b.call_graph if k.endswith(caller_suffix)]
+    return [e for k in keys for e in b.call_graph[k]]
+
+
+_SRC = (
+    "import os\n"
+    "class Danger:\n"
+    "    def run(self, c):\n        os.system(c)\n"
+    "class Widget:\n"
+    "    def run(self, c):\n        return c\n"
+    # outer.x is a PARAMETER (untyped here); the nested inner() constructs a
+    # DIFFERENT variable also named x. Its Danger type must NOT leak onto outer.x.
+    "def outer(x):\n"
+    "    x.run('boom')\n"
+    "    def inner():\n"
+    "        x = Danger()\n"
+    "        return x\n"
+    "    inner()\n"
+    # Same-scope construction must still resolve (no-regression).
+    "def legit():\n"
+    "    w = Widget()\n"
+    "    w.run('ok')\n"
+)
+
+
+def test_inner_scope_type_does_not_poison_outer():
+    b = _build(_SRC)
+    edges = _edges(b, ":outer")
+    assert not any("Danger.run" in e for e in edges), (
+        f"outer.x is an untyped param; the nested inner() `x = Danger()` must not "
+        f"leak onto it and fabricate an edge to Danger.run; got {edges}"
+    )
+
+
+def test_same_scope_construction_still_resolves():
+    # No-regression: a var constructed in the caller's OWN scope must still dispatch.
+    b = _build(_SRC)
+    edges = _edges(b, ":legit")
+    assert any("Widget.run" in e for e in edges), (
+        f"legit()'s own-scope `w = Widget(); w.run()` must still resolve; got {edges}"
+    )

--- a/libs/openant-core/tests/parsers/python/test_module_lambda_uniqgate_poison.py
+++ b/libs/openant-core/tests/parsers/python/test_module_lambda_uniqgate_poison.py
@@ -1,0 +1,100 @@
+"""Uniqueness-gate must not resolve a bare cross-file call to a module-level lambda.
+
+Bug (py-module-lambda-uniqgate-poison, S2/FAM-A): `_resolve_simple_call` step 3
+(`call_graph_builder.py:466-470`) resolves a simple name to its single same-named
+candidate across ALL files:
+
+    candidates = self.functions_by_name.get(func_name, [])
+    candidates = [c for c in candidates if not ...class_name]
+    if len(candidates) == 1:
+        return candidates[0]
+
+A module-level lambda (`handler = lambda ...`, emitted with is_lambda=True) is a
+MODULE-LOCAL binding: it is reachable only from its own file (step 1, same-file) or
+via an explicit `import` (step 2). A bare cross-file call `handler()` in another
+file that never imported it must NOT resolve to that lambda -- doing so poisons the
+edge with a spurious/wrong target. This is the S2 class: the additive lambda
+emission fed a name into the uniqueness gate that the gate then mis-resolves.
+
+Fix: exclude is_lambda candidates from the step-3 cross-file uniqueness gate.
+Same-file (step 1) and imported (step 2) lambda resolution are untouched.
+"""
+
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.python.call_graph_builder import CallGraphBuilder
+
+
+def _build(functions: dict, imports: dict) -> CallGraphBuilder:
+    b = CallGraphBuilder({"repository": "/tmp/fake", "imports": imports,
+                          "classes": {}, "functions": functions})
+    b.build_call_graph()
+    return b
+
+
+def _fn(file_path, name, code, class_name=None, is_lambda=False):
+    d = {"name": name,
+         "qualified_name": (f"{class_name}.{name}" if class_name else name),
+         "file_path": file_path, "class_name": class_name,
+         "unit_type": "function", "code": code}
+    if is_lambda:
+        d["is_lambda"] = True
+    return d
+
+
+# ---------- PRECISION: the poison edge must NOT appear ----------
+
+def test_no_poison_edge_to_module_lambda_cross_file():
+    """A bare cross-file call must NOT resolve to a module-level lambda."""
+    fns = {
+        "main.py:run": _fn("main.py", "run", "def run():\n    return handler()\n"),
+        "a.py:handler": _fn("a.py", "handler", "handler = lambda x: x\n", is_lambda=True),
+    }
+    b = _build(fns, imports={})  # main.py never imports handler
+    edges = b.call_graph.get("main.py:run", [])
+    assert "a.py:handler" not in edges, (
+        f"poison edge to module-level lambda a.py:handler: {edges}")
+
+
+# ---------- RECALL: legitimate lambda resolution paths must survive ----------
+
+def test_same_file_lambda_call_still_resolves():
+    """Step-1 same-file resolution of a module-level lambda is untouched."""
+    fns = {
+        "a.py:run": _fn("a.py", "run", "def run():\n    return handler()\n"),
+        "a.py:handler": _fn("a.py", "handler", "handler = lambda x: x\n", is_lambda=True),
+    }
+    b = _build(fns, imports={})
+    edges = b.call_graph.get("a.py:run", [])
+    assert "a.py:handler" in edges, (
+        f"same-file lambda edge lost: {edges}")
+
+
+def test_imported_lambda_call_still_resolves():
+    """Step-2 import resolution of a module-level lambda is untouched."""
+    fns = {
+        "main.py:run": _fn("main.py", "run", "def run():\n    return handler()\n"),
+        "a.py:handler": _fn("a.py", "handler", "handler = lambda x: x\n", is_lambda=True),
+    }
+    b = _build(fns, imports={"main.py": {"handler": "a.handler"}})
+    edges = b.call_graph.get("main.py:run", [])
+    assert "a.py:handler" in edges, (
+        f"imported lambda edge lost: {edges}")
+
+
+# ---------- RECALL: a real def uniquely named still resolves cross-file ----------
+
+def test_unique_real_def_still_resolves_cross_file():
+    """Excluding lambdas must not break the uniqueness gate for real defs."""
+    fns = {
+        "main.py:run": _fn("main.py", "run", "def run():\n    return helper()\n"),
+        "u.py:helper": _fn("u.py", "helper", "def helper():\n    return 1\n"),
+    }
+    b = _build(fns, imports={})
+    edges = b.call_graph.get("main.py:run", [])
+    assert "u.py:helper" in edges, (
+        f"unique-def cross-file edge lost: {edges}")


### PR DESCRIPTION
## What
Robustness/correctness hardening for `call_graph_builder.py`.

## Fixes in this PR (3)
- py ctor init edge drop
- py module lambda uniqgate poison
- py localtypes nested scope poison

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).