### PR TITLE
fix: harden stage1_consistency.py

### DIFF
--- a/libs/openant-core/tests/test_stage1_consistency_route_key_none.py
+++ b/libs/openant-core/tests/test_stage1_consistency_route_key_none.py
@@ -1,0 +1,26 @@
+"""Regression: a present-but-None ``route_key`` must not crash grouping.
+
+``_group_by_signature_pattern`` read ``result.get("route_key", "")`` which
+only defaults a MISSING key; a present ``route_key=None`` propagated None into
+``_extract_function_signature_pattern`` where ``":" not in None`` raised
+``TypeError: argument of type 'NoneType' is not iterable``. Same
+"get-default covers missing not None" class as the hardened-2 verdict guards
+in this file.
+"""
+
+from utilities.stage1_consistency import _group_by_signature_pattern
+
+
+def test_present_but_none_route_key_does_not_crash():
+    # route_key key is PRESENT but its value is None (not missing).
+    results = [{"route_key": None, "verdict": "SAFE"}]
+    groups = _group_by_signature_pattern(results)
+    # None must be coerced to the empty-pattern bucket, not propagate.
+    assert results[0] in next(iter(groups.values()))
+
+
+def test_missing_route_key_still_grouped():
+    # Regression guard: the None tolerance must not break the missing-key path.
+    results = [{"verdict": "SAFE"}]
+    groups = _group_by_signature_pattern(results)
+    assert results[0] in next(iter(groups.values()))

--- a/libs/openant-core/tests/test_stage1_nonstring_verdict.py
+++ b/libs/openant-core/tests/test_stage1_nonstring_verdict.py
@@ -1,0 +1,31 @@
+"""Regression: run_stage1_consistency_check must not crash on a non-string verdict.
+
+A result dict may carry ``verdict: None`` (before a verdict is assigned) or a
+stray int/list. The pre-fix code did ``r.get("verdict", "").upper()`` — the
+``""`` default only covers a *missing* key, so a present-but-non-string verdict
+reached ``.upper()`` and raised ``AttributeError``, aborting the consistency
+check for the whole group.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from utilities.stage1_consistency import run_stage1_consistency_check
+
+
+def test_none_verdict_does_not_crash():
+    results = [
+        {"route_key": "r1", "verdict": None},
+        {"route_key": "r1", "verdict": "VULNERABLE"},
+    ]
+    out = run_stage1_consistency_check(results, {}, None, None)
+    assert out is not None
+
+
+def test_int_verdict_does_not_crash():
+    results = [
+        {"route_key": "r1", "verdict": 1},
+        {"route_key": "r1", "verdict": "SAFE"},
+    ]
+    out = run_stage1_consistency_check(results, {}, None, None)
+    assert out is not None

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -144,7 +144,9 @@ def _group_by_signature_pattern(results: list) -> dict:
     groups = {}
 
     for result in results:
-        route_key = result.get("route_key", "")
+        # `or ""` also coerces a present-but-None route_key (not just a
+        # missing key) so None never reaches the str ops in the pattern helper.
+        route_key = result.get("route_key") or ""
         pattern = _extract_function_signature_pattern(route_key)
 
         if pattern not in groups:
@@ -192,7 +194,10 @@ def run_stage1_consistency_check(
         # Get verdicts (normalize to uppercase)
         verdicts = set()
         for r in group:
-            v = r.get("verdict", "").upper()
+            # Type-guard: verdict may be present-but-non-string (None before a
+            # verdict is assigned, or a stray int/list); treat any non-str as "".
+            raw_verdict = r.get("verdict")
+            v = raw_verdict.upper() if isinstance(raw_verdict, str) else ""
             # Treat VULNERABLE and BYPASSABLE as equivalent for grouping
             if v in ("VULNERABLE", "BYPASSABLE"):
                 verdicts.add("VULNERABLE")
@@ -229,7 +234,8 @@ def run_stage1_consistency_check(
                 # Apply updates
                 for update in consistency_result.findings_updated:
                     route_key = update.get("route_key")
-                    new_verdict = update.get("should_be", "").upper()
+                    raw_should_be = update.get("should_be")
+                    new_verdict = raw_should_be.upper() if isinstance(raw_should_be, str) else ""
 
                     if not new_verdict:
                         continue
@@ -237,7 +243,8 @@ def run_stage1_consistency_check(
                     for result in results:
                         if result.get("route_key") == route_key:
                             old_verdict = result.get("verdict", "UNKNOWN")
-                            if old_verdict.upper() != new_verdict:
+                            old_verdict_norm = old_verdict.upper() if isinstance(old_verdict, str) else ""
+                            if old_verdict_norm != new_verdict:
                                 result["verdict"] = new_verdict
                                 result["stage1_consistency_update"] = {
                                     "from": old_verdict,


### PR DESCRIPTION
## What
Robustness/correctness hardening for `stage1_consistency.py`.

## Fixes in this PR (2)
- stage1 147 route key present none
- stage1 none verdict crash

## Tests
Each fix ships a RED→GREEN regression test (added under `tests/`). All fixes were adversarially reviewed and the full set verified against the base with no new static-analysis findings (ruff/bandit/semgrep/CodeQL/go vet).

## Base / scope
Branched from `master` (base `af5e709`). This PR touches only the files listed above and is independently mergeable (no file overlap with the sibling hardening PRs).