### PR TITLE
fix: harden repository_scanner.py

### DIFF
--- a/libs/openant-core/parsers/ruby/repository_scanner.py
+++ b/libs/openant-core/parsers/ruby/repository_scanner.py
@@ -101,10 +101,19 @@ class RepositoryScanner:
             'directories_scanned': 0,
             'directories_excluded': 0,
             'test_files_skipped': 0,
+            # Directories whose contents could not be read (permission/OS error);
+            # every file under them is silently dropped, so surface the count in
+            # the structured result — not only on stderr — for consumers.
+            'directories_read_failed': 0,
         }
 
         # Results
         self.files: List[Dict] = []
+
+        # Cycle guard: (st_dev, st_ino) of every directory already descended
+        # into, so a symlink loop back to an ancestor does not cause infinite
+        # recursion / duplicate scanning.
+        self._visited_dirs: Set = set()
 
     def should_exclude_directory(self, dir_name: str) -> bool:
         """Check if a directory should be excluded."""
@@ -140,14 +149,30 @@ class RepositoryScanner:
 
     def scan_directory(self, dir_path: Path, relative_path: str = '') -> None:
         """Recursively scan a directory."""
+        # Cycle guard: identify the directory by (device, inode) and bail if we
+        # have already descended into it. Without this a directory symlink that
+        # points back at an ancestor loops forever (RecursionError / duplicates).
+        try:
+            st = dir_path.stat()
+            dir_key = (st.st_dev, st.st_ino)
+        except OSError:
+            dir_key = None
+        if dir_key is not None:
+            if dir_key in self._visited_dirs:
+                return
+            self._visited_dirs.add(dir_key)
+
         self.stats['directories_scanned'] += 1
 
         try:
             entries = list(dir_path.iterdir())
         except PermissionError:
+            # Record the drop in the structured result, not only on stderr.
+            self.stats['directories_read_failed'] += 1
             print(f"Warning: Cannot read directory {dir_path}: Permission denied", file=sys.stderr)
             return
         except Exception as e:
+            self.stats['directories_read_failed'] += 1
             print(f"Warning: Cannot read directory {dir_path}: {e}", file=sys.stderr)
             return
 
@@ -192,12 +217,14 @@ class RepositoryScanner:
 
         # Reset state
         self.files = []
+        self._visited_dirs = set()
         self.stats = {
             'total_files': 0,
             'total_size_bytes': 0,
             'directories_scanned': 0,
             'directories_excluded': 0,
             'test_files_skipped': 0,
+            'directories_read_failed': 0,
         }
 
         # Run scan

--- a/libs/openant-core/tests/parsers/ruby/test_repository_scanner_read_failure_surfaced.py
+++ b/libs/openant-core/tests/parsers/ruby/test_repository_scanner_read_failure_surfaced.py
@@ -1,0 +1,70 @@
+"""Regression test for RepositoryScanner silent directory-read-failure drop.
+
+When ``scan_directory`` cannot read a directory (PermissionError / OSError) it
+prints a warning to *stderr* and ``return``s, dropping every file underneath
+that directory from the scan. The structured ``scan()`` result, however, carried
+NO signal of this: ``statistics`` reported a fully "successful" scan even though
+the module promises to "Enumerate ALL Ruby source files ... for complete
+coverage". A programmatic consumer of the JSON/dict result (which does not watch
+stderr) therefore received a silently-incomplete file list.
+
+Fix: record failed directory reads in ``statistics`` so the drop is observable
+in the structured result. This test asserts that signal exists.
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_scanner():
+    path = _CORE_ROOT / "parsers" / "ruby" / "repository_scanner.py"
+    spec = importlib.util.spec_from_file_location("rs_ruby_read_failure", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.RepositoryScanner
+
+
+SCANNER = _load_scanner()
+
+
+def test_unreadable_directory_is_surfaced_in_statistics(tmp_path, monkeypatch):
+    # root.rb is readable; the nested dir will be made to fail on read.
+    (tmp_path / "root.rb").write_text("class A; end\n")
+    unreadable = tmp_path / "unreadable"
+    unreadable.mkdir()
+    (unreadable / "hidden.rb").write_text("class B; end\n")
+    target = unreadable.resolve()
+
+    orig_iterdir = Path.iterdir
+
+    def fake_iterdir(self):
+        if self.resolve() == target:
+            raise PermissionError("simulated read failure")
+        return orig_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", fake_iterdir)
+
+    scanner = SCANNER(str(tmp_path))
+    result = scanner.scan()
+    stats = result["statistics"]
+
+    # hidden.rb under the unreadable dir was dropped (documents the drop).
+    paths = {f["path"] for f in result["files"]}
+    assert "root.rb" in paths
+    assert not any(p.endswith("hidden.rb") for p in paths)
+
+    # The silent-drop must be surfaced in the structured result, not only stderr.
+    assert stats.get("directories_read_failed", 0) >= 1, (
+        "directory-read failure was swallowed silently: the scan result gives "
+        "no signal that files were dropped"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-p", "no:cacheprovider"]))

--- a/libs/openant-core/tests/parsers/ruby/test_repository_scanner_symlink_cycle.py
+++ b/libs/openant-core/tests/parsers/ruby/test_repository_scanner_symlink_cycle.py
@@ -1,0 +1,54 @@
+"""Regression test: RepositoryScanner must not infinitely recurse on a
+directory symlink loop.
+
+Before the fix, scan_directory() used ``entry.is_dir()`` (which *follows*
+symlinks) and recursed with no cycle guard, so a symlink pointing back at an
+ancestor directory produced unbounded recursion (RecursionError / duplicate
+scanning). This test builds a symlink loop and asserts scan() terminates with a
+bounded, duplicate-free result.
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_scanner():
+    path = _CORE_ROOT / "parsers" / "ruby" / "repository_scanner.py"
+    spec = importlib.util.spec_from_file_location("rs_ruby_symlink_cycle", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.RepositoryScanner
+
+
+SCANNER = _load_scanner()
+
+
+@pytest.mark.skipif(not hasattr(os, "symlink"), reason="symlinks unsupported")
+def test_symlink_loop_terminates_without_recursion_error(tmp_path):
+    repo = tmp_path / "repo"
+    sub = repo / "app"
+    sub.mkdir(parents=True)
+    (sub / "widget.rb").write_text("puts 'hi'\n")
+
+    # A directory symlink pointing back at the repo root -> infinite loop
+    # unless the scanner tracks visited directories.
+    try:
+        os.symlink(repo, sub / "loop", target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("cannot create directory symlink on this platform")
+
+    scanner = SCANNER(str(repo))
+    result = scanner.scan()  # buggy code raises RecursionError here
+
+    paths = [f["path"] for f in result["files"]]
+    # The single real source file must be found exactly once (no duplicates
+    # from re-entering the repo through the symlink loop).
+    assert sum(1 for p in paths if Path(p).name == "widget.rb") == 1, paths


### PR DESCRIPTION
## What
Robustness/correctness hardening for `repository_scanner.py`.

## Fixes in this PR (2)
- ruby scanner dir read failure sile
- ruby scanner symlink recursion no 

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).