### PR TITLE
fix(verifier): block consistency-downgrade of exploitable findings to any disclosure-dropped verdict

### DIFF
--- a/libs/openant-core/tests/test_verifier_consistency_disclosure_dropped_downgrade.py
+++ b/libs/openant-core/tests/test_verifier_consistency_disclosure_dropped_downgrade.py
@@ -1,0 +1,85 @@
+"""Disclosure-bypass FN: Stage-2 pattern-consistency must NOT silently downgrade a
+conclusively-EXPLOITABLE finding to ANY disclosure-dropping verdict.
+
+The anti-downgrade guard (``_has_conclusive_exploitable_path`` call site in
+``_check_consistency``) originally blocked only ``{"safe", "protected"}``. But
+``core.verdict_taxonomy.DISCLOSURE_DROPPED == {rejected, safe, protected,
+inconclusive}`` — a consistency downgrade to ``inconclusive`` or ``rejected``
+suppresses the finding from disclosure IDENTICALLY while BYPASSING the guard.
+That is a silent security false-negative.
+
+The guard's block-set must equal DISCLOSURE_DROPPED (referenced, not hardcoded)
+so the two sets cannot drift apart again. These tests pin every dropping verdict
+and assert a legit downgrade of a NON-exploitable finding still succeeds.
+"""
+from core.verdict_taxonomy import DISCLOSURE_DROPPED
+from utilities.finding_verifier import FindingVerifier, ConsistencyCheckResult
+
+
+def _verifier():
+    v = FindingVerifier.__new__(FindingVerifier)
+    v._use_logger = False
+    v.verbose = False
+    return v
+
+
+FILE = "pkg/logger/console.go"
+EXPLOIT_RK = f"{FILE}:runMsg.json"    # -> *Msg.json (groups with the safe sibling)
+SIB_RK = f"{FILE}:infoMsg.json"
+
+_EXPLOIT_V = {"correct_finding": "vulnerable",
+              "exploit_path": {"entry_point": "h", "sink_reached": True,
+                               "attacker_control_at_sink": "full", "path_broken_at": None}}
+
+
+def _run_downgrade(downgrade_to):
+    v = _verifier()
+    v._resolve_inconsistency = lambda group, cbr: ConsistencyCheckResult(
+        "logger json emitter", downgrade_to,
+        [{"route_key": EXPLOIT_RK, "should_be": downgrade_to, "reason": "sibling pattern"}], "x")
+    out = v._check_consistency([
+        {"route_key": EXPLOIT_RK, "finding": "vulnerable", "verification": dict(_EXPLOIT_V)},
+        {"route_key": SIB_RK, "finding": downgrade_to,
+         "verification": {"correct_finding": downgrade_to}}], {})
+    return next(r for r in out if r["route_key"] == EXPLOIT_RK)
+
+
+def test_exploitable_not_downgraded_to_inconclusive():
+    got = _run_downgrade("inconclusive")
+    verdict = got.get("verification", {}).get("correct_finding") or got.get("finding")
+    assert verdict == "vulnerable", f"exploitable finding was dropped to {verdict!r}"
+    assert "consistency_downgrade_blocked" in got
+
+
+def test_exploitable_not_downgraded_to_rejected():
+    got = _run_downgrade("rejected")
+    verdict = got.get("verification", {}).get("correct_finding") or got.get("finding")
+    assert verdict == "vulnerable", f"exploitable finding was dropped to {verdict!r}"
+    assert "consistency_downgrade_blocked" in got
+
+
+def test_exploitable_not_downgraded_to_any_disclosure_dropped_verdict():
+    # Full sweep: no verdict in DISCLOSURE_DROPPED may silently drop the finding.
+    for dv in sorted(DISCLOSURE_DROPPED):
+        got = _run_downgrade(dv)
+        verdict = got.get("verification", {}).get("correct_finding") or got.get("finding")
+        assert verdict == "vulnerable", f"downgrade to {dv!r} silently dropped the finding"
+        assert "consistency_downgrade_blocked" in got, f"no audit breadcrumb for {dv!r}"
+
+
+def test_non_exploitable_downgrade_still_applies():
+    # Regression guard against over-blocking: a finding with NO conclusive exploit
+    # path (neither broken nor exploitable) must still be consistency-downgraded.
+    v = _verifier()
+    v._resolve_inconsistency = lambda group, cbr: ConsistencyCheckResult(
+        "logger", "inconclusive",
+        [{"route_key": EXPLOIT_RK, "should_be": "inconclusive", "reason": "no path"}], "x")
+    out = v._check_consistency([
+        {"route_key": EXPLOIT_RK, "finding": "vulnerable",
+         "verification": {"correct_finding": "vulnerable"}},   # no exploit_path -> not conclusive
+        {"route_key": SIB_RK, "finding": "inconclusive",
+         "verification": {"correct_finding": "inconclusive"}}], {})
+    got = next(r for r in out if r["route_key"] == EXPLOIT_RK)
+    verdict = got.get("verification", {}).get("correct_finding") or got.get("finding")
+    assert verdict == "inconclusive", f"legit downgrade was over-blocked (verdict={verdict!r})"
+    assert "consistency_downgrade_blocked" not in got

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -61,7 +61,7 @@ from prompts.verification_prompts import (
     get_verification_system_prompt,
     get_consistency_check_prompt
 )
-from core.verdict_taxonomy import FINDING_VERDICT_ORDER
+from core.verdict_taxonomy import DISCLOSURE_DROPPED, FINDING_VERDICT_ORDER
 
 # Import application context type for type hints
 try:
@@ -890,10 +890,19 @@ class FindingVerifier:
                                 continue
 
                             # F-KB-1b: a conclusively-exploitable finding must not be
-                            # silently downgraded to safe by pattern matching (mirror of
-                            # the conclusive-broken guard above).
+                            # silently downgraded to ANY disclosure-dropping verdict by
+                            # pattern matching (mirror of the conclusive-broken guard
+                            # above). The block-set MUST reference
+                            # core.verdict_taxonomy.DISCLOSURE_DROPPED directly rather
+                            # than a hardcoded {safe, protected}: the original guard
+                            # covered only {safe, protected} while DISCLOSURE_DROPPED also
+                            # contains {inconclusive, rejected}, so a downgrade to
+                            # inconclusive/rejected silently dropped the finding from
+                            # disclosure (an identical security false-negative) while
+                            # bypassing the guard. Referencing the canonical set keeps the
+                            # two from drifting apart again — that drift WAS the bug.
                             if (self._has_conclusive_exploitable_path(result)
-                                    and str(new_verdict or "").strip().lower() in ("safe", "protected")):
+                                    and str(new_verdict or "").strip().lower() in DISCLOSURE_DROPPED):
                                 self._log("warning",
                                           f"Blocked consistency downgrade of conclusively-exploitable {route_key} -> {new_verdict}",
                                           unit_id=route_key)


### PR DESCRIPTION
## What
The Stage-2 consistency check has an anti-downgrade guard (`_has_conclusive_exploitable_path`) that stops the lower-trust pattern-matcher from silently downgrading a **conclusively-exploitable** finding — but it only blocked downgrades to `{safe, protected}`. A downgrade to **`inconclusive`** or **`rejected`** dropped the finding from disclosure *identically* while *bypassing* the guard — a silent false-negative (the cardinal SAST sin).

## Root cause
`utilities/finding_verifier.py` hardcoded the guard's block-set as `("safe", "protected")`, while `core/verdict_taxonomy.py` defines `DISCLOSURE_DROPPED = {rejected, safe, protected, inconclusive}` — the full set of producer verdicts excluded from disclosure. The guard's set was a strict subset of the disclosure-drop set, so two of the four drop-verdicts slipped through. The two sets had drifted apart — that drift **was** the bug.

## Fix
Reference the canonical `DISCLOSURE_DROPPED` directly instead of a hardcoded tuple, so the guard blocks a consistency-downgrade of a conclusively-exploitable finding to **any** disclosure-suppressing verdict, and the two sets can never drift again. Same shape as the existing guard (block + retain the more-severe verdict; never synthesize an upgrade). The `consistency_downgrade_blocked` audit breadcrumb is unchanged and greppable.

## Evidence (RED → GREEN, offline; differential vs pinned base a0fe722)
- `git diff --stat a0fe722 HEAD` → **2 files changed, +98 / -4**
- RED @ base `a0fe722`: `3 failed, 1 passed` — downgrade→inconclusive and →rejected both slip past the `{safe,protected}` guard.
- GREEN @ HEAD: `4 passed`. Full offline suite: **2795 passed, 30 skipped**. `ruff` clean; `semgrep --config auto` 0 findings.
- Anti-revert: reverting the guard to `("safe","protected")` re-fails 3 of 4 tests. Over-block regression pinned by `test_non_exploitable_downgrade_still_applies` (a non-exploitable finding still downgrades).
- Reachability: `_check_consistency` runs **unconditionally** in `verify_batch` (production Stage-2 under `--verify`); the guarded path is live, not dead.

## Direction / scope
- Fail-safe direction: **retains** a finding rather than silently dropping a true positive — never trades a false-negative for a false-positive.
- `_has_conclusive_exploitable_path` is fail-closed (requires positive proof: sink reached + attacker control full/partial + path not broken), so a benign finding cannot be mis-flagged and wrongly retained.
- Out of scope (by design, not a remaining bypass): `finding_verifier.py`'s primary Stage-2 verdict assignment (the verifier's own authoritative call) and the checkpoint-restore path (replays an already-guarded verdict).

Known limitation: no live billed T3 real-corpus differential / T4 efficacy A/B run pre-push (offline unit + differential evidence only); these are merge-time gates.
