### PR TITLE
fix(parsers/c): guard macro formal-param fabrication + add call-graph symmetry test

### DIFF
--- a/libs/openant-core/parsers/c/function_extractor.py
+++ b/libs/openant-core/parsers/c/function_extractor.py
@@ -446,7 +446,17 @@ class FunctionExtractor:
                     if body_stripped and '(' in body_stripped:
                         # Extract the called function name
                         called = body_stripped.split('(')[0].strip()
-                        if called.isidentifier():
+                        # A function-like macro whose body's leading token is one
+                        # of its OWN formal parameters is parameter substitution,
+                        # not a real callee (`#define WRAP(g) g()`). Aliasing it
+                        # would fabricate a call edge to any repo function literally
+                        # named after that parameter.
+                        formal_params = {
+                            p.split()[-1].strip(" *")
+                            for p in params_text.strip("()").split(",")
+                            if p.strip()
+                        }
+                        if called.isidentifier() and called not in formal_params:
                             self.macro_aliases[macro_name] = called
 
             stack.extend(reversed(node.children))

--- a/libs/openant-core/tests/parsers/c/test_c_callgraph_symmetry.py
+++ b/libs/openant-core/tests/parsers/c/test_c_callgraph_symmetry.py
@@ -1,0 +1,176 @@
+"""Y-test (per-parser call-graph symmetry) for C.
+
+Asserts the call-graph invariants reachability depends on:
+  - every call_graph / reverse_call_graph key AND callee/caller is a real
+    function id (no phantom nodes);
+  - exact BIDIRECTIONAL consistency — B in call_graph[A] iff A in
+    reverse_call_graph[B] (reachability BFS-walks the reverse graph, so a
+    one-directional edge silently corrupts it);
+  - no self-edges (A -> A).
+
+CallGraphBuilder consumes a plain extractor_output dict and builds the graph
+directly (no repo fixture / extractor run), matching the other C tests. It
+builds a tree-sitter C parser at init, so the module skips where tree_sitter_c
+is unavailable. Mirrors tests/parsers/rust/test_rust_callgraph_symmetry.py.
+"""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+CORE = Path(__file__).resolve().parents[3]  # libs/openant-core
+if str(CORE) not in sys.path:
+    sys.path.insert(0, str(CORE))
+
+pytest.importorskip("tree_sitter_c")
+
+from parsers.c.call_graph_builder import CallGraphBuilder  # noqa: E402
+from parsers.c.function_extractor import FunctionExtractor  # noqa: E402
+
+
+def _assert_symmetric(fids, fwd, rev):
+    """The three call-graph invariants reachability depends on."""
+    for k, callees in fwd.items():
+        assert k in fids, f"call_graph key {k} is not a function id"
+        assert len(callees) == len(set(callees)), f"duplicate forward edge from {k}"
+        for c in callees:
+            assert c in fids, f"callee {c} is not a function id"
+            assert c != k, f"self-edge {k} -> {k}"
+    for k, callers in rev.items():
+        assert k in fids, f"reverse_call_graph key {k} is not a function id"
+        assert len(callers) == len(set(callers)), f"duplicate reverse edge into {k}"
+        for c in callers:
+            assert c in fids
+    fwd_edges = {(a, b) for a, bs in fwd.items() for b in bs}
+    rev_edges = {(a, b) for b, as_ in rev.items() for a in as_}
+    assert fwd_edges == rev_edges, (
+        f"only-forward={fwd_edges - rev_edges}, only-reverse={rev_edges - fwd_edges}")
+
+
+def _graph():
+    """A small C program exercising free calls, a shared callee (two callers),
+    a leaf, recursion (self-call), and a call to an undeclared function."""
+    eo = {
+        "functions": {
+            "m.c:helper": {"name": "helper", "file_path": "m.c",
+                           "code": "int helper(int x){ return x + 1; }"},
+            "m.c:a": {"name": "a", "file_path": "m.c",
+                      "code": "int a(int x){ return helper(x); }"},
+            "m.c:b": {"name": "b", "file_path": "m.c",
+                      "code": "int b(int x){ return helper(x) + a(x); }"},
+            "m.c:fact": {"name": "fact", "file_path": "m.c",
+                         "code": "int fact(int n){ return n <= 1 ? 1 : n * fact(n - 1); }"},
+            "m.c:main": {"name": "main", "file_path": "m.c",
+                         "code": "int main(void){ return a(1) + b(2) + fact(3) + missing(); }"},
+        }
+    }
+    b = CallGraphBuilder(eo)
+    b.build_call_graph()
+    return set(eo["functions"].keys()), b.call_graph, b.reverse_call_graph
+
+
+def test_callgraph_keys_and_edges_are_functions():
+    fids, fwd, rev = _graph()
+    for k, callees in fwd.items():
+        assert k in fids, f"call_graph key {k} is not a function id"
+        for c in callees:
+            assert c in fids, f"callee {c} is not a function id"
+    for k, callers in rev.items():
+        assert k in fids, f"reverse_call_graph key {k} is not a function id"
+        for c in callers:
+            assert c in fids, f"caller {c} is not a function id"
+
+
+def test_callgraph_bidirectional_consistency():
+    fids, fwd, rev = _graph()
+    fwd_edges = {(a, b) for a, bs in fwd.items() for b in bs}
+    rev_edges = {(a, b) for b, as_ in rev.items() for a in as_}
+    assert fwd_edges == rev_edges, (
+        "forward and reverse call graphs disagree: "
+        f"only-forward={fwd_edges - rev_edges}, only-reverse={rev_edges - fwd_edges}"
+    )
+
+
+def test_no_self_edges():
+    _, fwd, _ = _graph()
+    for a, bs in fwd.items():
+        assert a not in bs, f"self-edge {a} -> {a}"
+
+
+def test_undeclared_callee_is_not_an_edge():
+    # `main` calls missing() which is not in the function set -> no phantom node.
+    fids, fwd, _ = _graph()
+    assert "m.c:missing" not in fids
+    for callees in fwd.values():
+        assert "m.c:missing" not in callees
+        assert not any(c.endswith(":missing") for c in callees)
+
+
+def test_shared_callee_has_both_callers_in_reverse():
+    # helper is called by both a and b -> reverse must list both (bidirectional).
+    _, _, rev = _graph()
+    assert set(rev.get("m.c:helper", [])) == {"m.c:a", "m.c:b"}
+
+
+def _pipeline_graph(src, filename="p.c"):
+    """Run the REAL extractor -> builder pipeline on a .c file (as the rust/swift
+    canonical symmetry tests do), so the invariant is proven on genuine extractor
+    output — macro_aliases, callback-arg resolution, member-call decline — not a
+    hand-shaped dict."""
+    repo = os.path.realpath(tempfile.mkdtemp())
+    (Path(repo) / filename).write_text(src)
+    eo = FunctionExtractor(repo).extract_all(files=[filename])
+    b = CallGraphBuilder(eo)
+    b.build_call_graph()
+    return set(eo["functions"].keys()), b.call_graph, b.reverse_call_graph, eo
+
+
+# A fixture that exercises the edge-producing paths with documented bug history —
+# callback-argument, member/field-expression call, and macro-alias resolution —
+# so a future construct-specific fwd/rev desync (not just a wholesale break) is
+# caught. (sol's empirical finding: the dict-only fixture misses these paths.)
+_REAL = """
+#define OPENSSL_malloc(s) CRYPTO_malloc(s)
+int CRYPTO_malloc(int n){ return n; }
+int my_cmp(const void *a, const void *b){ return 0; }
+void shared(void){ }
+void x(void){ shared(); }
+void y(void){ shared(); }
+void driver(struct S *obj, int *arr, int n){
+    qsort(arr, n, sizeof(int), my_cmp);
+    obj->cb();
+    OPENSSL_malloc(4);
+    x();
+    y();
+}
+"""
+
+
+def test_pipeline_symmetry_over_special_edge_paths():
+    fids, fwd, rev, _ = _pipeline_graph(_REAL)
+    _assert_symmetric(fids, fwd, rev)
+
+
+def test_pipeline_member_call_is_not_a_phantom_node():
+    # `obj->cb()` is a member / function-pointer call; the parser declines it, so
+    # no phantom `cb` node/edge — and the caller's OTHER edges stay symmetric.
+    fids, fwd, rev, _ = _pipeline_graph(_REAL)
+    for callees in fwd.values():
+        assert not any(c.endswith(":cb") for c in callees), "phantom obj->cb() edge"
+    _assert_symmetric(fids, fwd, rev)
+
+
+def test_no_duplicate_edges():
+    # Defense-in-depth: the bidirectional check above is set-based and would not
+    # catch a duplicated forward edge (call_graph[A] == [B, B]) that corrupts edge
+    # counts while looking symmetric. This is unreachable today (the extractor
+    # returns a set of calls), but a future refactor to a list would regress it
+    # silently — so assert every adjacency list is duplicate-free.
+    _, fwd, rev = _graph()
+    for a, bs in fwd.items():
+        assert len(bs) == len(set(bs)), f"duplicate forward edge from {a}: {bs}"
+    for b, callers in rev.items():
+        assert len(callers) == len(set(callers)), f"duplicate reverse edge into {b}: {callers}"

--- a/libs/openant-core/tests/parsers/c/test_c_macro_formal_param_guard.py
+++ b/libs/openant-core/tests/parsers/c/test_c_macro_formal_param_guard.py
@@ -1,0 +1,68 @@
+"""S5: a function-like macro must not alias to its OWN formal parameter.
+
+``#define WRAP(g) g()`` substitutes each call site's argument in place; the
+body's leading token ``g`` is the macro's formal PARAMETER, never a real
+callee. The alias extractor took the body's leading identifier unconditionally,
+fabricating an edge ``WRAP -> g`` to any repo function literally named ``g``
+(call_graph_builder rewrites ``WRAP(...)`` to ``g``). Guard: skip aliasing when
+the target is one of the macro's own formal parameters. Legitimate aliases whose
+target is a real function (``OPENSSL_malloc -> CRYPTO_malloc``) are unaffected.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tree_sitter_c")
+
+from parsers.c.function_extractor import FunctionExtractor  # noqa: E402
+
+
+def _macro_aliases(src: str) -> dict:
+    d = Path(os.path.realpath(tempfile.mkdtemp()))
+    (d / "f.c").write_text(src)
+    fe = FunctionExtractor(str(d))
+    fe.process_file(d / "f.c")
+    return dict(fe.macro_aliases)
+
+
+def test_macro_does_not_alias_to_its_own_formal_param():
+    """RED pre-fix: ``WRAP`` aliases to its formal param ``g`` (a phantom edge)."""
+    aliases = _macro_aliases(
+        "void g(void) { }\n"
+        "#define WRAP(g) g()\n"
+        "void caller(void) { WRAP(g); }\n"
+    )
+    assert aliases.get("WRAP") != "g", (
+        "WRAP aliased to its own formal parameter `g` -> fabricates a call edge "
+        f"to any repo function literally named g; macro_aliases={aliases}"
+    )
+    assert "WRAP" not in aliases, (
+        f"WRAP must not alias at all (body is a bare formal-param call); got {aliases}"
+    )
+
+
+def test_multi_param_formal_shadow_guarded():
+    """A later formal param used as the leading callee is also a fabrication."""
+    aliases = _macro_aliases(
+        "#define CALL(f, x) f(x)\n"
+        "void caller(void) { CALL(g, 1); }\n"
+    )
+    assert "CALL" not in aliases, (
+        f"CALL aliased to formal param `f`; got {aliases}"
+    )
+
+
+def test_legitimate_aliases_preserved():
+    """NEGATIVE CONTROL: aliases whose target is a real function must survive."""
+    aliases = _macro_aliases(
+        "int CRYPTO_malloc(int n) { return n; }\n"
+        "#define OPENSSL_malloc(size) CRYPTO_malloc(size)\n"
+        "#define LOG(m) fprintf(stderr, m)\n"
+    )
+    assert aliases.get("OPENSSL_malloc") == "CRYPTO_malloc", (
+        f"legit alias to a real function was dropped; got {aliases}")
+    assert aliases.get("LOG") == "fprintf", (
+        f"legit alias to a real function was dropped; got {aliases}")


### PR DESCRIPTION
Two commits: the C macro formal-param guard, and the missing C call-graph symmetry test.

### 1. fix(parsers/c): don't alias a function-like macro to its own formal parameter
The function-like-macro alias extractor took the body's leading identifier as
the callee unconditionally. For `#define WRAP(g) g()` the leading token `g` is
the macro's own formal PARAMETER (substituted at each call site), not a real
callee -- so it fabricated macro_aliases["WRAP"]="g", and call_graph_builder
rewrote every WRAP(...) call into an edge to any repo function literally named
`g`. Guard: skip aliasing when the leading identifier is one of the macro's own
formal parameters (params_text, already captured at the same site). Aliases
whose target is a real function are unaffected.

Test (RED pre-fix, GREEN post-fix):
tests/parsers/c/test_c_macro_formal_param_guard.py -- WRAP(g)->g and
CALL(f,x)->f are no longer aliased; OPENSSL_malloc->CRYPTO_malloc and
LOG->fprintf (real callees) are preserved. Full C suite: 91 passed.

Before/after at L1 (the fabricated edge is invisible to reachability, so measured
on macro_aliases directly), PYTHONHASHSEED=0:
  fixture: before {WRAP:g, OPENSSL_malloc:CRYPTO_malloc} -> after {OPENSSL_malloc:CRYPTO_malloc}
  security-pcc@e3b4584 (99 function-like macros, 14 aliases): byte-identical
    before/after (sha e349a0fc) -- the guard is a strict no-op on real code.

Precision fix. Real-repo BENEFIT is not demonstrable: no C repo in the corpus
aliases a macro to its own formal param, and the edge is invisible to
reachability; the value is removing a provably-wrong edge without touching any
legitimate alias.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


### 2. test(parsers/c): add call-graph symmetry test (Y-test)
C was the one parser with a schema-completeness test but no callgraph-symmetry
test (python/rust/swift have both). Adds the canonical
tests/parsers/c/test_c_callgraph_symmetry.py asserting the invariants reachability
depends on: every call_graph/reverse_call_graph key and edge is a real function
id, exact forward<->reverse bidirectional consistency, no self-edges, no
duplicate edges.

Two harnesses: dict-direct unit checks (matching the C suite's CallGraphBuilder
style) AND a real extractor->builder pipeline run (matching the rust/swift
canonical symmetry tests) over a fixture that exercises the edge-producing paths
with documented bug history — callback-argument (`qsort(...,my_cmp)`),
member/field-expression call (`obj->cb()`, correctly declined, no phantom), and
macro-alias resolution (`OPENSSL_malloc`->`CRYPTO_malloc`). Verified those edges
actually resolve (driver -> {CRYPTO_malloc, my_cmp, x, y}).

Regression value confirmed empirically: an injected construct-specific desync
(skip reverse-population for callers whose code contains `->`) leaves driver's 4
edges forward-only and the pipeline test FAILS — the dict-only fixture alone
missed it. The duplicate-edge case guards a latent fragility (the extractor
returns a set today, so dup edges are unreachable; a future list refactor would
regress silently).

8 tests pass (HASHSEED 0 and 12345); full C suite 97 passed; ruff clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

