### PR TITLE
fix(verifier): surface self-contradictory finish instead of dropping the vuln

### DIFF
--- a/libs/openant-core/tests/test_famreport2_agree_contradiction.py
+++ b/libs/openant-core/tests/test_famreport2_agree_contradiction.py
@@ -1,0 +1,118 @@
+"""FAM-REPORT-2 (trace c938311d): a self-contradictory verifier finish must not
+silently drop a vuln.
+
+The `finish` tool schema declares `agree` and `correct_finding` as independent
+fields (no cross-field constraint), so a model can emit `agree=True` (claims to
+agree with Stage-1) while `correct_finding` diverges from the Stage-1 verdict.
+Pre-fix, `_parse_finish_result` took `agree` verbatim and both write-back
+consumers (`finding_verifier._verify_one`, `experiment.py`) only propagate
+`correct_finding` on the disagree branch — so an UPGRADE contradiction
+(stage1=safe, correct_finding=vulnerable) left `result["finding"]="safe"` and the
+vuln was dropped by the reporter's disclosure filter (core/reporter.py:283).
+
+Fix (chokepoint `_parse_finish_result`): on a contradiction — `agree=True` AND
+`correct_finding != Stage-1` — treat it as a disagreement toward the MORE-SEVERE
+verdict and flag `incomplete=True`, so the finding surfaces as "unverified"
+(needs manual review) instead of a clean "agreed" that can be dropped. A single
+fix at the shared producer covers both consumers.
+
+Offline; no network. Pure `_parse_finish_result` translation + a verbatim copy of
+the reporter's disclosure predicate for the end-to-end impact check.
+"""
+from __future__ import annotations
+
+from utilities.finding_verifier import FindingVerifier
+
+
+def _parse(finish_args: dict, stage1: str):
+    # _parse_finish_result references no `self.*` — unbound-safe via __new__.
+    v = FindingVerifier.__new__(FindingVerifier)
+    return v._parse_finish_result(finish_args, stage1, 1, 10)
+
+
+def _reporter_discloses(result: dict) -> bool:
+    # Verbatim copy of core/reporter.py:283 disclosure predicate.
+    return str(result.get("finding") or result.get("verdict", "")).lower() in ("vulnerable", "bypassable")
+
+
+def _writeback(result: dict, vr) -> None:
+    # Mirror of the consumer write-back branch (_verify_one:728-736 /
+    # experiment.py:590-596): correct_finding propagates on the disagree branch.
+    if vr.agree:
+        pass
+    else:
+        result["finding"] = vr.correct_finding
+
+
+# --- RED: the FN (upgrade contradiction, reachable via experiment.py --verify) ---
+
+def test_upgrade_contradiction_is_flagged_not_clean_agreement():
+    # agree=True but correct_finding upgrades safe -> vulnerable: a self-
+    # contradiction, must NOT read as a clean completed agreement.
+    vr = _parse({"agree": True, "correct_finding": "vulnerable", "explanation": "x"}, "safe")
+    assert vr.incomplete is True          # surfaced as needs-review, not clean
+    assert vr.agree is False              # so consumers propagate the verdict
+    assert vr.correct_finding == "vulnerable"   # the more-severe reading is kept
+
+
+def test_upgrade_contradiction_end_to_end_not_dropped():
+    # Impact repro: after the consumer write-back + reporter filter, the vuln
+    # carried only in correct_finding must reach disclosure (not be dropped).
+    result = {"finding": "safe"}
+    vr = _parse({"agree": True, "correct_finding": "vulnerable", "explanation": "x"}, "safe")
+    _writeback(result, vr)
+    assert _reporter_discloses(result) is True
+
+
+# --- RED: downgrade contradiction (production relabel; more-severe preserved) ---
+
+def test_downgrade_contradiction_preserves_severe_and_flags():
+    # agree=True but correct_finding downgrades vulnerable -> safe: keep the
+    # more-severe (vulnerable) reading and flag incomplete (needs review).
+    vr = _parse({"agree": True, "correct_finding": "safe", "explanation": "x"}, "vulnerable")
+    assert vr.incomplete is True
+    assert vr.agree is False
+    assert vr.correct_finding == "vulnerable"
+
+
+def test_downgrade_contradiction_still_surfaced():
+    result = {"finding": "vulnerable"}
+    vr = _parse({"agree": True, "correct_finding": "safe", "explanation": "x"}, "vulnerable")
+    _writeback(result, vr)
+    assert _reporter_discloses(result) is True   # stays surfaced, not downgraded to safe
+
+
+# --- edge: contradiction between two non-vuln verdicts must not fabricate a vuln ---
+
+def test_nonvuln_contradiction_flags_but_no_vuln_fabricated():
+    vr = _parse({"agree": True, "correct_finding": "protected", "explanation": "x"}, "safe")
+    assert vr.incomplete is True
+    assert vr.agree is False
+    assert vr.correct_finding == "protected"     # more severe of {safe, protected}
+    result = {"finding": "safe"}
+    _writeback(result, vr)
+    assert _reporter_discloses(result) is False  # neither side vulnerable -> not disclosed
+
+
+# --- regression guards: normal (non-contradictory) paths must be UNCHANGED ---
+
+def test_normal_agreement_unchanged():
+    # agree=True and correct_finding matches Stage-1 -> a real, clean agreement.
+    vr = _parse({"agree": True, "correct_finding": "vulnerable", "explanation": "x"}, "vulnerable")
+    assert vr.agree is True
+    assert vr.incomplete is False
+    assert vr.correct_finding == "vulnerable"
+
+
+def test_normal_disagreement_unchanged():
+    vr = _parse({"agree": False, "correct_finding": "safe", "explanation": "x"}, "vulnerable")
+    assert vr.agree is False
+    assert vr.incomplete is False
+    assert vr.correct_finding == "safe"
+
+
+def test_missing_agree_still_incomplete():
+    # The pre-existing F4/F5 degenerate path (absent `agree`) stays incomplete.
+    vr = _parse({"correct_finding": "vulnerable", "explanation": "x"}, "safe")
+    assert vr.agree is False
+    assert vr.incomplete is True

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -61,6 +61,7 @@ from prompts.verification_prompts import (
     get_verification_system_prompt,
     get_consistency_check_prompt
 )
+from core.verdict_taxonomy import FINDING_VERDICT_ORDER
 
 # Import application context type for type hints
 try:
@@ -211,6 +212,17 @@ def _resolve_stage1_finding(result: dict) -> str:
     ``inconclusive`` and dropped from the report.
     """
     return str(result.get("finding") or result.get("verdict") or "inconclusive").lower()
+
+
+def _more_severe(a: str, b: str) -> str:
+    """Return the more-severe of two verdicts per FINDING_VERDICT_ORDER
+    (index 0 = most severe). An unknown verdict ranks least-severe. Used to pick
+    the surfacing verdict on a self-contradictory finish so a vuln on EITHER side
+    is not dropped (FAM-REPORT-2)."""
+    def _rank(v: str) -> int:
+        v = str(v or "").strip().lower()
+        return FINDING_VERDICT_ORDER.index(v) if v in FINDING_VERDICT_ORDER else len(FINDING_VERDICT_ORDER)
+    return a if _rank(a) <= _rank(b) else b
 
 
 @dataclass
@@ -1069,15 +1081,38 @@ class FindingVerifier:
         # carry `agree` (True or False) is a real, completed verdict and stays
         # incomplete=False.
         agree_missing = "agree" not in finish_result
+        agree = finish_result.get("agree", False)
+        correct_finding = finish_result.get("correct_finding", original_finding)
+        incomplete = agree_missing
+
+        # FAM-REPORT-2: a self-contradictory finish — `agree=True` (claims to
+        # agree with Stage-1) while `correct_finding` diverges from the Stage-1
+        # verdict — is NOT a clean agreement. The `finish` schema declares the
+        # two fields independently (no cross-field constraint), so a model can
+        # emit it. Reading it as agreed leaves result["finding"] at the Stage-1
+        # verdict (the write-back consumers only propagate correct_finding on the
+        # disagree branch), so an UPGRADE contradiction (stage1=safe,
+        # correct_finding=vulnerable) silently DROPS the vuln at the reporter's
+        # disclosure filter. Surface it: treat as a disagreement toward the
+        # MORE-SEVERE verdict (so a vuln on either side is never dropped, and a
+        # downgrade cannot silence a real Stage-1 vuln) and flag incomplete so
+        # the reporter renders "unverified" (needs manual review), not "agreed".
+        # Mirrors this file's R4-7 fail-safe philosophy (abnormal signal ->
+        # surface, don't silently resolve).
+        if agree and str(correct_finding or "").strip().lower() != str(original_finding or "").strip().lower():
+            correct_finding = _more_severe(original_finding, correct_finding)
+            agree = False
+            incomplete = True
+
         return VerificationResult(
-            agree=finish_result.get("agree", False),
-            correct_finding=finish_result.get("correct_finding", original_finding),
+            agree=agree,
+            correct_finding=correct_finding,
             explanation=finish_result.get("explanation", ""),
             iterations=iterations,
             total_tokens=total_tokens,
             exploit_path=exploit_path,
             security_weakness=finish_result.get("security_weakness"),
-            incomplete=agree_missing,
+            incomplete=incomplete,
         )
 
     def _try_parse_text_response(


### PR DESCRIPTION
## What

Surface a self-contradictory Stage-2 verifier `finish` instead of silently dropping the finding it carries.

## Why

The verifier's `finish` tool schema declares `agree` and `correct_finding` as independent required fields with no cross-field constraint (`utilities/finding_verifier.py:153-199`), so a model can return `agree=True` (claims to agree with the Stage-1 verdict) while `correct_finding` names a different verdict. `_parse_finish_result` took `agree` verbatim, and the two write-back consumers (`_verify_one:740`, `experiment.py:590`) only copy `correct_finding` into `result["finding"]` on the `agree==False` branch. So an upgrade contradiction — Stage-1 `safe`, `correct_finding=vulnerable` — left `result["finding"]="safe"`, and the reporter's disclosure filter (`core/reporter.py:283`, which selects on `finding in ("vulnerable","bypassable")`) dropped the vulnerable finding from the report.

The drop is reachable via the `experiment.py --verify` flow, which verifies every Stage-1 result (`experiment.py:551-552`). The production scanner path pre-filters to vulnerable/bypassable before verification (`core/verifier.py:101-105`), so on that path a downgrade contradiction conservatively keeps the vulnerable finding surfaced.

## How

- `utilities/finding_verifier.py::_parse_finish_result`: on a contradiction (`agree==True` and `correct_finding != Stage-1`), take the more-severe of the two verdicts, set `agree=False` and `incomplete=True`, then return that. The reporter renders it as `unverified` (needs manual review) rather than a droppable `agreed`.
- `_more_severe` helper ranks by the existing `FINDING_VERDICT_ORDER` (`core/verdict_taxonomy.py:32`), so a vulnerable reading on either side is kept and a downgrade cannot silence a real Stage-1 verdict.
- One edit at the shared chokepoint covers both consumers: `_verify_one` and `experiment.py` both reach `_parse_finish_result` via `verify_result`. Mirrors the file's existing degenerate-path fail-safe (which also returns `agree=False` + `incomplete=True`).

Observed: a contradictory finish now increments the `needs_review` bucket (`core/verifier.py:280`) and renders `stage2_verdict="unverified"` (`core/reporter.py:390`) instead of vanishing.

## Tests

`tests/test_famreport2_agree_contradiction.py` (8 tests): both contradiction directions, both consumers (via a mirror of the write-back branch + the verbatim reporter filter), a non-vuln-vs-non-vuln edge, and 3 regression guards for normal agree/disagree/missing-agree.

```
# RED on the pre-fix commit (fad4b01), proof test applied:
$ pytest tests/test_famreport2_agree_contradiction.py -q
4 failed, 4 passed          # the 4 contradiction tests fail: VerificationResult(agree=True, incomplete=False)

# GREEN on this commit:
$ pytest tests/test_famreport2_agree_contradiction.py -q
8 passed in 0.03s

# full suite on this branch:
$ pytest tests/ -q
2540 passed, 28 skipped     # 2 pre-existing tests/parsers/zig/ failures are unrelated (fail with this fix reverted)
```

## Compatibility

Behavior change on the production path only for a self-contradictory finish: a finding previously labeled `agreed`/`confirmed` despite the model contradicting itself now renders `unverified` (needs review). It stays surfaced either way. No API, schema, or signature changes. No changes to core/parsers/reachability.

## Author notes

- **Q1 — which lines implement the fix?** `utilities/finding_verifier.py` `_parse_finish_result`: the `if agree and correct_finding != original_finding:` block (sets `correct_finding = _more_severe(...)`, `agree=False`, `incomplete=True`) plus the `_more_severe` helper and the `FINDING_VERDICT_ORDER` import.
- **Q2 — one concrete input handled wrong before, right now?** `finish(agree=True, correct_finding="vulnerable")` over a Stage-1 `safe` finding: before, `result["finding"]` stayed `"safe"` and the reporter dropped it; now `result["finding"]` becomes `"vulnerable"` with `incomplete=True`, so it appears as an unverified finding for review.
- **Q3 — likely reviewer pushback + answer?** "Why not copy `correct_finding` on `agree==True` too?" Because that would override `agree` with `correct_finding` on every normal turn; the contradiction path is the only place the two disagree, and there the safe move is to surface for review, not to silently pick a side.
