### PR TITLE
fix: harden ast_parser.py, dataset_enhancer.py

### DIFF
--- a/libs/openant-core/parsers/python/ast_parser.py
+++ b/libs/openant-core/parsers/python/ast_parser.py
@@ -97,7 +97,8 @@ class PythonRouteParser:
             return "", 0, 0
 
         for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            # async def handlers (aiohttp/FastAPI/Flask 2.x) are AsyncFunctionDef, not FunctionDef.
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
                 lines = content.split('\n')
                 start = node.lineno - 1
                 end = node.end_lineno if hasattr(node, 'end_lineno') else start + 10
@@ -286,7 +287,8 @@ class PythonRouteParser:
 
         # Find route decorators
         for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef):
+            # async def route handlers (Flask 2.x) are AsyncFunctionDef, not FunctionDef.
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                 route_info = self._extract_flask_route_decorator(node)
                 if route_info:
                     path, methods = route_info
@@ -315,7 +317,7 @@ class PythonRouteParser:
                         )
                         self.routes.append(unit)
 
-    def _extract_flask_route_decorator(self, func_node: ast.FunctionDef) -> Optional[Tuple[str, List[str]]]:
+    def _extract_flask_route_decorator(self, func_node) -> Optional[Tuple[str, List[str]]]:
         """Extract route path and methods from Flask decorators."""
         for decorator in func_node.decorator_list:
             if isinstance(decorator, ast.Call):
@@ -425,8 +427,8 @@ class PythonRouteParser:
         """Extract string value from an AST node."""
         if isinstance(node, ast.Constant) and isinstance(node.value, str):
             return node.value
-        if isinstance(node, ast.Str):  # Python < 3.8
-            return node.s
+        # ast.Str was removed in CPython 3.12+; ast.Constant already covers str
+        # literals on all supported versions, so no legacy branch is needed.
         return None
 
     def _get_call_name(self, node) -> Optional[str]:

--- a/libs/openant-core/parsers/python/dataset_enhancer.py
+++ b/libs/openant-core/parsers/python/dataset_enhancer.py
@@ -107,7 +107,8 @@ class PythonDependencyResolver:
             return "", 0, 0
 
         for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef) and node.name == func_name:
+            # async def handlers (aiohttp/FastAPI/Flask 2.x) are AsyncFunctionDef, not FunctionDef.
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == func_name:
                 lines = content.split('\n')
                 start = node.lineno - 1
                 end = node.end_lineno if hasattr(node, 'end_lineno') else start + 10
@@ -123,7 +124,8 @@ class PythonDependencyResolver:
             # Also check class methods
             if isinstance(node, ast.ClassDef):
                 for item in node.body:
-                    if isinstance(item, ast.FunctionDef) and item.name == func_name:
+                    # async def methods are AsyncFunctionDef, not FunctionDef.
+                    if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)) and item.name == func_name:
                         lines = content.split('\n')
                         start = item.lineno - 1
                         end = item.end_lineno if hasattr(item, 'end_lineno') else start + 10

--- a/libs/openant-core/tests/parsers/python/test_async_route_handler_extract.py
+++ b/libs/openant-core/tests/parsers/python/test_async_route_handler_extract.py
@@ -1,0 +1,78 @@
+"""Bug (py-routeparser-async-def-miss): the Python route parser walked the AST
+looking only for `ast.FunctionDef`, so `async def` route handlers were never
+matched. Modern async web handlers (Flask 2.x `async def`, aiohttp views —
+which are async by definition) were therefore dropped as entry points and never
+analyzed.
+
+Two same-concern sibling sites are fixed and covered here:
+  1. parsers/python/ast_parser.py `_parse_flask_file` (anchor, :289) — the walk
+     that discovers Flask route decorators.
+  2. parsers/python/ast_parser.py `_get_function_source` (:100) — resolves a
+     handler's source by name; used by the aiohttp/django paths whose handlers
+     are frequently `async def`.
+
+On HEAD both sites test `isinstance(node, ast.FunctionDef)` only, so every async
+case below is a genuine RED -> GREEN.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.python.ast_parser import PythonRouteParser
+
+
+def _parse_flask_repo(src: str) -> list:
+    repo = Path(tempfile.mkdtemp()).resolve()
+    (repo / "app.py").write_text(src)
+    parser = PythonRouteParser(str(repo))
+    parser.framework = "flask"
+    parser._parse_flask()
+    return parser.routes
+
+
+def test_async_flask_route_handler_is_extracted():
+    src = (
+        "from flask import Flask\n"
+        "app = Flask(__name__)\n"
+        "@app.route('/async', methods=['GET'])\n"
+        "async def async_handler():\n"
+        "    return 'ok'\n"
+    )
+    routes = _parse_flask_repo(src)
+    handlers = {r["route"]["handler"] for r in routes}
+    assert "async_handler" in handlers, (
+        f"async def route handler was not extracted (got {handlers}) — async "
+        "Flask handlers are dropped as entry points."
+    )
+
+
+def test_sync_flask_route_handler_still_extracted():
+    # Regression guard: the sync path must keep working.
+    src = (
+        "from flask import Flask\n"
+        "app = Flask(__name__)\n"
+        "@app.route('/sync', methods=['GET'])\n"
+        "def sync_handler():\n"
+        "    return 'ok'\n"
+    )
+    handlers = {r["route"]["handler"] for r in _parse_flask_repo(src)}
+    assert "sync_handler" in handlers
+
+
+def test_get_function_source_resolves_async_handler():
+    # Sibling site :100 — resolve an `async def` handler's source by name.
+    repo = Path(tempfile.mkdtemp()).resolve()
+    views = repo / "views.py"
+    views.write_text(
+        "async def async_view(request):\n"
+        "    return web.Response(text='hi')\n"
+    )
+    parser = PythonRouteParser(str(repo))
+    code, start, end = parser._get_function_source(views, "async_view")
+    assert "async_view" in code and start > 0, (
+        f"_get_function_source failed to locate an async def handler "
+        f"(code={code!r}, start={start})"
+    )

--- a/libs/openant-core/tests/parsers/python/test_enricher_async_def_source.py
+++ b/libs/openant-core/tests/parsers/python/test_enricher_async_def_source.py
@@ -1,0 +1,72 @@
+"""Bug (py-routeparser-async-def-miss, A-class sibling): the route-parser
+`def`-only defect had two UNPATCHED clones in the ENRICHER
+(parsers/python/dataset_enhancer.py). `PythonDependencyResolver._get_function_source`
+walked the AST testing `isinstance(node, ast.FunctionDef)` only, so `async def`
+handlers/methods matched nothing and their source was re-dropped even after the
+route parser detected them.
+
+Two same-concern sibling sites are covered here:
+  1. dataset_enhancer.py :110 — module-level function lookup.
+  2. dataset_enhancer.py :126 — class-method lookup.
+
+On HEAD both sites test `ast.FunctionDef` only, so both async cases are a genuine
+RED -> GREEN; the sync cases are regression guards.
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.python.dataset_enhancer import PythonDependencyResolver
+
+
+def _write(src: str) -> Path:
+    repo = Path(tempfile.mkdtemp()).resolve()
+    f = repo / "views.py"
+    f.write_text(src)
+    return f
+
+
+def test_module_level_async_handler_source_is_enriched():
+    # Sibling site :110 — module-level `async def` handler.
+    f = _write(
+        "async def async_view(request):\n"
+        "    return web.Response(text='hi')\n"
+    )
+    resolver = PythonDependencyResolver(str(f.parent))
+    code, start, end = resolver._get_function_source(f, "async_view")
+    assert "async_view" in code and start > 0, (
+        f"enricher dropped async def handler source (code={code!r}, start={start})"
+    )
+
+
+def test_class_method_async_handler_source_is_enriched():
+    # Sibling site :126 — `async def` method inside a class.
+    f = _write(
+        "class MyView:\n"
+        "    async def get(self, request):\n"
+        "        return web.Response(text='hi')\n"
+    )
+    resolver = PythonDependencyResolver(str(f.parent))
+    code, start, end = resolver._get_function_source(f, "get")
+    assert "async def get" in code and start > 0, (
+        f"enricher dropped async def method source (code={code!r}, start={start})"
+    )
+
+
+def test_sync_handler_source_still_enriched():
+    # Regression guard: sync path must keep working at both sites.
+    f = _write(
+        "def sync_view(request):\n"
+        "    return 'ok'\n"
+        "class MyView:\n"
+        "    def get(self, request):\n"
+        "        return 'ok'\n"
+    )
+    resolver = PythonDependencyResolver(str(f.parent))
+    fn_code, fn_start, _ = resolver._get_function_source(f, "sync_view")
+    m_code, m_start, _ = resolver._get_function_source(f, "get")
+    assert "sync_view" in fn_code and fn_start > 0
+    assert "def get" in m_code and m_start > 0

--- a/libs/openant-core/tests/test_ast_parser_get_string_value.py
+++ b/libs/openant-core/tests/test_ast_parser_get_string_value.py
@@ -1,0 +1,36 @@
+"""Regression: _get_string_value must not reference the removed ``ast.Str``.
+
+``ast.Str`` was removed in CPython 3.12. The old code fell through to
+``isinstance(node, ast.Str)`` for any node that is not a string ``ast.Constant``,
+which raises ``AttributeError: module 'ast' has no attribute 'Str'`` on 3.12+.
+``ast.Constant`` already covers string literals on every supported version.
+"""
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from parsers.python.ast_parser import PythonRouteParser
+
+# The RED only manifests where ast.Str is gone (3.12+); guard so it is a
+# meaningful test on new runtimes and a clean skip on legacy ones.
+pytestmark = pytest.mark.skipif(
+    hasattr(ast, "Str"),
+    reason="ast.Str still present (<3.12); the removed-alias crash cannot occur",
+)
+
+
+def test_non_string_node_returns_none(tmp_path):
+    parser = PythonRouteParser(str(tmp_path))
+    name_node = ast.parse("x", mode="eval").body  # ast.Name -> not a str constant
+    assert parser._get_string_value(name_node) is None
+    int_node = ast.parse("42", mode="eval").body  # int constant -> not a str
+    assert parser._get_string_value(int_node) is None
+
+
+def test_string_constant_still_resolves(tmp_path):
+    parser = PythonRouteParser(str(tmp_path))
+    str_node = ast.parse("'hi'", mode="eval").body
+    assert parser._get_string_value(str_node) == "hi"


### PR DESCRIPTION
## What
Robustness/correctness hardening for `ast_parser.py, dataset_enhancer.py`.

## Fixes in this PR (2)
- py routeparser async def miss
- py astparser aststr removed py

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).