### PR TITLE
Count parse failures in enhance telemetry

### DIFF
--- a/libs/openant-core/tests/test_enhancer_parse_failure_counted.py
+++ b/libs/openant-core/tests/test_enhancer_parse_failure_counted.py
@@ -1,0 +1,38 @@
+"""enhancer-failed-context regression: a parse failure in the non-agentic enhancer
+must increment stats['errors'] (like the exception branch), so the [Enhance] Errors
+telemetry does not under-report parse failures. The unit still carries the error and is
+not dropped — this is a telemetry-honesty guard, not a coverage change.
+"""
+from utilities import context_enhancer as ce
+from utilities.context_enhancer import ContextEnhancer
+
+
+def _enhancer():
+    e = ContextEnhancer.__new__(ContextEnhancer)          # bypass binding-required ctor
+    e.binding = object()
+    e.tracker = None
+    e.stats = {"units_processed": 0, "units_enhanced": 0, "errors": 0,
+               "dependencies_added": 0, "callers_added": 0, "data_flows_extracted": 0}
+    return e
+
+
+def test_parse_failure_increments_errors(monkeypatch):
+    # Force an unparseable LLM response -> _parse_json_response returns falsy -> else branch.
+    monkeypatch.setattr(ce, "simple_text", lambda *a, **k: "this is not json {{{")
+    e = _enhancer()
+    unit = {"id": "f1", "code": {"primary_code": "def f(): pass"}}
+    e.enhance_unit(unit, {})
+    assert e.stats["errors"] == 1                          # parse failure counted
+    assert e.stats["units_enhanced"] == 0                 # not counted as a success
+    # unit still carries the error marker and is not dropped
+    assert unit["llm_context"]["error"]["type"] == "parse_error"
+
+
+def test_successful_parse_not_counted_as_error(monkeypatch):
+    monkeypatch.setattr(ce, "simple_text",
+                        lambda *a, **k: '{"missing_dependencies": [], "additional_callers": [], '
+                                        '"data_flow": {}, "imports": [], "reasoning": "", "confidence": 0.5}')
+    e = _enhancer()
+    e.enhance_unit({"id": "f1", "code": {"primary_code": "x"}}, {})
+    assert e.stats["errors"] == 0
+    assert e.stats["units_enhanced"] == 1

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -353,6 +353,10 @@ class ContextEnhancer:
                     "confidence": analysis.get("confidence", 0.5)
                 }
             else:
+                # enhancer-failed-context: a parse failure is an error, not a
+                # silent non-event. Count it like the exception branch below so the
+                # [Enhance] Errors telemetry does not under-report parse failures.
+                self.stats["errors"] += 1
                 unit["llm_context"] = self._get_default_context(
                     error={"type": "parse_error",
                            "message": "LLM response could not be parsed as JSON"}


### PR DESCRIPTION
# Count parse failures in enhance telemetry

**Branch:** `pr-2b-enhancer-telemetry` (1 commit off `master`/`d4caf8a`) · **Target:** `knostic/OpenAnt:master`
**Diff:** 2 files, +42 (fix +4, test +38) · **Not yet pushed — awaiting approval.**

## Problem
In the non-agentic enhancer (`utilities/context_enhancer.py::ContextEnhancer.enhance_unit`), when the LLM response can't be parsed, the `else` branch stores `_get_default_context(error={"type":"parse_error"})` on the unit but does **not** increment `self.stats["errors"]` — while the exception branch already does. So the `[Enhance] Errors: N` summary **under-reports parse failures**.

This is telemetry-only: the unit still carries `llm_context.error` and is analyzed with default context (not dropped). Benign for coverage, wrong for the error tally.

## Fix
Add `self.stats["errors"] += 1` to the parse-failure `else` branch, mirroring the exception branch. One line, purely additive; no verdict/coverage behavior change.

## Testing
- `tests/test_enhancer_parse_failure_counted.py` (2 tests): a parse failure increments `errors` (and is not counted as `units_enhanced`); a successful parse does not. **Passes on this `d4caf8a` base.**

## Blast radius (checked)
- `ContextEnhancer.stats["errors"]` is the **enhance-stage** counter (surfaced in the `[Enhance] Errors` line). It is a **different** counter from the analysis-stage `metrics["errors"]` that `core/reporter.py:442` reads (`"units_analyzed": total_units - metrics.get("errors", 0)`, at the `d4caf8a` base) — so this fix does **not** change `units_analyzed`.

## Provenance (direct re-derivation — NOT the KB grade-A record)
This fix stands on a **direct re-derivation at the PR base `d4caf8a`**: the parse-failure `else` branch stores
`_get_default_context(error={"type":"parse_error"})` but does **not** `self.stats["errors"] += 1`, while the
adjacent `except` branch does — verified at `d4caf8a`, and the guard test fails on the pre-fix `d4caf8a` source.

**Do NOT cite the KB `enhancer-failed-context-no` grade-A record as corroboration** (per fable review): that
record describes a *different* symptom — "failed enhance stored with **no error key**" — which is the `c81c0e1`
state and is **already fixed at `d4caf8a`** (the else-branch there carries `error={parse_error}`). Its grade row's
stated basis ("byte-identical blob at c81c0e1") is also false — `context_enhancer.py` blobs differ (`f90d29b`≠`e5365606`).
So the grade-A record neither matches this PR's target nor transfers by identity. (Both are KB-provenance defects
flagged for feedback in `KB-STUDY.md`.) This PR's narrower counter-defect is real and residual at `d4caf8a`.

## Rollback
Git-revert-clean: one commit, `context_enhancer.py` (+ its test), disjoint from all other changes. Reverting
restores the prior (under-counting) telemetry with zero coverage/verdict impact.
