### PR TITLE
fix: harden function_extractor.py

### DIFF
--- a/libs/openant-core/parsers/zig/function_extractor.py
+++ b/libs/openant-core/parsers/zig/function_extractor.py
@@ -138,8 +138,11 @@ class FunctionExtractor:
                 # recurse with current_struct unchanged and be emitted as bare top-level
                 # functions. Thread the function name as the struct context so they
                 # qualify as List.push and distinct containers' methods don't collide.
+                # NEST (not replace) the context: use the already-qualified name so a
+                # container defined inside a struct keeps its outer path (Outer.List),
+                # otherwise two outer scopes' same-named inner methods collide on func_id.
                 if self._returns_type(node, source):
-                    child_struct = func_info["name"]
+                    child_struct = func_info["qualified_name"]
 
         elif node.type == "variable_declaration":
             # `const Foo = struct { ... };` -- a named struct/enum definition.
@@ -151,7 +154,14 @@ class FunctionExtractor:
                 # function_declarations are emitted ONCE, qualified as
                 # Struct.method (a method visited via recursion produces the
                 # same func_id as the eager scan, so there is no bare duplicate).
-                child_struct = struct_info["name"]
+                # NEST (not replace) the parent context so nested structs qualify as
+                # Outer.Inner.method; replacing lost the outer name and made two
+                # different outer structs' same-named inner methods collide on func_id.
+                child_struct = (
+                    f"{current_struct}.{struct_info['name']}"
+                    if current_struct
+                    else struct_info["name"]
+                )
 
         elif node.type == "builtin_function" and self._get_node_text(
             node, source
@@ -191,12 +201,22 @@ class FunctionExtractor:
         if not name:
             return None
 
-        # Determine qualified name and unit type
+        # Determine qualified name and unit type.
+        # `current_struct` is the FULL nested scope path (Outer.Inner) so the func_id
+        # (keyed off qualified_name) is unique across different outer scopes -- this is
+        # what prevents the same-named-inner collision. But `class_name` must stay the
+        # BARE leaf struct name (Inner): the receiver resolver (_resolve_typed_member)
+        # matches class_name against the in-scope receiver TYPE, which is bare
+        # (`var x = Inner{}` -> "Inner"). Storing the dotted path in class_name broke
+        # that match and dropped the `x.method()` edge. Decouple the two: dotted
+        # qualified_name for the storage KEY, bare leaf for class_name resolution.
         if current_struct:
             qualified_name = f"{current_struct}.{name}"
+            class_name = current_struct.rpartition(".")[2]
             unit_type = "method"
         else:
             qualified_name = name
+            class_name = None
             unit_type = self._classify_function(name, file_path)
 
         start_line = node.start_point[0] + 1  # 1-indexed
@@ -209,7 +229,7 @@ class FunctionExtractor:
             "start_line": start_line,
             "end_line": end_line,
             "code": self._get_node_text(node, source),
-            "class_name": current_struct,
+            "class_name": class_name,
             "module_name": None,
             "parameters": parameters,
             "unit_type": unit_type,

--- a/libs/openant-core/tests/parsers/zig/test_function_extractor_nested_struct_collide.py
+++ b/libs/openant-core/tests/parsers/zig/test_function_extractor_nested_struct_collide.py
@@ -1,0 +1,149 @@
+"""Regression test: nested-struct methods must not collide on func_id.
+
+The walker threads a single struct name as the qualifier for a method's func_id
+(`file:Struct.method`). For a struct nested inside another struct the context was
+REPLACED rather than NESTED, so only the innermost struct name survived. Two
+different outer structs that each contain an inner struct of the same name with a
+same-named method therefore produced the SAME func_id
+(`file:Inner.method`) — last-write-wins silently dropped all but the last.
+
+Anchor: parsers/zig/function_extractor.py:133 (functions[func_id] = func_info).
+
+Driven through the REAL extractor (FunctionExtractor.extract()) on a temp .zig file.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.zig.function_extractor import FunctionExtractor
+from parsers.zig.call_graph_builder import CallGraphBuilder
+
+
+def _extract(src: str) -> dict:
+    workdir = tempfile.mkdtemp()
+    with open(os.path.join(workdir, "m.zig"), "w") as fh:
+        fh.write(src)
+    return FunctionExtractor(workdir, {"files": [{"path": "m.zig"}]}).extract()
+
+
+def _pipeline(src: str) -> dict:
+    """Real extractor -> builder pipeline on a single zig source file."""
+    workdir = tempfile.mkdtemp()
+    with open(os.path.join(workdir, "m.zig"), "w") as fh:
+        fh.write(src)
+    out = FunctionExtractor(workdir, {"files": [{"path": "m.zig"}]}).extract()
+    return CallGraphBuilder(out).build()
+
+
+def _zig_parser_is_grammar_aligned() -> bool:
+    """Prerequisite probe: does a *named* struct's method extract as Container.method?
+    Provided by the tree-sitter-zig>=1.1.2 grammar alignment; independent of this fix.
+    On a stale-grammar base no struct methods extract at all."""
+    probe = "const _Probe = struct {\n    pub fn _m(self: _Probe) void { _ = self; }\n};\n"
+    return "m.zig:_Probe._m" in _extract(probe)["functions"]
+
+
+pytestmark = pytest.mark.skipif(
+    not _zig_parser_is_grammar_aligned(),
+    reason=(
+        "Zig parser not grammar-aligned (needs tree-sitter-zig>=1.1.2). On such a base "
+        "no struct methods extract, so this nesting fix cannot be exercised."
+    ),
+)
+
+
+def test_nested_struct_same_named_methods_do_not_collide():
+    src = (
+        "const Http = struct {\n"
+        "    const Message = struct {\n"
+        "        pub fn parse(self: Message) void { _ = self; }\n"
+        "    };\n"
+        "};\n"
+        "const Ftp = struct {\n"
+        "    const Message = struct {\n"
+        "        pub fn parse(self: Message) void { _ = self; }\n"
+        "    };\n"
+        "};\n"
+    )
+    funcs = _extract(src)["functions"]
+    # Both parse methods must survive with fully-qualified, distinct func_ids.
+    assert "m.zig:Http.Message.parse" in funcs, f"keys = {sorted(funcs)}"
+    assert "m.zig:Ftp.Message.parse" in funcs, f"keys = {sorted(funcs)}"
+    assert funcs["m.zig:Http.Message.parse"]["qualified_name"] == "Http.Message.parse"
+    assert funcs["m.zig:Ftp.Message.parse"]["qualified_name"] == "Ftp.Message.parse"
+    # The un-nested (last-write-wins) key must NOT be the only survivor.
+    assert len([k for k in funcs if k.endswith("Message.parse")]) == 2, sorted(funcs)
+
+
+def test_generic_container_nested_in_struct_does_not_collide():
+    # Zig generic-container idiom (type-returning fn) nested inside two structs.
+    src = (
+        "const A = struct {\n"
+        "    pub fn Iter() type { return struct { pub fn next() void {} }; }\n"
+        "};\n"
+        "const B = struct {\n"
+        "    pub fn Iter() type { return struct { pub fn next() void {} }; }\n"
+        "};\n"
+    )
+    funcs = _extract(src)["functions"]
+    assert "m.zig:A.Iter.next" in funcs, f"keys = {sorted(funcs)}"
+    assert "m.zig:B.Iter.next" in funcs, f"keys = {sorted(funcs)}"
+
+
+def test_nested_struct_class_name_stays_bare_leaf_for_receiver_resolution():
+    """The storage KEY carries the full nested scope, but class_name stays the BARE
+    leaf so the receiver resolver still matches an in-scope `var x = Inner{}` type.
+
+    This asserts BOTH halves of the decoupling:
+      (a) two Outer/Ftp each with a same-named Inner.method do NOT collide -- they
+          keep two distinct, fully-qualified func_ids; AND
+      (b) a plain single Outer{Inner{...}} with `var x = Inner{}; x.method()` STILL
+          resolves the caller -> Inner.method edge. Making class_name dotted
+          (Outer.Inner) to fix (a) broke (b): _resolve_typed_member matches
+          class_name against the bare receiver type "Inner", so a dotted class_name
+          found no match and dropped the edge. This is the regression this closes.
+    """
+    # (a) collision-free storage keys with a bare class_name leaf.
+    collide_src = (
+        "const Http = struct {\n"
+        "    const Inner = struct {\n"
+        "        pub fn method(self: Inner) void { _ = self; }\n"
+        "    };\n"
+        "};\n"
+        "const Ftp = struct {\n"
+        "    const Inner = struct {\n"
+        "        pub fn method(self: Inner) void { _ = self; }\n"
+        "    };\n"
+        "};\n"
+    )
+    funcs = _extract(collide_src)["functions"]
+    distinct = [k for k in funcs if k.endswith("Inner.method")]
+    assert sorted(distinct) == ["m.zig:Ftp.Inner.method", "m.zig:Http.Inner.method"], distinct
+    # class_name is the bare leaf ("Inner"), not the dotted path ("Http.Inner").
+    assert funcs["m.zig:Http.Inner.method"]["class_name"] == "Inner", funcs["m.zig:Http.Inner.method"]
+    assert funcs["m.zig:Ftp.Inner.method"]["class_name"] == "Inner", funcs["m.zig:Ftp.Inner.method"]
+
+    # (b) regression: a bare-name receiver on a nested struct still resolves the edge.
+    edge_src = (
+        "const Outer = struct {\n"
+        "    const Inner = struct {\n"
+        "        pub fn method(self: Inner) void { _ = self; }\n"
+        "    };\n"
+        "    pub fn use(self: Outer) void {\n"
+        "        _ = self;\n"
+        "        var x = Inner{};\n"
+        "        x.method();\n"
+        "    }\n"
+        "};\n"
+    )
+    cg = _pipeline(edge_src)["call_graph"]
+    assert "m.zig:Outer.Inner.method" in cg.get("m.zig:Outer.use", []), (
+        f"expected use -> Inner.method edge; got call_graph={dict(cg)}"
+    )

--- a/libs/openant-core/tests/parsers/zig/test_zig_extractor_followup.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_extractor_followup.py
@@ -156,7 +156,11 @@ def test_nested_struct_and_import_not_dropped():
     class_names = {info["name"] for info in result["classes"].values()}
 
     assert "Outer.outerFn" in qualified, qualified
-    assert "Inner.innerFn" in qualified, qualified
+    # A nested struct's method is qualified by its FULL path (Outer.Inner.innerFn),
+    # not just the immediate struct. Single-level qualification let two different
+    # outer structs' same-named inner methods collide on one func_id (all but the
+    # last dropped); the full path keeps them distinct.
+    assert "Outer.Inner.innerFn" in qualified, qualified
     assert "Outer" in class_names, class_names
     assert "Inner" in class_names, class_names
     assert "builtin" in result["imports"]["main.zig"], result["imports"]


### PR DESCRIPTION
## What
Robustness/correctness hardening for `function_extractor.py`.

## Fixes in this PR (1)
- zig func store lastwrite struct co

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).