### PR TITLE
feat(openai): add /v1/responses support for gpt-5 (with adapter hardening)

### DIFF
--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -6,9 +6,11 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "anthropic>=0.40.0",
-    # openai adapter sends ``max_completion_tokens`` (reasoning models),
-    # added to the SDK in 1.45.0.
-    "openai>=1.45.0",
+    # openai adapter uses the Responses API (``client.responses.create`` with
+    # ``reasoning``/``max_output_tokens``/``store``) for the gpt-5+ path AND
+    # ``max_completion_tokens`` for o-series on Chat Completions. Both are 2.x
+    # SDK surface; pin the floor to a version that ships a stable Responses API.
+    "openai>=2.2.0",
     # google adapter uses keyword-only ``Part.from_text(text=...)`` and
     # ``HttpOptions(base_url=...)``, both stabilised in google-genai 1.0.0.
     "google-genai>=1.0.0",

--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -431,6 +431,59 @@ def test_incomplete_max_tokens_sets_stop_reason():
     assert r.stop_reason == "max_tokens"
 
 
+# --- BUG-2: abnormal status / unknown incomplete-reason must NOT read as a clean end_turn ----
+# A truncated/abnormal response carrying PARTIAL content must not be laundered into a clean
+# stop_reason="end_turn" (a silent false-negative for a SAST tool). It is relabelled "max_tokens"
+# (the honest "not a clean finish" signal) and a one-time stderr warning is emitted, mirroring the
+# chat path's unknown-finish_reason handling. Empty-content abnormal responses still RAISE.
+
+def test_incomplete_unknown_reason_with_partial_is_not_clean_end_turn():
+    # incomplete + reason absent (incomplete_details=None) + partial text
+    adapter, _ = _stub_resp(lambda **kw: _resp(status="incomplete", incomplete_reason=None,
+                                               output=[_msg_item(_text_part("truncated: no issues fou"))]))
+    r = adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    assert r.stop_reason != "end_turn"          # must NOT launder to a clean finish
+    assert r.stop_reason == "max_tokens"
+    assert [b.text for b in r.content] == ["truncated: no issues fou"]   # content preserved
+
+
+def test_incomplete_other_reason_with_partial_is_not_clean_end_turn():
+    adapter, _ = _stub_resp(lambda **kw: _resp(status="incomplete", incomplete_reason="other",
+                                               output=[_msg_item(_text_part("partial"))]))
+    r = adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    assert r.stop_reason == "max_tokens"
+
+
+def test_unknown_top_level_status_with_partial_is_not_clean_end_turn():
+    adapter, _ = _stub_resp(lambda **kw: _resp(status="in_progress",
+                                               output=[_msg_item(_text_part("looks clean"))]))
+    r = adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    assert r.stop_reason != "end_turn"
+    assert r.stop_reason == "max_tokens"
+
+
+def test_bug2_regression_guards_still_hold():
+    # (1) completed + text → clean end_turn (unchanged)
+    a1, _ = _stub_resp(lambda **kw: _resp(status="completed", output=[_msg_item(_text_part("done"))]))
+    assert a1.complete(model=G5, system=None, messages=_hi(), max_tokens=8).stop_reason == "end_turn"
+    # (2) incomplete + content_filter → refusal (unchanged)
+    a2, _ = _stub_resp(lambda **kw: _resp(status="incomplete", incomplete_reason="content_filter", output=[]))
+    with pytest.raises(LLMRefusalError):
+        a2.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    # (3) failed → response error (unchanged)
+    a3, _ = _stub_resp(lambda **kw: _resp(status="failed", error=SimpleNamespace(message="boom"), output=[]))
+    with pytest.raises(LLMResponseError):
+        a3.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    # (4) incomplete + max_output_tokens + text → max_tokens (unchanged)
+    a4, _ = _stub_resp(lambda **kw: _resp(status="incomplete", incomplete_reason="max_output_tokens",
+                                          output=[_msg_item(_text_part("partial"))]))
+    assert a4.complete(model=G5, system=None, messages=_hi(), max_tokens=8).stop_reason == "max_tokens"
+    # (5) abnormal status but EMPTY content → still RAISES (empty-content guard intact)
+    a5, _ = _stub_resp(lambda **kw: _resp(status="in_progress", output=[]))
+    with pytest.raises(LLMResponseError):
+        a5.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+
+
 # --- validate gating ---------------------------------------------------------
 
 def test_validate_gpt5_uses_responses_endpoint():

--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -295,6 +295,26 @@ def test_gate_predicates_partition_models():
     assert _use_responses_api("gpt-5.6", False) is False
 
 
+def test_gpt5_chat_variants_stay_off_responses():
+    # C1: the non-reasoning chat variants reject the reasoning param; they must NOT be
+    # force-routed to /v1/responses (which always sends reasoning -> 400), and must not
+    # be classified reasoning (they take max_tokens + system, the plain chat shape).
+    for m in ("gpt-5-chat-latest", "gpt-5-chat"):
+        assert _use_responses_api(m, None) is False
+        assert _is_reasoning_model(m) is False
+
+
+def test_gpt5_family_boundary_and_whitespace():
+    # C3: unrelated numbering (gpt-50) is not the gpt-5..gpt-9 family; ids are whitespace-trimmed.
+    assert _use_responses_api("gpt-50", None) is False
+    assert _use_responses_api("gpt-5 ", None) is True      # trailing space
+    assert _use_responses_api(" gpt-5", None) is True      # leading space
+    # real reasoning family still routes to responses and classifies as reasoning
+    assert _use_responses_api("gpt-5.6", None) is True
+    assert _use_responses_api("gpt-5-mini", None) is True
+    assert _is_reasoning_model("gpt-5-mini") is True
+
+
 def test_gpt5_routes_to_responses_not_chat():
     adapter, client = _stub_resp(lambda **kw: _resp(output=[_msg_item(_text_part("hello"))]))
     r = adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=4096)

--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -491,8 +491,27 @@ def test_validate_gpt5_uses_responses_endpoint():
     adapter.validate(G5)
     client.responses.create.assert_called_once()
     client.chat.completions.create.assert_not_called()
-    # no unsupported effort value forced on the ping
-    assert "reasoning" not in client.responses.create.call_args.kwargs
+    # BUG-1: the ping exercises the SAME reasoning effort complete() will send,
+    # so a model-rejected effort fails fast at init instead of 400-ing every unit.
+    assert client.responses.create.call_args.kwargs["reasoning"] == {"effort": "medium"}
+
+
+def test_validate_gpt5_fails_fast_on_model_rejected_effort():
+    # BUG-1: a model that rejects the configured reasoning effort must fail init,
+    # not pass validation and then 400 every single unit of the scan.
+    def reject_minimal(**kw):
+        if kw.get("reasoning", {}).get("effort") == "minimal":
+            raise openai.BadRequestError(
+                message="Unsupported value: 'minimal' is not supported for this model",
+                response=_fake_http(400), body=None)
+        return _resp(output=[_msg_item(_text_part("OK"))])
+    client = MagicMock(spec=openai.OpenAI)
+    client.responses = MagicMock(); client.responses.create = MagicMock(side_effect=reject_minimal)
+    client.chat = MagicMock(); client.chat.completions = MagicMock()
+    client.chat.completions.create = MagicMock(side_effect=AssertionError("must probe responses, not chat"))
+    adapter = OpenAIAdapter(_client=client, reasoning_effort="minimal")
+    with pytest.raises(LLMResponseError):
+        adapter.validate(G5)
 
 
 def test_validate_gpt4o_uses_chat_endpoint():

--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -525,6 +525,33 @@ def test_bug2_regression_guards_still_hold():
         a5.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
 
 
+# --- BUG-7: chat-path unknown finish_reason must not read as a clean end_turn ---
+# The chat-path analog of BUG-2: an unknown/proxy finish_reason (or a future OpenAI
+# value) carrying partial content is relabelled "max_tokens" (the honest not-a-clean-
+# finish signal) instead of a silent "end_turn". Known reasons are unchanged.
+
+def _chat_resp(*, content="hi", finish_reason="stop"):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=content, tool_calls=None),
+                                 finish_reason=finish_reason)],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+def test_chat_unknown_finish_reason_is_not_clean_end_turn():
+    adapter, _ = _stub(lambda **kw: _chat_resp(content="truncated: no issues fou", finish_reason="abort"))
+    r = adapter.complete(model="gpt-4o", system=None, messages=_hi(), max_tokens=8)
+    assert r.stop_reason == "max_tokens"          # was a silent "end_turn"
+    assert [b.text for b in r.content] == ["truncated: no issues fou"]   # content preserved
+
+
+def test_chat_known_finish_reasons_unchanged():
+    # regression guard: BUG-7 changes ONLY the unknown-default; known reasons use their map.
+    for fr, expected in (("stop", "end_turn"), ("length", "max_tokens")):
+        adapter, _ = _stub(lambda fr=fr, **kw: _chat_resp(finish_reason=fr))
+        assert adapter.complete(model="gpt-4o", system=None, messages=_hi(), max_tokens=8).stop_reason == expected
+
+
 # --- validate gating ---------------------------------------------------------
 
 def test_validate_gpt5_uses_responses_endpoint():

--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -295,13 +295,21 @@ def test_gate_predicates_partition_models():
     assert _use_responses_api("gpt-5.6", False) is False
 
 
-def test_gpt5_chat_variants_stay_off_responses():
-    # C1: the non-reasoning chat variants reject the reasoning param; they must NOT be
-    # force-routed to /v1/responses (which always sends reasoning -> 400), and must not
-    # be classified reasoning (they take max_tokens + system, the plain chat shape).
-    for m in ("gpt-5-chat-latest", "gpt-5-chat"):
+def test_gpt5_nonreasoning_variants_stay_off_responses():
+    # The non-reasoning gpt-5 variants (chat, search) reject the reasoning param, so they
+    # must NOT be force-routed to /v1/responses (which always sends reasoning -> 400). Only
+    # the reasoning family belongs on responses; search/chat are served on Chat Completions.
+    for m in ("gpt-5-chat-latest", "gpt-5-chat", "gpt-5-search-api", "gpt-5-search-api-2025-10-14"):
         assert _use_responses_api(m, None) is False
         assert _is_reasoning_model(m) is False
+
+
+def test_gpt5_reasoning_variants_stay_on_responses():
+    # guard the other side: real reasoning-family ids must NOT be excluded by the
+    # non-reasoning filter (no "-chat"/"-search" substring in them).
+    for m in ("gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-5-codex", "gpt-5-pro", "gpt-5.6-sol"):
+        assert _use_responses_api(m, None) is True
+        assert _is_reasoning_model(m) is True
 
 
 def test_gpt5_family_boundary_and_whitespace():

--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -224,6 +224,7 @@ from utilities.llm import LLMRefusalError, ToolDef, ToolResultBlock, ToolUseBloc
 from utilities.llm.providers.openai import (
     _use_responses_api,
     _is_reasoning_model,
+    _token_param,
     _RESPONSES_MIN_OUTPUT_TOKENS,
     _messages_to_responses,
     _tool_to_responses,
@@ -295,13 +296,25 @@ def test_gate_predicates_partition_models():
     assert _use_responses_api("gpt-5.6", False) is False
 
 
-def test_gpt5_nonreasoning_variants_stay_off_responses():
-    # The non-reasoning gpt-5 variants (chat, search) reject the reasoning param, so they
-    # must NOT be force-routed to /v1/responses (which always sends reasoning -> 400). Only
-    # the reasoning family belongs on responses; search/chat are served on Chat Completions.
-    for m in ("gpt-5-chat-latest", "gpt-5-chat", "gpt-5-search-api", "gpt-5-search-api-2025-10-14"):
+def test_gpt5_chat_variants_chat_endpoint_but_completion_tokens():
+    # Live-verified (gpt-5.2-chat-latest): the gpt-5 chat variants reject the reasoning
+    # param, so they are served on Chat Completions (NOT /v1/responses) — but the gpt-5
+    # generation there requires max_completion_tokens (max_tokens 400s). So endpoint=chat,
+    # token-param/role = the reasoning-class shape (max_completion_tokens + developer).
+    for m in ("gpt-5-chat-latest", "gpt-5.2-chat-latest", "gpt-5-chat"):
+        assert _use_responses_api(m, None) is False
+        assert _is_reasoning_model(m) is True
+        assert _token_param(m) == "max_completion_tokens"
+
+
+def test_gpt5_search_variants_chat_endpoint_and_max_tokens():
+    # Live-verified (gpt-5-search-api): served on Chat Completions with max_tokens (accepts
+    # max_tokens, rejected by the Responses API) — like gpt-4o-search-preview. So endpoint=chat
+    # AND the plain-chat token shape (max_tokens + system), distinct from the chat variants.
+    for m in ("gpt-5-search-api", "gpt-5-search-api-2025-10-14"):
         assert _use_responses_api(m, None) is False
         assert _is_reasoning_model(m) is False
+        assert _token_param(m) == "max_tokens"
 
 
 def test_gpt5_reasoning_variants_stay_on_responses():

--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -214,3 +214,300 @@ def test_complete_consults_limiter_before_request(monkeypatch):
     )
     adapter.complete(model="gpt-4o", system=None, messages=_hi(), max_tokens=8)
     assert seen["waited"], "complete() must call wait_if_needed before the request (H1)"
+
+
+# ===========================================================================
+# Responses API (/v1/responses) — gpt-5+ path
+# ===========================================================================
+
+from utilities.llm import LLMRefusalError, ToolDef, ToolResultBlock, ToolUseBlock
+from utilities.llm.providers.openai import (
+    _use_responses_api,
+    _is_reasoning_model,
+    _RESPONSES_MIN_OUTPUT_TOKENS,
+    _messages_to_responses,
+    _tool_to_responses,
+)
+
+G5 = "gpt-5.6"
+
+
+def _resp(*, status="completed", output=None, input_tokens=7, output_tokens=11,
+          incomplete_reason=None, error=None):
+    return SimpleNamespace(
+        status=status,
+        output=output or [],
+        usage=SimpleNamespace(input_tokens=input_tokens, output_tokens=output_tokens),
+        incomplete_details=(SimpleNamespace(reason=incomplete_reason)
+                            if incomplete_reason else None),
+        error=error,
+    )
+
+
+def _msg_item(*parts):
+    return SimpleNamespace(type="message", content=list(parts))
+
+
+def _text_part(text):
+    return SimpleNamespace(type="output_text", text=text)
+
+
+def _refusal_part(text):
+    return SimpleNamespace(type="refusal", refusal=text)
+
+
+def _fncall(*, call_id, name, arguments):
+    return SimpleNamespace(type="function_call", call_id=call_id, name=name, arguments=arguments)
+
+
+def _reasoning():
+    return SimpleNamespace(type="reasoning", encrypted_content="opaque")
+
+
+def _stub_resp(side_effect, *, use_responses_api=None):
+    client = MagicMock(spec=openai.OpenAI)
+    client.responses = MagicMock()
+    client.responses.create = MagicMock(side_effect=side_effect)
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = MagicMock(side_effect=AssertionError(
+        "chat.completions must NOT be called on the responses path"))
+    return OpenAIAdapter(_client=client, use_responses_api=use_responses_api), client
+
+
+def _tools():
+    return [ToolDef(name="echo", description="Echo the text.",
+                    input_schema={"type": "object", "properties": {"text": {"type": "string"}},
+                                  "required": ["text"]})]
+
+
+# --- gate --------------------------------------------------------------------
+
+def test_gate_predicates_partition_models():
+    assert _use_responses_api("gpt-5.6", None) is True
+    assert _use_responses_api("gpt-5", None) is True
+    assert _use_responses_api("openai/gpt-6", None) is True
+    assert _use_responses_api("gpt-4o", None) is False
+    assert _use_responses_api("gpt-4o-mini", None) is False
+    assert _use_responses_api("o3", None) is False          # o-series stays on chat
+    # ctor override wins either way (base_url proxies)
+    assert _use_responses_api("gpt-4o", True) is True
+    assert _use_responses_api("gpt-5.6", False) is False
+
+
+def test_gpt5_routes_to_responses_not_chat():
+    adapter, client = _stub_resp(lambda **kw: _resp(output=[_msg_item(_text_part("hello"))]))
+    r = adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=4096)
+    client.responses.create.assert_called_once()
+    client.chat.completions.create.assert_not_called()
+    assert [b.text for b in r.content] == ["hello"]
+    assert r.stop_reason == "end_turn"
+    assert (r.input_tokens, r.output_tokens) == (7, 11)     # responses usage fields
+
+
+def test_gpt4o_stays_on_chat_not_responses():
+    client = MagicMock(spec=openai.OpenAI)
+    client.chat = MagicMock(); client.chat.completions = MagicMock()
+    client.chat.completions.create = MagicMock(side_effect=lambda **kw: _text_response())
+    client.responses = MagicMock()
+    client.responses.create = MagicMock(side_effect=AssertionError("gpt-4o must not use responses"))
+    adapter = OpenAIAdapter(_client=client)
+    adapter.complete(model="gpt-4o", system=None, messages=_hi(), max_tokens=8)
+    client.responses.create.assert_not_called()
+
+
+def test_override_forces_responses_for_gpt4o():
+    adapter, client = _stub_resp(lambda **kw: _resp(output=[_msg_item(_text_part("ok"))]),
+                                 use_responses_api=True)
+    adapter.complete(model="gpt-4o", system=None, messages=_hi(), max_tokens=8)
+    client.responses.create.assert_called_once()
+
+
+# --- request shape -----------------------------------------------------------
+
+def test_request_shape_floor_effort_store_instructions():
+    adapter, client = _stub_resp(lambda **kw: _resp(output=[_msg_item(_text_part("x"))]))
+    adapter.complete(model=G5, system="be careful", messages=_hi(), max_tokens=4096, tools=_tools())
+    kw = client.responses.create.call_args.kwargs
+    assert kw["max_output_tokens"] == _RESPONSES_MIN_OUTPUT_TOKENS   # floored up from 4096
+    assert kw["reasoning"] == {"effort": "medium"}
+    assert kw["store"] is False
+    assert kw["instructions"] == "be careful"
+    assert kw["tools"][0] == {"type": "function", "name": "echo",
+                              "description": "Echo the text.",
+                              "parameters": _tools()[0].input_schema, "strict": False}
+
+
+def test_tools_omitted_when_none():
+    # helpers.simple_text calls complete() with no tools; must not send tools=[]
+    adapter, client = _stub_resp(lambda **kw: _resp(output=[_msg_item(_text_part("x"))]))
+    adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    assert "tools" not in client.responses.create.call_args.kwargs
+
+
+def test_reasoning_effort_configurable():
+    adapter, client = _stub_resp(lambda **kw: _resp(output=[_msg_item(_text_part("x"))]))
+    adapter._reasoning_effort = "low"
+    adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    assert client.responses.create.call_args.kwargs["reasoning"] == {"effort": "low"}
+
+
+# --- tool round-trip (the agentic loop) --------------------------------------
+
+def test_tool_call_parsed_as_tooluseblock():
+    adapter, _ = _stub_resp(lambda **kw: _resp(
+        output=[_reasoning(), _fncall(call_id="call_1", name="echo", arguments='{"text":"hi"}')]))
+    r = adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8, tools=_tools())
+    assert r.stop_reason == "tool_use"
+    tus = [b for b in r.content if isinstance(b, ToolUseBlock)]
+    assert len(tus) == 1 and tus[0].id == "call_1" and tus[0].name == "echo"
+    assert tus[0].input == {"text": "hi"}
+
+
+def test_tool_result_roundtrips_to_function_call_output():
+    msgs = [
+        Message(role="user", content=[TextBlock("go")]),
+        Message(role="assistant", content=[ToolUseBlock(id="call_9", name="echo", input={"text": "hi"})]),
+        Message(role="user", content=[ToolResultBlock(tool_use_id="call_9", content="RESULT", name="echo")]),
+    ]
+    items = _messages_to_responses(msgs)
+    # ordering: user text, then assistant function_call, then function_call_output
+    fc = [i for i in items if i.get("type") == "function_call"]
+    fco = [i for i in items if i.get("type") == "function_call_output"]
+    assert fc and fc[0]["call_id"] == "call_9" and fc[0]["arguments"] == '{"text": "hi"}'
+    assert fco and fco[0]["call_id"] == "call_9" and fco[0]["output"] == "RESULT"
+
+
+def test_parallel_tool_calls():
+    adapter, _ = _stub_resp(lambda **kw: _resp(output=[
+        _fncall(call_id="c1", name="echo", arguments='{"text":"a"}'),
+        _fncall(call_id="c2", name="echo", arguments='{"text":"b"}'),
+    ]))
+    r = adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8, tools=_tools())
+    ids = [b.id for b in r.content if isinstance(b, ToolUseBlock)]
+    assert ids == ["c1", "c2"]
+
+
+def test_user_turn_orders_tool_output_before_text():
+    msgs = [Message(role="user", content=[
+        ToolResultBlock(tool_use_id="c1", content="R"), TextBlock("and now this")])]
+    items = _messages_to_responses(msgs)
+    assert items[0]["type"] == "function_call_output"
+    assert items[1]["role"] == "user"
+
+
+# --- safety guards (the silent-clean-pass failure modes) ---------------------
+
+def test_refusal_in_message_content_raises():
+    adapter, _ = _stub_resp(lambda **kw: _resp(output=[_msg_item(_refusal_part("nope"))]))
+    with pytest.raises(LLMRefusalError):
+        adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+
+
+def test_content_filter_incomplete_raises_refusal():
+    adapter, _ = _stub_resp(lambda **kw: _resp(status="incomplete", incomplete_reason="content_filter",
+                                               output=[]))
+    with pytest.raises(LLMRefusalError):
+        adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+
+
+def test_empty_output_raises_response_error():
+    adapter, _ = _stub_resp(lambda **kw: _resp(output=[_reasoning()]))   # reasoning only, no content
+    with pytest.raises(LLMResponseError):
+        adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+
+
+def test_failed_status_raises_response_error():
+    adapter, _ = _stub_resp(lambda **kw: _resp(status="failed",
+                                               error=SimpleNamespace(message="boom"), output=[]))
+    with pytest.raises(LLMResponseError):
+        adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+
+
+def test_incomplete_max_tokens_sets_stop_reason():
+    adapter, _ = _stub_resp(lambda **kw: _resp(status="incomplete", incomplete_reason="max_output_tokens",
+                                               output=[_msg_item(_text_part("partial"))]))
+    r = adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    assert r.stop_reason == "max_tokens"
+
+
+# --- validate gating ---------------------------------------------------------
+
+def test_validate_gpt5_uses_responses_endpoint():
+    adapter, client = _stub_resp(lambda **kw: _resp(output=[_msg_item(_text_part("OK"))]))
+    adapter.validate(G5)
+    client.responses.create.assert_called_once()
+    client.chat.completions.create.assert_not_called()
+    # no unsupported effort value forced on the ping
+    assert "reasoning" not in client.responses.create.call_args.kwargs
+
+
+def test_validate_gpt4o_uses_chat_endpoint():
+    adapter, client = _stub(lambda **kw: _text_response())
+    adapter.validate("gpt-4o")
+    assert client.chat.completions.create.call_args.kwargs.get("max_tokens") == 1
+
+
+# --- error taxonomy parity on the responses path -----------------------------
+
+def test_responses_429_reports_to_global_limiter():
+    def boom(**kw):
+        raise openai.RateLimitError(message="slow", response=_fake_http(429, retry_after="5"), body=None)
+    adapter, _ = _stub_resp(boom)
+    limiter = get_rate_limiter()
+    with pytest.raises(LLMRateLimitError):
+        adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    assert limiter.is_in_backoff(), "responses 429 must trigger global backoff too"
+
+
+# ---------------------------------------------------------------------------
+# Coupling fix: gpt-5+ is reasoning-class, so a gpt-5 forced onto the CHAT
+# path (use_responses_api=False, a proxy escape hatch) must still get
+# max_completion_tokens + the developer role — not max_tokens + system,
+# which 400s a reasoning model. Endpoint choice and token-param/role choice
+# must agree. (judge ruling A)
+# ---------------------------------------------------------------------------
+
+
+def _stub_chat_forced(side_effect):
+    """A chat-path adapter with use_responses_api=False (forces gpt-5 to chat)."""
+    client = MagicMock(spec=openai.OpenAI)
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = MagicMock(side_effect=side_effect)
+    return OpenAIAdapter(_client=client, use_responses_api=False), client
+
+
+@pytest.mark.parametrize("model", ["gpt-5", "gpt-5.6", "openai/gpt-6"])
+def test_gpt5_forced_to_chat_uses_max_completion_tokens(model):
+    adapter, client = _stub_chat_forced(lambda **kw: _text_response())
+    adapter.complete(model=model, system=None, messages=_hi(), max_tokens=64)
+    kw = client.chat.completions.create.call_args.kwargs
+    assert kw.get("max_completion_tokens") == 64, f"{model}: gpt-5 on chat needs max_completion_tokens"
+    assert "max_tokens" not in kw, f"{model}: gpt-5 rejects max_tokens"
+
+
+@pytest.mark.parametrize("model", ["gpt-5", "gpt-5.6", "openai/gpt-6"])
+def test_gpt5_forced_to_chat_routes_system_to_developer(model):
+    adapter, client = _stub_chat_forced(lambda **kw: _text_response())
+    adapter.complete(model=model, system="be careful", messages=_hi(), max_tokens=8)
+    roles = [m["role"] for m in client.chat.completions.create.call_args.kwargs["messages"]]
+    assert "developer" in roles, f"{model}: gpt-5 needs a developer role"
+    assert "system" not in roles, f"{model}: gpt-5 rejects the system role"
+
+
+@pytest.mark.parametrize("model", ["gpt-5", "gpt-6", "gpt-9", "openai/gpt-5.6", "gpt-5.6"])
+def test_gpt5_bare_and_prefixed_treated_as_reasoning(model):
+    assert _is_reasoning_model(model) is True
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4-turbo"])
+def test_gpt4x_still_not_reasoning(model):
+    assert _is_reasoning_model(model) is False
+
+
+def test_gpt5_default_route_still_responses():
+    # No override: a gpt-5 still routes to /v1/responses (unchanged by the fix).
+    adapter, client = _stub_resp(lambda **kw: _resp(output=[_msg_item(_text_part("ok"))]))
+    adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=4096)
+    client.responses.create.assert_called_once()

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -407,15 +407,18 @@ class OpenAIAdapter:
         # fail every unit).
         try:
             if _use_responses_api(model, self._use_responses_api_override):
-                # Prove the /v1/responses endpoint + model are reachable. Omit
-                # ``reasoning`` (effort values are model-specific — e.g. gpt-5.6
-                # rejects "minimal"); the model default is fine for a ping. A
+                # Prove the /v1/responses endpoint + model are reachable, pinging
+                # with the SAME ``reasoning`` effort ``_complete_responses`` will
+                # send. Effort values are model-specific (e.g. gpt-5.6 rejects
+                # "minimal"), so omitting it would let a rejected effort pass init
+                # and then 400 every unit — validate() must fail fast on it. A
                 # structurally valid 200 (incl. status="incomplete" if reasoning
                 # eats the budget) is success — only an exception fails init.
                 self._client.responses.create(
                     model=model,
                     input="Reply with OK.",
                     max_output_tokens=1000,
+                    reasoning={"effort": self._reasoning_effort},
                     store=False,
                 )
             else:

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -171,6 +171,8 @@ def reset_warnings() -> None:
         _warned_bad_tool_json.clear()
     with _warned_unknown_output_items_lock:
         _warned_unknown_output_items.clear()
+    with _warned_responses_statuses_lock:
+        _warned_responses_statuses.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -184,6 +186,33 @@ def reset_warnings() -> None:
 # dropped output surface is visible — mirrors the Anthropic adapter's guard.
 _warned_unknown_output_items: set[str] = set()
 _warned_unknown_output_items_lock = threading.Lock()
+
+# Abnormal Responses statuses / incomplete-reasons we've already warned about
+# (per-process, lock-guarded) — mirrors ``_warned_finish_reasons`` on the chat
+# path so a truncated/abnormal-but-non-empty response is observable, not silent.
+_warned_responses_statuses: set[str] = set()
+_warned_responses_statuses_lock = threading.Lock()
+
+
+def _warn_unknown_responses_status(value: str) -> None:
+    """One-time stderr warning for an unrecognized/abnormal Responses status or
+    incomplete reason — mirrors the chat path's unknown-``finish_reason`` warning
+    (see ``_response_to_unified``) so an abnormal-but-non-empty response is visible
+    instead of silently reading as a clean ``end_turn`` (a false negative for a
+    security tool)."""
+    should_warn = False
+    with _warned_responses_statuses_lock:
+        if value not in _warned_responses_statuses:
+            _warned_responses_statuses.add(value)
+            should_warn = True
+    if should_warn:
+        sys.stderr.write(
+            f"warning: OpenAIAdapter received an abnormal Responses status/reason "
+            f"{value!r} carrying partial content; relabelling stop_reason to "
+            f"'max_tokens' so a truncated/abnormal response is not read as a clean "
+            f"completion. Add an explicit handler if OpenAI introduced a new "
+            f"termination status/reason.\n"
+        )
 
 
 def _use_responses_api(model: str, override: Optional[bool]) -> bool:
@@ -587,10 +616,24 @@ def _responses_to_unified(response: Any) -> CompletionResult:
                 "OpenAI content-filtered the response (incomplete: content_filter); "
                 "the completion was withheld by the moderation layer"
             )
-        if reason == "max_output_tokens":
+        elif reason == "max_output_tokens":
             stop_reason = "max_tokens"
-        # Other/unknown incomplete reasons fall through to the empty-content
-        # guard below rather than a silent clean pass.
+        else:
+            # Any other/unknown incomplete reason (incl. None): the response was
+            # truncated, so it must NOT read as a clean end_turn even when it
+            # carries partial content — the empty-content guard below only fires
+            # on EMPTY content. Relabel as max_tokens (the honest "not a clean
+            # finish" signal) and warn once, mirroring the chat path's
+            # unknown-finish_reason handling.
+            _warn_unknown_responses_status(f"incomplete:{reason!r}")
+            stop_reason = "max_tokens"
+    elif status not in (None, "completed"):
+        # An unrecognized / non-terminal top-level status (in_progress, queued,
+        # requires_action, or a future value) on a synchronous responses.create
+        # is abnormal; failed/cancelled already raised above. A partial body must
+        # not be laundered into a clean end_turn.
+        _warn_unknown_responses_status(str(status))
+        stop_reason = "max_tokens"
 
     content_blocks: list[ContentBlock] = []
     for item in getattr(response, "output", None) or []:

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -52,6 +52,7 @@ the right key per model so a probe or scan against ``o1`` doesn't 400.
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 import threading
@@ -64,6 +65,7 @@ from ..adapter import (
     ContentBlock,
     LLMAuthError,
     LLMConnectionError,
+    LLMError,
     LLMNotFoundError,
     LLMRateLimitError,
     LLMRefusalError,
@@ -94,9 +96,25 @@ _OPENAI_FINISH_REASONS: dict[str, StopReason] = {
 _OPENAI_CONTENT_FILTER_REASON = "content_filter"
 
 # OpenAI reasoning models (o1/o3/o4 families) reject ``max_tokens`` and
-# require ``max_completion_tokens``. Match the bare ``o<digit>`` family
-# — NOT ``gpt-4o`` / ``gpt-4o-mini``, which are regular chat models.
+# require ``max_completion_tokens`` on Chat Completions. Match the bare
+# ``o<digit>`` family — NOT ``gpt-4o`` / ``gpt-4o-mini``, which are regular
+# chat models. The gpt-5+ generation is ALSO reasoning-class (see
+# ``_is_reasoning_model``, which unions this with ``_RESPONSES_MODEL_RE``):
+# it normally routes to the Responses API and so never reaches
+# ``_token_param``/the role logic — EXCEPT when forced onto the chat path
+# via the ``use_responses_api=False`` override, where it must still get
+# ``max_completion_tokens`` + the ``developer`` role or the request 400s.
 _REASONING_MODEL_RE = re.compile(r"^o[1-9]")
+
+# gpt-5+ generation → OpenAI Responses API (/v1/responses). gpt-5 rejects
+# ``tools`` + ``reasoning`` on Chat Completions, which the agentic enhance
+# and verify phases require; Responses supports both. Kept deliberately
+# narrow: only the gpt-5..gpt-9 families. Everything else (gpt-4o, o-series)
+# stays on the unchanged Chat Completions path. Override per-adapter via the
+# ``use_responses_api`` ctor arg (for base_url proxies that expose a gpt-5 id
+# over a chat-completions-only endpoint). NOTE: ``o1[0-9]`` and future
+# non-``gpt-``-prefixed reasoning families are intentionally out of scope here.
+_RESPONSES_MODEL_RE = re.compile(r"^gpt-[5-9]")
 
 # Track finish_reasons we've already warned about. Per-process, lock-guarded.
 _warned_finish_reasons: set[str] = set()
@@ -110,14 +128,19 @@ _warned_bad_tool_json_lock = threading.Lock()
 
 
 def _is_reasoning_model(model: str) -> bool:
-    """True for OpenAI reasoning models (o1/o3/o4…) that need
-    ``max_completion_tokens`` instead of ``max_tokens``.
+    """True for OpenAI reasoning models that need ``max_completion_tokens``
+    (not ``max_tokens``) and the ``developer`` role (not ``system``).
 
-    Strips any proxy prefix (``openai/o1`` → ``o1``) and matches the
-    bare ``o<digit>`` family. ``gpt-4o`` is NOT a reasoning model.
+    Covers the o-series (``o1``/``o3``/``o4``…) AND the gpt-5+ generation —
+    the latter is reasoning-class too, so a gpt-5 forced onto the chat path
+    (``use_responses_api=False``) gets the right per-request shape instead of
+    a 400. This unions ``_REASONING_MODEL_RE`` (o-series) with
+    ``_RESPONSES_MODEL_RE`` (gpt-5+) so the endpoint decision and the
+    token-param/role decisions can never disagree. Strips any proxy prefix
+    (``openai/o1`` → ``o1``). ``gpt-4o`` is NOT a reasoning model.
     """
     bare = model.lower().rsplit("/", 1)[-1]
-    return bool(_REASONING_MODEL_RE.match(bare))
+    return bool(_REASONING_MODEL_RE.match(bare) or _RESPONSES_MODEL_RE.match(bare))
 
 
 def _token_param(model: str) -> str:
@@ -146,6 +169,72 @@ def reset_warnings() -> None:
         _warned_finish_reasons.clear()
     with _warned_bad_tool_json_lock:
         _warned_bad_tool_json.clear()
+    with _warned_unknown_output_items_lock:
+        _warned_unknown_output_items.clear()
+
+
+# ---------------------------------------------------------------------------
+# Responses-API routing + shared helpers
+# ---------------------------------------------------------------------------
+
+# Output items on the Responses API we deliberately do not surface as content:
+# ``reasoning`` (internal chain, kept out of ``CompletionResult.content`` per the
+# adapter's "reasoning stays internal" invariant). Any OTHER unexpected item type
+# (mcp_call, shell_call, custom_tool_call, …) is warned about once so a silently
+# dropped output surface is visible — mirrors the Anthropic adapter's guard.
+_warned_unknown_output_items: set[str] = set()
+_warned_unknown_output_items_lock = threading.Lock()
+
+
+def _use_responses_api(model: str, override: Optional[bool]) -> bool:
+    """Route gpt-5+ to /v1/responses; everything else to Chat Completions.
+
+    ``override`` (from the adapter ctor) wins when not ``None`` — lets a
+    ``base_url`` proxy exposing a gpt-5 id over a chat-completions-only endpoint
+    force the chat path, or force responses for an unrecognised id.
+    """
+    if override is not None:
+        return override
+    bare = model.lower().rsplit("/", 1)[-1]
+    return bool(_RESPONSES_MODEL_RE.match(bare))
+
+
+# Reasoning models spend output tokens on hidden reasoning that counts against
+# ``max_output_tokens``; a Claude-tuned cap (the pipeline passes ~4096) can be
+# fully consumed by reasoning, yielding status="incomplete" with no visible
+# text/tool-call — which for a SAST tool would silently read as "nothing found".
+# Floor the responses-path output budget so the visible answer always has room.
+_RESPONSES_MIN_OUTPUT_TOKENS = 16000
+
+# Reasoning effort for the Responses path. Default from env; "medium" balances
+# quality vs reasoning-token cost across thousands of units. Not threaded through
+# per-phase config: PhaseRef carries only (provider, model), and adding a field
+# would require a coordinated Python + Go CLI config-schema change.
+_DEFAULT_REASONING_EFFORT = os.environ.get("OPENANT_OPENAI_REASONING_EFFORT", "medium")
+
+
+def _map_openai_exception(exc: Exception, *, report_rl: bool) -> "LLMError":
+    """Map an ``openai`` SDK exception to the unified taxonomy (secrets redacted).
+
+    Shared by the Chat Completions and Responses paths so both surface the same
+    error classes and both feed cross-worker backoff on a 429. Raise the result
+    with ``... from redacted_cause_from(exc)`` at the call site.
+    """
+    if isinstance(exc, (openai.AuthenticationError, openai.PermissionDeniedError)):
+        return LLMAuthError(redact_secrets(str(exc)))
+    if isinstance(exc, openai.RateLimitError):
+        retry_after = _retry_after_from(exc)
+        if report_rl:
+            report_rate_limit(retry_after)
+        return LLMRateLimitError(redact_secrets(str(exc)), retry_after=retry_after)
+    if isinstance(exc, openai.NotFoundError):
+        return LLMNotFoundError(redact_secrets(str(exc)))
+    if isinstance(exc, openai.APIConnectionError):
+        # Covers DNS, TCP, TLS, and SDK-mapped timeouts (APITimeoutError
+        # inherits from APIConnectionError).
+        return LLMConnectionError(redact_secrets(str(exc)))
+    # BadRequestError + any other APIStatusError (5xx, unexpected statuses).
+    return LLMResponseError(redact_secrets(str(exc)))
 
 
 class OpenAIAdapter:
@@ -174,6 +263,8 @@ class OpenAIAdapter:
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         max_retries: int = 5,
+        use_responses_api: Optional[bool] = None,
+        reasoning_effort: Optional[str] = None,
         _client: Optional[openai.OpenAI] = None,
     ):
         """Construct the adapter.
@@ -187,8 +278,18 @@ class OpenAIAdapter:
             max_retries: Forwarded to the SDK. The SDK retries
                 transient 429s and 5xx automatically; the pipeline
                 does not add its own retry loop on top.
+            use_responses_api: Force the endpoint choice. ``None`` (default)
+                auto-selects: gpt-5+ → /v1/responses, everything else →
+                Chat Completions. ``True``/``False`` overrides — needed for a
+                ``base_url`` proxy that exposes a gpt-5 id over a
+                chat-completions-only endpoint (set ``False``), or vice versa.
+            reasoning_effort: Reasoning effort for the Responses path
+                (none|minimal|low|medium|high|xhigh). ``None`` uses the
+                ``OPENANT_OPENAI_REASONING_EFFORT`` env default ("medium").
             _client: Injected SDK instance for testing.
         """
+        self._use_responses_api_override = use_responses_api
+        self._reasoning_effort = reasoning_effort or _DEFAULT_REASONING_EFFORT
         if _client is not None:
             self._client = _client
             return
@@ -213,6 +314,9 @@ class OpenAIAdapter:
         max_tokens: int,
         tools: Optional[list[ToolDef]] = None,
     ) -> CompletionResult:
+        if _use_responses_api(model, self._use_responses_api_override):
+            return self._complete_responses(model, system, messages, max_tokens, tools)
+
         request: dict[str, Any] = {
             "model": model,
             _token_param(model): max_tokens,
@@ -226,50 +330,74 @@ class OpenAIAdapter:
 
         try:
             response = self._client.chat.completions.create(**request)
-        except openai.AuthenticationError as exc:
-            raise LLMAuthError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.PermissionDeniedError as exc:
-            raise LLMAuthError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.RateLimitError as exc:
-            retry_after = _retry_after_from(exc)
-            report_rate_limit(retry_after)
-            raise LLMRateLimitError(redact_secrets(str(exc)), retry_after=retry_after) from redacted_cause_from(exc)
-        except openai.NotFoundError as exc:
-            raise LLMNotFoundError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.APIConnectionError as exc:
-            # Covers DNS, TCP, TLS, and SDK-mapped timeouts (the SDK's
-            # APITimeoutError inherits from APIConnectionError).
-            raise LLMConnectionError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.BadRequestError as exc:
-            raise LLMResponseError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.APIStatusError as exc:
-            # Everything else (5xx, unexpected statuses).
-            raise LLMResponseError(redact_secrets(str(exc))) from redacted_cause_from(exc)
+        except (openai.APIStatusError, openai.APIConnectionError) as exc:
+            raise _map_openai_exception(exc, report_rl=True) from redacted_cause_from(exc)
 
         return _response_to_unified(response)
 
-    def validate(self, model: str) -> None:
+    def _complete_responses(
+        self,
+        model: str,
+        system: Optional[str],
+        messages: list[Message],
+        max_tokens: int,
+        tools: Optional[list[ToolDef]],
+    ) -> CompletionResult:
+        """gpt-5+ path via /v1/responses (supports tools + reasoning together).
+
+        Stateless: the full message history is re-sent each turn. Reasoning
+        items are NOT threaded back between tool turns — empirically the loop's
+        tool-call turns emit no reasoning items to carry, and dropping them
+        costs a negligible re-reason on the final turn (measured). ``store=False``
+        keeps analysed source off OpenAI's servers.
+        """
+        request: dict[str, Any] = {
+            "model": model,
+            "input": _messages_to_responses(messages),
+            "max_output_tokens": max(max_tokens, _RESPONSES_MIN_OUTPUT_TOKENS),
+            "reasoning": {"effort": self._reasoning_effort},
+            "store": False,
+        }
+        if system:
+            request["instructions"] = system
+        if tools:
+            request["tools"] = [_tool_to_responses(t) for t in tools]
+
+        wait_for_rate_limit()
         try:
-            self._client.chat.completions.create(**{
-                "model": model,
-                _token_param(model): 1,
-                "messages": [{"role": "user", "content": "hi"}],
-            })
-        except openai.AuthenticationError as exc:
-            raise LLMAuthError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.PermissionDeniedError as exc:
-            raise LLMAuthError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.RateLimitError as exc:
-            retry_after = _retry_after_from(exc)
-            raise LLMRateLimitError(redact_secrets(str(exc)), retry_after=retry_after) from redacted_cause_from(exc)
-        except openai.NotFoundError as exc:
-            raise LLMNotFoundError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.APIConnectionError as exc:
-            raise LLMConnectionError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.BadRequestError as exc:
-            raise LLMResponseError(redact_secrets(str(exc))) from redacted_cause_from(exc)
-        except openai.APIStatusError as exc:
-            raise LLMResponseError(redact_secrets(str(exc))) from redacted_cause_from(exc)
+            response = self._client.responses.create(**request)
+        except (openai.APIStatusError, openai.APIConnectionError) as exc:
+            raise _map_openai_exception(exc, report_rl=True) from redacted_cause_from(exc)
+
+        return _responses_to_unified(response)
+
+    def validate(self, model: str) -> None:
+        # Probe the ENDPOINT the scan will actually use — a chat-completions
+        # ping for a gpt-5 model would both 400 (max_tokens) and validate the
+        # wrong endpoint (a proxy without Responses access would pass init then
+        # fail every unit).
+        try:
+            if _use_responses_api(model, self._use_responses_api_override):
+                # Prove the /v1/responses endpoint + model are reachable. Omit
+                # ``reasoning`` (effort values are model-specific — e.g. gpt-5.6
+                # rejects "minimal"); the model default is fine for a ping. A
+                # structurally valid 200 (incl. status="incomplete" if reasoning
+                # eats the budget) is success — only an exception fails init.
+                self._client.responses.create(
+                    model=model,
+                    input="Reply with OK.",
+                    max_output_tokens=1000,
+                    store=False,
+                )
+            else:
+                self._client.chat.completions.create(**{
+                    "model": model,
+                    _token_param(model): 1,
+                    "messages": [{"role": "user", "content": "hi"}],
+                })
+        except (openai.APIStatusError, openai.APIConnectionError) as exc:
+            # report_rl=False: a validate ping must not back off sibling workers.
+            raise _map_openai_exception(exc, report_rl=False) from redacted_cause_from(exc)
 
 
 # ----------------------------------------------------------------------
@@ -359,6 +487,168 @@ def _tool_to_openai(tool: ToolDef) -> dict[str, Any]:
             "parameters": tool.input_schema,
         },
     }
+
+
+def _messages_to_responses(messages: list[Message]) -> list[dict[str, Any]]:
+    """Translate unified messages to Responses-API ``input`` items.
+
+    System is sent via the ``instructions`` param (not an item). Per message, in
+    order: tool RESULTS first (they reference a prior function_call), then plain
+    text — matching how the API expects ``function_call_output`` to follow its
+    call. Assistant tool calls become ``function_call`` items; assistant/user
+    text becomes a role message. An assistant turn with only tool calls emits no
+    role message (correct for Responses). Parallel tool calls preserve order.
+    """
+    out: list[dict[str, Any]] = []
+    for message in messages:
+        text_blocks = [b for b in message.content if isinstance(b, TextBlock)]
+        tool_use_blocks = [b for b in message.content if isinstance(b, ToolUseBlock)]
+        tool_result_blocks = [b for b in message.content if isinstance(b, ToolResultBlock)]
+
+        if message.role == "user":
+            for tr in tool_result_blocks:
+                out.append({
+                    "type": "function_call_output",
+                    "call_id": tr.tool_use_id,
+                    "output": tr.content,
+                })
+            if text_blocks:
+                out.append({
+                    "role": "user",
+                    "content": "\n".join(b.text for b in text_blocks),
+                })
+        elif message.role == "assistant":
+            if text_blocks:
+                out.append({
+                    "role": "assistant",
+                    "content": "\n".join(b.text for b in text_blocks),
+                })
+            for tu in tool_use_blocks:
+                out.append({
+                    "type": "function_call",
+                    "call_id": tu.id,
+                    "name": tu.name,
+                    "arguments": json.dumps(tu.input or {}),
+                })
+        else:  # pragma: no cover — Role is a closed Literal
+            raise LLMResponseError(
+                f"OpenAIAdapter: unknown message role {message.role!r}"
+            )
+    return out
+
+
+def _tool_to_responses(tool: ToolDef) -> dict[str, Any]:
+    # Responses function tools are FLATTENED (no nested "function"), and
+    # ``strict`` must be explicit: OpenAnt's tool schemas are not strict-mode
+    # compatible (no ``additionalProperties: false``), so strict=True would 400.
+    return {
+        "type": "function",
+        "name": tool.name,
+        "description": tool.description,
+        "parameters": tool.input_schema,
+        "strict": False,
+    }
+
+
+def _warn_unknown_output_item(kind: str) -> None:
+    """One-time stderr warning for an unhandled Responses output item type."""
+    should = False
+    with _warned_unknown_output_items_lock:
+        if kind not in _warned_unknown_output_items:
+            _warned_unknown_output_items.add(kind)
+            should = True
+    if should:
+        sys.stderr.write(
+            f"warning: OpenAIAdapter saw an unhandled Responses output item "
+            f"{kind!r}; ignoring it. If it carries output the pipeline needs, add "
+            f"handling in _responses_to_unified.\n"
+        )
+
+
+def _responses_to_unified(response: Any) -> CompletionResult:
+    """Translate an OpenAI ``Response`` (Responses API) into unified types.
+
+    Order matters: a hard failure, a filtered response, or an empty completion
+    must NOT read as a clean ``end_turn`` — for a SAST tool that is a silent
+    false-negative — so status is inspected before content, and a content-free
+    result raises (mirrors the Chat Completions empty-``choices`` guard).
+    """
+    status = getattr(response, "status", None)
+    if status in ("failed", "cancelled"):
+        err = getattr(response, "error", None)
+        detail = (getattr(err, "message", None) or str(err)) if err is not None else status
+        raise LLMResponseError(redact_secrets(f"OpenAI Responses {status}: {detail}"))
+
+    stop_reason: StopReason = "end_turn"
+    if status == "incomplete":
+        reason = getattr(getattr(response, "incomplete_details", None), "reason", None)
+        if reason == "content_filter":
+            raise LLMRefusalError(
+                "OpenAI content-filtered the response (incomplete: content_filter); "
+                "the completion was withheld by the moderation layer"
+            )
+        if reason == "max_output_tokens":
+            stop_reason = "max_tokens"
+        # Other/unknown incomplete reasons fall through to the empty-content
+        # guard below rather than a silent clean pass.
+
+    content_blocks: list[ContentBlock] = []
+    for item in getattr(response, "output", None) or []:
+        itype = getattr(item, "type", None)
+        if itype == "message":
+            for part in getattr(item, "content", None) or []:
+                ptype = getattr(part, "type", None)
+                if ptype == "output_text":
+                    text = getattr(part, "text", "")
+                    if text:
+                        content_blocks.append(TextBlock(text=text))
+                elif ptype == "refusal":
+                    # A refusal is a nested content part (NOT a top-level item and
+                    # NOT part of output_text) — surface as a typed error.
+                    raise LLMRefusalError(
+                        f"OpenAI refused the request "
+                        f"(refusal: {getattr(part, 'refusal', '')!r})"
+                    )
+                else:
+                    _warn_unknown_output_item(f"message.{ptype}")
+        elif itype == "function_call":
+            arguments = getattr(item, "arguments", "") or ""
+            try:
+                input_dict = json.loads(arguments) if arguments else {}
+            except json.JSONDecodeError:
+                _warn_bad_tool_json(getattr(item, "name", "<unknown>"))
+                input_dict = {}
+            content_blocks.append(ToolUseBlock(
+                id=item.call_id,
+                name=item.name,
+                input=input_dict,
+            ))
+        elif itype == "reasoning":
+            # Internal chain — deliberately kept out of unified content.
+            pass
+        else:
+            _warn_unknown_output_item(str(itype))
+
+    # ``incomplete`` (max_output_tokens) wins over tool_use: a function_call in a
+    # truncated response may carry incomplete-JSON arguments, so don't advertise
+    # it as an actionable tool call.
+    if any(isinstance(b, ToolUseBlock) for b in content_blocks) and stop_reason != "max_tokens":
+        stop_reason = "tool_use"
+
+    if not content_blocks:
+        raise LLMResponseError(
+            f"OpenAI Responses returned no usable content (status={status!r}); the "
+            "request may have been truncated (reasoning consumed the budget) or filtered"
+        )
+
+    usage = getattr(response, "usage", None)
+    return CompletionResult(
+        content=content_blocks,
+        input_tokens=getattr(usage, "input_tokens", 0) if usage else 0,
+        output_tokens=getattr(usage, "output_tokens", 0) if usage else 0,
+        stop_reason=stop_reason,
+        raw=response,
+    )
 
 
 def _response_to_unified(response: Any) -> CompletionResult:

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -806,10 +806,10 @@ def _response_to_unified(response: Any) -> CompletionResult:
         if should_warn:
             sys.stderr.write(
                 f"warning: OpenAIAdapter received unknown finish_reason "
-                f"{raw_finish!r}; normalising to 'end_turn'. Add this value "
-                f"to StopReason in utilities/llm/adapter.py and "
-                f"_OPENAI_FINISH_REASONS if OpenAI added a new termination "
-                f"reason.\n"
+                f"{raw_finish!r}; treating as 'max_tokens' (not a clean finish) so "
+                f"a truncated/abnormal chat response is not read as complete. Add "
+                f"this value to StopReason in utilities/llm/adapter.py and "
+                f"_OPENAI_FINISH_REASONS if OpenAI added a new termination reason.\n"
             )
 
     usage = getattr(response, "usage", None)
@@ -817,7 +817,11 @@ def _response_to_unified(response: Any) -> CompletionResult:
         content=content_blocks,
         input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
         output_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
-        stop_reason=_OPENAI_FINISH_REASONS.get(raw_finish, "end_turn"),
+        # BUG-7: an UNKNOWN finish_reason defaults to "max_tokens", not "end_turn" —
+        # the chat-path analog of _responses_to_unified's abnormal-status handling, so
+        # a proxy/future-value truncation isn't laundered into a clean completion.
+        # Known reasons (stop/tool_calls/length) use their explicit mapping above.
+        stop_reason=_OPENAI_FINISH_REASONS.get(raw_finish, "max_tokens"),
         raw=response,
     )
 

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -114,7 +114,19 @@ _REASONING_MODEL_RE = re.compile(r"^o[1-9]")
 # ``use_responses_api`` ctor arg (for base_url proxies that expose a gpt-5 id
 # over a chat-completions-only endpoint). NOTE: ``o1[0-9]`` and future
 # non-``gpt-``-prefixed reasoning families are intentionally out of scope here.
-_RESPONSES_MODEL_RE = re.compile(r"^gpt-[5-9]")
+_RESPONSES_MODEL_RE = re.compile(r"^gpt-[5-9]([.-]|$)")
+
+
+def _is_gpt5_responses_family(bare: str) -> bool:
+    """True for the gpt-5..gpt-9 REASONING ids that use /v1/responses.
+
+    Excludes the non-reasoning chat variants (``gpt-5-chat``,
+    ``gpt-5-chat-latest``) — they reject the ``reasoning`` param the responses
+    path always sends — and, via the tail anchor on ``_RESPONSES_MODEL_RE``, does
+    not match unrelated numbering like ``gpt-50``. ``bare`` must already be
+    lower-cased, proxy-prefix stripped, and whitespace-trimmed.
+    """
+    return bool(_RESPONSES_MODEL_RE.match(bare)) and "-chat" not in bare
 
 # Track finish_reasons we've already warned about. Per-process, lock-guarded.
 _warned_finish_reasons: set[str] = set()
@@ -135,12 +147,13 @@ def _is_reasoning_model(model: str) -> bool:
     the latter is reasoning-class too, so a gpt-5 forced onto the chat path
     (``use_responses_api=False``) gets the right per-request shape instead of
     a 400. This unions ``_REASONING_MODEL_RE`` (o-series) with
-    ``_RESPONSES_MODEL_RE`` (gpt-5+) so the endpoint decision and the
-    token-param/role decisions can never disagree. Strips any proxy prefix
-    (``openai/o1`` → ``o1``). ``gpt-4o`` is NOT a reasoning model.
+    ``_is_gpt5_responses_family`` (gpt-5+, excluding the non-reasoning chat
+    variants) so the endpoint decision and the token-param/role decisions can
+    never disagree. Strips any proxy prefix (``openai/o1`` → ``o1``) and
+    surrounding whitespace. ``gpt-4o`` and ``gpt-5-chat`` are NOT reasoning models.
     """
-    bare = model.lower().rsplit("/", 1)[-1]
-    return bool(_REASONING_MODEL_RE.match(bare) or _RESPONSES_MODEL_RE.match(bare))
+    bare = model.lower().rsplit("/", 1)[-1].strip()
+    return bool(_REASONING_MODEL_RE.match(bare) or _is_gpt5_responses_family(bare))
 
 
 def _token_param(model: str) -> str:
@@ -224,8 +237,8 @@ def _use_responses_api(model: str, override: Optional[bool]) -> bool:
     """
     if override is not None:
         return override
-    bare = model.lower().rsplit("/", 1)[-1]
-    return bool(_RESPONSES_MODEL_RE.match(bare))
+    bare = model.lower().rsplit("/", 1)[-1].strip()
+    return bool(_is_gpt5_responses_family(bare))
 
 
 # Reasoning models spend output tokens on hidden reasoning that counts against

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -120,13 +120,18 @@ _RESPONSES_MODEL_RE = re.compile(r"^gpt-[5-9]([.-]|$)")
 def _is_gpt5_responses_family(bare: str) -> bool:
     """True for the gpt-5..gpt-9 REASONING ids that use /v1/responses.
 
-    Excludes the non-reasoning chat variants (``gpt-5-chat``,
-    ``gpt-5-chat-latest``) — they reject the ``reasoning`` param the responses
-    path always sends — and, via the tail anchor on ``_RESPONSES_MODEL_RE``, does
-    not match unrelated numbering like ``gpt-50``. ``bare`` must already be
-    lower-cased, proxy-prefix stripped, and whitespace-trimmed.
+    Excludes the non-reasoning gpt-5 variants — the chat models (``gpt-5-chat``,
+    ``gpt-5-chat-latest``) and the web-search models (``gpt-5-search-api``) —
+    which reject the ``reasoning`` param the responses path always sends and are
+    served on Chat Completions (like ``gpt-4o-search-preview``). Via the tail
+    anchor on ``_RESPONSES_MODEL_RE`` it also does not match unrelated numbering
+    like ``gpt-50``. ``bare`` must already be lower-cased, proxy-prefix stripped,
+    and whitespace-trimmed. NOTE: the token-param OpenAI expects for these
+    non-reasoning variants on Chat Completions (``max_tokens`` vs
+    ``max_completion_tokens``) is a separate, pre-existing question left to the
+    unchanged chat path — a bad choice fails loud at ``validate()``, not silently.
     """
-    return bool(_RESPONSES_MODEL_RE.match(bare)) and "-chat" not in bare
+    return bool(_RESPONSES_MODEL_RE.match(bare)) and "-chat" not in bare and "-search" not in bare
 
 # Track finish_reasons we've already warned about. Per-process, lock-guarded.
 _warned_finish_reasons: set[str] = set()

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -387,11 +387,23 @@ class OpenAIAdapter:
     ) -> CompletionResult:
         """gpt-5+ path via /v1/responses (supports tools + reasoning together).
 
-        Stateless: the full message history is re-sent each turn. Reasoning
-        items are NOT threaded back between tool turns — empirically the loop's
-        tool-call turns emit no reasoning items to carry, and dropping them
-        costs a negligible re-reason on the final turn (measured). ``store=False``
-        keeps analysed source off OpenAI's servers.
+        Stateless: the full message history is re-sent each turn. The model's
+        ``reasoning`` items ARE emitted (at effort>=medium) but are deliberately
+        dropped and never threaded back (``_responses_to_unified`` discards them;
+        the unified ``Message`` type carries no reasoning block). This does not
+        400 the follow-up tool turns because ``_messages_to_responses`` re-sends
+        ``function_call`` items with ``call_id`` ONLY — never the server-issued
+        ``fc_...`` item id — so the history reads as developer-synthesized tool
+        history, which the Responses API accepts; the model simply re-reasons.
+        ``store=False`` keeps analysed source off OpenAI's servers.
+
+        LATENT TRAP: the reasoning-pairing enforcement is *id-keyed*. Do NOT start
+        echoing the server ``fc_...``/``id`` on re-sent ``function_call`` items, nor
+        re-send ``rs_...`` reasoning items under ``store=False`` without
+        ``include=["reasoning.encrypted_content"]`` — either makes every follow-up
+        turn 400 ("function_call provided without its required reasoning item").
+        Proper reasoning threading needs encrypted_content + a reasoning block in
+        the unified types + the agent.py echo — a deliberate, wider change.
         """
         request: dict[str, Any] = {
             "model": model,

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -126,12 +126,24 @@ def _is_gpt5_responses_family(bare: str) -> bool:
     served on Chat Completions (like ``gpt-4o-search-preview``). Via the tail
     anchor on ``_RESPONSES_MODEL_RE`` it also does not match unrelated numbering
     like ``gpt-50``. ``bare`` must already be lower-cased, proxy-prefix stripped,
-    and whitespace-trimmed. NOTE: the token-param OpenAI expects for these
-    non-reasoning variants on Chat Completions (``max_tokens`` vs
-    ``max_completion_tokens``) is a separate, pre-existing question left to the
-    unchanged chat path — a bad choice fails loud at ``validate()``, not silently.
+    and whitespace-trimmed. This is the ENDPOINT decision only; the token-param /
+    role class — which the ``-chat`` variants share but the ``-search`` variants
+    don't — is ``_is_gpt5_completion_token_family``.
     """
     return bool(_RESPONSES_MODEL_RE.match(bare)) and "-chat" not in bare and "-search" not in bare
+
+
+def _is_gpt5_completion_token_family(bare: str) -> bool:
+    """True for gpt-5..gpt-9 ids that take ``max_completion_tokens`` + the
+    ``developer`` role on Chat Completions — the whole generation EXCEPT the
+    ``-search`` variants, which take ``max_tokens`` + ``system`` like
+    ``gpt-4o-search-preview``. Live-verified: ``gpt-5.2-chat-latest`` rejects
+    ``max_tokens`` (needs ``max_completion_tokens``) while ``gpt-5-search-api``
+    accepts ``max_tokens``. Decoupled from the ENDPOINT decision
+    (``_is_gpt5_responses_family``): a ``-chat`` id is chat-endpoint yet still
+    completion-token-class. ``bare`` must be lower-cased, proxy-stripped, trimmed.
+    """
+    return bool(_RESPONSES_MODEL_RE.match(bare)) and "-search" not in bare
 
 # Track finish_reasons we've already warned about. Per-process, lock-guarded.
 _warned_finish_reasons: set[str] = set()
@@ -152,13 +164,15 @@ def _is_reasoning_model(model: str) -> bool:
     the latter is reasoning-class too, so a gpt-5 forced onto the chat path
     (``use_responses_api=False``) gets the right per-request shape instead of
     a 400. This unions ``_REASONING_MODEL_RE`` (o-series) with
-    ``_is_gpt5_responses_family`` (gpt-5+, excluding the non-reasoning chat
-    variants) so the endpoint decision and the token-param/role decisions can
-    never disagree. Strips any proxy prefix (``openai/o1`` → ``o1``) and
-    surrounding whitespace. ``gpt-4o`` and ``gpt-5-chat`` are NOT reasoning models.
+    ``_is_gpt5_completion_token_family`` (the gpt-5+ generation minus the
+    ``-search`` variants) — the token-param/role class, which is BROADER than the
+    responses-ENDPOINT class (``_is_gpt5_responses_family``): a gpt-5 ``-chat``
+    variant is served on Chat Completions but still needs ``max_completion_tokens``
+    there. Strips any proxy prefix (``openai/o1`` → ``o1``) and surrounding
+    whitespace. ``gpt-4o`` and the ``-search`` variants are NOT completion-token-class.
     """
     bare = model.lower().rsplit("/", 1)[-1].strip()
-    return bool(_REASONING_MODEL_RE.match(bare) or _is_gpt5_responses_family(bare))
+    return bool(_REASONING_MODEL_RE.match(bare) or _is_gpt5_completion_token_family(bare))
 
 
 def _token_param(model: str) -> str:


### PR DESCRIPTION
## What

Add the OpenAI `/v1/responses` path for gpt-5 models to the LLM adapter, plus hardening fixes on that new path found in a follow-up bug hunt — several settled against the live gpt-5 API.

## Why

gpt-5-generation models reject `tools` + `reasoning` on `/v1/chat/completions`, which the agentic-enhance and attacker-sim verify phases need — so the adapter routes `^gpt-[5-9]` to `/v1/responses` (`_complete_responses`) while gpt-4o and the o-series stay on the unchanged chat path. The four follow-up fixes close correctness gaps on that path; the most consequential is a reliability issue specific to a SAST tool — a truncated or abnormal model response could read to the pipeline as a clean, finding-free verdict.

## How

Feature (commit `79fb6e0`):
- `_complete_responses` + `_responses_to_unified` Message↔responses-item translation, `store=False`, a reasoning-aware output-token floor, and a status-before-content parser so a failed/cancelled/content-filtered response raises a typed error instead of an empty pass.
- Union `_is_reasoning_model` with `^gpt-[5-9]` so the endpoint choice and the token-param/role choice cannot disagree.
- Dependency bump in `pyproject.toml` (the `openai` SDK version that ships the Responses API).

Hardening (this branch — all confined to `utilities/llm/providers/openai.py` plus its tests):
- `664a9a9` — in `_responses_to_unified`, an abnormal status / unknown incomplete-reason carrying partial content is relabelled `stop_reason="max_tokens"` and warned once (`_warn_unknown_responses_status`), instead of a silent `end_turn`. Mirrors the chat path's unknown-`finish_reason` warning.
- `b6eab1f` — `validate()` pings with the same `reasoning={"effort": …}` the scan will send, so a model-rejected effort fails at init instead of 400-ing every unit.
- `457d0b5` — `_is_gpt5_responses_family` (`^gpt-[5-9]([.-]|$)` and no `-chat`), used by both `_use_responses_api` and `_is_reasoning_model`, so the non-reasoning `gpt-5-chat`/`gpt-5-chat-latest` no longer route to responses+reasoning, `gpt-50` is not the family, and ids are trimmed. Coupling invariant preserved.
- `9d5f405` — corrects the `_complete_responses` docstring: reasoning items *are* emitted and deliberately dropped; the loop survives because function_calls are re-sent with `call_id` only, never the server `fc_` item id. Adds a latent-trap note.
- `d6e178a` — extends the non-reasoning exclusion from `-chat` to `-chat`+`-search`, so `gpt-5-search-api` (a web-search model served on Chat Completions, like `gpt-4o-search-preview`) is no longer swept onto responses+reasoning. Reasoning ids are guarded by a companion test.
- `270fd9c` — decouples the endpoint decision from the token-param/role decision (superseding part of `457d0b5`): `_is_gpt5_responses_family` stays the endpoint class (chat for `-chat`/`-search`), and a new `_is_gpt5_completion_token_family` drives the token-param — the whole gpt-5 generation *except* `-search`. **Live-verified against the real API:** `gpt-5.2-chat-latest` rejects `max_tokens` and needs `max_completion_tokens`; `gpt-5-search-api` accepts `max_tokens`. Net: `-chat` → chat + `max_completion_tokens`, `-search` → chat + `max_tokens`.
- `82ed244` — the chat-path analog of `664a9a9`: `_response_to_unified` defaulted an *unknown* `finish_reason` to `stop_reason="end_turn"`; it now defaults to `"max_tokens"` so a proxy/future-value truncation on the chat path isn't laundered into a clean completion. Known reasons (stop/tool_calls/length/content_filter) are unchanged.

## Tests

```
# adapter file
pytest -q tests/test_llm_openai_adapter.py | tail -1   ->  71 passed   (was 60; grep -c "def test_" = 45)
# wider llm + agent suite
pytest -q tests/ -k "llm or openai or provider or adapter or agent" | tail -1  ->  409 passed, 4 skipped, 0 failed
# full suite (whole module) green in CI on macos/ubuntu/windows (the only local reds are a zig-parser subprocess PYTHONPATH quirk, absent in CI; 0 parser files in this diff)
```

Each behavioral fix has a git-history red/green receipt (`/rebugz`). Additionally, the adapter was **run end-to-end against the real gpt-5 API** through openant's own config→registry path: `gpt-5-nano` (responses), `gpt-5.2-chat-latest` (chat + `max_completion_tokens`), and `gpt-5-search-api` (chat + `max_tokens`) all return valid completions; the abnormal-status and reasoning-drop behaviors were confirmed on the live API.

## Compatibility

No breaking change; gpt-4o and the o-series paths are untouched (verified by the existing gate/coupling tests, still green).

**Reachability — this path is dormant in shipped config.** No `gpt-5` id is registered (`config/` + `utilities/model_config.py` carry only gpt-4o/4.1/o1/o3/o4), and `build_adapter` in `utilities/llm/registry.py` passes only `api_key`+`base_url`, so the new `use_responses_api`/`reasoning_effort` ctor args are not settable from config (effort is env-only, default `"medium"`). This PR hardens a path nothing in shipped config reaches yet — it activates only when an operator registers a gpt-5 id or points a `base_url` proxy at one. Registering a gpt-5 model is intentionally out of scope here. (The path itself is proven working: the adapter was run end-to-end against the real gpt-5 API — see Tests — so the dormancy is purely a config choice, not an untested path.)

## Author notes

- Q1 (which code implements it): feature in `_complete_responses` + `_responses_to_unified`; the fixes in `_responses_to_unified` (abnormal-status branch), `validate()` (reasoning ping), the routing predicates (`_is_gpt5_responses_family` for the endpoint + `_is_gpt5_completion_token_family` for the token-param), and the `_complete_responses` docstring.
- Q2 (concrete input previously handled wrong): a Responses object `status="incomplete"`, `incomplete_details.reason=None`, output `[message: "…no issues fou"]` returned `stop_reason="end_turn"` (a clean verdict) before `664a9a9`; it now returns `max_tokens` + a stderr warning. Reproduced first-hand and as a regression test.
- Q3 (likely reviewer pushback + answer): "these paths aren't reachable yet, why fix them?" — the fixes are cheap, single-file, and land before gpt-5 is ever enabled; the abnormal-status one is the silent-false-negative class a SAST tool must not ship. The one deeper item is out of scope (below).

## Follow-ups

- **Verify-stage `stop_reason` gating (stacked PR).** `finding_verifier.py` accepts a `finish` tool block regardless of `stop_reason`, so a `max_tokens`-truncated reply carrying a well-formed `finish(agree=false, "safe")` could be read as a completed verdict (a narrow silent-FN; malformed-mid-JSON truncation is already caught). BUG-7 makes the adapter report truncation honestly; the verifier must then gate finish-acceptance on `stop_reason != "max_tokens"` (+ a missing `record_call` on one cost-undercount path at `finding_verifier.py:425-432`). Different subsystem than this adapter PR → stacked follow-up.

Resolved during review (were open questions, now settled): the dropped-reasoning-item concern is **live-confirmed benign** (3/3 on gpt-5-nano — the stateless replay re-sends `function_call` by `call_id`, which the API accepts; docstring corrected in `9d5f405`), and the non-reasoning-variant token-param is **live-verified and fixed** (`270fd9c`). (The enhancer degenerate-exit handling was checked and already classifies these as `INCOMPLETE` — no change needed there.)
