### PR TITLE
fix(rust): seed libFuzzer fuzz_target! harnesses as reachability entry points

### DIFF
--- a/apps/openant-cli/cmd/parse.go
+++ b/apps/openant-cli/cmd/parse.go
@@ -24,13 +24,13 @@ If no repository path is given, the active project is used (see: openant init).`
 }
 
 var (
-	parseOutput    string
-	parseLanguage  string
-	parseLevel     string
-	parseDiffBase  string
-	parsePR        int
-	parseDiffScope string
-	parseFresh     bool
+	parseOutput      string
+	parseLanguage    string
+	parseLevel       string
+	parseDiffBase    string
+	parsePR          int
+	parseDiffScope   string
+	parseFresh       bool
 	parseLibraryMode bool
 )
 

--- a/apps/openant-cli/cmd/parse.go
+++ b/apps/openant-cli/cmd/parse.go
@@ -31,6 +31,7 @@ var (
 	parsePR        int
 	parseDiffScope string
 	parseFresh     bool
+	parseLibraryMode bool
 )
 
 func init() {
@@ -41,12 +42,13 @@ func init() {
 	parseCmd.Flags().IntVar(&parsePR, "pr", 0, "Incremental mode against a GitHub PR number (mutex with --diff-base)")
 	parseCmd.Flags().StringVar(&parseDiffScope, "diff-scope", "changed_functions", "Diff scope: changed_files, changed_functions, callers")
 	parseCmd.Flags().BoolVar(&parseFresh, "fresh", false, "Delete existing dataset.json and reparse from scratch (other artifacts preserved)")
+	parseCmd.Flags().BoolVar(&parseLibraryMode, "library-mode", false, "Seed the exported public API as reachability entry points, for a library whose public API is being dropped by the structural filter. Blunt: keeps most units — prefer letting fuzz/bin/route entry points seed reachability first.")
 }
 
 // buildParsePyArgs constructs the argv passed to the Python parse subcommand.
 // Extracted so tests can verify pass-through behavior without invoking the
 // full Python runtime.
-func buildParsePyArgs(repoPath, outputDir, datasetName, language, level, manifestPath string, fresh bool) []string {
+func buildParsePyArgs(repoPath, outputDir, datasetName, language, level, manifestPath string, fresh, libraryMode bool) []string {
 	pyArgs := []string{"parse", repoPath, "--output", outputDir}
 	if datasetName != "" {
 		pyArgs = append(pyArgs, "--name", datasetName)
@@ -62,6 +64,9 @@ func buildParsePyArgs(repoPath, outputDir, datasetName, language, level, manifes
 	}
 	if fresh {
 		pyArgs = append(pyArgs, "--fresh")
+	}
+	if libraryMode {
+		pyArgs = append(pyArgs, "--library-mode")
 	}
 	return pyArgs
 }
@@ -118,7 +123,7 @@ func runParse(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	pyArgs := buildParsePyArgs(repoPath, parseOutput, datasetName, parseLanguage, parseLevel, manifestPath, parseFresh)
+	pyArgs := buildParsePyArgs(repoPath, parseOutput, datasetName, parseLanguage, parseLevel, manifestPath, parseFresh, parseLibraryMode)
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, resolvedAPIKey())
 	if err != nil {

--- a/apps/openant-cli/cmd/parse_test.go
+++ b/apps/openant-cli/cmd/parse_test.go
@@ -46,7 +46,7 @@ func TestBuildParsePyArgsLevelForwarding(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			args := buildParsePyArgs("/repo", "/out", "", "auto", tc.level, "", false)
+			args := buildParsePyArgs("/repo", "/out", "", "auto", tc.level, "", false, false)
 			gotLevel, gotValue := findFlag(args, "--level")
 			if gotLevel != tc.wantLevel {
 				t.Errorf("--level present = %v, want %v (argv=%v)", gotLevel, tc.wantLevel, args)
@@ -59,7 +59,7 @@ func TestBuildParsePyArgsLevelForwarding(t *testing.T) {
 }
 
 func TestBuildParsePyArgsBaseline(t *testing.T) {
-	args := buildParsePyArgs("/repo", "/out", "org-repo-abc1234", "python", "exploitable", "/tmp/manifest.json", false)
+	args := buildParsePyArgs("/repo", "/out", "org-repo-abc1234", "python", "exploitable", "/tmp/manifest.json", false, false)
 	want := []string{
 		"parse", "/repo",
 		"--output", "/out",
@@ -132,7 +132,7 @@ func TestParseCmdFreshFlagParses(t *testing.T) {
 }
 
 func TestParsePyArgsIncludesFreshWhenSet(t *testing.T) {
-	args := buildParsePyArgs("/some/repo", "/out", "", "auto", "reachable", "", true)
+	args := buildParsePyArgs("/some/repo", "/out", "", "auto", "reachable", "", true, false)
 
 	found, _ := findFlag(args, "--fresh")
 	if !found {
@@ -141,11 +141,22 @@ func TestParsePyArgsIncludesFreshWhenSet(t *testing.T) {
 }
 
 func TestParsePyArgsOmitsFreshWhenUnset(t *testing.T) {
-	args := buildParsePyArgs("/some/repo", "/out", "", "auto", "reachable", "", false)
+	args := buildParsePyArgs("/some/repo", "/out", "", "auto", "reachable", "", false, false)
 
 	found, _ := findFlag(args, "--fresh")
 	if found {
 		t.Errorf("did not expect --fresh in pyArgs when fresh=false, got %v", args)
+	}
+}
+
+func TestParsePyArgsLibraryModeForwarding(t *testing.T) {
+	on := buildParsePyArgs("/some/repo", "/out", "", "auto", "reachable", "", false, true)
+	if found, _ := findFlag(on, "--library-mode"); !found {
+		t.Errorf("expected --library-mode in pyArgs when libraryMode=true, got %v", on)
+	}
+	off := buildParsePyArgs("/some/repo", "/out", "", "auto", "reachable", "", false, false)
+	if found, _ := findFlag(off, "--library-mode"); found {
+		t.Errorf("did not expect --library-mode when libraryMode=false, got %v", off)
 	}
 }
 func TestParseCmdIsRegisteredOnRoot(t *testing.T) {

--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -54,6 +54,7 @@ var (
 	scanDiffScope                   string
 	scanLLMReachability             bool
 	scanLLMReachabilityMaxCodeBytes int
+	scanLibraryMode                 bool
 )
 
 func init() {
@@ -84,6 +85,7 @@ func registerScanFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&scanDiffScope, "diff-scope", "changed_functions", "Diff scope: changed_files, changed_functions, callers")
 	cmd.Flags().BoolVar(&scanLLMReachability, "llm-reachability", false, "Enable the LLM reachability review stage (Opus). Surfaces entry points and external-input sites the structural pass would miss by reviewing the full codebase before the reachability filter is applied. Off by default — enabling this incurs cost proportional to total repo size, not the filtered unit count (~one Opus call per 25 units across the whole codebase).")
 	cmd.Flags().IntVar(&scanLLMReachabilityMaxCodeBytes, "llm-reachability-max-code-bytes", 1500, "Max code bytes per unit sent to the LLM reachability stage (default: 1500). Higher values (e.g. 4096, 8192) catch entry-point indicators past byte 1500 in long handlers / generated code, at proportional Opus cost increase. Only meaningful with --llm-reachability.")
+	cmd.Flags().BoolVar(&scanLibraryMode, "library-mode", false, "Seed the exported public API as reachability entry points, for a library whose public API is being dropped by the structural filter. Blunt: keeps most units — prefer letting fuzz/bin/route entry points seed reachability first.")
 }
 
 func runScan(cmd *cobra.Command, args []string) {
@@ -204,6 +206,9 @@ func runScan(cmd *cobra.Command, args []string) {
 	}
 	if scanLLMReachability {
 		pyArgs = append(pyArgs, "--llm-reachability")
+	}
+	if scanLibraryMode {
+		pyArgs = append(pyArgs, "--library-mode")
 	}
 	if scanLLMReachabilityMaxCodeBytes != 1500 {
 		pyArgs = append(pyArgs, "--llm-reachability-max-code-bytes", fmt.Sprintf("%d", scanLLMReachabilityMaxCodeBytes))

--- a/libs/openant-core/parsers/rust/call_graph_builder.py
+++ b/libs/openant-core/parsers/rust/call_graph_builder.py
@@ -1164,7 +1164,15 @@ class CallGraphBuilder:
             return same_file
         if len(candidates) == 1:
             return candidates
-        return []
+        # The qualifier bound nothing in Steps 1-3 and the raw leaf is ambiguous.
+        # Fall back to exactly what a bare `leaf(` call resolves to (free-function
+        # filter + import/external handling) -- this is what the pre-scoped-recovery
+        # bare capture produced, so macro scoped-call recovery stays strictly
+        # ADD-ONLY and never drops an edge the bare path would have kept (e.g. a
+        # leaf shared by a free fn and a method: raw count == 2 here, but the bare
+        # resolver picks the unique FREE function). Purely additive: only reached
+        # when the raw fallback above would have returned [].
+        return self._resolve_bare(leaf, caller_file, name_to_ids)
 
     def _mod_target_files(self, mod_name: str, caller_file: str) -> Set[str]:
         """Candidate file paths a `mod <mod_name>;` declaration could map to.

--- a/libs/openant-core/parsers/rust/call_graph_builder.py
+++ b/libs/openant-core/parsers/rust/call_graph_builder.py
@@ -419,9 +419,10 @@ class CallGraphBuilder:
         invisible to the AST walk above. For a small set of well-known
         macros whose arguments are ordinary expressions (format/print/assert/
         vec/...), regex-recover call-shaped identifiers from the raw token
-        text. This can only find bare/dotted names -- it cannot see argument
-        structure -- so results feed the same bare/field resolution paths
-        with a conservative shape.
+        text. It recovers bare, dotted, and scoped (`Type::method`) call names
+        -- it cannot see argument structure -- so results feed the same
+        bare/field/scoped resolution paths as the AST walk, with a conservative
+        shape.
         """
         macro_name = None
         token_tree = None

--- a/libs/openant-core/parsers/rust/call_graph_builder.py
+++ b/libs/openant-core/parsers/rust/call_graph_builder.py
@@ -49,10 +49,23 @@ _SCANNABLE_MACROS = {
 }
 
 # A conservative call-shaped pattern used ONLY inside macro token trees
-# (real code is parsed by the grammar and does not need this). Matches
-# `name(` and `recv.name(` / `recv.name::<T>(`.
+# (real code is parsed by the grammar and does not need this). Matches, in
+# alternation order:
+#   `A::B::c(`         scoped associated/module call -> emitted as a `scoped`
+#                      site so cross-file `Type::method`/`mod::fn` targets
+#                      resolve (the AST walk gets these for free; the macro
+#                      scanner did not, silently dropping the most common
+#                      fuzz-harness idiom `assert!(Type::method(d))`).
+#   `name(` / `recv.name(` / `recv.name::<T>(`   bare or dotted method chain.
+# Scoped is tried first so `Codec::roundtrip(` binds the qualifier rather than
+# degrading to a bare same-file-only `roundtrip`. A trailing turbofish
+# (`foo::<T>(`) is NOT an identifier after `::`, so it falls through to the
+# bare branch exactly as before (no scoped false-match).
 _MACRO_CALL_RE = re.compile(
-    r"\b([A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s*(?:::<[^>]*>)?\s*\("
+    r"\b("
+    r"(?:[A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*"       # A::B::c (scoped)
+    r"|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*"      # bare / recv.name
+    r")\s*(?:::<[^>]*>)?\s*\("
 )
 
 # String / char literals inside a macro token tree, blanked BEFORE the call-shaped
@@ -424,7 +437,21 @@ class CallGraphBuilder:
         text = _RUST_STR_LITERAL_RE.sub(" ", text)
         for match in _MACRO_CALL_RE.finditer(text):
             call_name = match.group(1)
-            if "." in call_name:
+            if "::" in call_name:
+                # Scoped `A::B::c` -> a `scoped` site with the IMMEDIATE
+                # qualifier (segment just before the leaf), matching the shape
+                # `_split_scoped` produces for an AST scoped_identifier so it
+                # routes through the same `_resolve_scoped` path (associated-fn
+                # via class_name, module via mod-file). Add-only vs the prior
+                # bare capture: a `Type::method(` token that previously yielded
+                # bare `method` (same-file-only) now yields the qualified call.
+                qualifier, leaf = call_name.rsplit("::", 1)
+                immediate = qualifier.rsplit("::", 1)[-1]
+                sites.append({
+                    "kind": "scoped", "qualifier": immediate, "leaf": leaf,
+                    "bare_filter_name": None,
+                })
+            elif "." in call_name:
                 receiver_name, method = call_name.rsplit(".", 1)
                 if receiver_name == "self":
                     sites.append({

--- a/libs/openant-core/parsers/rust/function_extractor.py
+++ b/libs/openant-core/parsers/rust/function_extractor.py
@@ -347,6 +347,19 @@ class FunctionExtractor:
                     pending_attrs = []
                     continue
 
+                # libFuzzer harness: `fuzz_target!(|data| { .. })`. The closure
+                # body is the real program entry point but sits inside an opaque
+                # macro token_tree, so no function_item is emitted and its calls
+                # (e.g. `Frame::decode`) never reach the call graph. Emit a
+                # synthetic entry-point unit carrying the body as ordinary Rust.
+                if t == "macro_invocation" and self._is_fuzz_target_macro(child, source):
+                    self._handle_fuzz_target(
+                        child, source, file_path, functions, classes,
+                        imports_local, cur_ctx, pending_attrs,
+                    )
+                    pending_attrs = []
+                    continue
+
                 # Anything else (block, let_declaration, if_expression,
                 # match_expression, closure_expression, unsafe_block, ...)
                 # may still contain nested fn/impl/struct/mod definitions
@@ -639,6 +652,133 @@ class FunctionExtractor:
                 "in_test_scope": ctx["in_test_scope"] or is_test_attr,
             }
             worklist.append((block, new_ctx))
+
+    _FUZZ_MACRO_NAMES = ("fuzz_target",)
+
+    def _is_fuzz_target_macro(self, node: Node, source: bytes) -> bool:
+        """True if `node` is a `fuzz_target!( .. )` macro invocation (bare or
+        path-qualified, e.g. `libfuzzer_sys::fuzz_target!`)."""
+        for child in node.children:
+            if child.type in ("identifier", "scoped_identifier"):
+                return _text(child, source).split("::")[-1] in self._FUZZ_MACRO_NAMES
+        return False
+
+    def _handle_fuzz_target(
+        self, node: Node, source: bytes, file_path: str,
+        functions: Dict[str, Any], classes: Dict[str, Any],
+        imports_local: List[dict], ctx: dict, attrs: List[str],
+    ) -> None:
+        """Synthesize an entry-point unit from a `fuzz_target!(|d| { .. })` body.
+
+        libFuzzer's `fuzz_target!` expands to the program `main`; its closure
+        body is the actual fuzzed code path but lives inside an opaque macro
+        token_tree that emits no `function_item`, so the calls it makes never
+        enter the call graph. We lift the body out as `fn <name>() { .. }` and
+        run the ORDINARY extractor walk over it, so any nested `fn`/`impl`/
+        `struct` in the body becomes its own same-file unit. This preserves the
+        call-graph builder's nested-fn invariant (a nested fn is its own unit, so
+        its edges are not lost and a bare call to it binds to the local unit, not
+        a same-named global) — a flat single-unit lift violates it, dropping the
+        nested fn's edges AND mis-binding its bare calls. The harness unit is
+        forced to ``unit_type="main"`` so it seeds reachability, and tagged
+        ``synthetic_harness`` so downstream stages can special-case it.
+        """
+        # Test-gated harness (`#[cfg(test)] fuzz_target!` or inside a test scope)
+        # is skipped like a normal test function when tests are excluded.
+        is_test_attr = any(_TEST_ATTR_RE.match(a) for a in attrs)
+        if (is_test_attr or ctx.get("in_test_scope")) and self.skip_tests:
+            return
+
+        # Locate the closure body via tree-sitter token_tree nodes (string/comment
+        # -safe, unlike a raw brace scan). Macro args are `( |params| BODY )`.
+        outer = next((c for c in node.children if c.type == "token_tree"), None)
+        if outer is None:
+            return
+        kids = outer.children
+        # Block form `|params| { .. }`: the LAST `{`-delimited token_tree (an
+        # earlier one would be a param destructure, before the body).
+        block_tts = [
+            c for c in kids
+            if c.type == "token_tree" and _text(c, source).lstrip().startswith("{")
+        ]
+        if block_tts:
+            body = _text(block_tts[-1], source)
+            base_line = block_tts[-1].start_point[0]  # 0-based line of body `{`
+        else:
+            # Expr form `|params| expr` (no block): lift the expression after the
+            # second top-level `|`, up to the closing `)`, into a statement body.
+            pipes = [i for i, c in enumerate(kids) if c.type == "|"]
+            if len(pipes) < 2:
+                return
+            expr = source[kids[pipes[1]].end_byte:kids[-1].start_byte].decode(
+                "utf-8", "replace"
+            ).strip()
+            if not expr:
+                return
+            body = "{ " + expr + "; }"
+            base_line = node.start_point[0]
+
+        # Unique harness fn name per file (multiple `fuzz_target!` in one file).
+        name = "fuzz_target"
+        n = 2
+        while f"{file_path}:{name}" in functions:
+            name = f"fuzz_target__{n}"
+            n += 1
+
+        # Run the lifted body through the ordinary walk so nested items become
+        # their own units. Use a fresh functions slice to post-process (retype the
+        # harness to `main`, offset lines) before merging; classes/imports go to
+        # the real tables since a nested struct/impl/use IS a same-file item.
+        synth = f"fn {name}() {body}".encode("utf-8")
+        synth_funcs: Dict[str, Any] = {}
+        # Throwaway classes table: the synth walk records nested `struct`/`enum`
+        # with synth-relative coordinates, and a harness that re-declares a real
+        # crate type's name would otherwise clobber the real entry (classes are
+        # bare-name keyed). Merge below with offset lines, never overwriting a
+        # real type.
+        synth_classes: Dict[str, Any] = {}
+        walk_ctx = {
+            "qual_prefix": "",
+            "class_name": None,
+            "module_path": ctx.get("module_path", ()),
+            "in_test_scope": ctx.get("in_test_scope", False),
+        }
+        try:
+            self._walk(
+                self.parser.parse(synth).root_node, synth, file_path,
+                synth_funcs, synth_classes, imports_local, walk_ctx,
+            )
+        except Exception:
+            return
+
+        harness_id = f"{file_path}:{name}"
+        if harness_id not in synth_funcs:
+            return  # body didn't parse to a fn; nothing to seed
+
+        def _offset(info):
+            for k in ("start_line", "end_line"):
+                if isinstance(info.get(k), int):
+                    info[k] = info[k] + base_line
+
+        for fid, info in synth_funcs.items():
+            # Offset the synthetic line numbers back onto the real harness body.
+            _offset(info)
+            if fid == harness_id:
+                # The walk classified the lifted `fn` as a plain function; retype
+                # it to a structural entry point and tag it synthetic.
+                info["unit_type"] = "main"
+                info["is_exported"] = False
+                info["synthetic_harness"] = True
+            if fid not in functions:
+                functions[fid] = info
+
+        # Nested harness-local types: record with offset lines, but never clobber
+        # a real same-named crate type (a real definition always wins).
+        for cid, cinfo in synth_classes.items():
+            if cid in classes:
+                continue
+            _offset(cinfo)
+            classes[cid] = cinfo
 
     def _classify(
         self, name: str, class_name: Optional[str], has_self: bool,

--- a/libs/openant-core/parsers/rust/function_extractor.py
+++ b/libs/openant-core/parsers/rust/function_extractor.py
@@ -695,28 +695,37 @@ class FunctionExtractor:
         if outer is None:
             return
         kids = outer.children
-        # Block form `|params| { .. }`: the LAST `{`-delimited token_tree (an
-        # earlier one would be a param destructure, before the body).
+        # The closure is `|params| body`. Everything after the SECOND top-level
+        # `|` is the body; a `{`-delimited token_tree BEFORE it is a param
+        # destructure (`|Wrap { inner }: Wrap| ..`), never the body. Restrict the
+        # body-brace search to after the params so an expr-form harness whose
+        # only brace IS the param destructure is not mis-lifted.
+        pipes = [i for i, c in enumerate(kids) if c.type == "|"]
+        after = pipes[1] if len(pipes) >= 2 else -1
         block_tts = [
-            c for c in kids
-            if c.type == "token_tree" and _text(c, source).lstrip().startswith("{")
+            c for i, c in enumerate(kids)
+            if i > after and c.type == "token_tree"
+            and _text(c, source).lstrip().startswith("{")
         ]
         if block_tts:
+            # Block form `|params| { .. }`: the body is the last such brace.
             body = _text(block_tts[-1], source)
             base_line = block_tts[-1].start_point[0]  # 0-based line of body `{`
-        else:
+        elif len(pipes) >= 2:
             # Expr form `|params| expr` (no block): lift the expression after the
             # second top-level `|`, up to the closing `)`, into a statement body.
-            pipes = [i for i, c in enumerate(kids) if c.type == "|"]
-            if len(pipes) < 2:
-                return
             expr = source[kids[pipes[1]].end_byte:kids[-1].start_byte].decode(
                 "utf-8", "replace"
             ).strip()
             if not expr:
                 return
-            body = "{ " + expr + "; }"
+            # Terminate on a fresh line so a trailing `//` line comment on the
+            # expr does not swallow the appended `;}` (which would make the lifted
+            # fn unparseable and silently drop the harness).
+            body = "{\n" + expr + "\n; }"
             base_line = node.start_point[0]
+        else:
+            return
 
         # Unique harness fn name per file (multiple `fuzz_target!` in one file).
         name = "fuzz_target"

--- a/libs/openant-core/parsers/rust/test_pipeline.py
+++ b/libs/openant-core/parsers/rust/test_pipeline.py
@@ -226,9 +226,24 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
     )
     reachable = analyzer.get_all_reachable()
 
-    if not entry_points and functions:
-        print("  [Warning] No entry points detected — keeping all units unfiltered "
-              "to avoid a silent blackout.", file=sys.stderr)
+    # A synthesized fuzz harness seeds the BFS but is NOT a real structural entry
+    # point (main/route/CLI). If the ONLY seeds are synthetic harnesses — a pure-
+    # library-with-fuzz target whose real public API is often macro-hidden from
+    # the call graph (e.g. httparse's `complete!`-wrapped internals) — keep the
+    # blackout safety net instead of trusting a harness-only reachable set, which
+    # would silently drop the un-reached public API. Hybrid targets that also ship
+    # a real bin/route still have real seeds, so they filter normally. `--library-
+    # mode` (which adds non-synthetic public-API seeds) also defeats the fallback.
+    real_entry_points = {
+        ep for ep in entry_points
+        if not functions.get(ep, {}).get("synthetic_harness")
+    }
+    if not real_entry_points and functions:
+        why = ("Only synthetic fuzz-harness entry points detected"
+               if entry_points else "No entry points detected")
+        print(f"  [Warning] {why} — keeping all units unfiltered to avoid a silent "
+              "blackout. Use --library-mode to seed the exported public API.",
+              file=sys.stderr)
         reachable = set(functions.keys())
 
     filtered_functions = {

--- a/libs/openant-core/parsers/rust/unit_generator.py
+++ b/libs/openant-core/parsers/rust/unit_generator.py
@@ -42,6 +42,14 @@ class UnitGenerator:
         dataset_name = name or Path(self.repository).name
 
         for func_id, func_info in self.functions.items():
+            # Seed-only: a synthesized `fuzz_target!` harness seeds reachability
+            # (its decode callees are kept and analyzed), but the harness itself
+            # is instrumentation, not an analysis target — its lifted body is
+            # synthetic (references the dropped closure param) and would ship
+            # non-compiling code to Stage-1 and re-analyze the decoder. It stays
+            # in analyzer_output below so the call graph remains symmetric.
+            if func_info.get("synthetic_harness"):
+                continue
             unit = self._generate_unit(func_id, func_info)
             units.append(unit)
 

--- a/libs/openant-core/tests/parsers/rust/test_rust_fuzz_target.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_fuzz_target.py
@@ -70,6 +70,34 @@ def test_expr_form_no_block(tmp_path):
     assert any("decode" in c for c in _callees(cg, ids[0]))
 
 
+def test_expr_form_with_line_comment_still_seeds(tmp_path):
+    # expr-form `fuzz_target!(|d| expr // comment)` — a trailing `//` line comment
+    # INSIDE the macro parens must not swallow the synthesized body terminator
+    # (`;}`) and make the lifted fn unparseable, silently dropping the harness and
+    # the fuzzed path from reachability. Regression for F-NEW-1.
+    _, cg = build(tmp_path, {
+        "src.rs": FRAME,
+        "fuzz/h.rs": "fuzz_target!(|data: &[u8]| Frame::decode(data) // fuzz it\n);\n",
+    }, skip_tests=False)
+    ids = _fuzz_ids(cg)
+    assert ids, "expr-form-with-comment harness was silently dropped"
+    assert any("decode" in c for c in _callees(cg, ids[0])), "fuzzed target not seeded"
+
+
+def test_expr_form_destructure_param_lifts_body_not_param(tmp_path):
+    # expr-form with a struct-destructure closure param `|Wrap { inner }: Wrap| body`:
+    # the `{ inner }` is the PARAM destructure, not the body — the lift must take the
+    # expression AFTER the closure params, not the first brace token. Regression for F-NEW-2.
+    _, cg = build(tmp_path, {
+        "src.rs": "pub struct Wrap { pub inner: u32 }\npub fn real_call(x: u32) -> u32 { x }\n",
+        "fuzz/h.rs": "fuzz_target!(|Wrap { inner }: Wrap| real_call(inner));\n",
+    }, skip_tests=False)
+    ids = _fuzz_ids(cg)
+    assert ids, "harness not synthesized"
+    assert any("real_call" in c for c in _callees(cg, ids[0])), \
+        f"real body dropped as param destructure; code={cg['functions'][ids[0]]['code']!r}"
+
+
 def test_path_qualified_macro(tmp_path):
     files = {
         "src.rs": FRAME,

--- a/libs/openant-core/tests/parsers/rust/test_rust_fuzz_target.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_fuzz_target.py
@@ -212,6 +212,32 @@ def test_synthetic_harness_seed_only_not_analyzed(tmp_path):
                for i in analyzer_output["functions"]), "harness must remain for call-graph symmetry"
 
 
+def test_harness_macro_wrapped_scoped_call_seeds_target(tmp_path):
+    # The most common fuzz-harness idiom wraps the target in an assert:
+    # `fuzz_target!(|d| { assert!(Type::method(d)); })`. The macro-body call
+    # scanner must recover the SCOPED call `Type::method` (not just bare
+    # `method`, which fails cross-file resolution) — otherwise, in a HYBRID repo
+    # (a real bin is present so the (C) keep-all net does NOT fire), the harness
+    # seeds zero edges and its decode target is silently pruned. Regression for
+    # F1 (call_graph_builder._MACRO_CALL_RE / _scan_macro_body scoped-call loss).
+    repo = {
+        "lib.rs": (
+            "pub struct Codec;\n"
+            "impl Codec { pub fn roundtrip(d: &[u8]) -> bool { vuln_decoder(d); true } }\n"
+            "pub fn vuln_decoder(d: &[u8]) -> u32 { d.len() as u32 }\n"
+        ),
+        "src/bin/cli.rs": "fn main() { boot(); }\nfn boot() { let _ = 1; }\n",
+        "fuzz/h.rs": "fuzz_target!(|d: &[u8]| { assert!(Codec::roundtrip(d)); });\n",
+    }
+    _, cg = build(tmp_path, repo, skip_tests=False)
+    hid = _fuzz_ids(cg)[0]
+    assert any("roundtrip" in c for c in _callees(cg, hid)), \
+        f"harness did not seed the macro-wrapped scoped call; edges={cg['call_graph'].get(hid)}"
+    kept = {leaf(k) for k in _apply_reachability(cg, tmp_path)["functions"].keys()}
+    assert "Codec.roundtrip" in kept, f"macro-wrapped scoped target pruned; kept={sorted(kept)}"
+    assert "vuln_decoder" in kept, f"transitive sink pruned; kept={sorted(kept)}"
+
+
 def test_hybrid_lib_with_bin_still_filters(tmp_path):
     # A hybrid target (a real `fn main` bin + fuzz harnesses) keeps real structural
     # seeds, so the keep-all net does NOT fire and reachability still prunes — the

--- a/libs/openant-core/tests/parsers/rust/test_rust_fuzz_target.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_fuzz_target.py
@@ -1,0 +1,208 @@
+"""libFuzzer `fuzz_target!` harness extraction (F8).
+
+The closure body of `fuzz_target!(|data| { .. })` is the real program entry
+point but lives inside an opaque macro token_tree, so no `function_item` is
+emitted and the decode calls it makes never enter the call graph. The parser
+synthesizes an `is_entry_point`/`unit_type=main` unit carrying that body as
+ordinary Rust so structural reachability seeds it. These tests lock in the
+body-extraction (incl. the string/comment brace-safety that a naive text scan
+gets wrong) and guard against over-triggering on non-fuzz macros.
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from _rust_helpers import build, leaf  # noqa: E402
+
+# A resolvable decode target so the harness edge can be asserted.
+FRAME = """
+pub struct Frame;
+impl Frame {
+    pub fn decode(d: &[u8]) -> Frame { Frame }
+}
+"""
+
+
+def _harness(k, body):
+    return {"src.rs": FRAME, f"fuzz/{k}.rs": f"fuzz_target!(|data: &[u8]| {body});\n"}
+
+
+def _fuzz_ids(cg):
+    # Multiple harnesses in one file get a `#N` collision suffix on the id.
+    return [k for k in cg["functions"] if k.rsplit(":", 1)[-1].startswith("fuzz_target")]
+
+
+def _callees(cg, fid):
+    return [leaf(c) for c in cg["call_graph"].get(fid, [])]
+
+
+def test_block_form_seeds_decode(tmp_path):
+    _, cg = build(tmp_path, _harness("f", "{ let _ = Frame::decode(data); }"), skip_tests=False)
+    ids = _fuzz_ids(cg)
+    assert len(ids) == 1
+    assert cg["functions"][ids[0]]["unit_type"] == "main"
+    assert any("decode" in c for c in _callees(cg, ids[0]))
+
+
+def test_string_and_comment_braces_do_not_truncate(tmp_path):
+    # A `}` inside a comment and a string must not desync body extraction and
+    # drop the trailing decode call (the naive text-scan regression).
+    body = (
+        '{\n'
+        '    // a stray } inside a comment\n'
+        '    let s = "closing } brace in a string";\n'
+        '    let _ = Frame::decode(data);\n'
+        '}'
+    )
+    _, cg = build(tmp_path, _harness("f", body), skip_tests=False)
+    ids = _fuzz_ids(cg)
+    assert ids, "no fuzz_target unit synthesized"
+    assert "Frame::decode" in cg["functions"][ids[0]]["code"]
+    assert any("decode" in c for c in _callees(cg, ids[0]))
+
+
+def test_expr_form_no_block(tmp_path):
+    # `fuzz_target!(|d| expr)` with no `{ }` body must still seed the call.
+    _, cg = build(tmp_path, _harness("f", "Frame::decode(data)"), skip_tests=False)
+    ids = _fuzz_ids(cg)
+    assert ids, "expr-form harness produced no unit"
+    assert any("decode" in c for c in _callees(cg, ids[0]))
+
+
+def test_path_qualified_macro(tmp_path):
+    files = {
+        "src.rs": FRAME,
+        "fuzz/f.rs": "libfuzzer_sys::fuzz_target!(|data: &[u8]| { let _ = Frame::decode(data); });\n",
+    }
+    _, cg = build(tmp_path, files, skip_tests=False)
+    assert _fuzz_ids(cg), "path-qualified fuzz_target! not recognized"
+
+
+def test_multiple_harnesses_one_file(tmp_path):
+    src = (
+        "fuzz_target!(|data: &[u8]| { let _ = Frame::decode(data); });\n"
+        "fuzz_target!(|data: &[u8]| { let _ = Frame::decode(data); });\n"
+    )
+    _, cg = build(tmp_path, {"src.rs": FRAME, "fuzz/f.rs": src}, skip_tests=False)
+    assert len(_fuzz_ids(cg)) == 2
+
+
+def test_non_fuzz_macro_does_not_synthesize(tmp_path):
+    # A normal macro invocation must not be mistaken for a harness.
+    _, cg = build(tmp_path, {"src.rs": "fn g() { let v = vec![1, 2, 3]; }\n"}, skip_tests=False)
+    assert not _fuzz_ids(cg)
+
+
+def test_nested_fn_in_harness_no_phantom_no_loss(tmp_path):
+    # A nested `fn decode` inside the closure, plus a cross-file global `fn decode`.
+    # The bare `decode(data)` call MUST bind to the LOCAL nested fn (same-file), not
+    # phantom-resolve to the unrelated global, AND the nested fn's own callee
+    # (`local_only`) must stay reachable. Regression for the PR#205 Fix-E invariant
+    # ("nested fn is its own unit, so no edge is lost") which flattening violated.
+    repo = {
+        "huffman.rs": "pub fn decode(x: &[u8]) -> u32 { 0 }\n",  # unrelated cross-file global
+        "fuzz/h.rs": (
+            "fuzz_target!(|data: &[u8]| {\n"
+            "    fn decode(d: &[u8]) -> u32 { local_only(); 0 }\n"
+            "    fn local_only() {}\n"
+            "    let _ = decode(data);\n"
+            "});\n"
+        ),
+    }
+    _, cg = build(tmp_path, repo, skip_tests=False)
+    all_edges = {(leaf(c), leaf(t)) for c, ts in cg["call_graph"].items() for t in ts}
+    hid = _fuzz_ids(cg)[0]
+    hleaf = leaf(hid)
+    # (a) no phantom: the harness must NOT edge to the cross-file global huffman::decode
+    assert ("huffman.rs" not in "".join(
+        t for c, ts in cg["call_graph"].items() if leaf(c) == hleaf for t in ts
+    )), f"phantom edge to cross-file global decode: {cg['call_graph'].get(hid)}"
+    # (b) no reachability loss: local_only (only reachable via the nested decode)
+    # stays in the graph — as its own same-file unit `fuzz_target::local_only`.
+    assert any("local_only" in callee for _, callee in all_edges), \
+        f"reachability lost: local_only orphaned; edges={sorted(all_edges)}"
+    # (c) the nested decode is its OWN unit (restores PR#205 Fix-E precondition)
+    assert any(leaf(f).endswith("::decode") for f in cg["functions"]), \
+        f"nested fn not extracted as a unit; units={[leaf(f) for f in cg['functions']]}"
+
+
+def test_harness_factoring_logic_into_local_fn_reaches_target(tmp_path):
+    # A harness that factors ALL its logic into a local `fn` reached 0 edges under
+    # the flat lift (nested fn invisible → outer `run(d)` resolves to nothing).
+    # After same-file extraction the decode target is reachable via the chain.
+    repo = {
+        "src.rs": "pub struct Frame; impl Frame { pub fn decode(d: &[u8]) {} }\n",
+        "fuzz/h.rs": "fuzz_target!(|d: &[u8]| { fn run(x: &[u8]) { Frame::decode(x); } run(d); });\n",
+    }
+    _, cg = build(tmp_path, repo, skip_tests=False)
+    all_edges = {(leaf(c), leaf(t)) for c, ts in cg["call_graph"].items() for t in ts}
+    assert any(callee.endswith("::run") for _, callee in all_edges), all_edges
+    assert any("decode" in callee for _, callee in all_edges), \
+        f"decode unreachable from harness→local fn chain; edges={sorted(all_edges)}"
+
+
+def test_synthetic_harness_is_marked(tmp_path):
+    # The harness unit carries the `synthetic_harness` tag (used downstream to
+    # special-case it — e.g. exclude from the blackout structural-seed count).
+    _, cg = build(tmp_path, _harness("f", "{ let _ = 1; }"), skip_tests=False)
+    hid = _fuzz_ids(cg)[0]
+    assert cg["functions"][hid].get("synthetic_harness") is True
+
+
+def _apply_reachability(cg, repo_path):
+    import importlib
+    return importlib.import_module(
+        "parsers.rust.test_pipeline"
+    ).apply_reachability_filter(cg, str(repo_path))
+
+
+def test_pure_fuzz_only_library_keeps_safety_net(tmp_path):
+    # A pure-library-with-fuzz target (only fuzz harnesses, no real main/route/CLI)
+    # must NOT silently filter down to the harness-reachable set — the library's
+    # real API is often macro-hidden from the call graph (httparse `complete!`),
+    # so dropping everything the harness doesn't reach is a silent coverage loss.
+    # Synthetic harnesses seed the BFS but are NOT real structural entry points,
+    # so the keep-all blackout safety net must still fire.
+    repo = {
+        "lib.rs": (
+            "pub fn unreached_public_api() {}\n"
+            "pub struct T; impl T { pub fn parse(d: &[u8]) {} }\n"
+        ),
+        "fuzz/h.rs": "fuzz_target!(|d: &[u8]| { T::parse(d); });\n",
+    }
+    _, cg = build(tmp_path, repo, skip_tests=False)
+    kept = set(_apply_reachability(cg, tmp_path)["functions"].keys())
+    assert any(leaf(k) == "unreached_public_api" for k in kept), \
+        f"pure-fuzz-only library silently dropped un-reached public API; kept={sorted(leaf(k) for k in kept)}"
+
+
+def test_nested_harness_struct_does_not_clobber_real_type(tmp_path):
+    # A harness that declares a `struct` re-using a real crate type's name must
+    # NOT overwrite the real type's `classes` entry (bare-name keyed). The real
+    # definition (file/line/code) must survive.
+    repo = {
+        "src.rs": "pub struct Cfg { pub real_field: u32 }\nimpl Cfg { pub fn run(&self) {} }\n",
+        "z_fuzz/h.rs": "fuzz_target!(|d: &[u8]| { struct Cfg { bogus: u8 } let _ = Cfg { bogus: 0 }; });\n",
+    }
+    _, cg = build(tmp_path, repo, skip_tests=False)
+    cfg = cg.get("classes", {}).get("Cfg", {})
+    assert cfg.get("file_path") == "src.rs", f"real Cfg clobbered by harness struct: {cfg}"
+    assert "bogus" not in str(cfg.get("code", "")), f"real Cfg code overwritten: {cfg}"
+
+
+def test_hybrid_lib_with_bin_still_filters(tmp_path):
+    # A hybrid target (a real `fn main` bin + fuzz harnesses) keeps real structural
+    # seeds, so the keep-all net does NOT fire and reachability still prunes — the
+    # neqo case. An unreachable helper must be filtered out.
+    repo = {
+        "lib.rs": (
+            "pub fn dead_helper() {}\n"
+            "pub struct T; impl T { pub fn parse(d: &[u8]) {} }\n"
+        ),
+        "src/bin/cli.rs": "fn main() { let _ = 1; }\n",
+        "fuzz/h.rs": "fuzz_target!(|d: &[u8]| { T::parse(d); });\n",
+    }
+    _, cg = build(tmp_path, repo, skip_tests=False)
+    kept = {leaf(k) for k in _apply_reachability(cg, tmp_path)["functions"].keys()}
+    assert "dead_helper" not in kept, f"hybrid target failed to prune; kept={sorted(kept)}"

--- a/libs/openant-core/tests/parsers/rust/test_rust_fuzz_target.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_fuzz_target.py
@@ -191,6 +191,27 @@ def test_nested_harness_struct_does_not_clobber_real_type(tmp_path):
     assert "bogus" not in str(cfg.get("code", "")), f"real Cfg code overwritten: {cfg}"
 
 
+def test_synthetic_harness_seed_only_not_analyzed(tmp_path):
+    # Seed-only: the harness seeds reachability (its decode callee stays an
+    # analysis unit) but the harness itself is NOT emitted as a Stage-1 unit —
+    # it's synthetic instrumentation (lifted body references the dropped closure
+    # param) that would ship broken code to the LLM and re-analyze the decoder.
+    from parsers.rust.unit_generator import UnitGenerator
+    repo = {
+        "src.rs": "pub struct Foo; impl Foo { pub fn decode(d: &[u8]) -> Foo { Foo } }\n",
+        "fuzz/h.rs": "fuzz_target!(|data: &[u8]| { Foo::decode(data); });\n",
+    }
+    _, cg = build(tmp_path, repo, skip_tests=False)
+    dataset, analyzer_output = UnitGenerator(cg, str(tmp_path)).generate()
+    unit_ids = {u["id"] for u in dataset["units"]}
+    assert not any(i.rsplit(":", 1)[-1].startswith("fuzz_target") for i in unit_ids), \
+        f"harness emitted as a Stage-1 analysis unit; units={sorted(unit_ids)}"
+    assert any("Foo.decode" in i for i in unit_ids), "the decode callee must stay analyzable"
+    # call-graph symmetry: the harness stays in analyzer_output (its edges exist)
+    assert any(i.rsplit(":", 1)[-1].startswith("fuzz_target")
+               for i in analyzer_output["functions"]), "harness must remain for call-graph symmetry"
+
+
 def test_hybrid_lib_with_bin_still_filters(tmp_path):
     # A hybrid target (a real `fn main` bin + fuzz harnesses) keeps real structural
     # seeds, so the keep-all net does NOT fire and reachability still prunes — the

--- a/libs/openant-core/tests/parsers/rust/test_rust_macro_string_literal.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_macro_string_literal.py
@@ -17,3 +17,25 @@ def test_real_call_outside_literal_still_recovered(tmp_path):
     repo = {"lib.rs": 'pub fn caller() { println!("{}", helper()); }\npub fn helper() -> i32 { 1 }\n'}
     e = edges(build(tmp_path, repo)[1])
     assert ("caller", "helper") in e, e
+
+
+def test_macro_wrapped_scoped_call_recovered_cross_file(tmp_path):
+    # A `Type::method(` call inside a scannable macro must recover the SCOPED
+    # call so a cross-file associated fn resolves (the AST walk gets this for
+    # free; the macro-body scanner used to drop the qualifier and degrade to a
+    # bare same-file-only `method`, which fails cross-file). General, not
+    # harness-specific — the same gap that silently no-op'd fuzz-harness seeding.
+    repo = {
+        "caller.rs": "pub fn caller(d: &[u8]) { assert!(Codec::roundtrip(d)); }\n",
+        "codec.rs": "pub struct Codec;\nimpl Codec { pub fn roundtrip(d: &[u8]) -> bool { true } }\n",
+    }
+    e = edges(build(tmp_path, repo)[1])
+    assert ("caller", "Codec.roundtrip") in e, e
+
+
+def test_macro_wrapped_bare_call_still_bare(tmp_path):
+    # Regression guard: a non-scoped bare call in a macro must STILL be
+    # recovered as before (the scoped alternation must not shadow bare calls).
+    repo = {"lib.rs": 'pub fn caller() { assert_eq!(helper(), 1); }\npub fn helper() -> i32 { 1 }\n'}
+    e = edges(build(tmp_path, repo)[1])
+    assert ("caller", "helper") in e, e

--- a/libs/openant-core/tests/parsers/rust/test_rust_macro_string_literal.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_macro_string_literal.py
@@ -39,3 +39,19 @@ def test_macro_wrapped_bare_call_still_bare(tmp_path):
     repo = {"lib.rs": 'pub fn caller() { assert_eq!(helper(), 1); }\npub fn helper() -> i32 { 1 }\n'}
     e = edges(build(tmp_path, repo)[1])
     assert ("caller", "helper") in e, e
+
+
+def test_scoped_recovery_is_add_only_on_leaf_collision(tmp_path):
+    # Add-only invariant: a scoped call whose qualifier is NOT a repo type/module,
+    # with the leaf shared by a free fn AND a method, must still bind the free fn
+    # (exactly what the pre-scoped bare capture resolved). Scoped recovery must
+    # never DROP an edge master produced. `_resolve_scoped` Step 4 previously
+    # returned [] here (raw candidate count == 2), losing the edge.
+    repo = {
+        "caller.rs": "pub fn drive() { assert!(alpha::beta::c(1)); }\n",
+        "cee.rs": "pub fn c(x: u32) -> u32 { x }\n",
+        "dee.rs": "pub struct S; impl S { pub fn c(x: u32) -> u32 { x } }\n",
+    }
+    e = edges(build(tmp_path, repo)[1])
+    assert ("drive", "c") in e, \
+        f"scoped recovery dropped the free-fn edge master had; drive edges={sorted(x for x in e if x[0]=='drive')}"

--- a/libs/openant-core/tests/parsers/rust/test_rust_schema_completeness.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_schema_completeness.py
@@ -32,9 +32,16 @@ def _run(tmp_path):
 
 
 def test_every_extracted_function_has_a_unit(tmp_path):
+    # Every extracted function has a dataset unit — EXCEPT a synthesized
+    # `fuzz_target!` harness, which is seed-only: it seeds reachability but is not
+    # itself an analysis target (kept in analyzer_output for call-graph symmetry).
+    # See test_rust_fuzz_target.test_synthetic_harness_seed_only_not_analyzed.
     ext, dataset, _ = _run(tmp_path)
     unit_ids = {u["id"] for u in dataset["units"]}
-    assert unit_ids == set(ext["functions"].keys())
+    analysis_functions = {
+        fid for fid, fi in ext["functions"].items() if not fi.get("synthetic_harness")
+    }
+    assert unit_ids == analysis_functions
 
 
 def test_unit_required_fields_present(tmp_path):


### PR DESCRIPTION
## What

Treat libFuzzer `fuzz_target!` harnesses as reachability entry points in the Rust parser, so a library's fuzzed untrusted-decode surface is analyzed instead of pruned as dead code.

## Why

OpenAnt's reachability filter seeds a forward BFS from entry points (main / route / CLI handler). A pure library ships none of those, so its public decode API — the exact surface a fuzz harness drives — was pruned before analysis. A crate's `fuzz_target!` harnesses are the authors' in-code declaration of that untrusted-input surface, but the Rust parser saw them as empty macro bodies: tree-sitter leaves a macro's token-tree opaque, so the closure body emitted no `function_item` and its decode calls never entered the call graph (`libs/openant-core/parsers/rust/function_extractor.py`).

## How

- Synthesize an entry-point unit from each `fuzz_target!` closure body, lifted as ordinary Rust and walked so nested `fn`/`impl`/`struct` become their own same-file units (`function_extractor.py` `_handle_fuzz_target`). Seed-only: the harness is kept in `analyzer_output` for call-graph symmetry but excluded from Stage-1 analysis units (`unit_generator.py:51`).
- Keep-all safety net when the only entry points are synthetic harnesses (pure-library-plus-fuzz), so a crate whose real API is macro-hidden is not silently blacked out (`parsers/rust/test_pipeline.py`).
- Recover scoped `Type::method(` calls inside scannable macros (`assert!` / `assert_eq!` / …), so the most common harness idiom `assert!(Type::roundtrip(d))` seeds its target rather than zero edges (`call_graph_builder.py` `_MACRO_CALL_RE` + `_scan_macro_body`, routed through the existing `_resolve_scoped`).
- Harden the expr-form lift: a trailing `//` comment no longer swallows the body terminator and drops the harness, and a struct-destructure closure param (`|Wrap { inner }: Wrap| …`) is no longer mis-lifted as the body (`function_extractor.py`).
- Keep scoped recovery add-only on a leaf-name collision: when a scoped qualifier binds nothing and the leaf is shared by a free fn and a method, delegate the fallback to the bare resolver so no edge master produced is dropped (`call_graph_builder.py` `_resolve_scoped` Step 4).
- Forward `--library-mode` through the Go CLI on both the parse and scan paths (`apps/openant-cli/cmd/parse.go`, `scan.go`).

## Reachability impact

Measured whole-branch vs `master`, production config (`--skip-tests`), via the real pipeline:

- **neqo**: reachable **854 → 967 (+113, −0 removed)**; edges +305, the 5 removed edges all bare→scoped retargets to the correct method (e.g. `tests::is_known_type → WebTransportFrame.is_known_type`), 0 pure loss.

The change adds real reachability (recovers the fuzz/decode/scoped surface) and removes phantom production→test reachability. On **hyper** the branch is reachable **−2** (`tests::length`, `Encoder.is_eof`) — a correct de-phantoming, not a regression: `master` mis-resolved a production `Encoder::length(...)` call to a same-named `#[cfg(test)]` helper `length`, and scoped recovery now binds it to the real method. Both de-reached nodes were reachable only through that production→test phantom (verified: `tests::length`'s sole `master` inbound was the production `Server.encode_headers`). No genuinely-reachable production code is de-reached.

## Tests

```
$ /Users/gadievron/.openant/venv/bin/python -m pytest tests/ -q   # from libs/openant-core
2688 passed, 30 skipped, 1 warning in 34.26s

$ git diff master..HEAD -- 'libs/openant-core/tests/**' | grep -cE '^\+\s*def test_'
19
```

19 new test functions (16 in `test_rust_fuzz_target.py`, 3 in `test_rust_macro_string_literal.py`), each a RED→GREEN regression for one behavior above. Static analysis on the changed files: `ruff` 0, `go vet` 0, `semgrep` 9 files / 373 rules / 0 findings, `codeql` python-security-and-quality 174 queries / 0 findings.

## Compatibility

No breaking change. `fuzz_target!` seeding is default-on and structural (no LLM call). `--library-mode` is opt-in. The keep-all net only widens output (never prunes more) for pure-library-plus-fuzz repos.

## Notes

- Scope: 2 concern areas (Rust parser + Go CLI wiring for `--library-mode`); 607 LOC. Cohesive around one feature (library-reachability via fuzz harnesses).
- Pre-existing gap, not introduced here: the repo has no `tests/parsers/rust/test_callgraph_symmetry.py` (only Python ships that canonical file today). Suggest a follow-up infra PR rather than bundling it.

## Author notes

- **Which lines implement the fix:** `function_extractor.py` `_handle_fuzz_target` (harness synthesis + expr-form lift); `call_graph_builder.py` `_MACRO_CALL_RE`/`_scan_macro_body` (scoped-call recovery) and `_resolve_scoped` Step 4 (add-only fallback); `unit_generator.py:51` (seed-only skip); `test_pipeline.py` (keep-all net).
- **One input the old code handled wrong:** a hybrid crate (real bin + fuzz harness) with `fuzz_target!(|d| { assert!(Codec::roundtrip(d)); })` — old code seeded zero edges and silently pruned `Codec::roundtrip` and its transitive decode sink; new code seeds them.
- **Likely reviewer pushback + answer:** "Does this reduce reachability precision / lose edges?" — No: measured add-only on neqo (reachable −0); the only reachability removed anywhere is a production→test phantom (hyper −2), which is a precision gain. Verified first-hand against a genuine `master` worktree across 8 repos.
