### PR TITLE
fix(checkpoint): gate LLM-verdict adoption on backend identity (minimal I2)

### DIFF
--- a/apps/openant-cli/internal/checkpoint/checkpoint.go
+++ b/apps/openant-cli/internal/checkpoint/checkpoint.go
@@ -23,6 +23,18 @@ import (
 
 const summaryFile = "_summary.json"
 
+// fingerprintFile is the backend-identity sidecar (I2) the Python pipeline
+// writes into each checkpoint dir. Like _summary.json it is NOT a per-unit
+// result and must be excluded from the fallback count, or a resume would
+// over-count "completed" units by one.
+const fingerprintFile = "_fingerprint.json"
+
+// isSidecar reports whether a checkpoint-dir entry is a bookkeeping sidecar
+// (never a per-unit result) and so must not be counted as a completed unit.
+func isSidecar(name string) bool {
+	return name == summaryFile || name == fingerprintFile
+}
+
 // Summary represents the _summary.json written by Python pipeline steps.
 type Summary struct {
 	Step           string         `json:"step"`
@@ -131,7 +143,7 @@ func DetectFallback(scanDir, stepName string) *Info {
 
 	count := 0
 	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") && e.Name() != summaryFile {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".json") && !isSidecar(e.Name()) {
 			count++
 		}
 	}

--- a/apps/openant-cli/internal/checkpoint/checkpoint_sidecar_test.go
+++ b/apps/openant-cli/internal/checkpoint/checkpoint_sidecar_test.go
@@ -1,0 +1,46 @@
+package checkpoint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestDetectFallbackExcludesFingerprintSidecar verifies the I2 backend-identity
+// sidecar (_fingerprint.json) is NOT counted as a completed unit by the
+// Python-less fallback scanner, mirroring the Python _RESERVED_FILES exclusion.
+func TestDetectFallbackExcludesFingerprintSidecar(t *testing.T) {
+	scanDir := t.TempDir()
+	dir := filepath.Join(scanDir, "analyze_checkpoints")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(name string) {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("unit1.json")
+	write("unit2.json")
+	write(summaryFile)     // must be excluded
+	write(fingerprintFile) // must be excluded (the new sidecar)
+
+	info := DetectFallback(scanDir, "analyze")
+	if info == nil {
+		t.Fatal("expected non-nil Info")
+	}
+	if info.Count != 2 {
+		t.Fatalf("expected 2 counted units (sidecars excluded), got %d", info.Count)
+	}
+}
+
+func TestIsSidecar(t *testing.T) {
+	for _, name := range []string{summaryFile, fingerprintFile} {
+		if !isSidecar(name) {
+			t.Errorf("%q should be a sidecar", name)
+		}
+	}
+	if isSidecar("unit1.json") {
+		t.Error("a per-unit file must not be a sidecar")
+	}
+}

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -336,6 +336,83 @@ def _count_verdicts(results):
     return counts
 
 
+def _analyze_fingerprint(binding) -> dict:
+    """Build the analyze-phase backend-identity fingerprint.
+
+    The static system + user-analysis templates are rendered with
+    ``app_context=None`` (mandatory: the LLM-generated threat model is
+    non-deterministic per scan and must not enter the key). An unrenderable
+    template becomes a sentinel via ``render_template_texts`` → forces re-run
+    rather than a stale adoption.
+    """
+    from core.backend_identity import fingerprint_for_binding, render_template_texts
+    from prompts.vulnerability_analysis import get_system_prompt
+    from prompts.prompt_selector import get_analysis_prompt
+    texts = render_template_texts([
+        lambda: get_system_prompt(app_context=None),
+        lambda: get_analysis_prompt(code="", language="code", app_context=None),
+    ])
+    return fingerprint_for_binding(binding, texts)
+
+
+def _archive_stale_results(output_dir: str, current_fp: str) -> None:
+    """Preserve a prior scan's report before this run overwrites it.
+
+    If ``output_dir/results.json`` exists and was produced under a DIFFERENT
+    ``analyze_fingerprint``, rename it to ``results__<short-fp>.json`` (an
+    unstamped file → ``results__legacy.json``) so a re-scan with a different
+    model/config preserves the prior analyze report. The suffix is the SAME short
+    form as ``StepCheckpoint._archive_dir`` — the last ``:``-split segment, first 8
+    hex — so the ``sha256:`` prefix's colon never lands in a filename (a colon
+    breaks ``os.replace`` on Windows: the OSError is swallowed and a later run
+    overwrites the prior results.json, defeating the preservation promise).
+
+    Scope (named residual): this preserves the Stage-1 ``results.json`` only.
+    ``results_verified.json`` (Stage-2, and the file the serve/report layer
+    prefers) is NOT fingerprint-checked or archived here — a backend-swap re-scan
+    run without ``--verify`` leaves the prior verified file in place. That is
+    pre-existing base behaviour (base overwrote ``results.json`` unconditionally);
+    extending identity/preservation to ``results_verified.json`` is a follow-up.
+
+    Collision-safe: if the target archive name already exists (an A→B→A config
+    alternation, or two unstamped reports both → ``results__legacy.json``), a
+    ``-<n>`` suffix is appended rather than overwriting — mirroring
+    ``_archive_dir`` — so no prior report is ever destroyed. Best-effort: any error
+    leaves the file in place (preserve-not-destroy; never crash the scan).
+    """
+    results_path = os.path.join(output_dir, "results.json")
+    if not os.path.exists(results_path):
+        return
+    try:
+        prior = read_json(results_path)
+    except (json.JSONDecodeError, OSError, ValueError):
+        return
+    if not isinstance(prior, dict):
+        return
+    old_fp = prior.get("analyze_fingerprint")
+    if old_fp == current_fp:
+        return
+    # Short, filesystem-safe suffix: drop the ``sha256:`` prefix (its colon is
+    # illegal in a Windows filename) and keep the first 8 hex chars. A machine
+    # stamp is always a str; a hand-corrupted non-string stamp must NOT crash the
+    # scan (the function's contract is best-effort) — treat it as unstamped.
+    suffix = old_fp.split(":")[-1][:8] if isinstance(old_fp, str) and old_fp else "legacy"
+    # Never clobber an existing archive (distinct prior report under the same
+    # short suffix): append -<n> until the name is free, as _archive_dir does.
+    base = os.path.join(output_dir, f"results__{suffix}")
+    archive = f"{base}.json"
+    n = 1
+    while os.path.exists(archive):
+        archive = f"{base}-{n}.json"
+        n += 1
+    try:
+        os.replace(results_path, archive)
+        print(f"[Analyze] Prior scan's results.json (fingerprint {suffix}) "
+              f"preserved as {os.path.basename(archive)}.", file=sys.stderr)
+    except OSError:
+        pass
+
+
 def run_analysis(
     dataset_path: str,
     output_dir: str,
@@ -411,6 +488,16 @@ def run_analysis(
         probe_registry_or_raise(registry)
     binding = registry.get("analyze")
     print(f"[Analyze] Provider: {binding.provider_name}, Model: {binding.model}", file=sys.stderr)
+
+    # I2 adopt gate: BEFORE loading any prior checkpoints, verify the backend
+    # identity that produced them matches the current one. A changed model /
+    # provider / adapter / static template archives the stale dir aside and
+    # forces a re-run rather than silently adopting another backend's verdicts.
+    # Run AFTER the checkpoint.dir override above.
+    analyze_fp = _analyze_fingerprint(binding)
+    checkpoint.sync_identity(analyze_fp)
+    # Preserve a prior scan's final report before this run overwrites it.
+    _archive_stale_results(output_dir, analyze_fp["key_digest"])
 
     # JSON corrector inherits the analyze binding so correction calls
     # route through the same provider+model.
@@ -619,6 +706,14 @@ def run_analysis(
         },
         "results": results,
         "code_by_route": code_by_route,
+        # Stamp the analyze-phase KEY digest so (a) a later re-scan with a
+        # different config archives this report instead of overwriting it, and
+        # (b) the verify phase can fold it into its own adopt-gate KEY — an
+        # analyze-model/provider/template swap regenerates this digest and
+        # thereby invalidates any verify checkpoints produced against the old
+        # analyze run (closes the verify-overwrite corruption). Deterministic +
+        # persisted → zero re-pay.
+        "analyze_fingerprint": analyze_fp["key_digest"],
     }
 
     write_json(results_path, experiment_result)

--- a/libs/openant-core/core/backend_identity.py
+++ b/libs/openant-core/core/backend_identity.py
@@ -1,0 +1,200 @@
+"""Minimal backend-identity fingerprints for checkpoint adopt-gating (I2).
+
+OpenAnt caches per-phase LLM results in ``{scan_dir}/{phase}_checkpoints/``
+keyed by ``unit_id`` (a PATH, e.g. ``file.py:func``). On a re-scan / resume
+into a reused ``output_dir`` the phase ADOPTS those prior verdicts. That is
+correct only when the SAME backend would have produced them. When the backend
+identity has changed — a different model, provider, or adapter, or a different
+static prompt template — adopting is a silent false-negative: the "scan" costs
+$0 and re-uses answers a different backend never gave. Verify additionally
+OVERWRITES the fresh Stage-1 verdict with the adopted one, corrupting the
+report.
+
+This module computes a scheme-versioned KEY that a phase stamps into its
+checkpoint dir (``_fingerprint.json``) and re-checks on the next run. The KEY
+is the invalidation identity: a change archives the old checkpoints aside and
+re-pays.
+
+KEY dimensions: ``scheme_version``, ``phase``, ``model``, ``provider_name``,
+``adapter_type``, ``config_base_url``, a digest of the phase's STATIC prompt
+template(s) (``templates_sha``), and any caller-supplied ``extra_key`` (verify
+folds in the producing analyze run's fingerprint so an analyze-model swap
+invalidates the dependent verify checkpoints too).
+
+Deliberate exclusions (minimal by mandate):
+  * NO endpoint DETECTION / drift_log / strict-mode — over-built, excluded.
+  * NO credential-derived value (api_key). A credential-routing gateway (same
+    URL + model, different key → different upstream) is a NAMED RESIDUAL.
+  * app_context / threat-model is LLM-generated and regenerates
+    non-deterministically every scan; callers MUST render templates with
+    ``app_context=None`` so it never enters ``templates_sha`` (including it
+    caused a VERIFIED ~17k-token spurious re-pay on a same-config resume).
+
+Bump ``FINGERPRINT_SCHEME_VERSION`` when the KEY definition changes; it is part
+of the KEY, so old sidecars invalidate cleanly.
+
+RESIDUALS (named, not closed here):
+  * ``config_base_url`` IS now carried on ``PhaseBinding`` and folded into the
+    KEY (sanitized: userinfo/query/fragment stripped, so no credential is
+    persisted). Two gateway configs sharing model+provider but routing to
+    different upstreams now discriminate; default-config users keep ``None`` →
+    digest unchanged.
+  * per-unit content drift — ``unit_id`` is PATH-based, not a content hash. A
+    body edit under the SAME symbol adopts the stale per-unit verdict.
+  * cred-routing / api_key — see above (same URL+model, different key → different
+    upstream is NOT discriminated; api_key deliberately excluded from the KEY).
+  * the ``enhance`` phase is NOT gated: it is default-on with PERMANENT
+    checkpoints and, across a backend swap, ADOPTS the prior enhance results at
+    base — restoring a stale ``agent_context`` that feeds the analyze prompt and
+    gates ``--exploitable`` / ``--limit``. Deliberately deferred (gate only once
+    a stale-enhance false-negative is demonstrated).
+  * the ``dynamic_test`` phase is NOT gated: it likewise adopts prior execution
+    facts across a backend swap at base. Deliberately deferred (same bar).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from urllib.parse import urlsplit, urlunsplit
+
+# Bump when the KEY definition below changes so pre-existing sidecars invalidate
+# cleanly (they will simply mismatch and trigger an archive-and-repay).
+FINGERPRINT_SCHEME_VERSION = 1
+
+# Sidecar filename written into each checkpoint dir. Excluded from every
+# checkpoint counter (see core/checkpoint.py and the Go DetectFallback).
+FINGERPRINT_FILE = "_fingerprint.json"
+
+# Substituted for any prompt template that fails to render. It differs from any
+# real template text, so a fingerprint built over it never matches a real one
+# → forces re-run rather than risking a stale adoption (the 93662c7 fail-safe).
+UNRENDERABLE_SENTINEL = "<<unrenderable>>"
+
+
+def _sanitize_base_url(url):
+    """Return ``scheme://host[:port]/path`` with **userinfo, query, and fragment**
+    stripped — the three standard credential-bearing URL components
+    (``user:pass@`` in the netloc, ``?api_key=...`` in the query, ``#...`` in the
+    fragment). The sidecar persists the raw KEY dict via ``_write_fingerprint``,
+    so these must not survive.
+
+    Named residual (NOT stripped): the ``path`` is preserved because it is
+    load-bearing for endpoint discrimination, so a credential embedded in the
+    PATH (``https://gw/…/sk-SECRET/v1``) or a matrix param (``;api_key=…`` inside
+    a path segment) WOULD persist. This is the same accepted-residual tier as the
+    ``api_key`` cred-routing exclusion — a gateway that puts a secret in the URL
+    path is not distinguished from one that does not; do not rely on this function
+    to redact path-embedded secrets. IPv6 literal hosts are re-bracketed so the
+    netloc stays well-formed. ``None`` passes through unchanged so default-config
+    users keep ``config_base_url=None`` (digest unchanged).
+    """
+    if not url:
+        return url
+    try:
+        p = urlsplit(url)
+        host = p.hostname or ""
+        port = p.port  # a property that PARSES the port → may raise ValueError
+    except ValueError:
+        # Unparseable url / invalid port → don't risk leaking; forego
+        # discrimination for this url rather than crash the scan.
+        return None
+    # Re-bracket an IPv6 literal (urlsplit's .hostname drops the [] netloc form).
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    netloc = f"{host}:{port}" if port is not None else host
+    # Keep scheme + sanitized netloc + path only; query and fragment dropped.
+    return urlunsplit((p.scheme, netloc, p.path, "", ""))
+
+
+def _sha256_hex(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+
+
+def templates_digest(template_texts) -> str:
+    """Digest the phase's STATIC prompt template text(s).
+
+    Callers MUST render templates with ``app_context=None`` so the
+    LLM-generated, per-scan-varying threat model never enters the digest.
+    """
+    joined = "\x00".join(t or "" for t in (template_texts or []))
+    return "sha256:" + _sha256_hex(joined)
+
+
+def render_template_texts(renderers) -> list[str]:
+    """Render each zero-arg template callable, substituting
+    ``UNRENDERABLE_SENTINEL`` for any that raises.
+
+    Fail-safe: an unrenderable prompt must force a re-run (a sentinel that
+    differs from every real fingerprint), never a stale adoption.
+    """
+    texts: list[str] = []
+    for r in renderers:
+        try:
+            texts.append(r())
+        except Exception:  # noqa: BLE001 — any render failure → sentinel
+            texts.append(UNRENDERABLE_SENTINEL)
+    return texts
+
+
+def _canonical(obj) -> str:
+    return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def _key_digest(key: dict) -> str:
+    return "sha256:" + _sha256_hex(_canonical(key))
+
+
+def build_fingerprint(phase: str, model: str, provider_name: str,
+                      adapter_type: str, config_base_url,
+                      template_texts, extra_key: dict | None = None) -> dict:
+    """Assemble the KEY fingerprint for a phase.
+
+    Returns the KEY dict (``scheme_version``, ``phase``, ``model``,
+    ``provider_name``, ``adapter_type``, ``config_base_url``, ``templates_sha``,
+    optional ``extra``) plus ``key_digest`` = sha256 over the KEY. That digest
+    is what the adopt gate compares. NO credential-derived value is included.
+    ``extra_key`` folds caller-supplied, deterministic identity into the KEY
+    (e.g. verify's producing-analyze fingerprint); its members are namespaced
+    under ``extra`` so a caller dimension can never collide with a core one.
+    """
+    key = {
+        "scheme_version": FINGERPRINT_SCHEME_VERSION,
+        "phase": phase,
+        "model": model,
+        "provider_name": provider_name,
+        "adapter_type": adapter_type,
+        "config_base_url": config_base_url,
+        "templates_sha": templates_digest(template_texts),
+    }
+    if extra_key:
+        key["extra"] = {k: extra_key[k] for k in sorted(extra_key)}
+    fingerprint = dict(key)
+    fingerprint["key_digest"] = _key_digest(key)
+    return fingerprint
+
+
+def fingerprint_for_binding(binding, template_texts, *,
+                            extra_key: dict | None = None) -> dict:
+    """Build a phase fingerprint from a ``PhaseBinding`` + its static template(s).
+
+    ``adapter_type`` comes from the adapter's class-level ``name``;
+    ``config_base_url`` from ``binding.base_url`` (the provider's configured
+    gateway endpoint), SANITIZED via :func:`_sanitize_base_url` so userinfo /
+    query / fragment (which can carry ``user:pass`` or ``?api_key=``) never enter
+    the KEY or the persisted sidecar. ``None`` (default-config users) passes
+    through → digest unchanged, zero re-pay. No api_key / credential material is
+    read. ``template_texts`` MUST be rendered with ``app_context=None``.
+    """
+    adapter = getattr(binding, "adapter", None)
+    adapter_type = getattr(adapter, "name", None) or (
+        type(adapter).__name__ if adapter is not None else "unknown")
+    return build_fingerprint(
+        phase=binding.phase,
+        model=binding.model,
+        provider_name=binding.provider_name,
+        adapter_type=adapter_type,
+        config_base_url=_sanitize_base_url(getattr(binding, "base_url", None)),
+        template_texts=template_texts,
+        extra_key=extra_key,
+    )

--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -28,10 +28,17 @@ from datetime import datetime, timezone
 
 from utilities.safe_filename import safe_filename
 from utilities.file_io import read_json, write_json
+from core.backend_identity import FINGERPRINT_FILE
 from pathlib import Path
 
 
 SUMMARY_FILE = "_summary.json"
+
+# Sidecar files that live inside a checkpoint dir but are NOT per-unit results.
+# They must be excluded from every checkpoint counter (exists/count/status/load)
+# and from the Go DetectFallback scan, or a resume would over-count "completed"
+# units by the number of sidecars.
+_RESERVED_FILES = frozenset({SUMMARY_FILE, FINGERPRINT_FILE})
 
 
 class StepCheckpoint:
@@ -51,7 +58,7 @@ class StepCheckpoint:
         """True if a checkpoint directory exists with at least one unit file."""
         if not os.path.isdir(self.dir):
             return False
-        return any(f.endswith(".json") and f != SUMMARY_FILE
+        return any(f.endswith(".json") and f not in _RESERVED_FILES
                    for f in os.listdir(self.dir))
 
     def count(self) -> int:
@@ -59,7 +66,7 @@ class StepCheckpoint:
         if not os.path.isdir(self.dir):
             return 0
         return sum(1 for f in os.listdir(self.dir)
-                   if f.endswith(".json") and f != SUMMARY_FILE)
+                   if f.endswith(".json") and f not in _RESERVED_FILES)
 
     def ensure_dir(self):
         """Create the checkpoint directory if it doesn't exist."""
@@ -76,7 +83,7 @@ class StepCheckpoint:
             return results
 
         for filename in os.listdir(self.dir):
-            if not filename.endswith(".json"):
+            if not filename.endswith(".json") or filename in _RESERVED_FILES:
                 continue
             filepath = os.path.join(self.dir, filename)
             try:
@@ -131,6 +138,111 @@ class StepCheckpoint:
         filepath = os.path.join(self.dir, filename)
         data["id"] = unit_id  # ensure id is always present
         write_json(filepath, data)
+
+    # ------------------------------------------------------------------
+    # Backend-identity adopt gate (I2, minimal)
+    # ------------------------------------------------------------------
+
+    def sync_identity(self, fingerprint: dict, *, verbose: bool = True) -> dict:
+        """Gate checkpoint adoption on backend identity.
+
+        Call AFTER ``self.dir`` is finalized (respect any dir override, e.g.
+        the verifier's ``verify_checkpoints``) and BEFORE any ``load()`` — it
+        decides whether the prior checkpoints in this dir may be adopted by the
+        current backend, and if not it archives them aside and starts fresh.
+
+        Returns ``{"status", "archived_to", "warnings"}`` where status is one
+        of:
+
+          * ``new``    — no sidecar and no units: stamp and proceed.
+          * ``legacy`` — units present but no sidecar (a pre-feature dir): we
+            cannot verify identity, so ADOPT (never spuriously re-pay) and
+            stamp for next time.
+          * ``match``  — sidecar KEY digest equals the current one: adopt.
+          * ``reset``  — sidecar KEY mismatch OR a corrupt/unreadable sidecar:
+            archive the whole dir aside (preserve-not-destroy) and start fresh
+            so the new backend re-pays.
+
+        FAIL-CLOSED: a corrupt / unreadable sidecar is treated as ``reset``
+        (archive + re-run), NEVER adopt — an unverifiable identity must not
+        silently serve another backend's verdicts.
+        """
+        sidecar_path = os.path.join(self.dir, FINGERPRINT_FILE)
+        has_units = self.exists
+        warnings: list[str] = []
+
+        sidecar_present = os.path.isfile(sidecar_path)
+        existing = None
+        corrupt = False
+        if sidecar_present:
+            try:
+                existing = read_json(sidecar_path)
+                if not isinstance(existing, dict):
+                    corrupt = True
+            except (json.JSONDecodeError, OSError, ValueError):
+                corrupt = True
+
+        # Corrupt / unreadable sidecar → FAIL CLOSED (archive + re-run).
+        if corrupt:
+            archived_to = self._archive_dir(fingerprint.get("key_digest", ""))
+            os.makedirs(self.dir, exist_ok=True)
+            self._write_fingerprint(fingerprint)
+            msg = ("checkpoint identity sidecar was unreadable/corrupt; refusing "
+                   "to adopt possibly-stale checkpoints (fail-closed). Archived "
+                   f"to {archived_to}. Re-running this phase.")
+            warnings.append(msg)
+            if verbose:
+                print(f"[{self.step_name}] {msg}", file=sys.stderr)
+            return {"status": "reset", "archived_to": archived_to,
+                    "warnings": warnings}
+
+        # No sidecar recorded.
+        if not sidecar_present:
+            self._write_fingerprint(fingerprint)
+            status = "legacy" if has_units else "new"
+            if status == "legacy" and verbose:
+                print(f"[{self.step_name}] Adopting pre-existing checkpoints "
+                      f"with no identity stamp (legacy); stamping for next run.",
+                      file=sys.stderr)
+            return {"status": status, "archived_to": None, "warnings": warnings}
+
+        # KEY match → adopt (refresh the stamp).
+        if existing.get("key_digest") == fingerprint.get("key_digest"):
+            self._write_fingerprint(fingerprint)
+            return {"status": "match", "archived_to": None, "warnings": warnings}
+
+        # KEY mismatch → backend identity changed. Archive and reset.
+        archived_to = self._archive_dir(fingerprint.get("key_digest", ""))
+        os.makedirs(self.dir, exist_ok=True)
+        self._write_fingerprint(fingerprint)
+        msg = ("backend identity changed since last run; prior checkpoints were "
+               "NOT adopted (they would be a silent false-negative). Archived to "
+               f"{archived_to}. Re-running this phase.")
+        warnings.append(msg)
+        if verbose:
+            print(f"[{self.step_name}] {msg}", file=sys.stderr)
+        return {"status": "reset", "archived_to": archived_to,
+                "warnings": warnings}
+
+    def _write_fingerprint(self, fingerprint: dict) -> None:
+        self.ensure_dir()
+        payload = dict(fingerprint)
+        payload["written_at"] = (
+            datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"))
+        write_json(os.path.join(self.dir, FINGERPRINT_FILE), payload)
+
+    def _archive_dir(self, key_digest: str) -> str:
+        """Move the current checkpoint dir aside — never delete it."""
+        short = key_digest.split(":")[-1][:8] or "reset"
+        base = self.dir.rstrip("/")
+        dest = f"{base}.superseded-{short}"
+        n = 1
+        while os.path.exists(dest):
+            dest = f"{base}.superseded-{short}-{n}"
+            n += 1
+        shutil.move(self.dir, dest)
+        return dest
+
     def write_summary(
         self,
         total_units: int,
@@ -232,7 +344,7 @@ class StepCheckpoint:
         error_breakdown = {}
 
         for filename in os.listdir(checkpoint_dir):
-            if not filename.endswith(".json") or filename == SUMMARY_FILE:
+            if not filename.endswith(".json") or filename in _RESERVED_FILES:
                 continue
             filepath = os.path.join(checkpoint_dir, filename)
             try:

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -155,6 +155,24 @@ def run_verification(
     verify_binding = registry.get("verify")
     print(f"[Verify] Provider: {verify_binding.provider_name}, Model: {verify_binding.model}", file=sys.stderr)
 
+    # I2 adopt gate. Runs AFTER the checkpoint.dir override above (line ~88 sets
+    # ``verify_checkpoints``, not the StepCheckpoint default) and BEFORE
+    # verify_batch's checkpoint.load(), so a backend swap archives the stale
+    # verify checkpoints aside instead of adopting them. The static verify
+    # system prompt is rendered with app_context=None. The producing analyze
+    # run's fingerprint is folded into verify's KEY: a verify checkpoint written
+    # against analyze run A is NOT adopted once results.json carries analyze run
+    # B (a model swap). This closes the finding where verify adopts a stale
+    # checkpoint and ``finding_verifier.py`` ``r["finding"] = cp_data["finding"]``
+    # overwrites the fresh Stage-1 verdict.
+    from core.backend_identity import fingerprint_for_binding, render_template_texts
+    from prompts.verification_prompts import get_verification_system_prompt
+    _verify_texts = render_template_texts(
+        [lambda: get_verification_system_prompt(None)])
+    checkpoint.sync_identity(fingerprint_for_binding(
+        verify_binding, _verify_texts,
+        extra_key={"analyze_fingerprint": experiment.get("analyze_fingerprint")}))
+
     # Run Stage 2 verification via verify_batch
     tracker = get_global_tracker()
     verifier = FindingVerifier(

--- a/libs/openant-core/tests/test_backend_identity.py
+++ b/libs/openant-core/tests/test_backend_identity.py
@@ -1,0 +1,204 @@
+"""Tests for the minimal I2 backend-identity adopt gate.
+
+Covers the KEY fingerprint (core/backend_identity.py) and the
+StepCheckpoint.sync_identity gate (core/checkpoint.py), including the
+FAIL-CLOSED-on-corruption requirement (a corrupt sidecar must archive-and-
+re-run, never adopt) and the results.json / preserve-not-destroy behaviour.
+"""
+
+import json
+import os
+
+import pytest
+
+from core import backend_identity as bi
+from core.checkpoint import StepCheckpoint, _RESERVED_FILES, FINGERPRINT_FILE
+
+
+# ---------------------------------------------------------------------------
+# build_fingerprint / KEY
+# ---------------------------------------------------------------------------
+
+def _fp(**over):
+    base = dict(
+        phase="analyze",
+        model="opus",
+        provider_name="anthropic",
+        adapter_type="anthropic",
+        config_base_url=None,
+        template_texts=["SYSTEM", "USER"],
+    )
+    base.update(over)
+    return bi.build_fingerprint(**base)
+
+
+def test_key_has_expected_fields_and_no_secrets():
+    fp = _fp()
+    for field in ("scheme_version", "phase", "model", "provider_name",
+                  "adapter_type", "config_base_url", "templates_sha",
+                  "key_digest"):
+        assert field in fp, f"missing {field}"
+    # No detection / endpoint / api_key leakage (explicitly excluded, minimal).
+    blob = json.dumps(fp)
+    for banned in ("detection", "effective_endpoint", "api_key", "endpoint",
+                   "drift_log"):
+        assert banned not in blob, f"{banned} must not be in the fingerprint"
+    assert fp["key_digest"].startswith("sha256:")
+
+
+def test_model_swap_changes_digest():
+    assert _fp(model="opus")["key_digest"] != _fp(model="haiku")["key_digest"]
+
+
+def test_provider_and_adapter_swap_change_digest():
+    assert _fp(provider_name="a")["key_digest"] != _fp(provider_name="b")["key_digest"]
+    assert _fp(adapter_type="anthropic")["key_digest"] != _fp(adapter_type="openai")["key_digest"]
+
+
+def test_template_edit_changes_digest():
+    # This is the user-prompt / system-prompt digest sensitivity (both folded
+    # into templates_sha).
+    assert _fp(template_texts=["SYSTEM", "USER"])["key_digest"] != \
+        _fp(template_texts=["SYSTEM", "USER-EDITED"])["key_digest"]
+
+
+def test_extra_key_folds_into_digest():
+    a = _fp(extra_key={"analyze_fingerprint": "AAA"})
+    b = _fp(extra_key={"analyze_fingerprint": "BBB"})
+    assert a["key_digest"] != b["key_digest"]
+    assert a["key_digest"] != _fp()["key_digest"]
+
+
+def test_scheme_version_folds_into_digest(monkeypatch):
+    d1 = _fp()["key_digest"]
+    monkeypatch.setattr(bi, "FINGERPRINT_SCHEME_VERSION", 999)
+    assert _fp()["key_digest"] != d1
+
+
+def test_render_or_sentinel_failsafe():
+    def boom():
+        raise RuntimeError("cannot render")
+    texts = bi.render_template_texts([lambda: "ok", boom])
+    assert texts[0] == "ok"
+    assert texts[1] == bi.UNRENDERABLE_SENTINEL
+    # A sentinelled render must differ from the real one → forces re-run.
+    assert _fp(template_texts=["ok", "ok"])["key_digest"] != \
+        _fp(template_texts=["ok", bi.UNRENDERABLE_SENTINEL])["key_digest"]
+
+
+# ---------------------------------------------------------------------------
+# EDIT 1: config_base_url sanitizer
+# ---------------------------------------------------------------------------
+
+def test_sanitize_base_url_strips_userinfo_query_fragment():
+    s = bi._sanitize_base_url("https://user:pass@host:8443/v1?api_key=SECRET#frag")
+    assert s == "https://host:8443/v1"
+    for banned in ("user", "pass", "SECRET", "frag", "@", "?", "#"):
+        assert banned not in s
+
+
+def test_sanitize_base_url_none_passthrough():
+    assert bi._sanitize_base_url(None) is None
+
+
+def test_sanitize_base_url_plain_unchanged():
+    assert bi._sanitize_base_url("https://api.example.com/v1") == \
+        "https://api.example.com/v1"
+
+
+def test_sanitize_base_url_ipv6_rebracketed():
+    # urlsplit's .hostname drops the [] form; we must re-bracket so the netloc
+    # is well-formed AND userinfo is still dropped.
+    s = bi._sanitize_base_url("https://user:pass@[::1]:8080/v1")
+    assert s == "https://[::1]:8080/v1"
+    assert "user" not in s and "pass" not in s
+
+
+def test_sanitize_base_url_path_secret_is_named_residual():
+    # DOCUMENTED residual: a credential embedded in the PATH is NOT stripped
+    # (the path is load-bearing for discrimination). This test pins the residual
+    # so the docstring stays honest — it is NOT a claim that path secrets are safe.
+    s = bi._sanitize_base_url("https://gw.example/tok/sk-SECRET/v1")
+    assert "sk-SECRET" in s  # path preserved verbatim (named residual)
+
+
+def test_sanitize_base_url_invalid_port_forgoes_not_crashes():
+    # p.port PARSES the port and raises ValueError on a bad one; the guard must
+    # catch it and return None (forego discrimination), never crash the scan.
+    assert bi._sanitize_base_url("https://host:99999/v1") is None
+    assert bi._sanitize_base_url("https://host:notaport/v1") is None
+
+
+# ---------------------------------------------------------------------------
+# sync_identity gate
+# ---------------------------------------------------------------------------
+
+def _cp(tmp_path):
+    cp = StepCheckpoint("analyze", str(tmp_path))
+    return cp
+
+
+def test_status_new_when_empty(tmp_path):
+    cp = _cp(tmp_path)
+    res = cp.sync_identity(_fp())
+    assert res["status"] == "new"
+    assert os.path.isfile(os.path.join(cp.dir, FINGERPRINT_FILE))
+
+
+def test_status_match_adopts(tmp_path):
+    cp = _cp(tmp_path)
+    cp.save("u1", {"result": {"finding": "vulnerable"}})
+    cp.sync_identity(_fp())  # stamp
+    res = cp.sync_identity(_fp())  # same identity again
+    assert res["status"] == "match"
+    assert cp.count() == 1  # unit preserved, adopted
+
+
+def test_status_legacy_adopts_when_units_but_no_sidecar(tmp_path):
+    cp = _cp(tmp_path)
+    cp.save("u1", {"result": {"finding": "vulnerable"}})
+    # No sidecar yet.
+    res = cp.sync_identity(_fp())
+    assert res["status"] == "legacy"
+    assert cp.count() == 1  # adopted, not archived
+    assert os.path.isfile(os.path.join(cp.dir, FINGERPRINT_FILE))
+
+
+def test_status_reset_archives_on_identity_change(tmp_path):
+    cp = _cp(tmp_path)
+    cp.save("u1", {"result": {"finding": "vulnerable"}})
+    cp.sync_identity(_fp(model="opus"))  # stamp opus
+    res = cp.sync_identity(_fp(model="haiku"))  # backend swap
+    assert res["status"] == "reset"
+    assert res["archived_to"] and os.path.isdir(res["archived_to"])
+    # Old unit preserved in the archive, NOT destroyed.
+    assert any(f.startswith("u1") for f in os.listdir(res["archived_to"]))
+    # Fresh dir has the new sidecar and no adopted units.
+    assert cp.count() == 0
+    assert os.path.isfile(os.path.join(cp.dir, FINGERPRINT_FILE))
+
+
+def test_fail_closed_on_corrupt_sidecar(tmp_path):
+    """CRITICAL: a corrupt / unreadable sidecar must RESET (archive + re-run),
+    never adopt the stale checkpoints."""
+    cp = _cp(tmp_path)
+    cp.save("u1", {"result": {"finding": "vulnerable"}})
+    # Write a corrupt sidecar.
+    with open(os.path.join(cp.dir, FINGERPRINT_FILE), "w") as fh:
+        fh.write("{ this is not json ")
+    res = cp.sync_identity(_fp())
+    assert res["status"] == "reset", "corrupt sidecar must fail CLOSED (reset)"
+    assert res["archived_to"] and os.path.isdir(res["archived_to"])
+    assert cp.count() == 0  # stale units NOT adopted
+    assert any(f.startswith("u1") for f in os.listdir(res["archived_to"]))
+
+
+def test_reserved_files_excluded_from_counters(tmp_path):
+    cp = _cp(tmp_path)
+    cp.save("u1", {"result": {"finding": "vulnerable"}})
+    cp.sync_identity(_fp())  # writes _fingerprint.json
+    assert FINGERPRINT_FILE in _RESERVED_FILES
+    assert cp.count() == 1  # sidecar not counted
+    assert cp.exists is True
+    st = StepCheckpoint.status(cp.dir)
+    assert st["total_files"] == 1  # sidecar excluded from status counter

--- a/libs/openant-core/tests/test_identity_gate_wiring.py
+++ b/libs/openant-core/tests/test_identity_gate_wiring.py
@@ -1,0 +1,211 @@
+"""Wiring tests for the I2 gate: analyze->verify fingerprint fold and the
+analyzer's results.json preservation. These exercise the seams the pipeline
+uses without any billed API call.
+"""
+
+import json
+import os
+import types
+
+from core import backend_identity as bi
+from core.checkpoint import StepCheckpoint, FINGERPRINT_FILE
+
+
+class _FakeAdapter:
+    name = "anthropic"
+
+
+def _binding(phase, model, base_url=None):
+    return types.SimpleNamespace(
+        phase=phase, model=model, provider_name="anthropic",
+        adapter=_FakeAdapter(), base_url=base_url,
+    )
+
+
+def test_fingerprint_for_binding_reads_adapter_name():
+    fp = bi.fingerprint_for_binding(_binding("analyze", "opus"), ["SYS", "USR"])
+    assert fp["adapter_type"] == "anthropic"
+    assert fp["model"] == "opus"
+    assert fp["phase"] == "analyze"
+
+
+def test_verify_fold_resets_stale_verify_checkpoints(tmp_path):
+    """The demonstrated finding-1 corruption: verify adopts a stale checkpoint
+    and overwrites the fresh Stage-1 verdict. Closed by folding the producing
+    analyze run's fingerprint into verify's KEY — an analyze-model swap changes
+    ``analyze_fingerprint``, so the verify checkpoints written against analyze
+    run A are NOT adopted once results.json carries analyze run B.
+    """
+    cp = StepCheckpoint("Verify", str(tmp_path))
+    cp.dir = os.path.join(str(tmp_path), "verify_checkpoints")  # the :88 override
+
+    vbind = _binding("verify", "verify-model")
+    tmpl = ["VERIFY-SYS"]
+
+    # First run: analyze produced fingerprint A. Verify stamps + writes a unit.
+    fp_a = bi.fingerprint_for_binding(
+        vbind, tmpl, extra_key={"analyze_fingerprint": "ANALYZE-A"})
+    r1 = cp.sync_identity(fp_a)
+    assert r1["status"] == "new"
+    cp.save("file.py:func", {"verification": {"correct_finding": "safe"},
+                             "finding": "safe"})
+
+    # Second run: analyze model swapped -> results.json now carries fingerprint B.
+    fp_b = bi.fingerprint_for_binding(
+        vbind, tmpl, extra_key={"analyze_fingerprint": "ANALYZE-B"})
+    r2 = cp.sync_identity(fp_b)
+    assert r2["status"] == "reset", "verify must NOT adopt across an analyze swap"
+    assert r2["archived_to"] and os.path.isdir(r2["archived_to"])
+    # Stale verify checkpoint preserved in the archive, gone from the live dir →
+    # finding_verifier.py:624 can no longer overwrite the fresh verdict with it.
+    assert cp.load() == {}
+    assert any(f.startswith("file.py") or "file" in f
+               for f in os.listdir(r2["archived_to"]))
+
+
+def test_verify_fold_adopts_when_analyze_unchanged(tmp_path):
+    """Same analyze fingerprint + same verify identity → adopt (no re-pay)."""
+    cp = StepCheckpoint("Verify", str(tmp_path))
+    cp.dir = os.path.join(str(tmp_path), "verify_checkpoints")
+    vbind = _binding("verify", "verify-model")
+    tmpl = ["VERIFY-SYS"]
+    fp = bi.fingerprint_for_binding(
+        vbind, tmpl, extra_key={"analyze_fingerprint": "ANALYZE-A"})
+    cp.sync_identity(fp)
+    cp.save("file.py:func", {"verification": {"correct_finding": "safe"}})
+    r = cp.sync_identity(bi.fingerprint_for_binding(
+        vbind, tmpl, extra_key={"analyze_fingerprint": "ANALYZE-A"}))
+    assert r["status"] == "match"
+    assert cp.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# EDIT 1: config_base_url wired onto PhaseBinding + sanitized before the KEY
+# ---------------------------------------------------------------------------
+
+def test_base_url_discriminates_once_wired():
+    a = bi.fingerprint_for_binding(
+        _binding("analyze", "opus", base_url="https://gw-a/v1"), ["S", "U"])
+    b = bi.fingerprint_for_binding(
+        _binding("analyze", "opus", base_url="https://gw-b/v1"), ["S", "U"])
+    assert a["config_base_url"] == "https://gw-a/v1"
+    assert a["key_digest"] != b["key_digest"]
+
+
+def test_base_url_same_same_digest():
+    a = bi.fingerprint_for_binding(
+        _binding("analyze", "opus", base_url="https://gw/v1"), ["S", "U"])
+    b = bi.fingerprint_for_binding(
+        _binding("analyze", "opus", base_url="https://gw/v1"), ["S", "U"])
+    assert a["key_digest"] == b["key_digest"]
+
+
+def test_none_base_url_digest_unchanged():
+    """Default-config users keep base_url=None → digest identical to a raw
+    build_fingerprint with config_base_url=None (zero spurious re-pay)."""
+    wired = bi.fingerprint_for_binding(_binding("analyze", "opus"), ["S", "U"])
+    raw = bi.build_fingerprint(
+        phase="analyze", model="opus", provider_name="anthropic",
+        adapter_type="anthropic", config_base_url=None,
+        template_texts=["S", "U"])
+    assert wired["key_digest"] == raw["key_digest"]
+
+
+def test_base_url_credentials_never_persisted_to_sidecar(tmp_path):
+    """The sidecar persists the raw KEY dict; a credential-bearing base_url must
+    be sanitized (userinfo/query/fragment stripped) BEFORE it enters the KEY, so
+    nothing secret ever hits disk."""
+    cp = StepCheckpoint("analyze", str(tmp_path))
+    fp = bi.fingerprint_for_binding(
+        _binding("analyze", "opus",
+                 base_url="https://user:pass@host/v1?api_key=SECRET#frag"),
+        ["S", "U"])
+    cp.sync_identity(fp)
+    raw = open(os.path.join(cp.dir, FINGERPRINT_FILE)).read()
+    for banned in ("user:pass", "SECRET", "api_key=", "#frag"):
+        assert banned not in raw, f"{banned} leaked into the persisted sidecar"
+    persisted = json.loads(raw)
+    assert persisted["config_base_url"] == "https://host/v1"
+
+
+# ---------------------------------------------------------------------------
+# results.json preservation (_archive_stale_results)
+# ---------------------------------------------------------------------------
+
+def test_archive_stale_results_preserves_prior_report(tmp_path):
+    from core.analyzer import _archive_stale_results
+    results = os.path.join(str(tmp_path), "results.json")
+    with open(results, "w") as fh:
+        json.dump({"analyze_fingerprint": "OLD", "results": [1, 2, 3]}, fh)
+    _archive_stale_results(str(tmp_path), "NEW")
+    # Prior report preserved under its old fingerprint, not overwritten/deleted.
+    assert not os.path.exists(results)
+    archived = os.path.join(str(tmp_path), "results__OLD.json")
+    assert os.path.isfile(archived)
+    assert json.load(open(archived))["results"] == [1, 2, 3]
+
+
+def test_archive_stale_results_noop_when_fingerprint_matches(tmp_path):
+    from core.analyzer import _archive_stale_results
+    results = os.path.join(str(tmp_path), "results.json")
+    with open(results, "w") as fh:
+        json.dump({"analyze_fingerprint": "SAME"}, fh)
+    _archive_stale_results(str(tmp_path), "SAME")
+    assert os.path.isfile(results)  # left in place — a resume, not a swap
+
+
+def test_archive_stale_results_legacy_when_unstamped(tmp_path):
+    from core.analyzer import _archive_stale_results
+    results = os.path.join(str(tmp_path), "results.json")
+    with open(results, "w") as fh:
+        json.dump({"results": []}, fh)  # no analyze_fingerprint (pre-feature)
+    _archive_stale_results(str(tmp_path), "NEW")
+    assert os.path.isfile(os.path.join(str(tmp_path), "results__legacy.json"))
+
+
+def test_archive_stale_results_uses_short_windows_safe_name(tmp_path):
+    """EDIT 3: the full ``sha256:<hex>`` digest embeds a colon that breaks
+    os.replace on Windows (OSError swallowed → the preservation silently fails).
+    Use the same short form as _archive_dir: last ':'-segment, first 8 hex."""
+    from core.analyzer import _archive_stale_results
+    results = os.path.join(str(tmp_path), "results.json")
+    old = "sha256:" + "a" * 64
+    with open(results, "w") as fh:
+        json.dump({"analyze_fingerprint": old, "results": [1]}, fh)
+    _archive_stale_results(str(tmp_path), "sha256:" + "b" * 64)
+    # No colon in any archived filename (Windows-safe), short 8-hex suffix.
+    names = os.listdir(str(tmp_path))
+    assert "results__aaaaaaaa.json" in names
+    assert not any(":" in n for n in names)
+    assert not os.path.exists(results)
+
+
+def test_archive_stale_results_nonstring_stamp_does_not_crash(tmp_path):
+    """A hand-corrupted non-string analyze_fingerprint must be treated as
+    unstamped (→ results__legacy.json), never crash the best-effort archiver."""
+    from core.analyzer import _archive_stale_results
+    results = os.path.join(str(tmp_path), "results.json")
+    with open(results, "w") as fh:
+        json.dump({"analyze_fingerprint": 123, "results": ["x"]}, fh)
+    _archive_stale_results(str(tmp_path), "NEW")  # must not raise
+    assert os.path.isfile(os.path.join(str(tmp_path), "results__legacy.json"))
+
+
+def test_archive_stale_results_never_clobbers_existing_archive(tmp_path):
+    """Two distinct prior reports that map to the SAME archive name (an A->B->A
+    config alternation, or two unstamped reports both -> results__legacy.json)
+    must BOTH survive: the second appends -<n>, never overwriting the first."""
+    from core.analyzer import _archive_stale_results
+    d = str(tmp_path)
+    results = os.path.join(d, "results.json")
+    # First unstamped report -> results__legacy.json
+    with open(results, "w") as fh:
+        json.dump({"results": ["first"]}, fh)
+    _archive_stale_results(d, "NEW")
+    # A second, DIFFERENT unstamped report also wants results__legacy.json
+    with open(results, "w") as fh:
+        json.dump({"results": ["second"]}, fh)
+    _archive_stale_results(d, "NEW")
+    # Both preserved — neither clobbered.
+    assert json.load(open(os.path.join(d, "results__legacy.json")))["results"] == ["first"]
+    assert json.load(open(os.path.join(d, "results__legacy-1.json")))["results"] == ["second"]

--- a/libs/openant-core/utilities/llm/registry.py
+++ b/libs/openant-core/utilities/llm/registry.py
@@ -205,6 +205,12 @@ class PhaseBinding:
     adapter: LLMAdapter
     model: str
     provider_name: str
+    # The provider's configured base_url (gateway/proxy endpoint), carried so the
+    # I2 backend-identity fingerprint can discriminate two configs that share a
+    # model+provider but route to different upstreams. ``None`` for default-config
+    # users (SDK default endpoint) → fingerprint unchanged, zero re-pay. Sanitized
+    # (userinfo/query/fragment stripped) before it ever enters the KEY / sidecar.
+    base_url: Optional[str] = None
 
 
 class PhaseRegistry:
@@ -327,6 +333,7 @@ def build_phase_registry(
             adapter=adapters[ref.provider],
             model=ref.model,
             provider_name=ref.provider,
+            base_url=unique_providers[ref.provider].base_url,
         )
 
     # Tool-support gating (plan §5): enhance + verify require an


### PR DESCRIPTION
## What
On a re-scan into a **reused `--output` dir**, OpenAnt adopts prior per-unit checkpoints keyed by path `unit_id` alone — with no check on which backend produced them. So re-scanning with a **different model/provider/endpoint** silently serves the *old* backend's verdicts at $0 (a silent false-negative). Stage-2 makes it worse: `finding_verifier.py` restores and **overwrites** the fresh Stage-1 verdict with the adopted one.

## Fix — a minimal, per-phase backend-identity gate
A new `core/backend_identity.py` computes a per-phase KEY digest over the deterministic verdict determinants: `{scheme, phase, model, provider_name, adapter_type, config_base_url, static-template-sha}` (rendered with `app_context=None` — the LLM-generated threat model is nondeterministic and must never enter a resume key). `StepCheckpoint.sync_identity` gates adoption:
- **match** → adopt (no re-pay); **reset** (identity changed) → archive the stale dir aside (`.superseded-<digest>`, never deleted) and re-analyze; **legacy** (pre-feature dir, no sidecar) → adopt once + stamp; **corrupt sidecar → fail CLOSED** (treat as reset, never adopt unverifiable state).
- Wired at the analyze **and** verify load paths; verify folds the producing run's `analyze_fingerprint` (stamped into `results.json`) so an analyze-model swap invalidates dependent verify checkpoints — closing the Stage-2 overwrite. `results.json` is preserved (`results__<fp>.json`) before overwrite. The `_fingerprint.json` sidecar is excluded from every checkpoint counter (Python `_RESERVED_FILES` + Go `DetectFallback`/`isSidecar`). Credentials in a `config_base_url` (userinfo/query/fragment) are stripped before the value enters the KEY/sidecar.

## Evidence
- `git diff --stat a0fe722 HEAD` → **9 files, +910 / -5**. RED @ base: net-new module → import/collection error + Go build failure; GREEN @ HEAD: identity suites **32 passed**, full offline suite **2825 passed / 30 skipped**, `ruff` clean, `go build`/`vet` clean + Go sidecar test, `semgrep` 0.
- **Live end-to-end (openant CLI, real Go→Python, twice into one output dir):**
  - scan(haiku) → writes `_fingerprint.json`.
  - scan(haiku, same dir) → *"Restored 1 units… 0 to process, $0.0000"* — adopt, identical digest (no re-pay).
  - scan(**sonnet**, same dir) → *"backend identity changed… prior checkpoints were NOT adopted (they would be a silent false-negative). Archived to …superseded-…. Re-running."* + prior report preserved as `results__<fp>.json` + unit re-analyzed. The silent-FN is prevented live.

## Scope / named residuals (honest)
- First/non-resumed scans are a **no-op** (the gate only engages on reused-dir resume).
- **Not gated (deferred, named):** `enhance` and `dynamic_test` phases still adopt un-gated; `config_base_url` catches only a config-declared endpoint (env/effective endpoint is deliberately DETECTION-not-KEY to avoid re-pay/cost-DoS, and is left out entirely here); a credential embedded in a URL **path** is not stripped (same tier as the api_key cred-routing residual); per-unit **content** drift under an unchanged path `unit_id` is not caught.
- No scanner phase is made to abort (preserves the KB catch-and-continue). `api_key` never enters the key or sidecar.

Known limitation: T3 real-corpus differential / T4 efficacy A/B not run pre-push (merge-time gates). Concurrent scans of one `--output` dir remain uncoordinated at this base (run-dir lock is a separate change).
