### PR TITLE
Fix two silent consistency-override security false-negatives (Stage-1 + Stage-2)

### DIFF
--- a/libs/openant-core/tests/test_stage1_consistency_no_downgrade.py
+++ b/libs/openant-core/tests/test_stage1_consistency_no_downgrade.py
@@ -1,0 +1,55 @@
+"""F-KB-1a regression: Stage-1 pattern-consistency must NOT silently downgrade a
+surfaced (VULNERABLE/BYPASSABLE) finding to SAFE/PROTECTED.
+
+At Stage 1 there is no per-finding exploit evidence — only pattern similarity, the
+weakest signal in the pipeline. Letting it overwrite a vulnerable verdict to safe is a
+silent security false-negative (the scan reports clean). The guard blocks downgrades,
+records the rejected suggestion for audit, and leaves upgrades/lateral moves untouched.
+"""
+from utilities import stage1_consistency as s1
+
+# Two route keys that normalize to one grouping key: client_utils.py:*_async_httpx_client
+VULN_RK = "libs/a/client_utils.py:build_async_httpx_client"
+SAFE_RK = "libs/b/client_utils.py:get_async_httpx_client"
+
+
+def _run(resolver, results):
+    orig = s1._resolve_stage1_inconsistency
+    s1._resolve_stage1_inconsistency = resolver
+    try:
+        return s1.run_stage1_consistency_check(
+            [dict(r) for r in results], {}, binding=object(), tracker=None)
+    finally:
+        s1._resolve_stage1_inconsistency = orig
+
+
+def test_route_keys_group_together():
+    assert s1._extract_function_signature_pattern(VULN_RK) == \
+        s1._extract_function_signature_pattern(SAFE_RK)
+
+
+def test_vulnerable_not_downgraded_to_safe_by_pattern():
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "async httpx client builder", "SAFE",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "SAFE", "reason": "resembles safe sibling"}], "grouped")
+    out = _run(resolver, [
+        {"route_key": VULN_RK, "verdict": "VULNERABLE", "confidence": 0.9},
+        {"route_key": SAFE_RK, "verdict": "SAFE", "confidence": 0.8}])
+    vuln = next(r for r in out if r["route_key"] == VULN_RK)
+    assert vuln["verdict"] == "VULNERABLE"                     # not silenced
+    assert "stage1_consistency_downgrade_blocked" in vuln       # audit trail kept
+
+
+def test_legitimate_upgrade_still_applies():
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "VULNERABLE",
+            [{"route_key": SAFE_RK, "should_be": "VULNERABLE",
+              "reason": "sibling is exploitable"}], "x")
+    out = _run(resolver, [
+        {"route_key": VULN_RK, "verdict": "VULNERABLE", "confidence": 0.9},
+        {"route_key": SAFE_RK, "verdict": "SAFE", "confidence": 0.8}])
+    upgraded = next(r for r in out if r["route_key"] == SAFE_RK)
+    assert upgraded["verdict"] == "VULNERABLE"                  # upgrades flow freely

--- a/libs/openant-core/tests/test_stage1_consistency_no_downgrade.py
+++ b/libs/openant-core/tests/test_stage1_consistency_no_downgrade.py
@@ -53,3 +53,28 @@ def test_legitimate_upgrade_still_applies():
         {"route_key": SAFE_RK, "verdict": "SAFE", "confidence": 0.8}])
     upgraded = next(r for r in out if r["route_key"] == SAFE_RK)
     assert upgraded["verdict"] == "VULNERABLE"                  # upgrades flow freely
+
+
+def test_same_basename_cross_directory_findings_group_and_downgrade_is_blocked():
+    """Regression for the cross-file / cross-language grouping coupling.
+
+    Stage-1 groups by BASENAME, so two findings in different directories that share a
+    filename (common in Swift: View.swift/Extensions.swift per module) land in ONE group.
+    If a resolver proposes downgrading the surfaced one to SAFE, the guard must block it and
+    leave an audit breadcrumb rather than silently drop it. (Documents the interaction a
+    concurrent Swift-parser PR would exercise; the mechanism is language-agnostic.)
+    """
+    VULN = "ModuleA/View.swift:Iterator.next"
+    SAFE = "ModuleB/View.swift:Iterator.next"
+    assert s1._extract_function_signature_pattern(VULN) == s1._extract_function_signature_pattern(SAFE)
+
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "iterator next", "SAFE",
+            [{"route_key": VULN, "should_be": "SAFE", "reason": "resembles the safe sibling"}], "grouped")
+    out = _run(resolver, [
+        {"route_key": VULN, "verdict": "VULNERABLE", "confidence": 0.9},
+        {"route_key": SAFE, "verdict": "SAFE", "confidence": 0.8}])
+    vuln = next(r for r in out if r["route_key"] == VULN)
+    assert vuln["verdict"] == "VULNERABLE"                        # not silently dropped
+    assert "stage1_consistency_downgrade_blocked" in vuln         # breadcrumb, triageable

--- a/libs/openant-core/tests/test_verifier_consistency_no_exploitable_downgrade.py
+++ b/libs/openant-core/tests/test_verifier_consistency_no_exploitable_downgrade.py
@@ -1,0 +1,80 @@
+"""F-KB-1b regression: Stage-2 pattern-consistency must NOT silently downgrade a
+conclusively-EXPLOITABLE finding to safe.
+
+_has_conclusive_exploit_path protects only conclusively-BROKEN paths. Its mirror,
+_has_conclusive_exploitable_path, protects conclusively-exploitable ones (sink reached,
+attacker control full/partial, path unbroken) so a sibling's SAFE verdict cannot silence
+a real exploit via pattern matching. Defaults require proof — a missing field is NOT
+exploitable — so the guard never fabricates protection.
+"""
+from utilities.finding_verifier import FindingVerifier, ConsistencyCheckResult
+
+
+def _pred(verification):
+    # unbound call, matching tests/test_exploit_path_nondict.py convention
+    return FindingVerifier._has_conclusive_exploitable_path(None, {"verification": verification})
+
+
+def test_predicate_true_on_conclusively_exploitable():
+    assert _pred({"exploit_path": {"entry_point": "h", "sink_reached": True,
+                                   "attacker_control_at_sink": "full",
+                                   "path_broken_at": None}}) is True
+
+
+def test_predicate_false_on_broken_path():
+    assert _pred({"exploit_path": {"sink_reached": False,
+                                   "attacker_control_at_sink": "none"}}) is False
+
+
+def test_predicate_false_on_missing_or_nondict():
+    assert _pred({}) is False
+    assert _pred({"exploit_path": "reached"}) is False          # truthy non-dict
+    assert _pred({"explanation": "Max iterations reached",
+                  "exploit_path": {"sink_reached": True,
+                                   "attacker_control_at_sink": "full"}}) is False
+
+
+def _verifier():
+    v = FindingVerifier.__new__(FindingVerifier)
+    v._use_logger = False
+    v.verbose = False
+    return v
+
+
+FILE = "pkg/logger/console.go"
+EXPLOIT_RK = f"{FILE}:runMsg.json"    # -> *Msg.json (groups with the safe sibling)
+SAFE_RK = f"{FILE}:infoMsg.json"
+
+
+def test_exploitable_finding_not_downgraded_to_safe():
+    v = _verifier()
+    v._resolve_inconsistency = lambda group, cbr: ConsistencyCheckResult(
+        "logger json emitter", "safe",
+        [{"route_key": EXPLOIT_RK, "should_be": "safe", "reason": "looks safe"}], "x")
+    exploit_v = {"correct_finding": "vulnerable",
+                 "exploit_path": {"entry_point": "h", "sink_reached": True,
+                                  "attacker_control_at_sink": "full", "path_broken_at": None}}
+    out = v._check_consistency([
+        {"route_key": EXPLOIT_RK, "finding": "vulnerable", "verification": dict(exploit_v)},
+        {"route_key": SAFE_RK, "finding": "safe", "verification": {"correct_finding": "safe"}}], {})
+    got = next(r for r in out if r["route_key"] == EXPLOIT_RK)
+    assert (got.get("verification", {}).get("correct_finding") or got.get("finding")) == "vulnerable"
+    assert "consistency_downgrade_blocked" in got
+
+
+def test_broken_path_downgrade_still_respected_by_existing_guard():
+    # A conclusively-BROKEN finding is protected by the pre-existing guard, so the mirror
+    # predicate must not misfire on it (it stays vulnerable via the broken-path guard).
+    v = _verifier()
+    v._resolve_inconsistency = lambda group, cbr: ConsistencyCheckResult(
+        "logger", "safe",
+        [{"route_key": EXPLOIT_RK, "should_be": "safe", "reason": "path broken"}], "x")
+    broken_v = {"correct_finding": "vulnerable",
+                "exploit_path": {"entry_point": "h", "sink_reached": False,
+                                 "attacker_control_at_sink": "none", "path_broken_at": "auth"}}
+    assert _pred(broken_v) is False
+    out = v._check_consistency([
+        {"route_key": EXPLOIT_RK, "finding": "vulnerable", "verification": dict(broken_v)},
+        {"route_key": SAFE_RK, "finding": "safe", "verification": {"correct_finding": "safe"}}], {})
+    got = next(r for r in out if r["route_key"] == EXPLOIT_RK)
+    assert (got.get("verification", {}).get("correct_finding") or got.get("finding")) == "vulnerable"

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -845,6 +845,21 @@ class FindingVerifier:
                                           unit_id=route_key)
                                 continue
 
+                            # F-KB-1b: a conclusively-exploitable finding must not be
+                            # silently downgraded to safe by pattern matching (mirror of
+                            # the conclusive-broken guard above).
+                            if (self._has_conclusive_exploitable_path(result)
+                                    and str(new_verdict or "").strip().lower() in ("safe", "protected")):
+                                self._log("warning",
+                                          f"Blocked consistency downgrade of conclusively-exploitable {route_key} -> {new_verdict}",
+                                          unit_id=route_key)
+                                result["consistency_downgrade_blocked"] = {
+                                    "proposed": new_verdict,
+                                    "reason": finding_update.get("reason"),
+                                    "pattern": consistency_result.pattern_identified,
+                                }
+                                continue
+
                             old_verdict = result.get("verification", {}).get("correct_finding") or result.get("finding")
                             if old_verdict != new_verdict:
                                 result["finding"] = new_verdict
@@ -904,6 +919,21 @@ class FindingVerifier:
             return True
 
         return False
+
+    def _has_conclusive_exploitable_path(self, result: dict) -> bool:
+        """Mirror of _has_conclusive_exploit_path: True when analysis conclusively
+        shows the path IS reachable, attacker-controlled, and unbroken. Defaults
+        require proof — a missing field must NOT read as exploitable."""
+        verification = result.get("verification", {})
+        if verification.get("explanation") == "Max iterations reached":
+            return False
+        exploit_path = verification.get("exploit_path")
+        if not isinstance(exploit_path, dict):
+            return False
+        sink_reached = exploit_path.get("sink_reached", False)
+        attacker_control = exploit_path.get("attacker_control_at_sink", "none")
+        path_broken_at = exploit_path.get("path_broken_at")
+        return bool(sink_reached) and attacker_control in ("full", "partial") and not path_broken_at
 
     def _group_by_pattern(self, results: list) -> dict:
         """Group results by code pattern for consistency checking."""

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -244,6 +244,20 @@ def run_stage1_consistency_check(
                         if result.get("route_key") == route_key:
                             old_verdict = result.get("verdict", "UNKNOWN")
                             old_verdict_norm = old_verdict.upper() if isinstance(old_verdict, str) else ""
+                            # F-KB-1a: pattern-consistency must not silently downgrade a
+                            # surfaced Stage-1 finding to safe. At Stage 1 there is no
+                            # per-finding exploit evidence, only pattern similarity (the
+                            # weakest signal); block the downgrade and record it for audit.
+                            if old_verdict_norm in ("VULNERABLE", "BYPASSABLE") and new_verdict in ("SAFE", "PROTECTED"):
+                                result["stage1_consistency_downgrade_blocked"] = {
+                                    "from": old_verdict,
+                                    "proposed": new_verdict,
+                                    "reason": update.get("reason"),
+                                    "pattern": consistency_result.pattern_identified,
+                                }
+                                log("warning", f"Blocked Stage-1 consistency downgrade: {old_verdict} -> {new_verdict}",
+                                    step="detect", unit_id=route_key)
+                                continue
                             if old_verdict_norm != new_verdict:
                                 result["verdict"] = new_verdict
                                 result["stage1_consistency_update"] = {


### PR DESCRIPTION
# Fix two silent consistency-override security false-negatives (Stage-1 + Stage-2)

**Branch:** `pr-2a-consistency-override-fixes` (3 commits off `master`/`d4caf8a`) · **Target:** `knostic/OpenAnt:master`
**Diff:** 4 files, +204 (2 fixes +44, 3 guard tests +160) · **Not yet pushed — awaiting approval.**

## Problem
Both stages of the pipeline can **silently downgrade a real vulnerable finding to `safe`** via pattern-consistency, so the scan reports clean and exits 0.

1. **Stage 1** (`utilities/stage1_consistency.py`): `run_stage1_consistency_check` applies LLM-proposed verdict overrides **unconditionally** (`result["verdict"] = new_verdict`). A same-signature-pattern sibling that is `SAFE` can overwrite a real `VULNERABLE` finding. At Stage 1 there is **no** per-finding exploit/verification evidence — only pattern similarity, the weakest signal in the pipeline.
2. **Stage 2** (`utilities/finding_verifier.py`): the override guard `_has_conclusive_exploit_path` protects only conclusively-**broken** paths. A conclusively-**exploitable** finding (sink reached, attacker control full/partial, path unbroken) is **not** protected → it can be overwritten to a sibling's `safe` verdict. One-sided guard.

Both are silent false-negatives — the cardinal sin for a SAST tool.

## Fix (directional, purely subtractive)
Make consistency-override **directional**: upgrades and lateral moves flow freely; only a **downgrade-to-safe with weaker-than-existing evidence** is blocked.
- **Stage 1:** block `VULNERABLE/BYPASSABLE → SAFE/PROTECTED` downgrades; record `stage1_consistency_downgrade_blocked` for audit.
- **Stage 2:** add the mirror predicate `_has_conclusive_exploitable_path` (defaults require proof — a missing field never reads as exploitable) + a direction-aware guard blocking a downgrade-to-safe of a conclusively-exploitable finding; record `consistency_downgrade_blocked`. The existing broken-path guard is untouched, and a legitimate `vulnerable→bypassable` refinement still applies.

Purely subtractive: it only *declines to apply* a proposed downgrade — it never synthesizes an upgrade (no group-inflation false positives).

## Testing
- New guard tests: `tests/test_stage1_consistency_no_downgrade.py` (4, incl. the cross-dir coupling test), `tests/test_verifier_consistency_no_exploitable_downgrade.py` (5) — **9 pass on this `d4caf8a` base**. On the pre-fix code the 6 downgrade-block assertions FAIL (verifier 5/5, stage1 1/3); the other 2 stage1 tests assert unchanged behaviors (grouping, upgrade) and correctly pass on base — the standard RED/GREEN split for regression guards.
- On the fork where developed: full suite **2299 passed / 0 failed**; two runnable repros flip RED→GREEN.

## Why it's safe (blast radius)
- Casing-consistent (both sides normalized), no crash paths (isinstance/None-guarded), audit keys serialize freely (`normalize_results` keeps all dict keys; no strict schema).
- Trade-off: blocking a downgrade can retain a false positive (deferred to the downstream FP filter) rather than drop a true positive — the correct direction for a security tool. Every retained finding carries an audit breadcrumb.

## Prior art / provenance
- Independently corroborated in the OpenAnt KB (`openant-kb`) as **grade-A** facts, re-derived at the KB pin `c81c0e1` (Stage-1 `stage1_consistency.py:241` unguarded override; Stage-2 one-sided `_has_conclusive_exploit_path`). **Not** in the KB's already-fixed / Do-Not-Reintroduce set.
- Present at `d4caf8a` (this PR's base) in identical form — verified.

## Reviewer notes
- The two commits are independent (Stage-1 and Stage-2) and can be reviewed separately.
- Interaction note for a concurrent "Add Swift" PR: Swift's same-basename cross-file findings feed Stage-1 basename grouping, where this guard can *retain* a Swift false positive (recall↑, precision↓, bounded, audited). Stage-2 groups by full path and is immune. Covered by the regression test `test_same_basename_cross_directory_findings_group_and_downgrade_is_blocked`. Not a blocker.
- **Operational triage hook** (make the recommendation runnable): after a scan, list every retained downgrade for review with
  `python -c "import json,sys; [print(r.get('route_key'), r.get('stage1_consistency_downgrade_blocked') or r.get('consistency_downgrade_blocked')) for r in json.load(open(sys.argv[1]))['results'] if 'stage1_consistency_downgrade_blocked' in r or 'consistency_downgrade_blocked' in r]" results.json`
  (or `jq '.results[] | select(.stage1_consistency_downgrade_blocked or .consistency_downgrade_blocked) | {route_key, stage1_consistency_downgrade_blocked, consistency_downgrade_blocked}' results.json`).

## Rollback
Git-revert-clean: the two commits touch only `stage1_consistency.py` + `finding_verifier.py` (+ their tests),
disjoint from every other in-flight change. Reverting restores the prior behavior exactly — with the caveat
that a revert re-opens the two silent `vulnerable→safe` false-negatives (that is the behavior being fixed).
Note the fix trades toward retaining a false positive over dropping a true positive; if a downstream consumer
mis-handles the new `*_downgrade_blocked` audit keys, revert is safe and immediate.
