### PR TITLE
docs: document the openant serve web UI

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ everything about analysis. They speak over a deliberately narrow contract.
 ```mermaid
 flowchart TB
     subgraph go["Go CLI — apps/openant-cli"]
-        cmd["cmd/*.go<br/>init · scan · parse · report"]
+        cmd["cmd/*.go<br/>init · scan · parse · report · serve"]
         invoke["internal/python/invoke.go<br/>process lifecycle, timeouts, signals"]
         gocfg["internal/config<br/>~/.config/openant/config.json"]
         golang_["internal/languages<br/>reads config/languages.json"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ All notable changes to OpenAnt are documented in this file.
   checkpointed, so a re-run resumes; the override lets a single large run finish
   outright.
 
+## [2026-08-14] — Local web UI
+
+### Added
+
+- **`openant serve` — a local, loopback-only web UI for the scan pipeline.**
+  Submit a repository URL or local path from the browser, watch scan logs stream
+  live (SSE), and read the HTML report / markdown summary / disclosures. Binds
+  127.0.0.1 only (refuses a non-loopback `--addr`); outputs persist under
+  `~/.openant/webui/`. Original work by @sounil, reconciled onto master and
+  security-hardened. See the "Web UI" section in the README.
+
 ## [2026-07-22] — Efficacy harness rescoped to a smoke test
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ Or run the full pipeline in one command:
 openant scan --verify
 ```
 
+### Web UI
+
+`openant serve` starts a local web UI over the same scan pipeline: submit a
+repository URL or local path, watch the scan logs stream live, and read the HTML
+report, markdown summary, and disclosures — all from the browser.
+
+```bash
+openant serve                       # http://127.0.0.1:8080, opens your browser
+openant serve --addr 127.0.0.1:9000 # choose a port
+```
+
+The server binds to loopback only (it refuses any non-loopback `--addr`) and is
+intended for local single-user use. Scan outputs persist under
+`~/.openant/webui/` across restarts. Analysis still sends source code to your
+configured LLM provider, the same as the CLI.
+
 ### Working with multiple projects
 
 The pipeline operates on one project at a time. Running `openant init` sets the newly initialized project as the active one, so all subsequent commands target it by default.


### PR DESCRIPTION
The web UI (`openant serve`) landed in #235 but its doc updates missed that merge due to a timing race. This adds them, docs-only:

- **README** — a `### Web UI` section under "Analyzing a project" (usage, `--addr`, loopback-only binding, output persistence, the LLM-data note).
- **CHANGELOG** — a dated `Local web UI` entry.
- **ARCHITECTURE** — `serve` added to the `cmd/*.go` command list.

All claims verified against the merged code on master. No code change.