### PR TITLE
fix(analyzer): retry recoverable analyze ERRORs in-run (parse failures + empty completions)

### DIFF
--- a/libs/openant-core/core/analysis_core.py
+++ b/libs/openant-core/core/analysis_core.py
@@ -104,7 +104,12 @@ def parse_response(response: str) -> dict:
             "confidence": 0,
             "vulnerabilities": [],
             "reasoning": f"Failed to parse response: {str(e)}",
-            "raw_response": response[:500]
+            "raw_response": response[:500],
+            # Tag the failure so the detection retry pass (core/analyzer.py) can
+            # re-attempt it: a malformed model response is often transient, and
+            # without this key the ERROR carries error=None and is never retried
+            # in-run, permanently masking the unit's true verdict.
+            "error": {"type": "parse_error", "message": str(e)[:200]},
         }
 
 

--- a/libs/openant-core/tests/test_parse_error_retry_efficacy.py
+++ b/libs/openant-core/tests/test_parse_error_retry_efficacy.py
@@ -1,0 +1,60 @@
+"""Efficacy (end-to-end A/B): a parse-failure ERROR is re-attempted by the
+detection retry pass and recovers the unit's true verdict.
+
+Driven with a stubbed LLM (no paid call) through the REAL detection primitives
+(core.analyzer._run_detection and _process_unit) and the REAL retry filter
+(utilities.rate_limiter.is_retryable_error). The retry pass is reproduced
+verbatim from core.analyzer.run_analysis (the retryable_indices comprehension +
+_process_unit re-run at run_analysis lines ~532-550); only run_analysis's
+checkpoint/registry/dataset-file scaffolding is omitted, none of which the fix
+touches.
+
+A/B: the load-bearing line is `retryable_indices == [0]`. On the pristine tree
+the parse ERROR carries error=None, so that list is [] and the unit is never
+retried (bug). With the fix it is [0], _process_unit re-runs, and the true
+verdict VULNERABLE is recovered instead of being permanently masked as ERROR.
+"""
+import core.analysis_core as ac
+import utilities.json_corrector as jc
+from core.analyzer import _run_detection, _process_unit
+from utilities.rate_limiter import is_retryable_error
+
+
+def test_parse_failure_recovered_by_retry(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_simple_text(binding, prompt, **kwargs):
+        calls["n"] += 1
+        # Attempt 1: the analyze call AND the JSONCorrector call both return
+        # unparseable prose -> permanent ERROR at the parser boundary.
+        if calls["n"] <= 2:
+            return "Sorry — here is prose analysis with no JSON object at all."
+        # Retry attempt: the model now returns well-formed JSON.
+        return '{"finding": "vulnerable", "confidence": 90}'
+
+    # Both modules import simple_text into their own namespace.
+    monkeypatch.setattr(ac, "simple_text", fake_simple_text)
+    monkeypatch.setattr(jc, "simple_text", fake_simple_text)
+
+    units = [{"id": "u1", "code": "def handler(req):\n    return eval(req.body)"}]
+    binding = object()  # only stored / passed to the stubbed simple_text
+
+    # --- Stage 1 detection (real) ---
+    results, _code_by_route = _run_detection(units, binding, None, None, workers=1)
+    assert results[0]["verdict"] == "ERROR"  # first attempt could not be parsed
+
+    # --- Retry pass, reproduced from core.analyzer.run_analysis:~532-550 ---
+    retryable_indices = [
+        i for i, r in enumerate(results)
+        if r and is_retryable_error(r.get("error"))
+    ]
+    # RED on pristine (error=None -> not retryable -> []); GREEN with the fix.
+    assert retryable_indices == [0]
+    for i in retryable_indices:
+        out = _process_unit(binding, units[i], i, None, None)
+        results[i] = out["result"]
+
+    # The malformed first response was retried and the true verdict recovered,
+    # instead of being permanently masked as ERROR.
+    assert results[0]["verdict"] == "VULNERABLE"
+    assert calls["n"] >= 3, "retry pass did not re-attempt the parse failure"

--- a/libs/openant-core/tests/test_parse_error_retryable.py
+++ b/libs/openant-core/tests/test_parse_error_retryable.py
@@ -1,0 +1,64 @@
+"""Regression tests: a parse-failure ERROR from parse_response must be retryable
+in-run, so a malformed-but-recoverable model response is re-attempted instead of
+permanently masking the unit's true verdict.
+
+Wired seam under test mirrors core/analyzer.py: the detection retry pass computes
+    retryable_indices = [i for i, r in enumerate(results)
+                         if r and is_retryable_error(r.get("error"))]
+where results[i] is the *inner* result dict returned by parse_response (via
+analyze_unit / _run_detection). So the faithful unit-level check is:
+    is_retryable_error(parse_response(<unparseable>).get("error"))
+"""
+from core.analysis_core import parse_response
+from utilities.rate_limiter import is_retryable_error
+
+
+# A response with no parseable JSON object at all (no braces) -> ERROR verdict.
+NO_JSON = "I cannot produce JSON here. In prose: the code is SAFE."
+
+# The realistic false-error shape: an example object then the real answer.
+# Two top-level objects -> json.loads raises "Extra data" -> brace-grab span
+# holds both -> also raises -> ERROR verdict, even though a good verdict existed.
+EXAMPLE_THEN_REAL = (
+    'Example format:\n{"verdict": "SAFE"}\n\n'
+    'Actual analysis:\n{"verdict": "VULNERABLE", "confidence": 0.95}'
+)
+
+# A recoverable-parse response: prose prefix + exactly one valid object, no
+# trailing brace. The brace-grab SUCCEEDS here -> verdict SAFE, NOT an error.
+RECOVERABLE_PARSE = 'Here is my analysis.\n{"verdict": "SAFE", "confidence": 0.9}'
+
+
+def test_no_json_parse_failure_is_retryable():
+    result = parse_response(NO_JSON)
+    assert result["verdict"] == "ERROR"
+    # BUG (RED on pristine): the ERROR dict carries no top-level `error` key, so
+    # is_retryable_error(None) is False and analyzer.py:534 never re-attempts it.
+    assert is_retryable_error(result.get("error")) is True
+
+
+def test_example_then_real_parse_failure_is_retryable():
+    result = parse_response(EXAMPLE_THEN_REAL)
+    assert result["verdict"] == "ERROR"
+    assert is_retryable_error(result.get("error")) is True
+
+
+def test_parse_error_dict_shape():
+    result = parse_response(NO_JSON)
+    err = result.get("error")
+    assert isinstance(err, dict)
+    assert err.get("type") == "parse_error"
+
+
+def test_is_retryable_error_classifies_parse_error_type():
+    # The classifier itself must treat a structured parse_error as retryable.
+    assert is_retryable_error({"type": "parse_error"}) is True
+
+
+def test_recoverable_parse_is_not_retryable():
+    # Over-correction guard: a response the brace-grab correctly parses must keep
+    # its verdict and must NOT be tagged retryable (no correct verdict re-run).
+    result = parse_response(RECOVERABLE_PARSE)
+    assert result["verdict"] == "SAFE"
+    assert result.get("error") is None
+    assert is_retryable_error(result.get("error")) is False

--- a/libs/openant-core/tests/test_retry_empty_completion.py
+++ b/libs/openant-core/tests/test_retry_empty_completion.py
@@ -1,0 +1,73 @@
+"""F21/F23 — a transient empty-completion ERROR must be retried in-run.
+
+The provider adapters RAISE on an empty completion (no usable content) instead of
+returning a fake SAFE — anthropic.py / google.py / openai.py raise
+``LLMResponseError`` with the message "no usable content (empty completion)".
+That surfaces as a visible ERROR (good, no silent false-negative), but the error
+string matches none of is_retryable_error's transient terms, so the detection
+retry pass in core/analyzer.py never re-attempts it in-run (only a later
+checkpoint-resume recovers it).
+
+The empty-completion cause is predominantly TRANSIENT (a thinking-block
+truncation or a malformed/overloaded response), because the DETERMINISTIC
+content-filter / policy case is a distinct exception, ``LLMRefusalError``
+("refused the request (stop_reason='refusal')"), raised earlier. So classifying
+"empty completion" as retryable recovers the transient case (mirroring the
+parse_error fix) WITHOUT retrying deterministic refusals, whose message does not
+contain "empty completion".
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+from utilities.rate_limiter import is_retryable_error  # noqa: E402
+
+
+# Verbatim adapter messages (str(e) of the raised exception is what reaches the
+# retry filter via core.analyzer._process_unit's except-branch error=str(e)).
+_EMPTY_ANTHROPIC = ("AnthropicAdapter returned no usable content (empty completion); "
+                    "the request may have been filtered or the response was malformed")
+_EMPTY_GEMINI = ("Gemini returned a candidate with no usable content (empty completion); "
+                 "the response may have been truncated (a thinking block)")
+# OpenAI Responses-API empty path (openai.py:730): says "no usable content" but
+# NOT "empty completion" — the term must match the shared "no usable content"
+# phrase so this sibling is covered too.
+_EMPTY_OPENAI_RESPONSES = ("OpenAI Responses returned no usable content (status='incomplete'); "
+                           "the request may have been truncated (reasoning consumed the budget) "
+                           "or filtered")
+# OpenAI Chat-Completions empty paths (openai.py:760, :816): say "empty
+# completion" but NOT "no usable content" — so the term set must include the
+# "empty completion" phrase too, or these (and OpenRouter, which reuses the
+# translator) are silently not retried.
+_EMPTY_OPENAI_CHAT_NOCHOICES = ("OpenAIAdapter returned no choices (empty completion); "
+                                "the request may have been filtered or the response was malformed")
+_EMPTY_OPENAI_CHAT_NOBLOCKS = ("OpenAIAdapter returned an empty completion (no text or tool "
+                               "calls); the request may have been filtered or malformed")
+_REFUSAL = ("AnthropicAdapter refused the request (stop_reason='refusal'); the model "
+            "declined to answer for safety or policy reasons")
+
+
+def test_empty_completion_is_retryable():
+    assert is_retryable_error(_EMPTY_ANTHROPIC) is True
+    assert is_retryable_error(_EMPTY_GEMINI) is True
+    assert is_retryable_error(_EMPTY_OPENAI_RESPONSES) is True
+    assert is_retryable_error(_EMPTY_OPENAI_CHAT_NOCHOICES) is True
+    assert is_retryable_error(_EMPTY_OPENAI_CHAT_NOBLOCKS) is True
+
+
+def test_refusal_is_not_retryable():
+    # NEGATIVE CONTROL: a deterministic refusal must stay non-retryable — its
+    # message lacks "empty completion", so the new term must not catch it.
+    assert is_retryable_error(_REFUSAL) is False
+
+
+def test_parse_error_still_retryable():
+    # REGRESSION: the stacked-on parse_error classification (F22) is preserved.
+    assert is_retryable_error({"type": "parse_error"}) is True
+
+
+def test_unrelated_response_error_not_retryable():
+    # A serialization/other LLMResponseError (different message) is not falsely
+    # caught by the "empty completion" term.
+    assert is_retryable_error("AnthropicAdapter: cannot serialise block of type Foo") is False

--- a/libs/openant-core/tests/test_retry_empty_completion_efficacy.py
+++ b/libs/openant-core/tests/test_retry_empty_completion_efficacy.py
@@ -1,0 +1,51 @@
+"""Efficacy (end-to-end A/B): a transient empty-completion ERROR is re-attempted
+by the detection retry pass and recovers the unit's true verdict.
+
+Driven with a stubbed LLM (no paid call) through the REAL detection primitives
+(_run_detection + _process_unit) and the REAL retry filter (is_retryable_error).
+The retry pass is reproduced from core.analyzer.run_analysis (the
+retryable_indices comprehension + _process_unit re-run). The load-bearing line is
+`retryable_indices == [0]`: pre-fix the empty-completion error string is not
+classified retryable, so the unit is never re-attempted (bug); with the fix it
+is, so the true verdict is recovered.
+"""
+import core.analysis_core as ac
+import utilities.json_corrector as jc
+from core.analyzer import _run_detection, _process_unit
+from utilities.rate_limiter import is_retryable_error
+from utilities.llm.adapter import LLMResponseError
+
+
+def test_empty_completion_recovered_by_retry(monkeypatch):
+    calls = {"n": 0}
+
+    def fake_simple_text(binding, prompt, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Adapter behaviour on a transient empty completion: it RAISES.
+            raise LLMResponseError(
+                "AnthropicAdapter returned no usable content (empty completion); "
+                "the request may have been filtered or the response was malformed")
+        return '{"finding": "vulnerable", "confidence": 90}'
+
+    monkeypatch.setattr(ac, "simple_text", fake_simple_text)
+    monkeypatch.setattr(jc, "simple_text", fake_simple_text)
+
+    units = [{"id": "u1", "code": "def h(r):\n    return eval(r.body)"}]
+    binding = object()
+
+    results, _ = _run_detection(units, binding, None, None, workers=1)
+    assert results[0]["verdict"] == "ERROR"  # first attempt raised -> ERROR
+
+    retryable_indices = [
+        i for i, r in enumerate(results)
+        if r and is_retryable_error(r.get("error"))
+    ]
+    # RED on base (empty-completion string not retryable -> []); GREEN with fix.
+    assert retryable_indices == [0]
+    for i in retryable_indices:
+        out = _process_unit(binding, units[i], i, None, None)
+        results[i] = out["result"]
+
+    assert results[0]["verdict"] == "VULNERABLE"
+    assert calls["n"] >= 2, "retry pass did not re-attempt the empty completion"

--- a/libs/openant-core/utilities/rate_limiter.py
+++ b/libs/openant-core/utilities/rate_limiter.py
@@ -219,6 +219,8 @@ def is_retryable_error(error_info: dict | str | None) -> bool:
     - connection: Network connectivity issues
     - timeout: Request timeout
     - api_status with 500+: Server errors (not client errors like 400)
+    - parse_error: Malformed (unparseable) LLM response; re-generating the
+      completion often yields well-formed output.
 
     Args:
         error_info: The error field from agent_context or similar.
@@ -232,8 +234,10 @@ def is_retryable_error(error_info: dict | str | None) -> bool:
     if isinstance(error_info, dict):
         error_type = error_info.get("type", "")
         
-        # Always retry these transient error types
-        if error_type in ("rate_limit", "connection", "timeout"):
+        # Always retry these transient error types. "parse_error" is a malformed
+        # LLM response (unparseable JSON): re-generating the completion often
+        # yields well-formed output, so it is treated as transient here.
+        if error_type in ("rate_limit", "connection", "timeout", "parse_error"):
             return True
         
         # Retry server errors (5xx), but not client errors (4xx)

--- a/libs/openant-core/utilities/rate_limiter.py
+++ b/libs/openant-core/utilities/rate_limiter.py
@@ -221,6 +221,11 @@ def is_retryable_error(error_info: dict | str | None) -> bool:
     - api_status with 500+: Server errors (not client errors like 400)
     - parse_error: Malformed (unparseable) LLM response; re-generating the
       completion often yields well-formed output.
+    - no usable content: an adapter's "... returned no usable content ..."
+      LLMResponseError (empty completion) — a transient thinking-truncation /
+      malformed reply, across anthropic/google/openai. Deterministic refusals
+      (LLMRefusalError, "refused the request") are NOT matched and stay
+      non-retryable.
 
     Args:
         error_info: The error field from agent_context or similar.
@@ -266,4 +271,33 @@ def is_retryable_error(error_info: dict | str | None) -> bool:
         # "not implemented" and is deliberately excluded.
         "500", "502", "503", "504", "520", "522", "523", "524", "529",
         "overloaded",
+        # A provider adapter raises LLMResponseError on an empty completion (no
+        # text/tool block) — typically a thinking-block truncation or a
+        # malformed/overloaded reply, which re-generating usually recovers. The
+        # phrasing differs across adapters, so BOTH substrings are needed to cover
+        # every empty path without missing one:
+        #   "no usable content" — anthropic.py:368, google.py:453,
+        #                          openai.py:730 (Responses API "status=...")
+        #   "empty completion"  — anthropic.py:368 / google.py:453 (also carry
+        #                          it), openai.py:760 "no choices (empty
+        #                          completion)", openai.py:816 "empty completion
+        #                          (no text or tool calls)"
+        # The DETERMINISTIC content-filter case is a distinct exception
+        # (LLMRefusalError, "refused the request") and Gemini's deterministic
+        # prompt-block ("no candidates (prompt blocked...)") — neither contains
+        # either substring, so both stay non-retryable.
+        # NOTE (openant-kb CONC-C2): the empty-completion raise happens before the
+        # call is recorded, so each retry is a billed-but-unrecorded call — this
+        # trades a small billing under-report for verdict recovery. Bounded to the
+        # single detection retry pass.
+        # DELIBERATELY NOT matched: OpenRouter's finish_reason='error'
+        # (openrouter.py, "the completion is incomplete") is left to that adapter's
+        # original handling (surface as ERROR). Unlike the direct-provider empty
+        # completions above (unambiguously transient truncations), that channel is
+        # MIXED — it also carries deterministic output-moderation / token-limit
+        # failures — and OpenRouter's structured error.metadata.error_type (the
+        # signal needed to retry only transient subtypes) is discarded at the
+        # adapter, so a precise fix belongs in openrouter.py, not this term.
+        "no usable content",
+        "empty completion",
     ))


### PR DESCRIPTION
## What
Retry recoverable analyze-phase ERRORs in-run — malformed-JSON parse failures and
transient empty completions — instead of letting them pass as permanent ERRORs.

## Why
When the analyze model returns unparseable JSON, `parse_response`
(`core/analysis_core.py`) returns an ERROR verdict with no top-level `error` key.
It reaches `results[i]` via the non-raising success path, so the detection retry
pass in `run_analysis` (`core/analyzer.py:532`, `is_retryable_error(r.get("error"))`)
never re-attempts it — the ERROR is permanent within the run, masking the unit's
true verdict until a later checkpoint resume. The same gap exists for an empty
completion: the adapters raise `LLMResponseError` ("no usable content / empty
completion"), which surfaces as an ERROR whose string matches none of the
transient terms, so it too is never retried in-run.

## How
- `parse_response` tags its parse-failure ERROR dict with
  `error={"type":"parse_error", ...}` (`core/analysis_core.py`).
- `is_retryable_error` classifies `parse_error` (dict branch) and the phrases
  "no usable content" / "empty completion" (string branch) as transient
  (`utilities/rate_limiter.py`). The two substrings cover the direct-provider
  empty paths (anthropic, google, openai Responses + Chat); deterministic
  refusals ("refused the request") and Gemini's prompt-block are not matched and
  stay non-retryable.
- OpenRouter's `finish_reason='error'` is deliberately left to that adapter's
  original handling (surface as ERROR, per PR #226): that channel is mixed (it
  also carries deterministic output-moderation / token-limit failures) and the
  `error_type` needed to retry only transient subtypes is discarded at the
  adapter, so a precise fix belongs in `openrouter.py`, not this term.
- Additive: the successful-parse paths never gain an `error` key, so a correct
  verdict is never re-attempted. Bounded to the pre-existing single detection
  retry pass.

## Deliberately unchanged
The brace-grab JSON-extraction heuristic is left as-is: no deterministic change
to it is false-negative-safe (recovering the first/last object turns a visible
ERROR into a silent wrong verdict on example-then-answer responses), so the
single-object silent-wrong case remains a documented limitation.

## Known limitation (disclosed)
- The empty-completion raise happens before the call is recorded, so each retry
  is a billed-but-unrecorded call (openant-kb CONC-C2) — a small, bounded
  telemetry under-report traded for verdict recovery. Fixing the
  record-before-raise ordering is a separate telemetry-accuracy change (it
  touches the exception class + every adapter + `helpers.py`, disjoint from retry
  classification).

## Tests
`test_parse_error_retryable`, `test_parse_error_retry_efficacy`,
`test_retry_empty_completion`, `test_retry_empty_completion_efficacy` — RED on
base, GREEN with the fix; the efficacy tests drive the real `_run_detection` +
`_process_unit` with a stubbed adapter and assert the unit recovers its verdict.
The existing suite is unchanged.

## Compatibility
None. Default behavior for a successful parse is byte-identical; only ERROR
units gain retry eligibility, bounded to the existing retry pass.
