### PR TITLE
fix: harden call_graph_builder.py

### DIFF
--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -4,6 +4,7 @@ Stage 3: Call Graph Builder for Zig
 Builds bidirectional call graphs showing function dependencies.
 """
 
+import posixpath
 import re
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set
@@ -154,7 +155,17 @@ class CallGraphBuilder:
 
         # Build per-file simple const fn-alias bindings (`const f = handler;`)
         # so that a later `f()` resolves to `handler`.
-        alias_to_target = self._build_alias_index(name_to_ids)
+        # Belt-and-suspenders: the alias index is an over-approximation AID, not
+        # essential to producing a call graph. The tree walks it drives are now
+        # iterative (no RecursionError), but any residual failure here must
+        # degrade GRACEFULLY to an empty alias map rather than abort the whole
+        # zig build -- `_resolve_call` reads it via `.get(caller_id, {})`, so an
+        # empty dict simply means no alias-based resolution (edges still form via
+        # every other path).
+        try:
+            alias_to_target = self._build_alias_index(name_to_ids)
+        except Exception:
+            alias_to_target = {}
 
         for func_id, func_info in self.functions.items():
             code = func_info.get("code", "")
@@ -316,41 +327,61 @@ class CallGraphBuilder:
         name_to_ids: Dict[str, List[str]],
         aliases: Dict[str, Set[str]],
     ) -> None:
-        """Collect `const <alias> = <known-fn>;` bindings from a parse tree."""
-        if node.type in ("variable_declaration", "VarDecl"):
-            ident_children = [
-                c for c in node.children if c.type in ("identifier", "IDENTIFIER")
-            ]
-            # A simple alias is exactly: const <alias> = <target-identifier>;
-            if len(ident_children) == 2:
-                alias_name = self._get_node_text(ident_children[0], source)
-                target_name = self._get_node_text(ident_children[1], source)
-                # Only record when the target is a known function name. A Zig
-                # `const` binding is immutable, but the SAME alias name can be
-                # declared on distinct control-flow paths within one function
-                # (`const doit = foo` in one branch, `= bar` in another).
-                # Accumulate every target in a set instead of last-wins
-                # overwriting, so a later `doit()` over-approximates to both.
-                if alias_name and target_name in name_to_ids:
-                    aliases.setdefault(alias_name, set()).add(target_name)
-            # Struct field-init fn pointers: `const h = T{ .cb = knownFn };` binds
-            # `h.cb` -> knownFn so a later `h.cb()` resolves. The first identifier
-            # child is the bound variable; the struct type name is nested inside the
-            # struct_initializer and is ignored.
-            if ident_children:
-                var_name = self._get_node_text(ident_children[0], source)
-                struct_init = next(
-                    (c for c in node.children
-                     if c.type in ("struct_initializer", "StructInit")),
-                    None,
-                )
-                if var_name and struct_init is not None:
-                    self._collect_field_fn_bindings(
-                        struct_init, source, name_to_ids, aliases, var_name
-                    )
+        """Collect `const <alias> = <known-fn>;` bindings from a parse tree.
 
-        for child in node.children:
-            self._collect_aliases_from_node(child, source, name_to_ids, aliases)
+        ITERATIVE walk over an explicit worklist stack -- deliberately NOT
+        self-recursive. A pathologically deep parse tree (deeply nested source)
+        would drive a recursive walker past Python's recursion limit and raise
+        RecursionError; because _build_alias_index invokes this walk OUTSIDE the
+        try/except that guards parsing, that error would propagate up and abort
+        the ENTIRE zig call-graph build. It is also ambient-stack-dependent (the
+        overflow point shifts with however many frames are already on the stack
+        at entry). The worklist form grows zero Python frames regardless of tree
+        depth or ambient stack, so it is robust for any AST and NEVER truncates.
+
+        This is a strict robustness improvement: it visits exactly the same
+        nodes and records exactly the same aliases as the prior recursive
+        version on real (shallow) Zig ASTs -- no behaviour change. (PR#87 marked
+        the sibling `_walk_node` recursion 'by-design'; this rewrite alters no
+        observable behaviour on real shallow ASTs, so it is safe to land
+        regardless of that annotation.)
+        """
+        stack = [node]
+        while stack:
+            current = stack.pop()
+            if current.type in ("variable_declaration", "VarDecl"):
+                ident_children = [
+                    c for c in current.children if c.type in ("identifier", "IDENTIFIER")
+                ]
+                # A simple alias is exactly: const <alias> = <target-identifier>;
+                if len(ident_children) == 2:
+                    alias_name = self._get_node_text(ident_children[0], source)
+                    target_name = self._get_node_text(ident_children[1], source)
+                    # Only record when the target is a known function name. A Zig
+                    # `const` binding is immutable, but the SAME alias name can be
+                    # declared on distinct control-flow paths within one function
+                    # (`const doit = foo` in one branch, `= bar` in another).
+                    # Accumulate every target in a set instead of last-wins
+                    # overwriting, so a later `doit()` over-approximates to both.
+                    if alias_name and target_name in name_to_ids:
+                        aliases.setdefault(alias_name, set()).add(target_name)
+                # Struct field-init fn pointers: `const h = T{ .cb = knownFn };` binds
+                # `h.cb` -> knownFn so a later `h.cb()` resolves. The first identifier
+                # child is the bound variable; the struct type name is nested inside the
+                # struct_initializer and is ignored.
+                if ident_children:
+                    var_name = self._get_node_text(ident_children[0], source)
+                    struct_init = next(
+                        (c for c in current.children
+                         if c.type in ("struct_initializer", "StructInit")),
+                        None,
+                    )
+                    if var_name and struct_init is not None:
+                        self._collect_field_fn_bindings(
+                            struct_init, source, name_to_ids, aliases, var_name
+                        )
+
+            stack.extend(current.children)
 
     def _collect_field_fn_bindings(
         self, struct_init, source, name_to_ids, aliases, var_name
@@ -439,31 +470,41 @@ class CallGraphBuilder:
     def _extract_calls_from_node(
         self, node: Node, source: bytes, calls: Set[str]
     ) -> None:
-        """Recursively extract call sites from AST nodes."""
-        if node.type in ("call_expression", "call_expr", "CallExpr"):
-            # The callee is the first child: an `identifier` for a plain call foo(), or a
-            # `field_expression` for a method/namespaced call obj.method() / mod.func().
-            callee = node.children[0] if node.children else None
-            if callee is not None and callee.type in ("identifier", "IDENTIFIER"):
-                calls.add(self._get_node_text(callee, source))
-            elif callee is not None and callee.type in ("field_expression", "field_access"):
-                # Carry the RECEIVER by keeping only the full dotted form
-                # (`recv.method`); the resolver splits it and dispatches on the
-                # receiver's static TYPE. Adding the bare method name here would
-                # independently over-connect to EVERY same-named method (the
-                # namespace-leak FP), defeating type-based dispatch. An un-typed
-                # receiver still resolves by unique/same-file bare-name fallback
-                # inside _resolve_call, so recall is preserved.
-                text = self._get_node_text(callee, source)
-                calls.add(text)  # full dotted `receiver.method`
-        elif node.type == "builtin_function":
-            # @call(.modifier, realFn, argsTuple): the wrapped function is the real call target;
-            # other @builtins are filtered out downstream.
-            self._extract_builtin_call_target(node, source, calls)
+        """Extract call sites from AST nodes.
 
-        # Recurse into children
-        for child in node.children:
-            self._extract_calls_from_node(child, source, calls)
+        ITERATIVE walk over an explicit worklist stack -- see
+        _collect_aliases_from_node for the full rationale. This is the DIRECT
+        TWIN of that walk and had the identical unbounded self-recursion; a
+        pathologically deep parse tree could overflow the Python stack here too.
+        The worklist form grows zero Python frames and is a strict robustness
+        improvement: same nodes visited, same calls recorded on real ASTs, no
+        behaviour change.
+        """
+        stack = [node]
+        while stack:
+            current = stack.pop()
+            if current.type in ("call_expression", "call_expr", "CallExpr"):
+                # The callee is the first child: an `identifier` for a plain call foo(), or a
+                # `field_expression` for a method/namespaced call obj.method() / mod.func().
+                callee = current.children[0] if current.children else None
+                if callee is not None and callee.type in ("identifier", "IDENTIFIER"):
+                    calls.add(self._get_node_text(callee, source))
+                elif callee is not None and callee.type in ("field_expression", "field_access"):
+                    # Carry the RECEIVER by keeping only the full dotted form
+                    # (`recv.method`); the resolver splits it and dispatches on the
+                    # receiver's static TYPE. Adding the bare method name here would
+                    # independently over-connect to EVERY same-named method (the
+                    # namespace-leak FP), defeating type-based dispatch. An un-typed
+                    # receiver still resolves by unique/same-file bare-name fallback
+                    # inside _resolve_call, so recall is preserved.
+                    text = self._get_node_text(callee, source)
+                    calls.add(text)  # full dotted `receiver.method`
+            elif current.type == "builtin_function":
+                # @call(.modifier, realFn, argsTuple): the wrapped function is the real call target;
+                # other @builtins are filtered out downstream.
+                self._extract_builtin_call_target(current, source, calls)
+
+            stack.extend(current.children)
 
     def _extract_builtin_call_target(
         self, node: Node, source: bytes, calls: Set[str]
@@ -686,12 +727,22 @@ class CallGraphBuilder:
         # and skip non-file stdlib imports (@import("std")/("builtin")/("root")) which would
         # otherwise substring-match unrelated candidate paths.
         file_imports = self.imports.get(caller_file, [])
+        caller_dir = posixpath.dirname(caller_file)
         for candidate in candidates:
             candidate_file = candidate.split(":")[0]
             for imp in file_imports:
                 if not imp.endswith(".zig"):
                     continue  # std / builtin / root are not file imports
-                if candidate_file == imp or candidate_file.endswith("/" + imp):
+                # The @import path is relative to the importing file's directory and
+                # may contain ./ or ../; normalize it against caller_dir to the same
+                # repo-relative form as the stored candidate key, or the cross-file
+                # edge is dropped whenever the import crosses a directory boundary.
+                resolved_imp = posixpath.normpath(posixpath.join(caller_dir, imp))
+                if (
+                    candidate_file == resolved_imp
+                    or candidate_file == imp
+                    or candidate_file.endswith("/" + imp)
+                ):
                     return [candidate]
 
         # 3. If unique match, use it

--- a/libs/openant-core/tests/parsers/zig/test_zig_alias_index_recursion_depth_bound.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_alias_index_recursion_depth_bound.py
@@ -1,0 +1,147 @@
+"""Deep-tree robustness regression for the zig call-graph tree walks.
+
+Finding: zig-alias-index-recursion-no-depth-bound.
+
+parsers/zig/call_graph_builder.py had TWO self-recursive parse-tree walks with
+no bound on Python-stack growth:
+
+  * `_collect_aliases_from_node` -- driven by `_build_alias_index`, which is
+    invoked OUTSIDE the try/except that guards parsing. A deeply-nested parse
+    tree therefore drove Python past its recursion limit, and the RecursionError
+    propagated up and aborted the ENTIRE zig call-graph build.
+  * `_extract_calls_from_node` -- the DIRECT TWIN, same unbounded recursion.
+
+A prior draft fix added a static `depth >= 500` cap to the alias walker only.
+That cap was ambient-stack-dependent (the overflow point shifts with whatever
+frames are already on the stack) and, worse, SILENTLY TRUNCATED any alias
+declared deeper than 500 nodes into the tree -- a real recall loss. The correct
+fix rewrites BOTH walks ITERATIVELY (explicit worklist stack, zero Python frame
+growth) so they are robust for any AST depth and never truncate.
+
+This test drives the REAL top-level `build_call_graph()` entry (not the walker
+in isolation) on a pathologically deep parse tree whose alias binding and call
+site sit at the very bottom, PLUS a shallow control function. It asserts:
+
+  1. build_call_graph() COMPLETES without raising (the recursive walk raised
+     RecursionError here and aborted the whole build).
+  2. the DEEP alias edge is still produced -- proving no truncation (the 500-cap
+     draft dropped it).
+  3. the SHALLOW alias edge is still produced -- proving no behaviour change on
+     ordinary shallow ASTs.
+
+Select the module under test with env CGB_PATH (defaults to the repo file):
+    CGB_PATH=/path/to/call_graph_builder.py pytest test_...depth_bound.py
+"""
+
+import importlib.util
+import os
+import sys
+
+# openant-core root must be importable for the module's own imports
+# (`utilities.file_io`, `tree_sitter_zig`).
+_CORE_ROOT = os.environ.get(
+    "OPENANT_CORE_ROOT",
+    "/Users/gadievron/Documents/ClaudeNew/OpenAnt/new-bugs-2/OpenAnt/libs/openant-core",
+)
+if _CORE_ROOT not in sys.path:
+    sys.path.insert(0, _CORE_ROOT)
+
+_CGB_PATH = os.environ.get(
+    "CGB_PATH",
+    os.path.join(_CORE_ROOT, "parsers", "zig", "call_graph_builder.py"),
+)
+
+
+def _load_builder_class():
+    from parsers.zig.call_graph_builder import CallGraphBuilder
+    return CallGraphBuilder
+
+
+FILE = "deep.zig"
+
+# Nesting depth far past Python's default recursion limit (~1000) so the old
+# recursive walks overflow, and far past the abandoned 500 cap so a truncating
+# walker would miss the innermost alias.
+_DEPTH = 1600
+
+
+def _deep_caller_code():
+    # A chain of nested anonymous blocks with the const-fn alias + its call at
+    # the very bottom. tree-sitter parses this into a tree whose depth is
+    # proportional to the nesting, so the walker must descend _DEPTH levels to
+    # reach the `const g = target; g();` binding.
+    open_braces = "{" * _DEPTH
+    close_braces = "}" * _DEPTH
+    return (
+        "fn deepCaller() void {\n"
+        + open_braces
+        + "\nconst g = target;\ng();\n"
+        + close_braces
+        + "\n}"
+    )
+
+
+# Ordinary shallow alias -- must keep working unchanged.
+SHALLOW_CALLER_CODE = """fn shallowCaller() void {
+    const s = target;
+    s();
+}"""
+
+
+def _extractor_output():
+    return {
+        "repository": "fixture",
+        "functions": {
+            f"{FILE}:target": {
+                "name": "target",
+                "qualified_name": "target",
+                "code": "fn target() void {}",
+                "file_path": FILE,
+            },
+            f"{FILE}:deepCaller": {
+                "name": "deepCaller",
+                "qualified_name": "deepCaller",
+                "code": _deep_caller_code(),
+                "file_path": FILE,
+            },
+            f"{FILE}:shallowCaller": {
+                "name": "shallowCaller",
+                "qualified_name": "shallowCaller",
+                "code": SHALLOW_CALLER_CODE,
+                "file_path": FILE,
+            },
+        },
+        "classes": {},
+        "imports": {},
+    }
+
+
+def test_build_call_graph_completes_on_deep_tree_without_truncation():
+    CallGraphBuilder = _load_builder_class()
+    builder = CallGraphBuilder(_extractor_output())
+
+    # (1) Completes: the recursive walk raised RecursionError from inside the
+    # un-guarded _build_alias_index call and aborted the whole build here.
+    builder.build_call_graph()
+
+    target_id = f"{FILE}:target"
+    deep_edges = set(builder.call_graph.get(f"{FILE}:deepCaller", []))
+    shallow_edges = set(builder.call_graph.get(f"{FILE}:shallowCaller", []))
+
+    # (3) Shallow alias still resolves -- no behaviour change on real ASTs.
+    assert target_id in shallow_edges, (
+        f"shallowCaller->target edge missing; got {sorted(shallow_edges)}"
+    )
+
+    # (2) Deep alias still resolves -- the walk descended the full tree and did
+    # not truncate past any static depth cap.
+    assert target_id in deep_edges, (
+        "deepCaller->target edge missing: the deeply-nested `const g = target` "
+        f"alias was truncated; got {sorted(deep_edges)}"
+    )
+
+
+if __name__ == "__main__":
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/libs/openant-core/tests/parsers/zig/test_zig_import_relpath_normalize.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_import_relpath_normalize.py
@@ -1,0 +1,64 @@
+"""Regression test: Zig @import relative paths must be normalized before
+matching the stored (repo-relative) file key.
+
+BUG (zig-import-relpath-no-normalize-edge-drop): the call-graph builder matches
+an `@import("...")` path string verbatim against candidate file keys. When the
+import uses a relative path with `../` or `./` (as any cross-directory Zig
+import does), the raw string never equals the repo-relative candidate key, so
+the import fails to disambiguate an otherwise-ambiguous bare-name call and the
+cross-file edge is DROPPED.
+
+Reproduced through the REAL extractor -> builder pipeline over a multi-file,
+multi-directory repo.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.zig.function_extractor import FunctionExtractor
+from parsers.zig.call_graph_builder import CallGraphBuilder
+
+
+def _run_multifile(files: dict) -> dict:
+    """files: {repo_relative_path: source}. Runs extractor -> builder."""
+    workdir = tempfile.mkdtemp()
+    for rel, src in files.items():
+        full = os.path.join(workdir, rel)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w") as fh:
+            fh.write(src)
+    scan_results = {"files": [{"path": p} for p in files]}
+    extractor_output = FunctionExtractor(workdir, scan_results).extract()
+    return CallGraphBuilder(extractor_output).build()
+
+
+def test_relative_import_with_dotdot_resolves_cross_file_edge():
+    """`a/main.zig` importing `../b/helper.zig` must link to b's `helpFn`,
+    not be dropped as ambiguous against an unrelated same-named `helpFn`.
+
+    A second, unrelated `c/other.zig:helpFn` makes the bare name ambiguous, so
+    the edge survives ONLY if the `../b/helper.zig` import is normalized to the
+    repo-relative key `b/helper.zig` and used to disambiguate.
+    """
+    files = {
+        "a/main.zig": (
+            "const helper = @import(\"../b/helper.zig\");\n"
+            "fn f() void { helper.helpFn(); }\n"
+        ),
+        "b/helper.zig": "fn helpFn() void {}\n",
+        "c/other.zig": "fn helpFn() void {}\n",
+    }
+    cg = _run_multifile(files)["call_graph"]
+    edges = cg.get("a/main.zig:f", [])
+    assert "b/helper.zig:helpFn" in edges, (
+        "Expected f -> b/helper.zig:helpFn edge via normalized ../ import, "
+        f"got call_graph[a/main.zig:f]={edges}"
+    )
+    assert "c/other.zig:helpFn" not in edges, (
+        f"Should NOT over-connect to unrelated helpFn, got {edges}"
+    )


### PR DESCRIPTION
## What
Robustness/correctness hardening for `call_graph_builder.py`.

## Fixes in this PR (2)
- zig alias index recursion no depth
- zig import relpath no normalize ed

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).