### PR TITLE
fix(parser/python): seed custom-named router routes as entry points

### DIFF
--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -251,21 +251,37 @@ class FunctionExtractor:
                 for t in targets:
                     if isinstance(t, ast.Name):
                         names.add(t.id.lower())
-        # Alias propagation (B-FN-02): `r = <known router var>` makes `r` a
-        # router too. Fixpoint over simple Name = Name assignments whose RHS is
-        # already a router. Pure recall: a non-router RHS is never in `names`,
-        # so `r = cache` is not promoted.
-        changed = True
-        while changed:
-            changed = False
-            for node in ast.walk(tree):
-                if (isinstance(node, ast.Assign)
-                        and isinstance(node.value, ast.Name)
-                        and node.value.id.lower() in names):
-                    for t in node.targets:
-                        if isinstance(t, ast.Name) and t.id.lower() not in names:
-                            names.add(t.id.lower())
-                            changed = True
+        # Alias propagation (B-FN-02): `r = <known router>` (plain OR annotated
+        # `r: T = <known router>`) makes `r` a router too. Build the Name->targets
+        # alias-edge map in ONE pass, then BFS from the ctor-bound routers over it
+        # (O(V+E)) -- not a per-round full-AST re-walk, which was O(n^2) on long
+        # alias chains (a DoS risk on untrusted scanned repos). Pure recall: a
+        # non-router RHS is never a BFS source, so `r = cache` is not promoted.
+        # (KNOWN over-seed, reachability-safe & documented: names are `.lower()`d
+        # to match the lowercased decorator string, so two vars differing only in
+        # case -- `APP=FastAPI()` + `app=cache` -- collide; contrived, and an
+        # over-seed only mislabels a non-route AS reachable, never drops a route.)
+        alias_edges = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                a_targets, a_value = node.targets, node.value
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                a_targets, a_value = [node.target], node.value
+            else:
+                continue
+            if not isinstance(a_value, ast.Name):
+                continue
+            src_name = a_value.id.lower()
+            for t in a_targets:
+                if isinstance(t, ast.Name):
+                    alias_edges.setdefault(src_name, set()).add(t.id.lower())
+        frontier = list(names)
+        while frontier:
+            src_name = frontier.pop()
+            for tgt in alias_edges.get(src_name, ()):
+                if tgt not in names:
+                    names.add(tgt)
+                    frontier.append(tgt)
         return frozenset(names)
 
     def _router_vars_for(self, file_path: str, content: str) -> frozenset:

--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -211,7 +211,7 @@ class FunctionExtractor:
     # Constructors whose returned object is a route-registering router/app. A
     # module-level `name = <one of these>()` makes `@name.<verb>(...)` a route.
     _ROUTER_CTORS = frozenset({
-        "APIRouter", "FastAPI",          # FastAPI / Starlette
+        "APIRouter", "FastAPI", "Starlette",   # FastAPI / Starlette
         "Blueprint", "Flask",            # Flask
         "RouteTableDef",                 # aiohttp (`web.RouteTableDef()`)
     })
@@ -251,6 +251,21 @@ class FunctionExtractor:
                 for t in targets:
                     if isinstance(t, ast.Name):
                         names.add(t.id.lower())
+        # Alias propagation (B-FN-02): `r = <known router var>` makes `r` a
+        # router too. Fixpoint over simple Name = Name assignments whose RHS is
+        # already a router. Pure recall: a non-router RHS is never in `names`,
+        # so `r = cache` is not promoted.
+        changed = True
+        while changed:
+            changed = False
+            for node in ast.walk(tree):
+                if (isinstance(node, ast.Assign)
+                        and isinstance(node.value, ast.Name)
+                        and node.value.id.lower() in names):
+                    for t in node.targets:
+                        if isinstance(t, ast.Name) and t.id.lower() not in names:
+                            names.add(t.id.lower())
+                            changed = True
         return frozenset(names)
 
     def _router_vars_for(self, file_path: str, content: str) -> frozenset:
@@ -291,7 +306,7 @@ class FunctionExtractor:
         # (the silent reachability false-negative) WITHOUT the over-match a bare
         # `@\w+.<verb>(` regex causes (e.g. `@cache.get(...)` on a non-router object, which
         # would mislabel a cache helper as an attacker-facing route and mis-prime the LLM).
-        m = re.search(r'@(\w+)\.(get|post|put|delete|patch|options|head|websocket|route|api_route)\s*\(', dec_str)
+        m = re.search(r'@(\w+)\.(get|post|put|delete|patch|options|head|websocket_route|websocket|route|api_route)\s*\(', dec_str)
         if m and m.group(1) in getattr(self, '_active_router_vars', frozenset()):
             return 'route_handler'
         # F4 additive: aiohttp RouteTableDef — `routes = web.RouteTableDef()` then

--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -208,6 +208,57 @@ class FunctionExtractor:
         segments = {s.lower() for s in p.with_suffix('').parts}
         return token.lower() in segments
 
+    # Constructors whose returned object is a route-registering router/app. A
+    # module-level `name = <one of these>()` makes `@name.<verb>(...)` a route.
+    _ROUTER_CTORS = frozenset({
+        "APIRouter", "FastAPI",          # FastAPI / Starlette
+        "Blueprint", "Flask",            # Flask
+        "RouteTableDef",                 # aiohttp (`web.RouteTableDef()`)
+    })
+
+    def _collect_router_vars(self, content: str) -> frozenset:
+        """Lowercased names of module variables bound to a router/app constructor.
+
+        Receiver identity — not path syntax — is the correct route signal (a
+        `@cache.get("/k")` cache decorator has a slash-path too). Handles bare and
+        attribute-qualified constructors (`APIRouter()`, `web.RouteTableDef()`),
+        plain and annotated assignments, and multiple targets.
+        """
+        names = set()
+        try:
+            tree = ast.parse(content)
+        except SyntaxError:
+            return frozenset()
+        # Local names that resolve to a router ctor, incl. import aliases
+        # (`from fastapi import APIRouter as AR` -> `AR` is a router ctor).
+        ctor_names = set(self._ROUTER_CTORS)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                for a in node.names:
+                    if a.name in self._ROUTER_CTORS and a.asname:
+                        ctor_names.add(a.asname)
+        for node in ast.walk(tree):
+            targets, value = [], None
+            if isinstance(node, ast.Assign):
+                targets, value = node.targets, node.value
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                targets, value = [node.target], node.value
+            if not (isinstance(value, ast.Call)):
+                continue
+            f = value.func
+            ctor = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
+            if ctor in ctor_names:
+                for t in targets:
+                    if isinstance(t, ast.Name):
+                        names.add(t.id.lower())
+        return frozenset(names)
+
+    def _router_vars_for(self, file_path: str, content: str) -> frozenset:
+        cache = self.__dict__.setdefault("_router_var_cache", {})
+        if file_path not in cache:
+            cache[file_path] = self._collect_router_vars(content)
+        return cache[file_path]
+
     def classify_function(self, func_name: str, decorators: List[str],
                           class_name: Optional[str], file_path: str) -> str:
         """Classify a function by its type/purpose."""
@@ -232,6 +283,16 @@ class FunctionExtractor:
         # receiver is a route. This is ADDED alongside (never replaces) those checks;
         # over-approximating a route is reachability-safe.
         if re.search(r'@(api|v1|router)\.\w', dec_str):
+            return 'route_handler'
+        # FIX (silent-FN, precise): a decorator `@<var>.<httpverb>(` is a route ONLY when
+        # <var> is a known router INSTANCE (`admin = APIRouter()`, `auth = Blueprint()`,
+        # `v2 = FastAPI()`, `routes = web.RouteTableDef()`, ...) collected per-file from the
+        # module AST. This catches custom-named routers the fixed allowlist above misses
+        # (the silent reachability false-negative) WITHOUT the over-match a bare
+        # `@\w+.<verb>(` regex causes (e.g. `@cache.get(...)` on a non-router object, which
+        # would mislabel a cache helper as an attacker-facing route and mis-prime the LLM).
+        m = re.search(r'@(\w+)\.(get|post|put|delete|patch|options|head|websocket|route|api_route)\s*\(', dec_str)
+        if m and m.group(1) in getattr(self, '_active_router_vars', frozenset()):
             return 'route_handler'
         # F4 additive: aiohttp RouteTableDef — `routes = web.RouteTableDef()` then
         # `@routes.get(...)` / `@routes.post(...)` / `@routes.view(...)` / `@routes.route(...)`.
@@ -607,6 +668,9 @@ class FunctionExtractor:
         docstring = self.get_docstring(node)
         code = self.get_source_segment(content, node)
         is_async = isinstance(node, ast.AsyncFunctionDef)
+        # Router-instance set for THIS file drives precise route classification
+        # (`@<router_var>.<verb>(` -> route_handler; a non-router receiver does not).
+        self._active_router_vars = self._router_vars_for(file_path, content)
         unit_type = self.classify_function(func_name, decorators, class_name, relative_path)
 
         # The captured `code` (get_source_segment) includes any decorator lines,

--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -237,44 +237,50 @@ class FunctionExtractor:
                 for a in node.names:
                     if a.name in self._ROUTER_CTORS and a.asname:
                         ctor_names.add(a.asname)
-        for node in ast.walk(tree):
-            targets, value = [], None
-            if isinstance(node, ast.Assign):
-                targets, value = node.targets, node.value
-            elif isinstance(node, ast.AnnAssign) and node.value is not None:
-                targets, value = [node.target], node.value
-            if not (isinstance(value, ast.Call)):
-                continue
-            f = value.func
-            ctor = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
-            if ctor in ctor_names:
-                for t in targets:
-                    if isinstance(t, ast.Name):
-                        names.add(t.id.lower())
-        # Alias propagation (B-FN-02): `r = <known router>` (plain OR annotated
-        # `r: T = <known router>`) makes `r` a router too. Build the Name->targets
-        # alias-edge map in ONE pass, then BFS from the ctor-bound routers over it
-        # (O(V+E)) -- not a per-round full-AST re-walk, which was O(n^2) on long
-        # alias chains (a DoS risk on untrusted scanned repos). Pure recall: a
-        # non-router RHS is never a BFS source, so `r = cache` is not promoted.
-        # (KNOWN over-seed, reachability-safe & documented: names are `.lower()`d
-        # to match the lowercased decorator string, so two vars differing only in
-        # case -- `APP=FastAPI()` + `app=cache` -- collide; contrived, and an
-        # over-seed only mislabels a non-route AS reachable, never drops a route.)
-        alias_edges = {}
+        # Collect (target_name, value) bindings from every LOCAL binding form:
+        # plain Assign (incl. multi-target `a = b = ...`), AnnAssign, and walrus
+        # NamedExpr (`(r := ...)`) anywhere. For a value that is itself a walrus
+        # (`x = (y := r)`) the outer target binds to the walrus's inner value, so
+        # both x and y alias r. (Interprocedural forms -- factory returns, imported
+        # routers, attribute targets `self.router` -- stay documented FN limits.)
+        bindings = []   # list[(name_lower, value_node)]
         for node in ast.walk(tree):
             if isinstance(node, ast.Assign):
-                a_targets, a_value = node.targets, node.value
+                pairs = [(t, node.value) for t in node.targets]
             elif isinstance(node, ast.AnnAssign) and node.value is not None:
-                a_targets, a_value = [node.target], node.value
+                pairs = [(node.target, node.value)]
+            elif isinstance(node, ast.NamedExpr):
+                pairs = [(node.target, node.value)]
             else:
                 continue
-            if not isinstance(a_value, ast.Name):
+            for tgt, val in pairs:
+                while isinstance(val, ast.NamedExpr):   # unwrap x = (y := r)
+                    val = val.value
+                if isinstance(tgt, ast.Name):
+                    bindings.append((tgt.id.lower(), val))
+        # Ctor-bound routers: `name = <RouterCtor>()` (bare or attribute-qualified
+        # like `web.RouteTableDef()`), across all binding forms above.
+        for name, val in bindings:
+            if not isinstance(val, ast.Call):
                 continue
-            src_name = a_value.id.lower()
-            for t in a_targets:
-                if isinstance(t, ast.Name):
-                    alias_edges.setdefault(src_name, set()).add(t.id.lower())
+            f = val.func
+            ctor = f.id if isinstance(f, ast.Name) else (f.attr if isinstance(f, ast.Attribute) else None)
+            if ctor in ctor_names:
+                names.add(name)
+        # Alias propagation (B-FN-02): `r = <known router>` (plain, annotated, or
+        # walrus) makes `r` a router too. Build the Name->targets alias-edge map in
+        # ONE pass, then BFS from the ctor-bound routers over it (O(V+E)) -- not a
+        # per-round full-AST re-walk, which was O(n^2) on long alias chains (a DoS
+        # risk on untrusted scanned repos). Pure recall: a non-router RHS is never a
+        # BFS source, so `r = cache` is not promoted.
+        # (KNOWN over-seed, reachability-safe & documented: names are `.lower()`d to
+        # match the lowercased decorator string, so two vars differing only in case
+        # -- `APP=FastAPI()` + `app=cache` -- collide; contrived, and an over-seed
+        # only mislabels a non-route AS reachable, never drops a route.)
+        alias_edges = {}
+        for name, val in bindings:
+            if isinstance(val, ast.Name):
+                alias_edges.setdefault(val.id.lower(), set()).add(name)
         frontier = list(names)
         while frontier:
             src_name = frontier.pop()

--- a/libs/openant-core/tests/parsers/python/test_router_var_recall_extensions.py
+++ b/libs/openant-core/tests/parsers/python/test_router_var_recall_extensions.py
@@ -66,3 +66,34 @@ def test_router_alias_is_route_handler(src):
 ])
 def test_alias_and_wsroute_do_not_overmatch_nonrouter(src):
     assert _unit_type(src, "helper") != "route_handler"
+
+
+# ---- F2 (re-exam round 1): annotated alias must propagate (was FN) ----------
+def test_annotated_alias_is_route_handler():
+    src = ("from fastapi import APIRouter\nadmin = APIRouter()\n"
+           "ws: APIRouter = admin\n@ws.websocket_route('/ws')\nasync def handler(websocket): pass\n")
+    assert _unit_type(src, "handler") == "route_handler"
+
+
+# ---- F3 (re-exam round 1): deep alias chain resolves (edge-map correctness) --
+def test_deep_alias_chain_resolves():
+    n = 200
+    src = ("from fastapi import APIRouter\nadmin = APIRouter()\n"
+           + "".join(f"x{i} = x{i-1}\n" for i in range(2, n + 1)).replace("x1", "admin", 1)
+           + f"x1 = admin\n@x{n}.get('/deep')\ndef handler(): pass\n")
+    assert _unit_type(src, "handler") == "route_handler"
+
+
+# ---- coverage gaps (test-quality finder): declared ctors + verbs + targets ---
+@pytest.mark.parametrize("src", [
+    # Flask ctor under a CUSTOM name (only Blueprint/app were exercised before)
+    "from flask import Flask\nsrv = Flask(__name__)\n@srv.route('/x')\ndef handler(): pass\n",
+    # multi-target assignment a = b = APIRouter()
+    "from fastapi import APIRouter\na = b = APIRouter()\n@b.get('/x')\ndef handler(): pass\n",
+    # under-sampled verb: delete
+    "from fastapi import APIRouter\nadmin = APIRouter()\n@admin.delete('/x')\ndef handler(): pass\n",
+    # Starlette custom name, HTTP verb (not just websocket_route)
+    "from starlette.applications import Starlette\nsvc = Starlette()\n@svc.get('/x')\ndef handler(): pass\n",
+])
+def test_declared_ctor_and_verb_coverage(src):
+    assert _unit_type(src, "handler") == "route_handler"

--- a/libs/openant-core/tests/parsers/python/test_router_var_recall_extensions.py
+++ b/libs/openant-core/tests/parsers/python/test_router_var_recall_extensions.py
@@ -1,0 +1,68 @@
+"""Recall extensions to the custom-router classifier (re-exam 2026-08-14).
+
+Two zero-FP-risk recall gains found by adversarial re-examination (engineer +
+Fable + Sol, each re-derived first-hand):
+  * B8  — `@<router>.websocket_route(...)` on a custom-named router was missed
+          (the verb alternation had `websocket` and `route` but not the
+          `websocket_route` method) → a silent reachability FN for WS routes.
+  * B-FN-02 — a simple alias `r = <router>` was not propagated, so `@r.get(...)`
+          was missed.
+Both only ADD `route_handler` for genuine routers (pure recall; the negative
+controls below pin that a non-router alias / receiver is NOT promoted). The
+flow/scope over-seed FPs (B2/B11) are deliberately NOT "fixed": tightening them
+regresses function-scoped custom routers to FN, which is net-harmful for a SAST
+reachability tool (missed route >> over-analyzed non-route).
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+CORE = str(Path(__file__).resolve().parents[3])
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+sys.path.insert(0, str(Path(CORE) / "parsers" / "python"))
+from parsers.python.function_extractor import FunctionExtractor  # noqa: E402
+
+
+def _unit_type(src: str, func_name: str) -> str:
+    repo = Path(tempfile.mkdtemp()).resolve()
+    (repo / "m.py").write_text(src)
+    ex = FunctionExtractor(str(repo))
+    ex.process_file(repo / "m.py")
+    return ex.functions[f"m.py:{func_name}"]["unit_type"]
+
+
+# ---- B8: websocket_route on a custom-named router --------------------------
+@pytest.mark.parametrize("src", [
+    "from fastapi import FastAPI\nchat = FastAPI()\n"
+    "@chat.websocket_route('/ws')\nasync def handler(websocket): pass\n",
+    "from starlette.applications import Starlette\napp2 = Starlette()\n"
+    "@app2.websocket_route('/ws')\nasync def handler(websocket): pass\n",
+])
+def test_custom_router_websocket_route_is_route_handler(src):
+    assert _unit_type(src, "handler") == "route_handler"
+
+
+# ---- B-FN-02: alias of a router variable -----------------------------------
+@pytest.mark.parametrize("src", [
+    "from fastapi import APIRouter\nbase = APIRouter()\nr = base\n"
+    "@r.get('/x')\ndef handler(): pass\n",
+    # two-hop alias chain
+    "from fastapi import APIRouter\nbase = APIRouter()\nr = base\nq = r\n"
+    "@q.post('/x')\ndef handler(): pass\n",
+])
+def test_router_alias_is_route_handler(src):
+    assert _unit_type(src, "handler") == "route_handler"
+
+
+# ---- negative controls: aliasing must NOT promote a non-router -------------
+@pytest.mark.parametrize("src", [
+    # alias of a non-router object stays a non-route
+    "cache = TTLCache(100)\nc = cache\n@c.get('/k')\ndef helper(): pass\n",
+    # websocket_route on a NON-router receiver is not a route
+    "cache = TTLCache(100)\n@cache.websocket_route('/k')\ndef helper(): pass\n",
+])
+def test_alias_and_wsroute_do_not_overmatch_nonrouter(src):
+    assert _unit_type(src, "helper") != "route_handler"

--- a/libs/openant-core/tests/parsers/python/test_router_var_recall_extensions.py
+++ b/libs/openant-core/tests/parsers/python/test_router_var_recall_extensions.py
@@ -97,3 +97,20 @@ def test_deep_alias_chain_resolves():
 ])
 def test_declared_ctor_and_verb_coverage(src):
     assert _unit_type(src, "handler") == "route_handler"
+
+
+# ---- F-R2-1 (re-exam round 2): walrus (NamedExpr) binding forms --------------
+@pytest.mark.parametrize("src", [
+    # router constructed by a walrus
+    "from fastapi import APIRouter\nif (r := APIRouter()):\n    pass\n@r.get('/x')\ndef handler(): pass\n",
+    # alias THROUGH a walrus: x = (y := admin) -> both x and y alias admin
+    "from fastapi import APIRouter\nadmin = APIRouter()\nx = (y := admin)\n@y.get('/x')\ndef handler(): pass\n",
+])
+def test_walrus_bound_router_is_route_handler(src):
+    assert _unit_type(src, "handler") == "route_handler"
+
+
+def test_walrus_bound_nonrouter_is_not_route_handler():
+    # walrus binding a NON-router must NOT be promoted
+    src = "d = (r := dict())\n@r.get('/x')\ndef helper(): pass\n"
+    assert _unit_type(src, "helper") != "route_handler"

--- a/libs/openant-core/tests/parsers/python/test_router_var_route_classification.py
+++ b/libs/openant-core/tests/parsers/python/test_router_var_route_classification.py
@@ -1,0 +1,274 @@
+"""Custom-named router variables classify as route_handler (FN fix) while
+non-router receivers with HTTP-verb-shaped decorators do NOT (over-match guard).
+
+Proposed location: tests/parsers/python/test_router_var_route_classification.py
+"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+CORE = str(Path(__file__).resolve().parents[3])   # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+sys.path.insert(0, str(Path(CORE) / "parsers" / "python"))
+
+# OPENANT_FE_MODULE lets the harness point at an alternate copy of the module
+# (used only to demonstrate red on the pre-fix broad regex). In-repo the test
+# simply imports the real module.
+_FE = os.environ.get("OPENANT_FE_MODULE")
+if _FE:
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("fe_under_test", _FE)
+    fe = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(fe)
+    FunctionExtractor = fe.FunctionExtractor
+else:
+    from parsers.python.function_extractor import FunctionExtractor
+
+
+def _unit_type(src: str, func_name: str) -> str:
+    repo = Path(tempfile.mkdtemp()).resolve()
+    (repo / "m.py").write_text(src)
+    ex = FunctionExtractor(str(repo))
+    ex.process_file(repo / "m.py")
+    return ex.functions[f"m.py:{func_name}"]["unit_type"]
+
+
+# ---- FN fix: custom-named router instances ARE routes -----------------------
+
+@pytest.mark.parametrize("src", [
+    # the original silent-FN repro
+    "from fastapi import APIRouter\nadmin = APIRouter()\n"
+    "@admin.post('/grant')\ndef handler(): pass\n",
+    # annotated assignment
+    "from fastapi import APIRouter\nauth: APIRouter = APIRouter()\n"
+    "@auth.get('/login')\ndef handler(): pass\n",
+    # custom-named Flask Blueprint via .route
+    "from flask import Blueprint\nbilling = Blueprint('b', __name__)\n"
+    "@billing.route('/pay', methods=['POST'])\ndef handler(): pass\n",
+    # attribute-qualified ctor (aiohttp), custom name
+    "from aiohttp import web\ntables = web.RouteTableDef()\n"
+    "@tables.get('/x')\ndef handler(request): pass\n",
+    # sub-app FastAPI instance under a custom name
+    "from fastapi import FastAPI\nservice = FastAPI()\n"
+    "@service.put('/v')\ndef handler(): pass\n",
+    # import-aliased ctor (`from fastapi import APIRouter as AR`) — alias resolution
+    "from fastapi import APIRouter as AR\nadmin = AR()\n"
+    "@admin.post('/grant')\ndef handler(): pass\n",
+])
+def test_custom_router_variable_is_route_handler(src):
+    assert _unit_type(src, "handler") == "route_handler"
+
+
+# ---- over-match guard: verb-shaped decorators on NON-router receivers -------
+
+@pytest.mark.parametrize("src", [
+    # cache helper — the @cache.get('/k') over-match repro
+    "cache = TTLCache(100)\n@cache.get('/k')\ndef helper(): pass\n",
+    # HTTP-client mock/recorder
+    "client = Recorder()\n@client.get('https://internal/x')\ndef helper(): pass\n",
+    # plugin registry with a .route verb
+    "registry = PluginRegistry()\n@registry.route('plugin')\ndef helper(): pass\n",
+])
+def test_non_router_receiver_is_not_route_handler(src):
+    assert _unit_type(src, "helper") != "route_handler"
+
+
+# ---- isolation: a router name in file A must not qualify file B -------------
+
+def test_router_names_do_not_leak_across_files():
+    repo = Path(tempfile.mkdtemp()).resolve()
+    (repo / "a.py").write_text(
+        "from fastapi import APIRouter\nadmin = APIRouter()\n"
+        "@admin.post('/grant')\ndef grant(): pass\n"
+    )
+    (repo / "b.py").write_text(
+        "admin = SomethingElse()\n@admin.post('/n')\ndef notroute(): pass\n"
+    )
+    ex = FunctionExtractor(str(repo))
+    ex.process_file(repo / "a.py")
+    ex.process_file(repo / "b.py")
+    assert ex.functions["a.py:grant"]["unit_type"] == "route_handler"
+    assert ex.functions["b.py:notroute"]["unit_type"] != "route_handler"
+
+
+# ---- no regression: legacy allowlist receivers still classify ---------------
+
+@pytest.mark.parametrize("src", [
+    "@app.route('/x')\ndef handler(): pass\n",
+    "@app.get('/x')\ndef handler(): pass\n",
+    "from fastapi import APIRouter\nrouter = APIRouter()\n"
+    "@router.get('/x')\ndef handler(): pass\n",
+    # F4 allowlist names still work WITHOUT a visible assignment
+    "@api.get('/x')\ndef handler(): pass\n",
+    "@v1.post('/x')\ndef handler(): pass\n",
+    "@routes.get('/x')\ndef handler(): pass\n",
+])
+def test_legacy_route_forms_still_route_handler(src):
+    assert _unit_type(src, "handler") == "route_handler"
+
+
+# ---- #165 conformance: full-pipeline strict-superset seed invariant ---------
+#
+# PR #165's invariant: an additive route-recognition change must yield
+# set(entry_points_patched) >= set(entry_points_pristine), with the delta being
+# EXACTLY the intended new seeds. Its own pristine-vs-patched subprocess harness
+# (test_F4_entry_root_additive_v3.py::test_strict_superset_and_new_seeds) became
+# a permanent skip the day #165 merged — the durable in-repo encoding is
+# extensional: run the FULL extractor -> detector pipeline (subprocess, like the
+# F4 harness) over a union fixture and assert the complete expected seed set:
+#   - #165's pristine spine, INCLUDING its two anti-regression fixtures (a real
+#     `@app.route def test_connection()` and a route under `svc/test/`),
+#   - #165's own additive seeds,
+#   - the router-var fix's new seeds,
+# are ALL present, and that non-router verb-decorator decoys plus the CBV helper
+# are NEVER seeded. Any future change that drops one of these seeds — the
+# failure mode the superset invariant exists to catch — turns this red.
+#
+# (The literal pristine-vs-patched A/B was run at development time against a
+# HEAD-5449b72 worktree: superset held; delta == exactly the 3 new router-var
+# seeds; decoys seeded on neither side.)
+
+import json
+import subprocess
+
+_PIPELINE_DRIVER = r"""
+import json, sys
+core, repo = sys.argv[1], sys.argv[2]
+sys.path.insert(0, core)
+from parsers.python.function_extractor import FunctionExtractor
+from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector
+res = FunctionExtractor(repo).extract_all()
+eps = EntryPointDetector(res["functions"], {}).detect_entry_points()
+print(json.dumps(sorted(eps)))
+"""
+
+_SUPERSET_FIXTURES = {
+    # (#165 anti-regression) real @app.route whose handler is NAMED test_connection
+    "app_routes.py": (
+        "from flask import Flask\napp = Flask(__name__)\n\n"
+        "@app.route('/health')\ndef test_connection():\n    return 'ok'\n"
+    ),
+    # (#165 anti-regression) real route living UNDER a test/ directory
+    "svc/test/handler.py": (
+        "from flask import Flask\napp = Flask(__name__)\n\n"
+        "@app.route('/svc')\ndef svc_handler():\n    return 'ok'\n"
+    ),
+    # #165 allowlist receivers (api/v1/router)
+    "custom_router.py": (
+        "from fastapi import APIRouter\n"
+        "router = APIRouter()\napi = APIRouter()\nv1 = APIRouter()\n\n"
+        "@router.api_route('/r', methods=['GET'])\ndef router_apiroute():\n    return {}\n\n"
+        "@api.get('/a')\ndef api_get_handler():\n    return {}\n\n"
+        "@v1.get('/v1')\ndef v1_get_handler():\n    return {}\n"
+    ),
+    # #165 aiohttp + Starlette + Django-CBV shapes
+    "aiohttp_routes.py": (
+        "from aiohttp import web\nroutes = web.RouteTableDef()\n\n"
+        "@routes.get('/ah')\ndef aiohttp_get_handler(req):\n    return web.Response()\n"
+    ),
+    "starlette_app.py": (
+        "from starlette.applications import Starlette\napp = Starlette()\n\n"
+        "@app.websocket_route('/ws')\nasync def ws_handler(websocket):\n"
+        "    await websocket.accept()\n"
+    ),
+    "views.py": (
+        "from django.views import View\n\n"
+        "def legacy_view(req):\n    return None\n\n"
+        "class MyView(View):\n"
+        "    def get(self, req):\n        return None\n"
+        "    def post(self, req):\n        return None\n"
+        "    def get_queryset(self):\n        return []\n"
+    ),
+    # router-var fix: custom-NAMED router instances (the silent-FN class)
+    "named_routers.py": (
+        "from fastapi import APIRouter\nfrom flask import Blueprint\n"
+        "admin = APIRouter()\nbilling = Blueprint('b', __name__)\n\n"
+        "@admin.post('/grant')\ndef grant_handler():\n    return {}\n\n"
+        "@billing.route('/pay', methods=['POST'])\ndef pay_handler():\n    return 'ok'\n"
+    ),
+    "aliased_router.py": (
+        "from fastapi import APIRouter as AR\ninternal = AR()\n\n"
+        "@internal.get('/i')\ndef internal_handler():\n    return {}\n"
+    ),
+    # decoys: verb-shaped decorators on NON-router receivers
+    "cache_helper.py": (
+        "cache = TTLCache(100)\n\n@cache.get('/k')\ndef cache_helper():\n    pass\n"
+    ),
+    "http_client.py": (
+        "client = Recorder()\n\n"
+        "@client.get('https://internal/x')\ndef replay_helper():\n    pass\n"
+    ),
+}
+
+# The superset spine: every seed the pipeline produced BEFORE the router-var fix
+# (#165 pristine spine + #165's own additive seeds). Dropping ANY of these
+# violates the strict-superset invariant.
+_PRE_FIX_SEEDS = {
+    "app_routes.py:test_connection",
+    "svc/test/handler.py:svc_handler",
+    "custom_router.py:router_apiroute",
+    "custom_router.py:api_get_handler",
+    "custom_router.py:v1_get_handler",
+    "aiohttp_routes.py:aiohttp_get_handler",
+    "starlette_app.py:ws_handler",
+    "views.py:MyView.get",
+    "views.py:MyView.post",
+    "views.py:legacy_view",
+}
+# The router-var fix's intended delta — exactly these, nothing else new.
+_ROUTER_VAR_SEEDS = {
+    "named_routers.py:grant_handler",
+    "named_routers.py:pay_handler",
+    "aliased_router.py:internal_handler",
+}
+_NEVER_SEEDED = {
+    "views.py:MyView.get_queryset",
+    "cache_helper.py:cache_helper",
+    "http_client.py:replay_helper",
+}
+
+
+def _run_full_pipeline(repo: Path) -> set:
+    proc = subprocess.run(
+        [sys.executable, "-c", _PIPELINE_DRIVER, CORE, str(repo)],
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"pipeline driver failed:\n{proc.stderr}")
+    return set(json.loads(proc.stdout.strip().splitlines()[-1]))
+
+
+def _superset_fixture_repo() -> Path:
+    repo = Path(tempfile.mkdtemp(prefix="router_superset_")).resolve()
+    for rel, src in _SUPERSET_FIXTURES.items():
+        dest = repo / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text(src, encoding="utf-8")
+    return repo
+
+
+def test_entry_point_seed_set_is_strict_superset_of_pre_fix_pipeline():
+    seeds = _run_full_pipeline(_superset_fixture_repo())
+
+    # Superset: every pre-fix seed (incl. #165's two anti-regression fixtures)
+    # survives the router-var change.
+    dropped = _PRE_FIX_SEEDS - seeds
+    assert not dropped, (
+        f"strict-superset violated — pre-fix entry-point seeds dropped: {sorted(dropped)}"
+    )
+
+    # Delta: the fix's new seeds are present...
+    missing = _ROUTER_VAR_SEEDS - seeds
+    assert not missing, f"router-var fix did not seed: {sorted(missing)}"
+
+    # ...and nothing outside the intended sets is seeded from this fixture repo.
+    unexpected = seeds - _PRE_FIX_SEEDS - _ROUTER_VAR_SEEDS
+    assert not unexpected, f"unintended new seeds (over-seeding): {sorted(unexpected)}"
+
+    # Decoys and the CBV helper are never seeded.
+    leaked = _NEVER_SEEDED & seeds
+    assert not leaked, f"non-entry-point unit(s) seeded: {sorted(leaked)}"


### PR DESCRIPTION
## What

Classify a route decorator on a **custom-named** router instance as a
`route_handler`, so its handler is seeded as a reachability entry point instead
of being silently excluded from analysis.

## Root cause

`classify_function` in `libs/openant-core/parsers/python/function_extractor.py`
recognized route decorators only when the decorator receiver was on a hardcoded
name allowlist (`app` / `router` / `blueprint` / `api` / `v1` / `routes`). A
route registered on any other name —

```python
admin = APIRouter()
@admin.post("/reset")
def reset_password(): ...
```

— matched none of those checks, so `reset_password` was classified `function`,
never entered `ENTRY_POINT_TYPES`, and was dropped from the reachable set at
`--processing-level reachable`. The receiver name, not the decorator's path
argument, is the signal that distinguishes a router from a look-alike such as
`@cache.get("/k")`.

## Reproduction (clean base `5449b72` vs this branch)

The full extractor → entry-point-detector pipeline, same input both sides:

```
WITHOUT fix (base 5449b72)   'api.py:reset_password' seeded=False  entry_points=[]      (route dropped)
WITH fix    (this branch)    'api.py:reset_password' seeded=True   entry_points=[...]   (route reachable)
```

## How

- **Receiver identity** (`_collect_router_vars`): collect the per-file names
  bound to a router/app constructor (`APIRouter`, `FastAPI`, `Starlette`,
  `Blueprint`, `Flask`, aiohttp `RouteTableDef`), including `import ... as`
  aliases. A `@<name>.<verb>(` decorator is a route only when `<name>` is a
  collected router — so `@cache.get("/k")` on a non-router stays `function`.
- **Binding forms**: one `(target, value)` pass over `Assign` (incl.
  multi-target `a = b = ...`), `AnnAssign`, and walrus `NamedExpr`; a value that
  is itself a walrus (`x = (y := r)`) binds both targets.
- **Alias propagation**: `r = <known router>` makes `r` a router too, resolved
  by BFS over a one-pass alias-edge map — `O(V+E)`, not a per-round AST re-walk.
- **Verbs**: adds `websocket_route` alongside the existing HTTP verbs.
- The new branch runs *after* the allowlist branches and only ever *returns*
  `route_handler`; it demotes nothing.

## Regression test (RED → GREEN, clean base)

```
RED   (pristine 5449b72):  20 failed, 12 passed
GREEN (this branch):       32 passed
```

The suite pins: custom-named ctors of every supported framework, import-alias
ctors, annotated + walrus + multi-target + alias-chain bindings, the
`websocket_route` verb; over-match negative controls (`@cache.get`,
`@cache.websocket_route`, alias-of-non-router stay `function`); cross-file
name isolation; a full extractor→detector subprocess **strict-superset**
conformance test asserting the entry-point seed set is a superset of the
pre-fix set with the delta being exactly the intended new seeds and no decoy
seeded.

## Tests

```
tests/parsers/python/  ->  150 passed, 1 skipped
```

## Compatibility

Additive-only. A base-vs-branch differential of the full pipeline output on
several repos (including non-fixture) shows only `function → route_handler`
flips (a reachability-monotone change): zero dropped seeds, no changed unit ids,
no edge/callgraph or other-field change. No public signature change.

## Reachability-coverage context

This closes a **reachability-coverage** gap — a real HTTP route handler was
excluded from the analyzed set — not a defect in program behavior. CodeQL
(`python-security-and-quality`, base vs branch) reports no new finding in the
changed file; ruff and semgrep are clean.

## Known limitations (documented, out of scope)

Router forms that need interprocedural or cross-module resolution stay a
false-negative and are noted in-code: factory returns (`r = make_router()`), a
router imported and decorated in a *different* module, and attribute targets
(`self.router = APIRouter()`). A same-file same-case name collision can
over-seed a non-route; that is reachability-safe (it only marks a non-route as
reachable, never drops a route) and tightening it would regress function-scoped
custom routers, so it is left intentional.

## Note: per-parser test infra

`tests/parsers/python/test_callgraph_symmetry.py` and
`test_python_schema_completeness.py` do not exist for any parser in this repo;
adding them is a repo-wide effort outside this fix's scope.
