### PR TITLE
docs(cli): fix stale "dominant language only" docstring for -l auto

### DIFF
--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -1107,9 +1107,10 @@ def resolve_language_selection(args, counts: dict[str, int]):
     Kept as a standalone function so the flag semantics are testable without
     running a scan, and so `scan` and `parse` cannot drift apart.
 
-    `-l auto` (the default) deliberately still means "dominant language only".
-    Multi-language is opt-in via --languages / --all-languages, so no existing
-    invocation changes behaviour.
+    `-l auto` (the default) means every detected language above the size
+    threshold — not the dominant one (see ``_select_languages_for``). ``-l <lang>``
+    narrows to a single language, ``--languages`` to a named subset, and
+    ``--all-languages`` scans everything detected regardless of the threshold.
 
     Raises:
         ValueError: If an explicit `-l <lang>` is combined with a multi-language


### PR DESCRIPTION
`resolve_language_selection`'s docstring (`openant/cli.py:1110`) claimed `-l auto` (the default) "deliberately still means 'dominant language only'" — but that contradicts `_select_languages_for`'s docstring in the same file (":127`, "`auto` now means every detected language, not the dominant one") and the actual behavior.

`auto` calls `select_languages(include=None, all_languages=False, …)`, which selects **every detected language above the size threshold** — asserted by `tests/test_auto_scans_all_languages.py`. This corrects the stale docstring to match; **no code change**.

```
$ pytest tests/test_auto_scans_all_languages.py tests/test_cli_multilang_flags.py tests/test_language_selection.py -q
52 passed
```