### PR TITLE
feat(parsers/rust): recognize AFL + aliased libFuzzer fuzz-harness macros

### DIFF
--- a/libs/openant-core/parsers/rust/function_extractor.py
+++ b/libs/openant-core/parsers/rust/function_extractor.py
@@ -307,6 +307,22 @@ class FunctionExtractor:
                     pending_attrs = []
                     continue
 
+                if t == "extern_crate_declaration":
+                    # `#[macro_use] extern crate afl;` (classic afl.rs form)
+                    # brings the crate's macros into bare scope. Record the crate
+                    # only when #[macro_use] is present (plain `extern crate` does
+                    # NOT scope the macros).
+                    if any("macro_use" in a for a in pending_attrs):
+                        cname = next((_text(c, source) for c in child.children
+                                      if c.type == "identifier"), None)
+                        if cname:
+                            imports_local.append({
+                                "kind": "extern_macro_use", "crate": cname,
+                                "leaf": None, "alias": None,
+                            })
+                    pending_attrs = []
+                    continue
+
                 if t == "mod_item":
                     self._handle_mod(
                         child, source, file_path, functions, classes,
@@ -697,7 +713,27 @@ class FunctionExtractor:
             crate, macro_name = self._resolve_macro_origin(text, imports_local)
         if macro_name in self._FUZZ_MACRO_NAMES:
             return True
-        return (crate, macro_name) == self._AFL_FUZZ
+        if (crate, macro_name) == self._AFL_FUZZ:
+            return True
+        # AFL brought into bare macro scope via `#[macro_use] extern crate afl`
+        # or `use afl::*`: an otherwise-unresolved bare `fuzz!` is then afl's
+        # harness macro. Gated on afl provenance so a generic `fuzz!` in a file
+        # that doesn't scope afl's macros is NOT matched.
+        if (crate is None and macro_name == "fuzz"
+                and self._afl_in_macro_scope(imports_local)):
+            return True
+        return False
+
+    def _afl_in_macro_scope(self, imports_local: List[dict]) -> bool:
+        """True if the file brings AFL's macros into bare scope, via
+        ``#[macro_use] extern crate afl`` or a ``use afl::*`` glob."""
+        for imp in imports_local:
+            kind = imp.get("kind")
+            if kind == "extern_macro_use" and imp.get("crate") == "afl":
+                return True
+            if kind == "use_glob" and (imp.get("path") or "").split("::")[0] == "afl":
+                return True
+        return False
 
     def _handle_fuzz_target(
         self, node: Node, source: bytes, file_path: str,
@@ -881,7 +917,18 @@ class FunctionExtractor:
         if target is None:
             return
         for path_segs, leaf, alias in self._flatten_use_node(target, source, ()):
-            if leaf == "*" or not leaf:
+            if not leaf:
+                continue
+            if leaf == "*":
+                # A glob `use crate::*` is not resolvable to a specific symbol,
+                # but it DOES bring the crate's macros into bare scope — recorded
+                # (kind=use_glob) so fuzz-harness recognition can see `use afl::*`.
+                imports_local.append({
+                    "kind": "use_glob",
+                    "path": "::".join(path_segs),
+                    "leaf": None,
+                    "alias": None,
+                })
                 continue
             imports_local.append({
                 "kind": "use",
@@ -942,6 +989,20 @@ class FunctionExtractor:
                     results.extend(self._flatten_use_node(child, source, prefix))
             return results
         if t == "use_wildcard":
+            # `path::*` — recover the path prefix from the wildcard's own path
+            # child (e.g. `use afl::*` -> prefix ('afl',)) so a glob import records
+            # its crate. Previously the prefix was dropped (wildcards were skipped
+            # by the caller, so it never mattered).
+            path_child = next(
+                (c for c in node.children
+                 if c.type in ("identifier", "scoped_identifier",
+                               "crate", "self", "super")),
+                None,
+            )
+            if path_child is not None:
+                sub = self._flatten_use_node(path_child, source, prefix)
+                base = sub[0][0] if sub else prefix
+                return [(base, "*", None)]
             return [(prefix, "*", None)]
         return []
 

--- a/libs/openant-core/parsers/rust/function_extractor.py
+++ b/libs/openant-core/parsers/rust/function_extractor.py
@@ -352,7 +352,7 @@ class FunctionExtractor:
                 # macro token_tree, so no function_item is emitted and its calls
                 # (e.g. `Frame::decode`) never reach the call graph. Emit a
                 # synthetic entry-point unit carrying the body as ordinary Rust.
-                if t == "macro_invocation" and self._is_fuzz_target_macro(child, source):
+                if t == "macro_invocation" and self._is_fuzz_target_macro(child, source, imports_local):
                     self._handle_fuzz_target(
                         child, source, file_path, functions, classes,
                         imports_local, cur_ctx, pending_attrs,
@@ -654,14 +654,50 @@ class FunctionExtractor:
             worklist.append((block, new_ctx))
 
     _FUZZ_MACRO_NAMES = ("fuzz_target",)
+    _AFL_FUZZ = ("afl", "fuzz")  # AFL's generic `fuzz!` — gated on the afl crate
 
-    def _is_fuzz_target_macro(self, node: Node, source: bytes) -> bool:
-        """True if `node` is a `fuzz_target!( .. )` macro invocation (bare or
-        path-qualified, e.g. `libfuzzer_sys::fuzz_target!`)."""
-        for child in node.children:
-            if child.type in ("identifier", "scoped_identifier"):
-                return _text(child, source).split("::")[-1] in self._FUZZ_MACRO_NAMES
-        return False
+    def _resolve_macro_origin(self, name: str, imports_local: List[dict]):
+        """Resolve a bare macro name through the file's `use` imports to its
+        ``(crate, real_macro_name)`` origin. Returns ``(None, name)`` when the
+        name is not imported (locally defined or prelude)."""
+        for imp in imports_local:
+            if imp.get("kind") != "use":
+                continue
+            local = imp.get("alias") or imp.get("leaf")
+            if local == name:
+                path = imp.get("path") or ""
+                crate = path.split("::")[0] if path else None
+                return crate, imp.get("leaf")
+        return None, name
+
+    def _is_fuzz_target_macro(self, node: Node, source: bytes,
+                              imports_local: List[dict]) -> bool:
+        """True if `node` is a fuzz-harness macro invocation.
+
+        Recognizes libFuzzer `fuzz_target!` (bare, path-qualified, or
+        import-aliased `use libfuzzer_sys::fuzz_target as ft; ft!(..)`) and AFL's
+        `fuzz!` (path-qualified `afl::fuzz!` or `use afl::fuzz; fuzz!(..)`). A
+        bare name is resolved THROUGH the file's `use` imports to its origin
+        crate + real macro name, so an alias to an unrelated macro
+        (`use evil::thing as fuzz_target`) and a bare `fuzz!` with no afl import
+        are NOT matched (path-resolution is the over-match guard). `fuzz_target`
+        is accepted from any crate (a distinctive libFuzzer name); the generic
+        `fuzz` is accepted only from the `afl` crate. macro_rules!-wrapped
+        harnesses are out of scope (a deliberate deferral: recognizing them
+        needs macro-definition scanning + expansion-shape handling)."""
+        ref = next((c for c in node.children
+                    if c.type in ("identifier", "scoped_identifier")), None)
+        if ref is None:
+            return False
+        text = _text(ref, source)
+        if "::" in text:
+            segs = text.split("::")
+            crate, macro_name = segs[0], segs[-1]
+        else:
+            crate, macro_name = self._resolve_macro_origin(text, imports_local)
+        if macro_name in self._FUZZ_MACRO_NAMES:
+            return True
+        return (crate, macro_name) == self._AFL_FUZZ
 
     def _handle_fuzz_target(
         self, node: Node, source: bytes, file_path: str,

--- a/libs/openant-core/tests/parsers/rust/test_rust_fuzz_macro_forms.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_fuzz_macro_forms.py
@@ -1,0 +1,97 @@
+"""S4: recognize more fuzz-harness macro forms — aliased libFuzzer imports and
+AFL's `fuzz!` — while NOT over-matching an unrelated macro.
+
+The base recognizer (_FUZZ_MACRO_NAMES=('fuzz_target',), leaf-name match) sees
+only libFuzzer's `fuzz_target!` (bare or path-qualified). It misses:
+  - an aliased import `use libfuzzer_sys::fuzz_target as ft; ft!(...)`
+  - AFL's `fuzz!` (path-qualified `afl::fuzz!` or `use afl::fuzz; fuzz!(...)`)
+A fuzz harness is an untrusted entry point; a missed one makes everything
+reachable only from it a reachability false-negative.
+
+Recognition resolves the invoked macro name THROUGH the file's `use` imports to
+its origin crate, and matches only:
+  - macro_name == 'fuzz_target'  (any crate — the distinctive libFuzzer name), OR
+  - macro_name == 'fuzz' AND origin crate is 'afl'  (generic name, afl-gated).
+Path-resolution is the over-match guard: `use evil::thing as fuzz_target` resolves
+to evil::thing and is NOT a harness; a bare `fuzz!` with no afl import is NOT one.
+
+Out of scope (deferred follow-up): macro_rules!-wrapped harnesses.
+"""
+
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+from _rust_helpers import build  # noqa: E402
+
+FRAME = """
+pub struct Frame;
+impl Frame {
+    pub fn decode(d: &[u8]) -> Frame { Frame }
+}
+"""
+
+
+def _harness_ids(cg):
+    return [k for k, v in cg["functions"].items() if v.get("synthetic_harness")]
+
+
+def _one(tmp_path, fuzz_src):
+    _, cg = build(tmp_path, {"src.rs": FRAME, "fuzz/h.rs": fuzz_src}, skip_tests=False)
+    return cg
+
+
+# --- forms that MUST now be recognized (RED pre-fix: 0 harnesses) ---
+
+def test_aliased_libfuzzer_import_is_seeded(tmp_path):
+    cg = _one(tmp_path,
+              "use libfuzzer_sys::fuzz_target as ft;\n"
+              "ft!(|data: &[u8]| { let _ = Frame::decode(data); });\n")
+    assert len(_harness_ids(cg)) == 1, "aliased `fuzz_target as ft` harness not seeded"
+
+
+def test_afl_path_qualified_is_seeded(tmp_path):
+    cg = _one(tmp_path,
+              "afl::fuzz!(|data: &[u8]| { let _ = Frame::decode(data); });\n")
+    assert len(_harness_ids(cg)) == 1, "`afl::fuzz!` harness not seeded"
+
+
+def test_afl_imported_fuzz_is_seeded(tmp_path):
+    cg = _one(tmp_path,
+              "use afl::fuzz;\n"
+              "fuzz!(|data: &[u8]| { let _ = Frame::decode(data); });\n")
+    assert len(_harness_ids(cg)) == 1, "`use afl::fuzz; fuzz!` harness not seeded"
+
+
+# --- negative controls: must NOT be recognized ---
+
+def test_bare_fuzz_without_afl_import_is_not_seeded(tmp_path):
+    # A user macro coincidentally named `fuzz!`, no afl import -> not a harness.
+    cg = _one(tmp_path,
+              "fuzz!(some, args, here);\n")
+    assert len(_harness_ids(cg)) == 0, "over-matched a non-afl `fuzz!` macro"
+
+
+def test_evil_alias_to_fuzz_target_name_is_not_seeded(tmp_path):
+    # `fuzz_target` is here an ALIAS for an unrelated macro -> must resolve to
+    # evil::thing and NOT be treated as the libFuzzer harness. Uses a CLOSURE
+    # body so the recognizer (not the closure-shape guard in _handle_fuzz_target)
+    # is what must reject it.
+    cg = _one(tmp_path,
+              "use evil::thing as fuzz_target;\n"
+              "fuzz_target!(|data: &[u8]| { let _ = Frame::decode(data); });\n")
+    assert len(_harness_ids(cg)) == 0, "over-matched an aliased non-harness macro"
+
+
+# --- guard: the base forms must still work (byte-identity) ---
+
+def test_base_bare_fuzz_target_still_seeded(tmp_path):
+    cg = _one(tmp_path,
+              "fuzz_target!(|data: &[u8]| { let _ = Frame::decode(data); });\n")
+    assert len(_harness_ids(cg)) == 1, "base bare fuzz_target! regressed"
+
+
+def test_base_path_qualified_libfuzzer_still_seeded(tmp_path):
+    cg = _one(tmp_path,
+              "libfuzzer_sys::fuzz_target!(|data: &[u8]| { let _ = Frame::decode(data); });\n")
+    assert len(_harness_ids(cg)) == 1, "base libfuzzer_sys::fuzz_target! regressed"

--- a/libs/openant-core/tests/parsers/rust/test_rust_fuzz_macro_forms.py
+++ b/libs/openant-core/tests/parsers/rust/test_rust_fuzz_macro_forms.py
@@ -95,3 +95,39 @@ def test_base_path_qualified_libfuzzer_still_seeded(tmp_path):
     cg = _one(tmp_path,
               "libfuzzer_sys::fuzz_target!(|data: &[u8]| { let _ = Frame::decode(data); });\n")
     assert len(_harness_ids(cg)) == 1, "base libfuzzer_sys::fuzz_target! regressed"
+
+
+# --- AFL brought into bare macro scope (classic afl.rs forms) ---
+
+def test_afl_macro_use_extern_crate_is_seeded(tmp_path):
+    # The classic afl.rs README form: `#[macro_use] extern crate afl;` brings
+    # `fuzz!` into bare scope.
+    cg = _one(tmp_path,
+              "#[macro_use] extern crate afl;\n"
+              "fn main() { fuzz!(|data: &[u8]| { let _ = Frame::decode(data); }); }\n")
+    assert len(_harness_ids(cg)) == 1, "`#[macro_use] extern crate afl` harness not seeded"
+
+
+def test_afl_glob_import_is_seeded(tmp_path):
+    cg = _one(tmp_path,
+              "use afl::*;\n"
+              "fuzz!(|data: &[u8]| { let _ = Frame::decode(data); });\n")
+    assert len(_harness_ids(cg)) == 1, "`use afl::*; fuzz!` harness not seeded"
+
+
+def test_plain_extern_crate_afl_without_macro_use_is_not_seeded(tmp_path):
+    # `extern crate afl;` WITHOUT `#[macro_use]` does NOT bring the macro into
+    # scope (edition-2015 rule) — a bare `fuzz!` must not be recognized.
+    cg = _one(tmp_path,
+              "extern crate afl;\n"
+              "fn main() { fuzz!(|data: &[u8]| { let _ = Frame::decode(data); }); }\n")
+    assert len(_harness_ids(cg)) == 0, "over-matched `fuzz!` under plain `extern crate afl`"
+
+
+def test_afl_non_macro_import_does_not_scope_fuzz(tmp_path):
+    # Importing a specific non-macro item from afl does NOT bring `fuzz!` into
+    # scope; a coincidental bare `fuzz!` must not be recognized.
+    cg = _one(tmp_path,
+              "use afl::Corpus;\n"
+              "fuzz!(some, args);\n")
+    assert len(_harness_ids(cg)) == 0, "over-matched a bare `fuzz!` on a non-macro afl import"


### PR DESCRIPTION
Two commits broadening rust fuzz-harness recognition by resolving the invoked macro name through the file's imports.

### 1. recognize aliased libFuzzer + AFL fuzz-harness macros
The harness recognizer matched only the literal leaf name `fuzz_target`
(_FUZZ_MACRO_NAMES), so it missed real fuzz harnesses written as:
  - an aliased import: `use libfuzzer_sys::fuzz_target as ft; ft!(|d| {..})`
  - AFL's macro: `afl::fuzz!(|d| {..})` or `use afl::fuzz; fuzz!(|d| {..})`
A fuzz harness is an untrusted entry point; a missed one makes everything
reachable only from it a reachability false-negative.

It also had a latent OVER-match: a leaf-name match treats
`use evil::thing as fuzz_target; fuzz_target!(|d| {..})` as a harness and lifts
the closure as a seed-only unit — mis-removing a real unit from analysis.

Fix: resolve the invoked macro name THROUGH the file's `use` imports to its
origin crate + real macro name (_resolve_macro_origin), then match only:
  - macro_name == `fuzz_target`  (any crate — the distinctive libFuzzer name), OR
  - macro_name == `fuzz` AND origin crate == `afl`  (generic name, afl-gated).
Path-resolution is the over-match guard. macro_rules!-wrapped harnesses are a
deliberate deferral (need macro-definition scanning + expansion-shape handling;
tracked as a follow-up) and opaque cross-crate expansion is out of scope (would
require executing untrusted scanned-repo code).

Reachability-safe: adds real harness seeds (over-seed direction, no FN) and
removes the evil-alias over-match (which mis-lifted a real unit as seed-only).

Test (RED pre-fix, GREEN post-fix): tests/parsers/rust/test_rust_fuzz_macro_forms.py
— aliased / afl-qualified / afl-imported now seeded; bare `fuzz!` without an afl
import and the `evil` alias are NOT (negative controls); base bare and
path-qualified `fuzz_target!` still seeded (guards). 7 passed; rust suite 59
passed; full suite (pytest tests/) 2575 passed, 151 skipped.

Before/after (4-harness fixture, synthetic_harness unit count): base 1
(base.rs only) -> patched 4 (base + aliased + afl-qualified + afl-imported).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


### 2. recognize AFL harnesses brought into bare macro scope
Follow-up to the aliased/afl-import recognition, from an adversarial bug-hunt:
the classic afl.rs form `#[macro_use] extern crate afl; ... fuzz!(|d| {..})` and
the glob form `use afl::*; fuzz!(|d| {..})` were still missed, re-instating the
#228 blackout for those AFL styles (the fuzzed callees inside the opaque `fuzz!`
token-tree stay unreachable). `#[macro_use] extern crate` is the classic afl.rs
README form, so this is the most common AFL usage.

Fix:
  - record glob imports (`use crate::*`) as kind=use_glob with the crate path
    (the use_wildcard flatten branch previously dropped the path prefix);
  - record `#[macro_use] extern crate <crate>` as kind=extern_macro_use;
  - recognize a bare, unresolved `fuzz!` as an AFL harness when the file brings
    AFL's macros into bare scope (_afl_in_macro_scope: a `use afl::*` glob or a
    `#[macro_use] extern crate afl`). Gated on afl provenance.

Negative controls (must NOT match): plain `extern crate afl;` without
#[macro_use] (edition-2015 rule: macros not in scope); `use afl::Corpus;` (a
non-macro import does not scope `fuzz!`); a bare `fuzz!` with no afl at all.

Import-record changes are blast-safe: the call-graph builder reads records via
.get("leaf")/.get("alias"), and a "kind" discriminator already precedents
(kind=mod). New records carry leaf/alias=None.

Test: 4 new cases (2 recognized forms + 2 negative controls) in
test_rust_fuzz_macro_forms.py — 11 passed; rust suite 63 passed; full suite
(pytest tests/) 2700 passed, 30 skipped. Before/after (6-form fixture): base 1
harness -> patched 6 (base + aliased + afl-qualified + afl-imported +
extern-crate + glob). Reachability-safe (over-seed; negative controls prevent
over-match). ruff clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>


## Coordination
- Pairs with the harness-aware reachability PR (#233) via the `synthetic_harness` flag: this PR tags more units as synthetic harnesses; #233's keep-all net + blackout advisory key on that flag. Reinforcing (more fuzz-only libs protected); land aware of each other.
