### PR TITLE
fix(analyzer): recover reasoning-only empty-completion analyze responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 
 All notable changes to OpenAnt are documented in this file.
 
+## [2026-08-14] — Recover reasoning-only (empty-completion) analyze responses
+
+### Fixed
+
+- **A unit is no longer silently dropped when a thinking-on model spends its
+  whole token budget reasoning.** Claude-5-family models run adaptive thinking by
+  default; on a large unit the model could exhaust the 8192-token `simple_text`
+  budget on a thinking block and return no text, which errored the unit
+  permanently (a coverage loss — the unit never got a verdict). The default
+  `max_tokens` is raised to 20000 (under the non-streaming ceiling) so thinking
+  and the JSON verdict both fit, and `parse_response` now scans the response for
+  a lone verdict-bearing JSON object instead of spanning from the first prose/code
+  brace, so a verdict emitted after a prose-and-code preamble parses. When several
+  verdict objects appear (an example beside the real one) it stays an ERROR and is
+  retried rather than guessed. Complements the in-run ERROR-retry added the same
+  day: fewer units reach the retry path at all.
+
 ## [2026-08-14] — Configurable Python-subprocess timeout
 
 ### Fixed

--- a/libs/openant-core/core/analysis_core.py
+++ b/libs/openant-core/core/analysis_core.py
@@ -85,32 +85,109 @@ def parse_response(response: str) -> dict:
 
     response = response.strip()
 
+    err = None
     try:
         result = json.loads(response)
-        return _normalize_result(result)
     except json.JSONDecodeError as e:
-        # Try to find JSON object in response
-        start = response.find("{")
-        end = response.rfind("}") + 1
-        if start >= 0 and end > start:
-            try:
-                result = json.loads(response[start:end])
-                return _normalize_result(result)
-            except json.JSONDecodeError:
-                pass
+        err = e
+    else:
+        if isinstance(result, dict):
+            return _normalize_result(result)
+        # Top-level JSON that is NOT an object (e.g. an array-of-findings
+        # `[{"verdict":...}]`) — do NOT hand a list to _normalize_result (it
+        # indexes by str keys -> TypeError -> uncaught, permanent coverage loss,
+        # PY-2). Fall through to the depth-0 scanner, which recovers a lone
+        # verdict object inside the array for free.
+    # Thinking-on models wrap the final JSON verdict in prose + code on BOTH
+    # sides. Scan for verdict objects at brace-DEPTH 0 only, tracking JSON-string
+    # state (with escapes) so braces inside string values -- or balanced code
+    # braces in the preamble -- don't offset the depth. Recovering only depth-0
+    # objects stops a nested example dict INSIDE a malformed outer verdict from
+    # being mistaken for the verdict.
+    #
+    # Recover a verdict ONLY when EXACTLY ONE depth-0 object decodes to a
+    # verdict-bearing dict AND no COMPETING verdict signal exists:
+    #  - several decoded verdict objects (example beside the real one, either
+    #    order) -> ambiguous -> ERROR+retry (never let a trailing example {SAFE}
+    #    override a real {VULNERABLE}); and
+    #  - a depth-0 span that FAILED to decode but still looks like a verdict
+    #    object (its text carries "verdict"/"finding") is a real verdict that
+    #    didn't parse (a common trailing-comma / missing-comma slip) sitting
+    #    beside a clean example -> also ambiguous -> ERROR+retry. Without this,
+    #    the malformed real VULNERABLE is dropped and the clean example SAFE is
+    #    returned: a silent SAST false negative (PY-NEW-1).
+    # If the scan ends mid-string, quote parity is untrustworthy -> don't guess.
+    # (Accepted residual, pre-existing in the prior find/rfind code: adversarial
+    # stray quotes in prose can still steer depth parity; the safe fallback is
+    # always ERROR->retry.)
+    decoder = json.JSONDecoder()
+    verdict_objs = []
+    malformed_verdict_spans = 0
+    depth = 0
+    in_string = False
+    escape = False
+    obj_start = None
+    for pos, ch in enumerate(response):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "{":
+            if depth == 0:
+                obj_start = pos
+            depth += 1
+        elif ch == "}":
+            if depth > 0:
+                depth -= 1
+                if depth == 0 and obj_start is not None:
+                    # Decode the balanced depth-0 span in isolation: bounds the
+                    # JSONDecodeError position math to the span (avoids O(n^2) on
+                    # multi-MB responses, PY-NEW-2) and gives the span text for
+                    # the malformed-verdict check.
+                    span = response[obj_start:pos + 1]
+                    try:
+                        obj = decoder.decode(span)
+                        if isinstance(obj, dict) and ("verdict" in obj or "finding" in obj):
+                            verdict_objs.append(obj)
+                    except json.JSONDecodeError:
+                        # Count as a competing verdict only if the failed span
+                        # carries a verdict/finding KEY (quoted, single or double)
+                        # -- so a malformed real verdict triggers the ambiguity
+                        # guard, but a preamble code block that merely contains the
+                        # word "finding" does not over-reject to ERROR.
+                        # ACCEPTED TRADE-OFF: a preamble that echoes verdict-SHAPED
+                        # broken JSON (e.g. `{"verdict": v}` in analyzed code) also
+                        # counts, so a legit lone verdict beside it is sent to
+                        # ERROR+retry rather than recovered. That is a recovery-rate
+                        # cost, not a wrong verdict (the retry re-derives it) -- the
+                        # deliberate safe direction, chosen over risking the
+                        # PY-NEW-1 false negative (malformed real verdict beside a
+                        # clean example -> example returned as SAFE).
+                        if any(k in span for k in ('"verdict"', "'verdict'", '"finding"', "'finding'")):
+                            malformed_verdict_spans += 1
+                    obj_start = None
+    if not in_string and len(verdict_objs) == 1 and malformed_verdict_spans == 0:
+        return _normalize_result(verdict_objs[0])
 
-        return {
-            "verdict": "ERROR",
-            "confidence": 0,
-            "vulnerabilities": [],
-            "reasoning": f"Failed to parse response: {str(e)}",
-            "raw_response": response[:500],
-            # Tag the failure so the detection retry pass (core/analyzer.py) can
-            # re-attempt it: a malformed model response is often transient, and
-            # without this key the ERROR carries error=None and is never retried
-            # in-run, permanently masking the unit's true verdict.
-            "error": {"type": "parse_error", "message": str(e)[:200]},
-        }
+    detail = str(err) if err is not None else "top-level JSON is not an object"
+    return {
+        "verdict": "ERROR",
+        "confidence": 0,
+        "vulnerabilities": [],
+        "reasoning": f"Failed to parse response: {detail}",
+        "raw_response": response[:500],
+        # Tag the failure so the detection retry pass (core/analyzer.py) can
+        # re-attempt it: a malformed model response is often transient, and
+        # without this key the ERROR carries error=None and is never retried
+        # in-run, permanently masking the unit's true verdict.
+        "error": {"type": "parse_error", "message": detail[:200]},
+    }
 
 
 def analyze_unit(

--- a/libs/openant-core/tests/test_bughunt2_regressions.py
+++ b/libs/openant-core/tests/test_bughunt2_regressions.py
@@ -172,3 +172,154 @@ def test_tm2_mixed_length_fences_extract_real_block():
             "purpose": "runs ```bash``` deploy", "impact_statement": "y"}
     mixed = "```json\nDECOY not closed with 3 ticks\n\n" + T.render_threat_model_md(data)
     assert T.parse_threat_model_md(mixed).get("purpose") == data["purpose"]
+
+
+def test_parse_response_prose_and_code_braces_before_json():
+    """A thinking-on model emits prose + a code snippet (with braces) before the
+    final JSON verdict. The naive find('{')/rfind('}') span mis-decodes; the
+    raw_decode scan must return the trailing assessment object, not ERROR."""
+    from core.analysis_core import parse_response
+    resp = (
+        "## Analysis\n"
+        "Here is the function:\n"
+        "```rust\nfn f() { if x == 0 { return; } }\n```\n"
+        "The `x == 0` case is guarded. Not exploitable.\n\n"
+        '{"finding": "safe", "confidence": 0.82, "cwe_id": 0, "reasoning": "guarded"}'
+    )
+    out = parse_response(resp)
+    assert out.get("verdict") == "SAFE", out
+
+
+def test_parse_response_ignores_trailing_non_verdict_json_block():
+    """A thinking-on model emits the verdict, THEN a remediation code block whose
+    body is itself valid JSON. The scan must return the VERDICT object, not the
+    trailing config dict. Keeping the last decodable dict unconditionally would
+    return the config (no verdict, no error) -- silently dropping the unit and
+    bypassing the parse_error retry tag. Requiring a verdict/finding key fixes it."""
+    from core.analysis_core import parse_response
+    resp = (
+        "## Security Analysis\n"
+        "The handler concatenates user input into the SQL string.\n\n"
+        '{"finding": "vulnerable", "confidence": 0.9, "cwe_id": 89, "reasoning": "x"}\n\n'
+        "### Recommended fix\n"
+        "```json\n"
+        '{"use_prepared_statements": true, "escape": "all"}\n'
+        "```\n"
+    )
+    out = parse_response(resp)
+    assert out.get("verdict") == "VULNERABLE", out
+
+
+def test_parse_response_no_verdict_dict_still_tagged_for_retry():
+    """When nothing decodable carries a verdict/finding key, parse_response must
+    fall through to the ERROR return WITH the parse_error tag, so #236's in-run
+    retry pass re-runs the unit instead of silently dropping it."""
+    from core.analysis_core import parse_response
+    resp = "Here is some config:\n```json\n{\"debug\": true, \"level\": 3}\n```\n"
+    out = parse_response(resp)
+    assert out.get("verdict") == "ERROR", out
+    assert out.get("error", {}).get("type") == "parse_error", out
+
+
+def test_parse_response_trailing_verdict_example_does_not_override_real_verdict():
+    """False-negative guard: a real VULNERABLE verdict followed by a trailing
+    'example: {SAFE}' block must NOT be silently downgraded to SAFE. Two
+    verdict-bearing objects are ambiguous, so parse_response must refuse to guess
+    and route to ERROR + retryable (never return SAFE)."""
+    from core.analysis_core import parse_response
+    from utilities.rate_limiter import is_retryable_error
+    resp = (
+        '{"verdict": "VULNERABLE", "confidence": 0.95, "cwe_id": 89}\n\n'
+        "For reference, a safe reply would look like:\n"
+        '{"verdict": "SAFE"}'
+    )
+    out = parse_response(resp)
+    assert out.get("verdict") != "SAFE", out          # never a false negative
+    assert out.get("verdict") == "ERROR", out
+    assert is_retryable_error(out.get("error")) is True, out
+
+
+def test_parse_response_malformed_outer_with_nested_example_is_not_false_negative():
+    """REGRESSION (bug-hunt 2026-08-15): a malformed OUTER verdict object (e.g. a
+    trailing comma — a very common LLM slip) that contains a nested example dict
+    with a verdict/finding key must NOT have the nested example recovered as THE
+    verdict. The real outer verdict is VULNERABLE; returning the nested SAFE is a
+    silent false negative in a SAST tool. Master returns ERROR+parse_error here
+    (→ JSONCorrector/#236 retry can recover the real verdict); PR-1 must not
+    regress that to SAFE. All three inputs carry a real VULNERABLE outer."""
+    from core.analysis_core import parse_response
+    bad_inputs = [
+        '{"verdict":"VULNERABLE", "note":{"finding":"safe"},}',              # trailing comma
+        "{'verdict': 'VULNERABLE', 'ex': {\"finding\": \"safe\"}}",          # single-quoted outer
+        '{"verdict":"VULNERABLE","cwe_id":89,"ex":{"finding":"safe"}, oops}',# junk tail
+    ]
+    for inp in bad_inputs:
+        out = parse_response(inp)
+        assert out.get("verdict") != "SAFE", f"FALSE NEGATIVE on {inp!r}: {out}"
+        # must be ERROR so analyze_unit's JSONCorrector/#236 retry fires (verdict in ERROR/None)
+        assert out.get("verdict") == "ERROR", f"expected ERROR (retryable) on {inp!r}: {out}"
+
+
+def test_parse_response_depth0_scan_full_matrix():
+    """PY-1 fix (depth-0 scan, sol-consulted): the full behavior matrix. Recover a
+    verdict ONLY when exactly one DEPTH-0 verdict object decodes; a nested object
+    inside a malformed outer must never be recovered (silent-FN guard)."""
+    from core.analysis_core import parse_response as p
+    # must-pass recoveries
+    assert p('## Analysis\n```rust\nfn f() { if x==0 { return; } }\n```\nGuarded.\n\n{"finding":"safe","cwe_id":0}').get("verdict") == "SAFE"
+    assert p('{"verdict":"SAFE","meta":{"x":1}}').get("verdict") == "SAFE"           # nested non-verdict not double-counted
+    assert p('{"verdict":"VULNERABLE","reasoning":"has a { brace in string"}').get("verdict") == "VULNERABLE"  # brace in string value
+    # ambiguous -> ERROR (both orders)
+    assert p('Example: {"verdict":"SAFE"} ... Actual: {"verdict":"VULNERABLE"}').get("verdict") == "ERROR"
+    assert p('Real: {"verdict":"VULNERABLE"} ... Example: {"verdict":"SAFE"}').get("verdict") == "ERROR"
+    # malformed-outer + nested example -> ERROR, never the nested SAFE (the regression)
+    for bad in ['{"verdict":"VULNERABLE", "note":{"finding":"safe"},}',
+                "{'verdict': 'VULNERABLE', 'ex': {\"finding\": \"safe\"}}",
+                '{"verdict":"VULNERABLE","cwe_id":89,"ex":{"finding":"safe"}, oops}']:
+        assert p(bad).get("verdict") == "ERROR", bad
+    # unbalanced brace in code before a real verdict -> safe-fail ERROR (depth never returns to 0)
+    assert p('```\ndef f(): return {  # oops unbalanced\n```\n{"finding":"safe"}').get("verdict") == "ERROR"
+    # truncated / no close -> ERROR
+    assert p('{"verdict":"VULNERABLE"').get("verdict") == "ERROR"
+    assert p('no json at all here').get("verdict") == "ERROR"
+
+
+def test_parse_response_malformed_real_beside_valid_example_sibling():
+    """PY-NEW-1 (round-2 bug hunt): a MALFORMED real verdict object sitting BESIDE
+    a well-formed example sibling must NOT recover the example. Only the clean
+    sibling decodes, but the malformed span still carries a verdict key -> ambiguous
+    -> ERROR (retryable), never the sibling's SAFE. Distinct from the nested case."""
+    from core.analysis_core import parse_response as p
+    for bad in [
+        'Actual analysis:\n{"verdict": "VULNERABLE", "confidence": 0.95,}\n\nFor reference the safe form:\n{"verdict": "SAFE"}',
+        'Result: {"verdict": "VULNERABLE" "cwe_id": 79}\nExample clean unit: {"verdict": "SAFE"}',
+    ]:
+        out = p(bad)
+        assert out.get("verdict") == "ERROR", (bad, out)
+
+
+def test_parse_response_top_level_array_does_not_crash():
+    """PY-2 (bug hunt): a top-level JSON ARRAY (array-of-findings) must not raise
+    TypeError from _normalize_result. It routes through the depth-0 scanner, which
+    recovers a lone verdict object inside the array."""
+    from core.analysis_core import parse_response as p
+    assert p('[{"verdict": "SAFE"}]').get("verdict") == "SAFE"
+    assert p('```json\n[{"verdict":"VULNERABLE"}]\n```').get("verdict") == "VULNERABLE"
+    # two verdicts in the array -> ambiguous -> ERROR, still no crash
+    assert p('[{"verdict":"SAFE"},{"verdict":"VULNERABLE"}]').get("verdict") == "ERROR"
+    # a non-object, non-recoverable top-level (scalar) -> ERROR, no crash
+    assert p('42').get("verdict") == "ERROR"
+
+
+def test_parse_response_verdict_shaped_preamble_prefers_retry_over_false_negative():
+    """ACCEPTED trade-off (round-3 bug hunt): when the preamble echoes verdict-SHAPED
+    broken JSON (e.g. analyzed code `{"verdict": v}`) beside a lone clean verdict, the
+    parser routes to ERROR+retryable rather than recover — the safe direction. It is a
+    recovery-rate cost (the in-run retry re-derives the verdict), NOT a wrong verdict,
+    and it is what prevents the PY-NEW-1 false negative (malformed real verdict beside a
+    clean example being returned as SAFE). Pinned so the trade-off is intentional."""
+    from core.analysis_core import parse_response as p
+    from utilities.rate_limiter import is_retryable_error
+    out = p('The sink builds {"verdict": v} dynamically.\nFinal: {"verdict":"VULNERABLE"}')
+    assert out.get("verdict") == "ERROR"                       # not a silently-wrong verdict
+    assert is_retryable_error(out.get("error")) is True        # self-heals via the in-run retry

--- a/libs/openant-core/tests/test_llm_helpers.py
+++ b/libs/openant-core/tests/test_llm_helpers.py
@@ -97,7 +97,7 @@ class TestSimpleText:
             CompletionResult(content=[TextBlock("x")], input_tokens=1, output_tokens=1, stop_reason="end_turn")
         )
         simple_text(_binding(adapter), "p", tracker=TokenTracker())
-        assert adapter.calls[0]["max_tokens"] == 8192
+        assert adapter.calls[0]["max_tokens"] == 20000
 
         simple_text(_binding(adapter), "p", max_tokens=128, tracker=TokenTracker())
         assert adapter.calls[1]["max_tokens"] == 128

--- a/libs/openant-core/utilities/llm/helpers.py
+++ b/libs/openant-core/utilities/llm/helpers.py
@@ -38,7 +38,15 @@ def simple_text(
     prompt: str,
     *,
     system: Optional[str] = None,
-    max_tokens: int = 8192,
+    # Thinking-era default. Claude-5 / Gemini-2.5+ / OpenAI o-series spend
+    # output budget on hidden reasoning; 8192 can be fully consumed by
+    # reasoning on a large unit, yielding a reasoning-only (empty) completion
+    # that the adapter drops -> hard "no usable content" error. 20000 is under
+    # the Anthropic non-streaming 10-min ceiling (32000 is rejected with a
+    # "Streaming is required" ValueError; 20000 is accepted) and is a CAP, not
+    # a floor on generation -- models still stop at end_turn on small prompts,
+    # so this does not raise cost for short answers.
+    max_tokens: int = 20000,
     tracker: Optional[TokenTracker] = None,
 ) -> str:
     """Send one user-prompt completion, return the concatenated text reply.


### PR DESCRIPTION
## What
Recover **reasoning-only empty-completion** analyze responses. A thinking-enabled model can spend its whole token budget on reasoning and return an effectively empty completion, which the analyzer then dropped — a silent loss of a unit's verdict (a silent false-negative, the cardinal SAST sin).

## Root cause
1. `simple_text`'s default `max_tokens` (8192) was too small for reasoning-on models on the analyze path (`core/analysis_core.py` calls `simple_text` with no override), so the budget was exhausted on reasoning → empty completion.
2. `parse_response` used a naive `find("{")`/`rfind("}")` span that mis-handled prose-plus-code-brace responses and could crash on a top-level JSON array.

## Fix
- `utilities/llm/helpers.py`: `simple_text` default `max_tokens` **8192 → 20000** (reaches the analyze path, which passes no override).
- `core/analysis_core.py`: `parse_response` rewritten as a depth-0 brace scanner that recovers a verdict only when exactly one depth-0 verdict-bearing object decodes; competing/ambiguous signals return `ERROR` + the `error:{type:"parse_error"}` retry tag; a top-level non-dict JSON no longer reaches `_normalize_result` (was a `TypeError` crash).

## Relationship to #236 (supersedes a documented limitation, FN-safely)
#236 deliberately **left the brace-grab JSON heuristic as-is**, documenting that "no deterministic change to it is false-negative-safe" because recovering the first/last object would turn a visible ERROR into a silent wrong verdict on example-then-answer responses. **This PR supersedes that limitation in an FN-safe way**: the depth-0 scanner does **not** blind-pick first/last — an ambiguous/competing decode stays `ERROR` (→ retry), so it only ever *narrows* the silent-wrong window, never widens it. It also preserves #236's `error:{type:"parse_error"}` retry contract.

## Evidence (RED → GREEN, offline; differential vs pinned base a0fe722)
- `git diff --stat a0fe722 HEAD` → **5 files changed, 278 insertions(+), 25 deletions(-)**
- RED @ base `a0fe722`: new/edited tests fail — **6 failed / 33 passed**, incl. a real `TypeError: list indices must be integers` crash on the top-level-array case.
- GREEN @ HEAD `bc2dd72`: `pytest tests/test_bughunt2_regressions.py tests/test_llm_helpers.py -q` → **39 passed**.
- `ruff check` on the 4 changed Python files → clean. CI: 14/14 green.

## Scope (C8) — explicit-`max_tokens` sites NOT covered by the default bump (re-derived at a0fe722; disclosed, not regressions)
The default-budget bump fixes only call sites that omit `max_tokens`. These sites pass it explicitly and remain at their smaller budget, so a reasoning-on model can still empty-complete on their paths (FN-relevant; follow-up, out of scope here):
- `core/llm_reachability.py:392` = 4096
- `openant/cli.py:990` = 4096
- `report/generator.py:200` / `:292` = 4096
- `utilities/context_enhancer.py:331` = 4096
- `utilities/json_corrector.py:149` = 8192
- `context/application_context.py:677` = 2000
(Provider probe calls `max_tokens=1` in adapter/anthropic/bedrock are `validate()` health-checks, not verdict paths.) Also unchanged: 7 sibling LLM-response parsers still use the naive `rfind("}")` span.

## Known limitation (C2 — billed-but-unrecorded)
Retried empty/parse-error completions remain **billed-but-unrecorded** in the usage ledger (openant-kb CONC-C2). Fixing the record-before-raise ordering is a **separate telemetry PR** (it touches the exception class + every adapter + `helpers.py`) and is intentionally not bundled here.

## Checkpoint-identity note
Generation params (e.g. `max_tokens`) are deliberately **not** part of checkpoint identity — this config-only change does not invalidate prior checkpoints. (Rationale is FN-safe: pre-fix empty completions were recorded as `ERROR`, which never adopts on resume, so truncation-degraded successes are the only carry-over.)

No live/billed e2e was run pre-push (offline unit suite only).
