### PR TITLE
fix(analyzer): extend #243's canonical downgrade-guard to the Stage-1 consistency check

### DIFF
--- a/libs/openant-core/tests/test_stage1_consistency_inconclusive_downgrade.py
+++ b/libs/openant-core/tests/test_stage1_consistency_inconclusive_downgrade.py
@@ -1,0 +1,98 @@
+"""FIX4 RED: Stage-1 pattern-consistency must also block VULNERABLE/BYPASSABLE ->
+INCONCLUSIVE, not only ->SAFE/PROTECTED. `inconclusive` is a disclosure-dropped
+verdict (core/verdict_taxonomy.py DISCLOSURE_DROPPED), so a weak-signal pattern
+downgrade to INCONCLUSIVE silently drops a real finding from disclosure — the same
+false-negative F-KB-1a exists to prevent. Also guards the .upper() case invariant.
+"""
+from utilities import stage1_consistency as s1
+
+VULN_RK = "libs/a/client_utils.py:build_async_httpx_client"
+SAFE_RK = "libs/b/client_utils.py:get_async_httpx_client"
+
+
+def _run(resolver, results):
+    orig = s1._resolve_stage1_inconsistency
+    s1._resolve_stage1_inconsistency = resolver
+    try:
+        return s1.run_stage1_consistency_check(
+            [dict(r) for r in results], {}, binding=object(), tracker=None)
+    finally:
+        s1._resolve_stage1_inconsistency = orig
+
+
+def test_vulnerable_not_downgraded_to_inconclusive_by_pattern():
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "async httpx client builder", "INCONCLUSIVE",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "INCONCLUSIVE", "reason": "pattern resembles uncertain sibling"}],
+            "grouped")
+    out = _run(resolver, [
+        {"route_key": VULN_RK, "verdict": "VULNERABLE", "confidence": 0.9},
+        {"route_key": SAFE_RK, "verdict": "SAFE", "confidence": 0.8}])
+    vuln = next(r for r in out if r["route_key"] == VULN_RK)
+    assert vuln["verdict"] == "VULNERABLE", "INCONCLUSIVE downgrade silently dropped a real finding"
+    assert "stage1_consistency_downgrade_blocked" in vuln
+
+
+def test_bypassable_not_downgraded_to_inconclusive():
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "INCONCLUSIVE",
+            [{"route_key": VULN_RK, "original_verdict": "BYPASSABLE",
+              "should_be": "INCONCLUSIVE", "reason": "x"}], "g")
+    out = _run(resolver, [
+        {"route_key": VULN_RK, "verdict": "BYPASSABLE", "confidence": 0.9},
+        {"route_key": SAFE_RK, "verdict": "SAFE", "confidence": 0.8}])
+    vuln = next(r for r in out if r["route_key"] == VULN_RK)
+    assert vuln["verdict"] == "BYPASSABLE"
+    assert "stage1_consistency_downgrade_blocked" in vuln
+
+
+def test_dropped_to_dropped_still_applies_not_overblocked():
+    """Guard must fire only on an ELIGIBLE->DROPPED crossing. A safe->inconclusive
+    move (dropped->dropped, no disclosure change) must NOT be blocked, proving the
+    ELIGIBLE-keyed old-side did not over-block ordinary non-eligible corrections."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "INCONCLUSIVE",
+            [{"route_key": SAFE_RK, "original_verdict": "SAFE",
+              "should_be": "INCONCLUSIVE", "reason": "x"}], "g")
+    out = _run(resolver, [
+        {"route_key": VULN_RK, "verdict": "VULNERABLE", "confidence": 0.9},
+        {"route_key": SAFE_RK, "verdict": "SAFE", "confidence": 0.8}])
+    safe = next(r for r in out if r["route_key"] == SAFE_RK)
+    assert "stage1_consistency_downgrade_blocked" not in safe
+
+
+def test_whitespace_padded_downgrade_still_blocked():
+    """sol-caught: should_be must be .strip()'d before the guard compares, or a padded
+    '  inconclusive  ' bypasses the block AND is written as an invalid verdict (Stage-2
+    strips; Stage-1 must too)."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "INCONCLUSIVE",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "  inconclusive  ", "reason": "x"}], "g")
+    out = _run(resolver, [
+        {"route_key": VULN_RK, "verdict": "VULNERABLE", "confidence": 0.9},
+        {"route_key": SAFE_RK, "verdict": "SAFE", "confidence": 0.8}])
+    vuln = next(r for r in out if r["route_key"] == VULN_RK)
+    assert vuln["verdict"] == "VULNERABLE", "padded verdict bypassed the guard"
+    assert "stage1_consistency_downgrade_blocked" in vuln
+
+
+def test_case_invariant_safe_still_blocked():
+    """Regression lock: the guard compares UPPERCASE; ensure adding INCONCLUSIVE did
+    not break the existing SAFE block (e.g. via a lowercase-set import mistake)."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "SAFE",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "safe", "reason": "x"}], "g")  # lowercase input -> .upper()
+    out = _run(resolver, [
+        {"route_key": VULN_RK, "verdict": "VULNERABLE", "confidence": 0.9},
+        {"route_key": SAFE_RK, "verdict": "SAFE", "confidence": 0.8}])
+    vuln = next(r for r in out if r["route_key"] == VULN_RK)
+    assert vuln["verdict"] == "VULNERABLE"
+    assert "stage1_consistency_downgrade_blocked" in vuln

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -16,6 +16,14 @@ from dataclasses import dataclass
 
 from utilities.llm_client import TokenTracker
 from utilities.llm import PhaseBinding, simple_text
+from core.verdict_taxonomy import DISCLOSURE_DROPPED
+
+# Uppercase mirror of the canonical disclosure-dropped set (this module compares
+# verdicts .upper()'d). Keyed off core.verdict_taxonomy so the guard's block-set
+# cannot drift from the partition — the same canonical-reference fix #243 applied to
+# the Stage-2 verifier, extended here to the Stage-1 consistency guard (#243 did not
+# touch Stage-1, so its guard still blocked only ->{SAFE,PROTECTED}).
+_DISCLOSURE_DROPPED_UPPER = frozenset(v.upper() for v in DISCLOSURE_DROPPED)
 
 
 MAX_TOKENS = 4096
@@ -235,7 +243,10 @@ def run_stage1_consistency_check(
                 for update in consistency_result.findings_updated:
                     route_key = update.get("route_key")
                     raw_should_be = update.get("should_be")
-                    new_verdict = raw_should_be.upper() if isinstance(raw_should_be, str) else ""
+                    # .strip() before .upper() so a whitespace-padded verdict cannot
+                    # bypass the downgrade guard (and get written verbatim as an invalid
+                    # verdict). new_verdict is unconstrained LLM `should_be` output.
+                    new_verdict = raw_should_be.strip().upper() if isinstance(raw_should_be, str) else ""
 
                     if not new_verdict:
                         continue
@@ -243,12 +254,21 @@ def run_stage1_consistency_check(
                     for result in results:
                         if result.get("route_key") == route_key:
                             old_verdict = result.get("verdict", "UNKNOWN")
-                            old_verdict_norm = old_verdict.upper() if isinstance(old_verdict, str) else ""
+                            old_verdict_norm = old_verdict.strip().upper() if isinstance(old_verdict, str) else ""
                             # F-KB-1a: pattern-consistency must not silently downgrade a
                             # surfaced Stage-1 finding to safe. At Stage 1 there is no
                             # per-finding exploit evidence, only pattern similarity (the
                             # weakest signal); block the downgrade and record it for audit.
-                            if old_verdict_norm in ("VULNERABLE", "BYPASSABLE") and new_verdict in ("SAFE", "PROTECTED"):
+                            # F-KB-1a (extends #243's canonical-set fix to Stage-1):
+                            # widen the BLOCK-set from the hardcoded {SAFE,PROTECTED} to the
+                            # full DISCLOSURE_DROPPED. A pattern-consistency (no-evidence)
+                            # downgrade of a surfaced VULNERABLE/BYPASSABLE finding to
+                            # INCONCLUSIVE or REJECTED drops it from disclosure just as
+                            # silently as ->SAFE — the identical false-negative #243 fixed
+                            # in the Stage-2 verifier but which still lived here at Stage-1.
+                            # Old-side kept at {VULNERABLE,BYPASSABLE} to match Stage-1's
+                            # existing scope and #243's non-over-block stance.
+                            if old_verdict_norm in ("VULNERABLE", "BYPASSABLE") and new_verdict in _DISCLOSURE_DROPPED_UPPER:
                                 result["stage1_consistency_downgrade_blocked"] = {
                                     "from": old_verdict,
                                     "proposed": new_verdict,


### PR DESCRIPTION
## What
A Stage-1 pattern-consistency (no-evidence) update could silently downgrade a
surfaced VULNERABLE/BYPASSABLE finding to INCONCLUSIVE or REJECTED — dropping it
from disclosure just as silently as ->SAFE. A silent false-negative.

## Root cause
#243 (b94e71b) fixed exactly this drift in the Stage-2 verifier by referencing the
canonical core.verdict_taxonomy.DISCLOSURE_DROPPED set, but did NOT touch Stage-1.
utilities/stage1_consistency.py:251 still blocked only the hardcoded ->{SAFE,PROTECTED},
so a ->{INCONCLUSIVE,REJECTED} downgrade (both in DISCLOSURE_DROPPED) bypassed the guard.

## Fix (subtractive; reference the canonical set)
Widen the Stage-1 block-set from {SAFE,PROTECTED} to DISCLOSURE_DROPPED via a
`_DISCLOSURE_DROPPED_UPPER` derived from the taxonomy (so it cannot drift again) —
the identical change #243 made at Stage-2. Also .strip() the verdict before the guard
so a whitespace-padded `should_be` cannot bypass it. Old-side kept at {VULNERABLE,
BYPASSABLE} to match Stage-1's existing scope and #243's non-over-block stance
(test_non_exploitable_downgrade_still_applies) — this PR does not touch Stage-2.

## Evidence (offline, RED->GREEN)
- RED @ base 8e507b6 (stash the guard): 3 failed of the new Stage-1 tests.
- GREEN @ HEAD: 9 passed (vulnerable/bypassable ->inconclusive blocked; padded blocked;
  case-invariant); test_dropped_to_dropped_still_applies + test_non_exploitable_downgrade
  (#243's) confirm NO over-block.
- Full offline suite: 2845 passed, 30 skipped, 0 failed.
- Liveness: run_stage1_consistency_check is called unconditionally from
  core/analyzer.py in the production scan — the guarded path is live, not dead.

## Scope / open question (deferred, not in this PR)
Stage-1 receives UNFILTERED results, so an `error` (disclosure-eligible) verdict can also
reach the apply loop; keying the OLD-side off DISCLOSURE_ELIGIBLE would additionally block
an error->dropped pattern downgrade. Left out here as a separate scope decision (it
changes which producer verdicts are downgrade-protected) — happy to follow up if wanted.

Depends-on: #243 (references the DISCLOSURE_DROPPED partition it established).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
