### PR TITLE
fix: harden repository_scanner.py

### DIFF
--- a/libs/openant-core/parsers/zig/repository_scanner.py
+++ b/libs/openant-core/parsers/zig/repository_scanner.py
@@ -66,7 +66,22 @@ class RepositoryScanner:
         directories_scanned = 0
         directories_excluded = 0
 
-        for root, dirs, filenames in os.walk(self.repo_path):
+        # followlinks=True so .zig files reachable ONLY through a symlinked
+        # directory are still scanned (matches the iterdir()+is_dir() behaviour
+        # of the other four language scanners). Following symlinks needs a guard
+        # against two hazards, applied by pruning directory symlinks from `dirs`
+        # (os.walk descends whatever remains in `dirs`):
+        #   1. Alias duplication / canonical loss: a symlink pointing back INSIDE
+        #      the repo names a real directory that os.walk already reaches on its
+        #      canonical (non-symlink) path. Descending the alias would emit files
+        #      under the symlink path and, worse, could suppress the real path
+        #      entirely. We always drop the alias and keep the canonical visit.
+        #   2. External symlink loops: a symlink pointing OUTSIDE the repo whose
+        #      real target we have already descended (a self-referential loop)
+        #      would recurse forever; an inode guard prevents re-descending it.
+        seen_real_dirs: set = set()
+        repo_real = os.path.realpath(self.repo_path)
+        for root, dirs, filenames in os.walk(self.repo_path, followlinks=True):
             # Filter out excluded directories
             original_dirs = dirs.copy()
             dirs[:] = [
@@ -77,10 +92,35 @@ class RepositoryScanner:
                 and not (self.skip_tests and self._is_test_directory(d))
             ]
             directories_excluded += len(original_dirs) - len(dirs)
+
+            # Cycle / alias guard on the surviving directory symlinks.
+            kept = []
+            for d in dirs:
+                full = os.path.join(root, d)
+                if os.path.islink(full):
+                    real = os.path.realpath(full)
+                    # In-repo alias: the real directory is walked canonically,
+                    # so never descend the symlink (prefer the canonical path).
+                    if real == repo_real or real.startswith(repo_real + os.sep):
+                        continue
+                    # External target: guard against symlink loops by inode.
+                    try:
+                        st = os.stat(full)
+                        real_key = (st.st_dev, st.st_ino)
+                    except OSError:
+                        continue
+                    if real_key in seen_real_dirs:
+                        continue
+                    seen_real_dirs.add(real_key)
+                kept.append(d)
+            dirs[:] = kept
+
             directories_scanned += 1
 
             for filename in filenames:
-                if not filename.endswith(".zig"):
+                # Case-insensitive: filesystems (macOS/Windows) and users may
+                # spell the extension .ZIG/.Zig; skipping those silently loses files.
+                if not filename.lower().endswith(".zig"):
                     continue
 
                 file_path = Path(root) / filename

--- a/libs/openant-core/tests/parsers/zig/test_repository_scanner_case_insensitive_ext.py
+++ b/libs/openant-core/tests/parsers/zig/test_repository_scanner_case_insensitive_ext.py
@@ -1,0 +1,53 @@
+"""Regression test: the Zig RepositoryScanner must match the .zig extension
+case-insensitively.
+
+Bug: repository_scanner.py used ``filename.endswith(".zig")`` (case-sensitive),
+so a file named ``Main.ZIG`` (uppercase extension) was silently skipped from the
+scan and never analysed.
+"""
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_scanner():
+    path = _CORE_ROOT / "parsers" / "zig" / "repository_scanner.py"
+    spec = importlib.util.spec_from_file_location("rs_zig_case_insensitive", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.RepositoryScanner
+
+
+SCANNER = _load_scanner()
+
+
+def _scanned_paths(repo: Path):
+    results = SCANNER(str(repo)).scan()
+    return {f["path"] for f in results["files"]}
+
+
+def test_uppercase_zig_extension_is_scanned():
+    with tempfile.TemporaryDirectory() as d:
+        repo = Path(d)
+        (repo / "lower.zig").write_text("const x = 1;")
+        (repo / "Main.ZIG").write_text("const y = 2;")
+        (repo / "Mixed.Zig").write_text("const z = 3;")
+        paths = _scanned_paths(repo)
+    assert "lower.zig" in paths
+    assert "Main.ZIG" in paths
+    assert "Mixed.Zig" in paths
+
+
+def test_non_zig_extension_still_skipped():
+    with tempfile.TemporaryDirectory() as d:
+        repo = Path(d)
+        (repo / "readme.md").write_text("hi")
+        (repo / "code.zig").write_text("const x = 1;")
+        paths = _scanned_paths(repo)
+    assert "code.zig" in paths
+    assert "readme.md" not in paths

--- a/libs/openant-core/tests/parsers/zig/test_repository_scanner_symlink_dir.py
+++ b/libs/openant-core/tests/parsers/zig/test_repository_scanner_symlink_dir.py
@@ -1,0 +1,126 @@
+"""Regression test: the Zig RepositoryScanner must follow symlinked directories.
+
+The scanner used ``os.walk(repo)`` which defaults to ``followlinks=False``, so a
+``.zig`` file reachable only through a symlinked directory was silently dropped
+(the other four language scanners use ``Path.iterdir()`` + ``is_dir()`` which
+follow symlinks). Following symlinks must be paired with a cycle guard so a
+self-referential symlink loop does not hang the walk.
+"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+
+def _load_scanner():
+    path = _CORE_ROOT / "parsers" / "zig" / "repository_scanner.py"
+    spec = importlib.util.spec_from_file_location("rs_zig_symlink_dir", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.RepositoryScanner
+
+
+SCANNER = _load_scanner()
+
+
+def test_symlinked_directory_is_followed(tmp_path):
+    # A .zig file that exists ONLY under a symlinked directory.
+    external = tmp_path / "external_pkg"
+    external.mkdir()
+    (external / "util.zig").write_text("pub fn f() void {}\n")
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "linked_pkg").symlink_to(external, target_is_directory=True)
+
+    results = SCANNER(str(repo)).scan()
+    found = {f["path"] for f in results["files"]}
+    assert "linked_pkg/util.zig" in found, f"symlinked dir not followed; found={found}"
+
+
+def test_symlink_cycle_is_bounded_and_emits_target_once(tmp_path):
+    # Self-referential symlink loop (sub/loop -> repo). The walk must terminate
+    # AND must not re-emit the target file once per loop iteration. Asserting
+    # mere membership ("sub/a.zig" in found) is FALSE-GREEN: os.walk terminates
+    # on its own via ELOOP/ENAMETOOLONG, so membership holds even with no guard.
+    # We assert the result set is BOUNDED and that the target appears EXACTLY
+    # ONCE, so the test FAILS if the cycle guard is removed.
+    repo = tmp_path / "repo"
+    sub = repo / "sub"
+    sub.mkdir(parents=True)
+    (sub / "a.zig").write_text("pub fn g() void {}\n")
+    (sub / "loop").symlink_to(repo, target_is_directory=True)
+
+    results = SCANNER(str(repo)).scan()
+    paths = [f["path"] for f in results["files"]]
+
+    # Bounded: without a guard the loop yields a.zig under sub/, sub/loop/sub/,
+    # sub/loop/sub/loop/sub/ ... (dozens of aliases before ELOOP).
+    assert len(paths) <= 2, f"unbounded/duplicated walk; paths={paths}"
+    # Exactly once, under the canonical (loop-free) path.
+    zig_paths = [p for p in paths if p.endswith("a.zig")]
+    assert zig_paths.count("sub/a.zig") == 1, f"expected sub/a.zig exactly once; got {zig_paths}"
+    assert len(zig_paths) == 1, f"target emitted more than once; got {zig_paths}"
+
+
+def _force_scandir_order(monkeypatch, os_module, reverse):
+    """Force a deterministic os.scandir order so the alias-vs-canonical race is
+    testable regardless of the underlying filesystem's natural ordering."""
+    orig = os_module.scandir
+
+    class _Ordered:
+        def __init__(self, entries):
+            self._it = iter(entries)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
+        def __iter__(self):
+            return self._it
+
+        def __next__(self):
+            return next(self._it)
+
+        def close(self):
+            pass
+
+    def fake_scandir(path=".", *args, **kwargs):
+        with orig(path, *args, **kwargs) as it:
+            entries = sorted(it, key=lambda e: e.name, reverse=reverse)
+        return _Ordered(entries)
+
+    monkeypatch.setattr(os_module, "scandir", fake_scandir)
+
+
+def test_in_repo_symlink_emits_canonical_path_not_alias(tmp_path, monkeypatch):
+    # Regression: a real dir aaa/ (aaa/x.zig) and an in-repo symlink zzz -> aaa.
+    # An inode-dedup guard that keys on the FIRST visited path emits x.zig under
+    # whichever of {aaa, zzz} os.walk sees first -- if zzz wins, the canonical
+    # aaa/x.zig is inode-suppressed and NEVER emitted (a non-deterministic
+    # regression vs HEAD, which never followed the symlink at all). The scanner
+    # must emit x.zig EXACTLY ONCE under the canonical aaa/ path, regardless of
+    # directory-scan order. We force the adversarial order (zzz before aaa) so
+    # the failure is deterministic.
+    repo = tmp_path / "repo"
+    aaa = repo / "aaa"
+    aaa.mkdir(parents=True)
+    (aaa / "x.zig").write_text("pub fn h() void {}\n")
+    (repo / "zzz").symlink_to(aaa, target_is_directory=True)
+
+    # reverse=True => 'zzz' is yielded before 'aaa' (worst case for the alias).
+    _force_scandir_order(monkeypatch, os, reverse=True)
+
+    results = SCANNER(str(repo)).scan()
+    paths = [f["path"] for f in results["files"]]
+    zig_paths = [p for p in paths if p.endswith("x.zig")]
+
+    assert zig_paths == ["aaa/x.zig"], (
+        f"expected x.zig exactly once under canonical aaa/; got {zig_paths}"
+    )


### PR DESCRIPTION
## What
Robustness/correctness hardening for `repository_scanner.py`.

## Fixes in this PR (2)
- zig scanner case sensitive zig ext
- zig scanner oswalk symlink dir ski

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).