### PR TITLE
fix(report): include errors in results so buckets reconcile to total

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -466,6 +466,9 @@ def build_pipeline_output(
             "vulnerable": metrics.get("vulnerable", 0) + metrics.get("bypassable", 0),
             "safe": metrics.get("safe", 0) + metrics.get("protected", 0),
             "inconclusive": metrics.get("inconclusive", 0),
+            # F13: errored units are part of `total` (see units_analyzed above), so the
+            # results buckets must include them or they cannot reconcile to `total`.
+            "errors": metrics.get("errors", 0),
             "total": total_units,
         },
         "findings": findings_data,

--- a/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
+++ b/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
@@ -1,0 +1,82 @@
+"""F13: the pipeline_output `results` block must reconcile to its own `total`.
+
+`total` (== metrics["total"]) counts ALL units including errored ones — proven
+in-code by `units_analyzed = total_units - metrics.get("errors", 0)` in
+build_pipeline_output. Before the fix the `results` block emitted only
+vulnerable/safe/inconclusive/total, so vulnerable+safe+inconclusive == total-errors,
+i.e. the buckets silently under-summed `total` by the error count. The fix adds an
+`errors` bucket so the partition closes.
+
+SCOPE (honest): this reconciles the buckets GIVEN a well-formed `metrics` dict. It
+does NOT repair an upstream mis-partition: `analyzer._count_verdicts` drops any row
+whose verdict is unrecognized (neither a known bucket nor verdict=="ERROR") from
+ALL buckets, so metrics built from such rows already have sum(buckets) < total. That
+pre-existing gap is documented by `test_count_verdicts_drops_unrecognized_verdict`
+below and is explicitly out of F13's scope.
+"""
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from core.reporter import build_pipeline_output  # noqa: E402
+from core.analyzer import _count_verdicts  # noqa: E402
+
+
+def _emit(metrics: dict) -> dict:
+    """Run the real builder on a crafted results fixture (no LLM, no scan)."""
+    d = Path(tempfile.mkdtemp()).resolve()
+    results_path = d / "results_verified.json"
+    out_path = d / "pipeline_output.json"
+    results_path.write_text(json.dumps(
+        {"metrics": metrics, "results": [], "confirmed_findings": []}
+    ))
+    build_pipeline_output(str(results_path), str(out_path))
+    return json.loads(out_path.read_text())["results"]
+
+
+def test_results_block_reconciles_to_total_including_errors():
+    # 2 vulnerable + 3 safe + 1 inconclusive + 4 errors == 10 total
+    r = _emit({"vulnerable": 2, "safe": 3, "inconclusive": 1,
+               "errors": 4, "total": 10})
+    assert r["errors"] == 4, "errors bucket must be emitted (RED on pristine base)"
+    assert r["vulnerable"] + r["safe"] + r["inconclusive"] + r["errors"] == r["total"]
+
+
+def test_folds_bypassable_and_protected_then_still_reconciles():
+    r = _emit({"vulnerable": 1, "bypassable": 1, "safe": 2, "protected": 1,
+               "inconclusive": 1, "errors": 2, "total": 8})
+    assert r["vulnerable"] == 2 and r["safe"] == 3  # folded
+    assert r["vulnerable"] + r["safe"] + r["inconclusive"] + r["errors"] == r["total"]
+
+
+@pytest.mark.parametrize("metrics,expected_errors", [
+    ({"vulnerable": 2, "safe": 3, "inconclusive": 1, "total": 6}, 0),  # key absent
+    ({"vulnerable": 2, "safe": 3, "inconclusive": 1, "errors": 0, "total": 6}, 0),
+])
+def test_graceful_when_no_errors(metrics, expected_errors):
+    r = _emit(metrics)
+    assert r["errors"] == expected_errors  # .get default, no crash, no double-count
+    assert r["vulnerable"] + r["safe"] + r["inconclusive"] + r["errors"] == r["total"]
+
+
+def test_count_verdicts_drops_unrecognized_verdict():
+    """DOCUMENTS the pre-existing partition gap F13 does NOT close: a row with an
+    unrecognized verdict is dropped from every bucket, so the produced metrics
+    already under-sum `total`. Kept as a red-flag guard: if a future change makes
+    _count_verdicts total-preserving, update F13's scope note."""
+    rows = [
+        {"finding": "vulnerable"},
+        {"verdict": "ERROR"},
+        {"verdict": "SOMETHING_WEIRD"},  # neither a bucket nor "ERROR" -> dropped
+    ]
+    counts = _count_verdicts(rows)
+    assert sum(counts.values()) == 2          # only 2 of 3 rows partitioned
+    assert sum(counts.values()) < len(rows)   # the gap is real, and out of F13 scope

--- a/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
+++ b/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
@@ -15,7 +15,6 @@ pre-existing gap is documented by `test_count_verdicts_drops_unrecognized_verdic
 below and is explicitly out of F13's scope.
 """
 import json
-import os
 import sys
 import tempfile
 from pathlib import Path


### PR DESCRIPTION
## What

Add an `errors` bucket to the `results` block of `pipeline_output.json` so the
per-verdict counts reconcile to their own `total`.

## Root cause

In `build_pipeline_output` (`libs/openant-core/core/reporter.py`), the `results`
block emitted `vulnerable` / `safe` / `inconclusive` / `total` but omitted
`errors`, while `total` (`= metrics["total"]`) counts errored units too. The
sibling line `units_analyzed = total_units - metrics.get("errors", 0)` in the
same function proves `total` already includes errors. So the emitted buckets
summed to `total - errors` and silently under-counted `total` by the error
count — the report's own numbers did not add up.

## Reproduction (clean base `5449b72` vs this branch)

`build_pipeline_output` driven by a crafted `results_verified.json` (no model,
no scan), metrics `{vulnerable:3, protected:14, safe:762, errors:3, total:782}`:

```
WITHOUT fix (base 5449b72)   results sum = 779  total = 782   (3 errored units unaccounted)
WITH fix    (this branch)    results sum = 782  total = 782   (reconciles)
```

## How

- One added key: `"errors": metrics.get("errors", 0)` in the `results` block
  (`libs/openant-core/core/reporter.py`). `metrics["errors"]` is already
  produced by `analyzer._count_verdicts`; the `.get(..., 0)` default keeps
  legacy metrics dicts that lack the key working with no crash and no
  double-count.

## Regression test (RED → GREEN, clean base)

```
RED   (pristine 5449b72):  4 failed, 1 passed   (KeyError: 'errors')
GREEN (this branch):       42 passed
```

The new `tests/report/test_results_bucket_reconciliation.py` pins: buckets sum
to `total` including errors; the `bypassable→vulnerable` / `protected→safe`
folds still reconcile; graceful defaulting when `errors` is absent or `0` (no
crash, no double-count). It also documents, as an explicitly out-of-scope
pre-existing gap, that `analyzer._count_verdicts` drops an unrecognized verdict
from every bucket — so reconciliation holds for a well-formed `metrics` dict,
which this PR does not attempt to widen.

## Tests

```
tests/report/  ->  42 passed
```

## Compatibility

Additive-only. A full-output base-vs-branch diff for a fixture shows a single
new leaf path `results.errors`; no removed or changed field (`total`,
`pipeline_stats`, `findings`, everything else identical). The `results` block
is consumed as an opaque dict by `report/schema.py` (presence-checked, no key
whitelist) and ignored by the Go consumer (no `DisallowUnknownFields`), so the
added key breaks no reader.

## Observability

The change is to the emitted report itself: the previously-omitted `errors`
count is now present in `pipeline_output.json`, so a run with errored units is
distinguishable from one without directly in the artifact.
