### PR TITLE
fix(openai): raise on empty chat completion instead of clean end_turn

### DIFF
--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -172,6 +172,23 @@ def test_empty_choices_raises_llm_response_error():
         adapter.complete(model="gpt-4o", system=None, messages=_hi(), max_tokens=8)
 
 
+def test_empty_content_raises_llm_response_error():
+    # A choice with neither text nor tool calls is an empty completion: it must
+    # surface via the taxonomy, not read as a clean end_turn. Parity with the
+    # Responses path's no-usable-content guard and the Anthropic/Gemini adapters
+    # -- for a security tool an empty end_turn would read as a clean pass.
+    empty = SimpleNamespace(
+        choices=[SimpleNamespace(
+            message=SimpleNamespace(content=None, tool_calls=None),
+            finish_reason="stop",
+        )],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=0),
+    )
+    adapter, _ = _stub(lambda **kw: empty)
+    with pytest.raises(LLMResponseError):
+        adapter.complete(model="gpt-4o", system=None, messages=_hi(), max_tokens=8)
+
+
 # ---------------------------------------------------------------------------
 # L3 — pricing table carries current models so they don't report $0
 # ---------------------------------------------------------------------------

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -797,6 +797,20 @@ def _response_to_unified(response: Any) -> CompletionResult:
             "or truncated by the moderation layer"
         )
 
+    # An empty completion -- no text AND no tool calls (``message.content`` is
+    # None/empty with no ``tool_calls``) -- carries nothing the pipeline can act
+    # on. Surface it via the taxonomy instead of returning an empty end_turn
+    # (mirrors the Responses path's no-usable-content guard and the Anthropic/
+    # Gemini adapters); for a SECURITY tool an empty end_turn would read as a
+    # clean, passing result. A tool-use-only response is VALID and not caught
+    # here because ``content_blocks`` is non-empty. Refusal/content_filter is the
+    # more specific signal and already raised above.
+    if not content_blocks:
+        raise LLMResponseError(
+            "OpenAI returned an empty completion (no text or tool calls); the "
+            "request may have been filtered or the response was malformed"
+        )
+
     if raw_finish not in _OPENAI_FINISH_REASONS:
         should_warn = False
         with _warned_finish_reasons_lock:


### PR DESCRIPTION
## Root cause
The OpenAI Chat Completions translation (`_response_to_unified` in `utilities/llm/providers/openai.py`) guarded an empty `choices` array but not an empty *message*. A choice whose `message.content` is `None`/empty with no `tool_calls` fell through to a clean `end_turn` carrying zero content blocks. For a security tool, an empty `end_turn` is read as a clean, passing verdict — so a blank completion became a silent false-negative.

This is the same silent-empty-completion shape #207 closed across the other paths, but the chat path never had the guard (it predates #207, which never touched `openai.py`). The three sibling paths already raise on empty content:
- Responses path — `openai.py` `_responses_to_unified` "no usable content" guard
- Anthropic adapter — R4-1 empty-completion guard
- Gemini adapter — empty-`candidates` guard

## Fix
Add the missing no-usable-content guard to the chat path, mirroring the siblings: after the `content_filter` refusal check (the more specific signal, raised first), `if not content_blocks: raise LLMResponseError(...)`. A tool-use-only response stays valid because `content_blocks` is non-empty.

## Reproduction
A `ChatCompletion` with one choice, `message.content=None`, `tool_calls=None`, `finish_reason="stop"`.

## Regression test
`tests/test_llm_openai_adapter.py::test_empty_content_raises_llm_response_error` — sibling of the existing `test_empty_choices_raises_llm_response_error`.

```
# RED (before fix):
FAILED tests/test_llm_openai_adapter.py::test_empty_content_raises_llm_response_error
# GREEN (after fix):
72 passed
# Full suite unchanged otherwise:
2413 passed, 149 skipped, 0 failed   (baseline 2412; +1 = this test)
```

## Compatibility
No API/signature change. Behavior change is narrow: a chat response with neither text nor tool calls now raises `LLMResponseError` instead of returning an empty `end_turn`. Tool-use-only and normal text responses are unaffected; refusal/`content_filter` still raises first.

Surfaced by a post-merge collision review of #206/#207 (this gap is pre-existing, not introduced by either).
