### PR TITLE
fix(reachability): exclude non-runtime mains from the blackout structural count

### DIFF
--- a/libs/openant-core/tests/test_blackout_build_script.py
+++ b/libs/openant-core/tests/test_blackout_build_script.py
@@ -1,0 +1,101 @@
+"""F18 — a non-runtime `fn main` must not count as a structural entry point.
+
+The Rust extractor classifies `unit_type="main"` for ANY function named `main`
+(parsers/rust/function_extractor.py: `if name == "main": return "main"`), with no
+file-path check. Several Cargo file kinds carry a `fn main` that is NOT the
+crate's deployed runtime user-input entry point:
+
+  * a crate-root `build.rs` (a compile-time build script), and
+  * `examples/` and `benches/` targets (auxiliary binaries that CONSUME the
+    public API rather than being it).
+
+Each becomes unit_type=main and is counted `structural` by blackout_warning, so a
+Rust LIBRARY crate that ships any of them has its library-blackout advisory
+silently suppressed. `examples/` is the more common masker than build.rs.
+
+Fix mirrors synthetic_harness: tag `non_runtime_main` on such a main and exclude
+it from the structural count, while KEEPING it seeded (over-seeding an entry
+point is reachability-safe; only the advisory count changes). The exclusion keys
+on the FLAG, never on unit_type — a real `main` (src/main.rs) has no flag and
+must stay structural.
+
+Documented residual limits (out of scope, pre-existing): a build script renamed
+via Cargo's `build = "custom.rs"` manifest key, and a test-scoped literal
+`fn main`, still count structural.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # libs/openant-core
+
+from utilities.agentic_enhancer import blackout_warning, EntryPointDetector  # noqa: E402
+
+
+# --- blackout_warning half: the non_runtime_main flag must not count structural ---
+
+def test_non_runtime_main_does_not_suppress_warning():
+    # Library crate whose ONLY seed is a non-runtime main, 500 -> 20 (96% pruned)
+    # — the public API was dropped. Warning MUST fire.
+    details = {"b": {"reasons": ["unit_type:main"], "non_runtime_main": True}}
+    assert blackout_warning(details, original_count=500, reachable_count=20) is not None
+
+
+def test_non_runtime_main_plus_incidental_still_warns():
+    details = {
+        "b": {"reasons": ["unit_type:main"], "non_runtime_main": True},
+        "i": {"reasons": ["input_pattern:read"]},
+    }
+    assert blackout_warning(details, original_count=712, reachable_count=24) is not None
+
+
+def test_real_main_alongside_non_runtime_still_suppresses():
+    # NEGATIVE CONTROL: a genuine src/main.rs main (no flag) IS structural, so a
+    # binary crate that also ships a build.rs/examples stays silent.
+    details = {
+        "b": {"reasons": ["unit_type:main"], "non_runtime_main": True},
+        "m": {"reasons": ["unit_type:main"]},
+    }
+    assert blackout_warning(details, original_count=712, reachable_count=24) is None
+
+
+# --- detect_entry_points half: tag non_runtime_main from file_path, keep the seed ---
+
+def _det(functions):
+    d = EntryPointDetector(functions, call_graph={})
+    d.detect_entry_points()
+    return d
+
+
+def _main(fid, file_path):
+    return (fid, {"name": "main", "unit_type": "main", "file_path": file_path, "code": ""})
+
+
+def test_detect_tags_non_runtime_mains():
+    cases = dict([
+        _main("build.rs:main", "build.rs"),                 # crate-root build script
+        _main("crate/build.rs:main", "mycrate/build.rs"),   # workspace member build script
+        _main("examples/demo.rs:main", "examples/demo.rs"), # Cargo example target
+        _main("benches/bench.rs:main", "benches/bench.rs"), # Cargo bench target
+    ])
+    d = _det(cases)
+    for fid in cases:
+        assert d.entry_point_details[fid]["non_runtime_main"] is True, fid
+        # Over-seed-safe: still an entry point (seed kept).
+        assert fid in d.entry_points, fid
+
+
+def test_detect_does_not_tag_real_main():
+    d = _det(dict([_main("src/main.rs:main", "src/main.rs")]))
+    assert d.entry_point_details["src/main.rs:main"].get("non_runtime_main") is False
+    assert "src/main.rs:main" in d.entry_points
+
+
+def test_detect_does_not_tag_src_modules_named_like_targets():
+    # A module UNDER src/ named build.rs / in a src/examples subdir is a normal
+    # module, NOT a Cargo build script or example target. Must NOT be tagged.
+    d = _det(dict([
+        _main("src/build.rs:main", "src/build.rs"),
+        _main("src/examples/x.rs:main", "src/examples/x.rs"),
+    ]))
+    assert d.entry_point_details["src/build.rs:main"].get("non_runtime_main") is False
+    assert d.entry_point_details["src/examples/x.rs:main"].get("non_runtime_main") is False

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -290,6 +290,12 @@ class EntryPointDetector:
                     'synthetic_harness': bool(
                         func_data.get('synthetic_harness')
                         or func_data.get('syntheticHarness')),
+                    # A build.rs / examples/ / benches/ `main` seeds the BFS
+                    # (unit_type=main) but is NOT the crate's runtime entry point;
+                    # tag it so the blackout advisory excludes it from the
+                    # structural count (the seed is kept).
+                    'non_runtime_main': _is_non_runtime_main(
+                        func_data.get('file_path') or func_data.get('filePath') or ''),
                 }
 
         return self.entry_points
@@ -449,6 +455,54 @@ def real_entry_point_ids(entry_points, functions):
 _STRUCTURAL_REASON_CATEGORIES = {"unit_type", "decorator", "name"}
 
 
+def _is_non_runtime_main(file_path: str) -> bool:
+    """True when a `main` in this file runs at build/example/bench time rather
+    than as the crate's deployed runtime entry point, so it must NOT count as a
+    structural entry point for the blackout advisory. The main is still SEEDED
+    (over-seeding is reachability-safe); only the advisory's structural count
+    excludes it. Mirrors the ``synthetic_harness`` exclusion, path-based on Cargo
+    conventions:
+
+      * a crate-root ``build.rs`` (compile-time build script), and
+      * ``examples/`` and ``benches/`` targets (auxiliary binaries that consume
+        the public API rather than being it).
+
+    A file UNDER ``src/`` is an ordinary module, never one of these targets, so
+    it is left alone (a ``src/build.rs`` module or ``src/examples/`` submodule
+    stays structural).
+
+    Scope note: this is a purely path-based check applied to every language's
+    functions (the detector is shared across all parsers), not gated to Rust.
+    ``build.rs`` is Rust-specific, but ``examples/`` and ``benches/`` are a
+    common cross-language layout for non-runtime auxiliary code, so treating a
+    top-level ``examples/``/``benches/`` main as non-structural is intended for
+    any language — a Go/Python ``examples/`` demo is a consumer of the API, not
+    its structural entry point. The effect is confined to the advisory string
+    (never seeding), so the worst case is the library-blackout advisory firing
+    for a project whose only entry lives under ``examples/`` — which is itself a
+    library-shaped project the advisory means to flag.
+
+    Documented residual limits: a build script renamed via Cargo's
+    ``build = "custom.rs"`` manifest key is not recognised; a non-crate-root file
+    literally named ``build.rs`` (e.g. ``scripts/build.rs``) is over-tagged
+    (advisory noise only); and — pre-existing, orthogonal to this change — the
+    advisory itself is written only to ``metadata.reachability_filter.warning``
+    and stderr, not the CLI JSON/exit envelope, so a correctly-fired warning is
+    not yet surfaced to a CI consumer. This is a conservative check: an
+    unknown/empty path returns False (counts structural, i.e. pre-fix
+    behaviour), never dropping a real structural seed.
+    """
+    if not file_path:
+        return False
+    parts = file_path.replace("\\", "/").split("/")
+    ancestors = parts[:-1]
+    if "src" in ancestors:
+        return False
+    if parts[-1] == "build.rs":
+        return True
+    return "examples" in ancestors or "benches" in ancestors
+
+
 def blackout_warning(entry_point_details, original_count, reachable_count,
                      library_mode=False, reduction_threshold=0.90):
     """Advisory string when a reachability result looks like a silent library
@@ -474,6 +528,7 @@ def blackout_warning(entry_point_details, original_count, reachable_count,
     structural = sum(
         1 for d in (entry_point_details or {}).values()
         if not d.get("synthetic_harness")
+        and not d.get("non_runtime_main")
         and any(r.split(":", 1)[0] in _STRUCTURAL_REASON_CATEGORIES
                 for r in d.get("reasons", []))
     )


### PR DESCRIPTION
## What
Exclude non-runtime `main`s (a crate-root `build.rs`, and `examples/` / `benches/`
targets) from the blackout advisory's structural-entry-point count, so a library
crate that ships one no longer has its library-blackout warning suppressed.

## Why
`blackout_warning` (`utilities/agentic_enhancer/entry_point_detector.py`) advises
a library-blackout when reachability prunes >= 90% of units AND no structural
entry point (route/main/CLI/handler) was found. The Rust extractor classifies
`unit_type="main"` for any function named `main`, with no file-path check — so a
compile-time `build.rs` script, and `examples/`/`benches/` auxiliary binaries
(which consume the public API rather than being it), each count as `structural`
and silently suppress the advisory for a library that ships one.

## How
- Tag such a main `non_runtime_main` (path-based) in `detect_entry_points` and
  exclude it from the `structural` sum in `blackout_warning`, exactly mirroring
  the existing `synthetic_harness` exclusion (PR #233).
- The main stays SEEDED — over-seeding an entry point is reachability-safe; only
  the advisory's structural count changes, never the kept set. A `main` under
  `src/` stays structural (a `src/build.rs` module is not the build script).
- The seed set (`detect_entry_points` result) is byte-identical before and after;
  only `entry_point_details` gains a key.

## Known limitations (disclosed)
- The path check is not Rust-gated (the detector is shared across parsers), so a
  top-level `examples/` main in any language is excluded from the structural
  count — advisory-only, never a dropped seed.
- A build script renamed via Cargo's `build = "custom.rs"` is not recognised.
- Pre-existing and orthogonal: the advisory is written only to
  `metadata.reachability_filter.warning` and stderr, not the CLI exit envelope,
  so a fired warning is not yet surfaced to a CI consumer.

## Tests
`tests/test_blackout_build_script.py` — the flag is excluded from the structural
count (advisory fires) while a real `src/main.rs` stays structural (no spurious
warning); `detect_entry_points` tags build.rs/examples/benches mains and keeps
them seeded. RED on base, GREEN with the fix; existing suite unchanged.

## Compatibility
None. Advisory-only string change; the seed/reachability output is byte-identical.
