### PR TITLE
fix(reachability): harness-aware keep-all net + un-poison the blackout advisory

### DIFF
--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -455,6 +455,7 @@ def apply_reachability_filter(
     EntryPointDetector = _epd.EntryPointDetector
     blackout_warning = _epd.blackout_warning
     library_seed_ids = _epd.library_seed_ids
+    real_entry_point_ids = _epd.real_entry_point_ids
     ReachabilityAnalyzer = _ra.ReachabilityAnalyzer
 
     call_graph_path = os.path.join(output_dir, "call_graph.json")
@@ -495,16 +496,20 @@ def apply_reachability_filter(
     # pass-through (keep all units, unfiltered) and record a loud warning so the
     # degraded result is never silent. Higher-level callers may still seed
     # ``extra_entry_points`` to get real filtering.
-    if not entry_points and original_count > 0:
+    real_eps = real_entry_point_ids(entry_points, functions)
+    if not real_eps and original_count > 0:
+        why = ("Only synthetic fuzz-harness entry points detected"
+               if entry_points else "No entry points detected")
         warning = (
-            "No entry points detected — reachability cannot seed a frontier. "
+            f"{why} — reachability cannot seed a real frontier. "
             "Returning all units unfiltered to avoid a silent blackout; "
-            f"'{processing_level}' filtering was NOT applied."
+            f"'{processing_level}' filtering was NOT applied. "
+            "Use --library-mode to seed the exported public API surface."
         )
         print(f"  [Warning] {warning}", file=sys.stderr)
         dataset.setdefault("metadata", {})["reachability_filter"] = {
             "original_units": original_count,
-            "entry_points": 0,
+            "entry_points": len(entry_points),
             "reachable_units": original_count,
             "filtered_out": 0,
             "reduction_percentage": 0,

--- a/libs/openant-core/parsers/rust/test_pipeline.py
+++ b/libs/openant-core/parsers/rust/test_pipeline.py
@@ -200,7 +200,7 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
     the Zig/PHP/Ruby/C parser pipelines for the identical shape).
     """
     try:
-        from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector, blackout_warning, library_seed_ids
+        from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector, blackout_warning, library_seed_ids, real_entry_point_ids
         from utilities.agentic_enhancer.reachability_analyzer import ReachabilityAnalyzer
     except ImportError:
         print(
@@ -234,10 +234,7 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
     # would silently drop the un-reached public API. Hybrid targets that also ship
     # a real bin/route still have real seeds, so they filter normally. `--library-
     # mode` (which adds non-synthetic public-API seeds) also defeats the fallback.
-    real_entry_points = {
-        ep for ep in entry_points
-        if not functions.get(ep, {}).get("synthetic_harness")
-    }
+    real_entry_points = real_entry_point_ids(entry_points, functions)
     if not real_entry_points and functions:
         why = ("Only synthetic fuzz-harness entry points detected"
                if entry_points else "No entry points detected")

--- a/libs/openant-core/tests/test_blackout_warning.py
+++ b/libs/openant-core/tests/test_blackout_warning.py
@@ -59,3 +59,37 @@ def test_library_mode_suppresses_warning():
 
 def test_empty_dataset_no_warning():
     assert blackout_warning(_details(), original_count=0, reachable_count=0) is None
+
+
+# --- S2: a synthetic fuzz harness must NOT count as a structural seed ---
+# The libFuzzer harness is lifted as unit_type=main (so it seeds the BFS) AND
+# tagged synthetic_harness=True. Its `unit_type:main` reason would otherwise
+# satisfy the structural count and silence the advisory for exactly the
+# fuzz-only-library blackout it is meant to catch. Exclusion keys on the FLAG,
+# never on unit_type (a real `main` has no flag and must stay structural).
+
+def test_synthetic_harness_seed_does_not_suppress_warning():
+    # Fuzz-only library: the ONLY seed is the synthetic harness (unit_type:main),
+    # 500 -> 20 (96% pruned) — the public API was dropped. Warning MUST fire.
+    details = {"h": {"reasons": ["unit_type:main"], "synthetic_harness": True}}
+    assert blackout_warning(details, original_count=500, reachable_count=20) is not None
+
+
+def test_synthetic_harness_plus_incidental_still_warns():
+    # Harness + a coincidental input_pattern seed — neither is a real structural
+    # entry point, so the blackout must still fire.
+    details = {
+        "h": {"reasons": ["unit_type:main"], "synthetic_harness": True},
+        "i": {"reasons": ["input_pattern:read"]},
+    }
+    assert blackout_warning(details, original_count=712, reachable_count=24) is not None
+
+
+def test_real_main_alongside_harness_still_suppresses():
+    # NEGATIVE CONTROL: a genuine `main` (no synthetic flag) IS structural, so a
+    # hybrid target (real bin + fuzz harness) must stay silent — #134 preserved.
+    details = {
+        "h": {"reasons": ["unit_type:main"], "synthetic_harness": True},
+        "m": {"reasons": ["unit_type:main"]},
+    }
+    assert blackout_warning(details, original_count=712, reachable_count=24) is None

--- a/libs/openant-core/tests/test_reachability_synthetic_harness_net.py
+++ b/libs/openant-core/tests/test_reachability_synthetic_harness_net.py
@@ -1,0 +1,107 @@
+"""S1: the shared reachability filter must keep-all when the ONLY entry points
+are synthetic fuzz harnesses.
+
+Under ``--llm-reachability`` the initial parse runs at level ``all`` (scanner.py
+forces it), so every parser skips its own filter and the post-LLM re-filter calls
+``core.parser_adapter.apply_reachability_filter`` for EVERY language. That shared
+filter's keep-all net fired only on a fully-EMPTY seed set (``if not
+entry_points``). A rust fuzz-only library seeds exactly one entry point — the
+synthetic ``fuzz_target!`` harness (``unit_type='main'`` + ``synthetic_harness``)
+— so the net did NOT fire, the BFS pruned to the harness-reachable sliver, and
+the un-reached exported public API was silently dropped.
+
+The rust parser's OWN filter already guards this (``parsers/rust/test_pipeline.py``
+computes ``real_entry_points`` excluding ``synthetic_harness``), but that filter
+never runs on the ``--llm-reachability`` path. This pins the harness-aware keep-all
+invariant on the shared core filter.
+"""
+
+import importlib.util
+import json
+import pathlib
+
+_CORE = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_parser_adapter():
+    spec = importlib.util.spec_from_file_location(
+        "isolated_parser_adapter_s1", _CORE / "core" / "parser_adapter.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _fuzz_only_graph():
+    # Only entry point is the synthetic harness; parse/helper are reachable from
+    # it, but public_api_a/b are the un-reached EXPORTED surface.
+    return {
+        "functions": {
+            "fuzz/h.rs:fuzz_target": {
+                "name": "fuzz_target", "unit_type": "main",
+                "synthetic_harness": True, "code": "parse(data)",
+            },
+            "lib.rs:parse": {"name": "parse", "unit_type": "function", "code": "helper(d)"},
+            "lib.rs:helper": {"name": "helper", "unit_type": "function", "code": "d.len()"},
+            "lib.rs:public_api_a": {"name": "public_api_a", "unit_type": "function", "code": "1"},
+            "lib.rs:public_api_b": {"name": "public_api_b", "unit_type": "function", "code": "2"},
+        },
+        "call_graph": {
+            "fuzz/h.rs:fuzz_target": ["lib.rs:parse"],
+            "lib.rs:parse": ["lib.rs:helper"],
+        },
+        "reverse_call_graph": {
+            "lib.rs:parse": ["fuzz/h.rs:fuzz_target"],
+            "lib.rs:helper": ["lib.rs:parse"],
+        },
+    }
+
+
+def _units():
+    # The harness is seed-only (not analyzed as a unit); the 4 real fns are units.
+    return [
+        {"id": "lib.rs:parse"},
+        {"id": "lib.rs:helper"},
+        {"id": "lib.rs:public_api_a"},
+        {"id": "lib.rs:public_api_b"},
+    ]
+
+
+def test_synthetic_harness_only_seed_keeps_all_units(tmp_path):
+    pa = _load_parser_adapter()
+    (tmp_path / "call_graph.json").write_text(json.dumps(_fuzz_only_graph()))
+    dataset = {"units": _units(), "metadata": {}}
+
+    out = pa.apply_reachability_filter(dataset, str(tmp_path), "reachable")
+
+    kept = {u["id"] for u in out["units"]}
+    # RED pre-fix: only {parse, helper} survive; public_api_a/b are dropped.
+    assert kept == {
+        "lib.rs:parse", "lib.rs:helper",
+        "lib.rs:public_api_a", "lib.rs:public_api_b",
+    }, (
+        "a synthetic-harness-only seed must degrade to keep-all (the un-reached "
+        f"exported public API was silently dropped); kept={sorted(kept)}"
+    )
+
+
+def test_mixed_real_plus_harness_still_filters(tmp_path):
+    """NEGATIVE CONTROL: a real entry point alongside the harness must filter
+    normally — keep-all must NOT fire when a real (non-synthetic) seed exists."""
+    pa = _load_parser_adapter()
+    graph = _fuzz_only_graph()
+    # Add a real `main` (not synthetic) that reaches only parse/helper.
+    graph["functions"]["bin.rs:main"] = {
+        "name": "main", "unit_type": "main", "code": "parse(d)",
+    }
+    graph["call_graph"]["bin.rs:main"] = ["lib.rs:parse"]
+    (tmp_path / "call_graph.json").write_text(json.dumps(graph))
+    dataset = {"units": _units(), "metadata": {}}
+
+    out = pa.apply_reachability_filter(dataset, str(tmp_path), "reachable")
+    kept = {u["id"] for u in out["units"]}
+    # A real seed exists -> real filtering -> unreached public API is pruned.
+    assert "lib.rs:public_api_a" not in kept and "lib.rs:public_api_b" not in kept, (
+        "keep-all wrongly fired despite a real (non-synthetic) entry point; "
+        f"kept={sorted(kept)}"
+    )

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -284,6 +284,12 @@ class EntryPointDetector:
                     'reasons': reasons,
                     'unit_type': _unit_type(func_data),
                     'name': func_data.get('name'),
+                    # A synthesized fuzz harness seeds the BFS (unit_type=main) but
+                    # is NOT a real structural entry point; record the tag so the
+                    # blackout advisory can exclude it from the structural count.
+                    'synthetic_harness': bool(
+                        func_data.get('synthetic_harness')
+                        or func_data.get('syntheticHarness')),
                 }
 
         return self.entry_points
@@ -413,6 +419,28 @@ def library_seed_ids(functions):
     return seeds
 
 
+def real_entry_point_ids(entry_points, functions):
+    """Entry-point ids that are REAL structural seeds — excludes synthesized
+    fuzz harnesses.
+
+    A libFuzzer ``fuzz_target!`` harness is lifted as an entry point with
+    ``unit_type=main`` (so it seeds the BFS) but it is NOT a program root: it is
+    tagged ``synthetic_harness=True``. When the ONLY seeds are synthetic
+    harnesses — a pure-library-plus-fuzz target whose real public API is often
+    macro-hidden from the call graph — the keep-all blackout net must still fire
+    instead of trusting the harness-only reachable set, which would silently drop
+    the un-reached exported surface. Shared by ``core.parser_adapter`` and the
+    rust pipeline so the two nets cannot drift. Both key casings are accepted
+    (subprocess pipelines normalize to camelCase while the on-disk call_graph is
+    snake_case), matching ``library_seed_ids``.
+    """
+    return {
+        ep for ep in entry_points
+        if not (functions.get(ep, {}).get("synthetic_harness")
+                or functions.get(ep, {}).get("syntheticHarness"))
+    }
+
+
 # Reason categories that indicate a STRUCTURAL entry point — a real route, program
 # main, CLI command, framework handler, or decorator-marked endpoint — as opposed
 # to an INCIDENTAL match (code merely contains an input-reading pattern). A result
@@ -445,8 +473,9 @@ def blackout_warning(entry_point_details, original_count, reachable_count,
     reduction = 1.0 - (reachable_count / original_count)
     structural = sum(
         1 for d in (entry_point_details or {}).values()
-        if any(r.split(":", 1)[0] in _STRUCTURAL_REASON_CATEGORIES
-               for r in d.get("reasons", []))
+        if not d.get("synthetic_harness")
+        and any(r.split(":", 1)[0] in _STRUCTURAL_REASON_CATEGORIES
+                for r in d.get("reasons", []))
     )
     if reduction >= reduction_threshold and structural == 0:
         return (f"Reachability kept {reachable_count} of {original_count} units "


### PR DESCRIPTION
Under --llm-reachability the initial parse runs at level "all" (scanner.py forces
it), so each parser skips its own filter and the post-LLM re-filter calls the
shared core.parser_adapter.apply_reachability_filter for EVERY language
(scanner.py:542). Two nets failed there for a rust fuzz-only library, because the
synthesized libFuzzer harness is emitted as unit_type=main (seeds the BFS) AND
tagged synthetic_harness=True:

  S1 - the core keep-all net fired only on a fully-empty seed set
       (`if not entry_points`). The harness is a non-empty seed, so the net did
       NOT fire; the BFS collapsed to the harness-reachable sliver and the
       un-reached exported public API was silently dropped.
  S2 - blackout_warning counted the harness's `unit_type:main` reason as a
       STRUCTURAL seed, so the partial-blackout advisory stayed silent for
       exactly the fuzz-only-library case it exists to catch.

Reproduced end-to-end (real scan_repository, stubbed LLM promoting nothing) on a
rust fuzz-only fixture: --llm-reachability collapsed 4 -> 2 units, dropping the
unreferenced public API (public_api_a/b), warning None.

Fix:
  - Shared helper real_entry_point_ids(entry_points, functions) in
    utilities.agentic_enhancer.entry_point_detector (both core and the rust
    pipeline already import from there) excludes synthetic_harness-tagged seeds.
    The core net now keeps-all when no REAL (non-synthetic) seed exists; the rust
    pipeline's inline predicate is refactored to the same helper so the two nets
    cannot drift. Byte-identical rust behaviour (truthiness-preserving).
  - Record synthetic_harness into entry_point_details at build time (single seam,
    no threading through 9 call sites); blackout_warning's structural count now
    discounts synthetic harnesses. Keyed on the FLAG, never unit_type, so a real
    `main`/`name:main` stays structural (#134 preserved).

After fix (same fixture): --llm-reachability keeps 4/4, public API retained.

Tests (RED pre-fix, GREEN post-fix):
  - tests/test_reachability_synthetic_harness_net.py: synthetic-harness-only seed
    keeps all units; mixed real+harness still filters (negative control).
  - tests/test_blackout_warning.py: synthetic harness (with or without incidental
    seeds) no longer suppresses the advisory; real main alongside a harness still
    suppresses it (#134 negative control). Verified RED on base, GREEN on fix.
  - test_pure_fuzz_only_library_keeps_safety_net stays green (rust byte-identity).
Full suite (pytest tests/, the CI command): 2694 passed, 30 skipped.

Scope note: the S1 warning is written to reachability_filter metadata at the
filter level but scanner.py rebuilds the dataset from outer metadata, so it does
not reach scan-level output today. Surfacing that advisory is a separate
follow-up (the reachability-warning envelope-drop), deliberately out of scope.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


## Coordination
- This PR bundles S1 (core keep-all net) and S2 (blackout advisory) deliberately: a core keep-all net raises reachable_count, so the blackout advisory never fires without S2's fix — they must co-land. This is why the diff spans core/ + utilities/ + parsers/rust/.
- Pairs with the AFL/aliased fuzz-macro PR via the `synthetic_harness` flag (that PR tags more units; this PR's net + advisory key on the flag). Reinforcing; land aware of each other.
