### PR TITLE
fix(parsers/rust): replace O(n^2) macro literal-scan with a linear stripper (ReDoS)

### DIFF
--- a/libs/openant-core/parsers/rust/call_graph_builder.py
+++ b/libs/openant-core/parsers/rust/call_graph_builder.py
@@ -80,6 +80,97 @@ _RUST_STR_LITERAL_RE = re.compile(
     r"|'(?:\\.|[^'\\])'"          # char literal
 )
 
+
+def _blank_rust_literals(text: str) -> str:
+    """Single-pass O(n) equivalent of ``_RUST_STR_LITERAL_RE.sub(" ", text)``.
+
+    The regex form is O(n^2) on an unterminated-``r#"`` flood (its ``(?:[^"]|"(?!#))*``
+    branch restarts at every position). This hand-written forward-cursor scanner blanks
+    the SAME four literal forms — collapsing each matched span to a single space, exactly
+    like ``re.sub(" ", ...)`` — with a monotonic index, so it is linear and cannot ReDoS.
+    Running it BEFORE the length budget (rather than the reverse) also restores the calls
+    that the bound-then-strip ordering dropped when a large literal pushed a real trailing
+    call past the cap. A differential test asserts byte-identical output vs the regex on a
+    real-code corpus (any divergence is a call-graph/reachability change and must fail).
+
+    Deliberately matches the regex's EXACT (incomplete) scope — 1-hash raw strings only,
+    no ``r##``/byte-string/``br`` forms — so the extracted call set is unchanged. Extending
+    it to more literal forms would remove real phantom edges but is a call-set change; see
+    residual-evasion.md (tracked as future work, alongside the token-tree-walk that would
+    retire this scanner entirely).
+    """
+    # An UNTERMINATED literal is left UNCHANGED, exactly like the regex: with no
+    # closing delimiter the corresponding alternative fails to match, so re.sub emits
+    # the single opening char and retries at the next position. Only a fully-terminated
+    # literal is collapsed to one space. (Getting this wrong would blank a stray trailing
+    # quote to EOF and drop real trailing calls — the divergence the differential caught.)
+    n = len(text)
+    out = []
+    i = 0
+    # Monotonic short-circuits keep the scan O(n): once we learn there is no `"#`
+    # (resp. no `"`) at/after some index, every LATER raw-string opener starts
+    # scanning even further right, so it is also unterminated -- return -1 without
+    # re-scanning to EOF. Without this, a repeated-`r#"` flood (no closing `"#`)
+    # calls find() to EOF from ~n/3 positions -> O(n^2) (a real ReDoS: measured
+    # ~1.8s at 240KB). The result is byte-identical to calling find() every time.
+    no_hashclose_from = None   # if set: no `"#` exists at/after this index
+    no_quote_from = None       # if set: no `"`  exists at/after this index
+    while i < n:
+        c = text[i]
+        # r#"..."#  (one hash, matching the regex's single-hash branch only)
+        if c == 'r' and text.startswith('r#"', i):
+            start = i + 3
+            if no_hashclose_from is not None and start >= no_hashclose_from:
+                close = -1
+            else:
+                close = text.find('"#', start)
+                if close == -1:
+                    no_hashclose_from = start
+            if close != -1:
+                out.append(' '); i = close + 2; continue
+            out.append(c); i += 1; continue                  # unterminated -> unchanged
+        # r"..."
+        if c == 'r' and text.startswith('r"', i):
+            start = i + 2
+            if no_quote_from is not None and start >= no_quote_from:
+                close = -1
+            else:
+                close = text.find('"', start)
+                if close == -1:
+                    no_quote_from = start
+            if close != -1:
+                out.append(' '); i = close + 1; continue
+            out.append(c); i += 1; continue                  # unterminated -> unchanged
+        # "..." — content is (?:\\.|[^"\\])*, where \\. is backslash + any NON-newline
+        # (re's '.' excludes '\n' without DOTALL, so \<newline> ends the group and the
+        # literal fails to match — must be replicated or the scanner over-consumes).
+        if c == '"':
+            j = i + 1
+            matched = False
+            while j < n:
+                cj = text[j]
+                if cj == '"':
+                    matched = True; break
+                if cj == '\\':
+                    if j + 1 < n and text[j + 1] != '\n':
+                        j += 2; continue
+                    break                                    # \\. fails -> group ends, no close
+                j += 1                                       # [^"\\]
+            if matched:
+                out.append(' '); i = j + 1; continue
+            out.append(c); i += 1; continue                  # unterminated -> unchanged
+        # '.' or '\.' char literal — NOT a lifetime ('a), label ('x:), or unterminated.
+        # The '\X' escape form also excludes \<newline> (same '.' rule as above).
+        if c == "'":
+            if i + 3 < n and text[i + 1] == '\\' and text[i + 2] != '\n' and text[i + 3] == "'":
+                out.append(' '); i += 4; continue            # '\X'
+            if i + 2 < n and text[i + 1] not in "'\\" and text[i + 2] == "'":
+                out.append(' '); i += 3; continue            # 'X'
+            out.append(c); i += 1; continue                  # lifetime/label/unterminated
+        out.append(c)
+        i += 1
+    return ''.join(out)
+
 RUST_BUILTINS = {
     # core::fmt / println-family macro names (recovered via token-tree scan,
     # so they can appear as bare "calls" and must be filtered like any std fn)
@@ -144,6 +235,11 @@ class CallGraphBuilder:
 
         self.call_graph: Dict[str, List[str]] = {}
         self.reverse_call_graph: Dict[str, List[str]] = {}
+        # Machine-readable record of macro bodies whose call-scan input was truncated by
+        # the ReDoS budget (scan_budget.py). A non-empty list means the call graph for
+        # those contexts is KNOWN-INCOMPLETE — downstream reachability should over-seed
+        # rather than trust the callee list. See residual-evasion.md.
+        self.scan_truncated: List[str] = []
 
     # -- public API (parity with sibling parsers) ----------------------------
 
@@ -198,6 +294,7 @@ class CallGraphBuilder:
             "imports": self.imports,
             "call_graph": self.call_graph,
             "reverse_call_graph": self.reverse_call_graph,
+            "scan_truncated": self.scan_truncated,
             "statistics": self.get_statistics(),
         }
 
@@ -423,6 +520,13 @@ class CallGraphBuilder:
         -- it cannot see argument structure -- so results feed the same
         bare/field/scoped resolution paths as the AST walk, with a conservative
         shape.
+
+        NOTE (2026-08-15): "opaque token tree" describes only how THIS scanner
+        treats the body, not the grammar. tree-sitter DOES lex the `token_tree`
+        into structured nodes (string_literal / identifier / nested token_tree),
+        so a node-walk could recover these calls without any regex or scan
+        budget. That rewrite is deferred (see residual-evasion.md R1/T); the
+        regex path is retained for now with a linear literal-stripper in front.
         """
         macro_name = None
         token_tree = None
@@ -434,8 +538,19 @@ class CallGraphBuilder:
         if macro_name not in _SCANNABLE_MACROS or token_tree is None:
             return
         text = self._text(token_tree, source)
-        # Blank literals so a call-shaped substring inside a string is not scanned.
-        text = _RUST_STR_LITERAL_RE.sub(" ", text)
+        # Blank literals FIRST, via the linear _blank_rust_literals (byte-identical to
+        # _RUST_STR_LITERAL_RE.sub but O(n), so it cannot ReDoS the way the regex did on an
+        # unterminated-raw-string flood). Stripping before the budget also collapses a large
+        # string literal to one space, so a real trailing call is no longer pushed past the
+        # cap -- fixing the recall regression the earlier bound-first ordering introduced.
+        text = _blank_rust_literals(text)
+        # THEN bound the stripped text for _MACRO_CALL_RE, which is still O(n^2) on an
+        # adversarial dotted/scoped chain with no trailing '('. This residual (a call after
+        # >8KB of non-literal token soup can be truncated) is tracked in residual-evasion.md.
+        from utilities.scan_budget import bound_macro_scan_text
+        text, _truncated = bound_macro_scan_text(text, context=f"rust macro {macro_name}")
+        if _truncated:
+            self.scan_truncated.append(f"rust macro {macro_name}")
         for match in _MACRO_CALL_RE.finditer(text):
             call_name = match.group(1)
             if "::" in call_name:

--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -141,6 +141,9 @@ class CallGraphBuilder:
         # Populated by build_call_graph(); read via the canonical API (export/get_statistics/...).
         self.call_graph: Dict[str, List[str]] = {}
         self.reverse_call_graph: Dict[str, List[str]] = {}
+        # Contexts whose fallback call-scan input was truncated by the ReDoS budget
+        # (scan_budget.py) — the call graph there is KNOWN-INCOMPLETE. See residual-evasion.md.
+        self.scan_truncated: List[str] = []
 
     def build_call_graph(self) -> None:
         """Build the bidirectional call graph, populating self.call_graph / self.reverse_call_graph.
@@ -209,6 +212,7 @@ class CallGraphBuilder:
             "imports": self.imports,
             "call_graph": self.call_graph,
             "reverse_call_graph": self.reverse_call_graph,
+            "scan_truncated": self.scan_truncated,
             "statistics": self.get_statistics(),
         }
 
@@ -538,6 +542,12 @@ class CallGraphBuilder:
         # Matches: foo(), bar.baz(), self.method()
         pattern = r"\b([a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*)\s*\("
 
+        # Bound the input to this O(n^2)-on-adversarial-input finditer scan (ReDoS guard);
+        # the pattern is unchanged, so the extracted call set is identical.
+        from utilities.scan_budget import bound_macro_scan_text
+        code, _truncated = bound_macro_scan_text(code, context="zig regex fallback")
+        if _truncated:
+            self.scan_truncated.append("zig regex fallback")
         for match in re.finditer(pattern, code):
             call_name = match.group(1)
             if "." in call_name:

--- a/libs/openant-core/tests/test_macro_scan_budget_redos.py
+++ b/libs/openant-core/tests/test_macro_scan_budget_redos.py
@@ -1,0 +1,70 @@
+"""FIX1 RED: the Rust and Zig call-graph regex scanners run finditer over a whole
+macro-body / function-body token text. On a long dotted/scoped identifier chain with
+no trailing '(', finditer restarts at every interior position and re-scans the chain
+forward — O(n^2) (measured: rust ~5.5s @32KB, zig ~4.5s @40KB). Possessive quantifiers
+do NOT fix it (they stop intra-match backtracking, not finditer's per-position restart)
+AND regress the match set on rust's scoped-turbofish branch (a::b::<T>( -> b). So the
+edge-preserving fix is a bounded per-body scan input (the exact regex is UNCHANGED, so
+zero call-graph edge change), truncating only pathological bodies with a logged gap.
+
+RED pre-fix: utilities.scan_budget.bound_macro_scan_text does not exist.
+"""
+import re
+import time
+
+
+def test_bound_helper_exists_and_caps():
+    from utilities.scan_budget import bound_macro_scan_text, MAX_MACRO_SCAN_BYTES
+    huge = "a" + ".a" * 300_000            # ~600KB single body
+    bounded, trunc = bound_macro_scan_text(huge, context="test")
+    assert trunc is True  # machine-readable flag set on truncation
+    assert len(bounded) <= MAX_MACRO_SCAN_BYTES
+    # realistic bodies (under the cap) pass through UNCHANGED -> zero coverage/edge loss
+    small = "vec![a::b::c(), foo.bar()]"
+    small_out, small_trunc = bound_macro_scan_text(small, context="test")
+    assert small_out == small and small_trunc is False
+
+
+def test_over_cap_truncation_loses_calls_past_the_cut_KNOWN_RESIDUAL():
+    """HONEST residual (sol-flagged): edge-preservation holds ONLY for bodies <= cap.
+    A call pushed past the cut by large leading content IS lost — a bounded, disclosed
+    coverage-gap chosen over an unbounded regex DoS. This test documents that behavior
+    so the tradeoff is explicit, not an accidental silent FN."""
+    import re
+    from utilities.scan_budget import bound_macro_scan_text, MAX_MACRO_SCAN_BYTES
+    RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+    body = (" " * MAX_MACRO_SCAN_BYTES) + "security_sink()"
+    before = [m.group(1) for m in RE.finditer(body)]
+    after = [m.group(1) for m in RE.finditer(bound_macro_scan_text(body, context="test")[0])]
+    assert "security_sink" in before
+    assert "security_sink" not in after   # documented loss past the cap
+
+
+def test_bounded_scan_is_fast_where_raw_is_quadratic():
+    from utilities.scan_budget import bound_macro_scan_text
+    RUST_RE = re.compile(
+        r"\b((?:[A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*"
+        r"|[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)\s*(?:::<[^>]*>)?\s*\(")
+    adversarial = "a" + ".a" * 300_000      # the ReDoS payload, no trailing '('
+    t = time.time()
+    list(RUST_RE.finditer(bound_macro_scan_text(adversarial, context="test")[0]))
+    bounded_dt = time.time() - t
+    assert bounded_dt < 1.0, f"bounded scan still slow: {bounded_dt:.2f}s"
+
+
+def test_rust_and_zig_regex_unchanged():
+    """Edge-preservation guard: the fix must NOT alter either call-detection regex
+    (altering it changes the call graph = reachability regression). Verified by source
+    text (parsers need tree_sitter, unavailable in unit-test env). The exact OLD
+    patterns must be present, and NO possessive quantifier (++/*+) may be introduced —
+    possessive both fails to fix the DoS and regresses rust's scoped-turbofish match."""
+    import os
+    here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    rust = open(os.path.join(here, "parsers/rust/call_graph_builder.py")).read()
+    zig = open(os.path.join(here, "parsers/zig/call_graph_builder.py")).read()
+    assert r"(?:[A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*" in rust
+    assert r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*" in rust
+    assert r"[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*" in zig
+    # no possessive quantifier introduced into either scanner regex
+    for src, name in ((rust, "rust"), (zig, "zig")):
+        assert "++" not in src and "*+" not in src, f"{name}: possessive quantifier introduced (regresses/insufficient)"

--- a/libs/openant-core/tests/test_rust_literal_stripper_differential.py
+++ b/libs/openant-core/tests/test_rust_literal_stripper_differential.py
@@ -1,0 +1,126 @@
+"""F2 (linear literal stripper): `_blank_rust_literals` replaces the O(n^2)
+`_RUST_STR_LITERAL_RE.sub(" ", text)` in `_scan_macro_body`. It must be:
+
+  1. BYTE-IDENTICAL to the regex it replaces (any divergence is a change to the
+     macro-body call set = a reachability/call-graph change). Asserted over hand
+     fixtures + real-code windows + a large seeded fuzz corpus. `_RUST_STR_LITERAL_RE`
+     is retained deliberately as the executable oracle for this equivalence.
+  2. LINEAR — the regex ReDoS'd on an unterminated-`r#"` flood (measured multi-second);
+     the stripper is a single forward cursor and stays sub-second on adversarial input.
+  3. RECALL-PRESERVING — stripping BEFORE the length budget collapses a large string
+     literal to one space, so a real trailing call is no longer pushed past the 8 KB cap.
+     This is the regression the earlier bound-then-strip ordering introduced (a VULNERABLE
+     callee silently dropped from the graph = an unreachable false-negative).
+"""
+import glob
+import os
+import random
+import re
+import time
+
+from parsers.rust.call_graph_builder import (
+    _MACRO_CALL_RE,
+    _RUST_STR_LITERAL_RE,
+    _blank_rust_literals,
+)
+
+
+def _old(s):
+    return _RUST_STR_LITERAL_RE.sub(" ", s)
+
+
+_FIXTURES = [
+    'println!("hello {}", name)',
+    'panic!("call init() first")',
+    'assert_eq!(actual, vec![Token::new(0, foo()), bar()])',
+    'let c = \'a\'; foo()',
+    "fn f<'a>(x: &'a str) { g() }",                 # lifetimes must NOT blank
+    "'static lifetime and call h()",
+    'r#"has "# inside"#',                            # raw one-hash w/ embedded quote-hash
+    r'"esc \" quote" then call()',                   # escaped quote
+    "'\\n' '\\\\' '\\'' newline_call()",             # escaped char literals
+    "match x { 'A'..='Z' => up() }",                 # char ranges
+    'a::b::<T>(); x.y.z()',                           # turbofish + dotted
+    '"" empty() r"" q() r#""# raw_empty()',           # empty literals of each kind
+    "label: 'outer loop { break 'outer; call() }",
+    'unterminated "string with call( no close',       # malformed: unterminated normal
+    'unterminated r#"raw with call( no close',        # malformed: unterminated raw-hash
+    '"a\\\nb" trailing()',                            # backslash-newline: \\. must NOT match
+    'vec![\'a\', \'b\', \'c\']',
+    'no_literals_at_all(foo, bar, baz)',
+    '',
+]
+
+
+def test_differential_on_fixtures():
+    for s in _FIXTURES:
+        assert _blank_rust_literals(s) == _old(s), repr(s)
+
+
+def test_differential_on_real_source_windows():
+    here = os.path.dirname(os.path.abspath(__file__))
+    files = glob.glob(os.path.join(here, "**", "*.py"), recursive=True)
+    assert files, "no corpus files found"
+    for fp in files:
+        txt = open(fp, encoding="utf-8", errors="ignore").read()
+        for chunk in [txt] + [txt[k:k + 500] for k in range(0, len(txt), 500)]:
+            assert _blank_rust_literals(chunk) == _old(chunk), f"{os.path.basename(fp)}"
+
+
+def test_differential_seeded_fuzz():
+    rng = random.Random(0xA17)
+    alph = list('abcXYZ_0129 ()[]{}.:;,<>&*=+-/\n\t') + \
+        ['"', "'", 'r"', 'r#"', '"#', '\\', '::', '\\"', "\\'", '\\n']
+    for _ in range(50000):
+        s = ''.join(rng.choice(alph) for _ in range(rng.randint(0, 40)))
+        assert _blank_rust_literals(s) == _old(s), repr(s)
+
+
+def test_stripper_is_linear_not_redos():
+    # Several adversarial flood shapes must all stay well under 1s. The
+    # repeated-`r#"` flood (no closing `"#`) is the one an earlier cut got wrong:
+    # find('"#') scanned to EOF from ~n/3 positions -> O(n^2) (~1.8s at 240KB).
+    # The monotonic short-circuit in _blank_rust_literals restores O(n).
+    floods = [
+        'r#"' * 200_000,            # repeated r#" (the regression shape) ~600KB
+        'r"' * 200_000,             # repeated r"
+        'r#"' + 'a"' * 100_000,     # single r#" prefix + quote flood
+        '"' + 'a' * 200_000,        # unterminated normal string
+        '"' + '\\a' * 100_000,      # backslash flood
+        "'" * 200_000,              # repeated char-quote
+        'r#"a' * 100_000,           # interleaved r#" + char
+    ]
+    for payload in floods:
+        t = time.time()
+        _blank_rust_literals(payload)
+        dt = time.time() - t
+        assert dt < 1.0, f"slow ({dt:.2f}s) on {payload[:8]!r}... len={len(payload)}"
+
+
+def test_stripper_scaling_is_subquadratic():
+    """Doubling the input must not ~quadruple the time (that's O(n^2)). Guards
+    against a future edit reintroducing a find()-to-EOF-per-position regression."""
+    def _time(payload):
+        t = time.time(); _blank_rust_literals(payload); return time.time() - t
+    small = _time('r#"' * 100_000)
+    big = _time('r#"' * 400_000)          # 4x the input
+    # linear -> ~4x; quadratic -> ~16x. Assert well under quadratic. Guard the
+    # denominator against a near-zero small time on a fast machine.
+    if small > 0.005:
+        assert big / small < 8.0, f"scaling {big/small:.1f}x for 4x input looks quadratic"
+
+
+def _calls(t):
+    return [m.group(1) for m in _MACRO_CALL_RE.finditer(t)]
+
+
+def test_recall_call_after_large_literal_is_preserved():
+    """RED against the committed bound-first ordering: a call AFTER a >8KB string
+    literal was dropped because the budget truncated the still-unstripped literal.
+    Strip-first collapses the literal to one space, so both calls survive."""
+    from utilities.scan_budget import bound_macro_scan_text
+    body = 'foo(), "%s", bar()' % ("x" * 9016)
+    stripped = _blank_rust_literals(body)
+    bounded, truncated = bound_macro_scan_text(stripped, context="t")
+    assert truncated is False
+    assert _calls(bounded) == ["foo", "bar"]

--- a/libs/openant-core/utilities/scan_budget.py
+++ b/libs/openant-core/utilities/scan_budget.py
@@ -1,0 +1,60 @@
+"""Shared input budget for the regex-based call-detection scanners (Rust macro bodies,
+Zig fallback function bodies).
+
+Those scanners run ``re.finditer`` over a whole macro/function token-text. On a long
+``::``/``.`` identifier chain with no trailing ``(``, ``finditer`` restarts at every
+interior position and re-scans the chain forward — O(n^2) on adversarial input (a
+single ~575KB macro body burns ~30 min of CPU). Possessive/atomic quantifiers do NOT
+fix this (they stop intra-match backtracking, not the per-position restart) and, on
+Rust's scoped-turbofish branch, change the matched call set (a reachability regression).
+
+DESIGN DECISION (2026-08-15, user-chosen, "if it's more than a second it's not a good
+balance"): the call-detection regex is left UNCHANGED and the input length fed to it is
+bounded to MAX_MACRO_SCAN_CHARS. The cap is deliberately LOW (8192 → ~0.35s worst-case
+adversarial body, safely under the 1s DoS budget). Because the regex is quadratic, the
+cap CANNOT be raised to cover large real bodies while staying under 1s (16KB is already
+~1.4s), so DoS-safety is prioritised over coverage here.
+
+The truncation is therefore a real, disclosed reachability tradeoff — a body over the cap
+loses the calls past the cut. To keep that loss NON-SILENT (a scanner that quietly
+analyses less than it claims is the exact failure mode this project designs against),
+``bound_macro_scan_text`` returns a ``truncated`` flag that the builders surface in the
+call-graph output as ``scan_truncated`` — a MACHINE-READABLE record downstream reachability
+can consume (e.g. to over-seed the truncated unit rather than trust a possibly-incomplete
+callee list). This converts a silent false-negative into a flagged, known-incomplete scan.
+
+RESIDUAL (deferred): the truly coverage-safe fix is overlapped-window chunking (O(n), zero
+call loss except a token longer than one window, which IS the attack). It is NOT
+implemented here — see ``residual-evasion.md``. Under the current low-cap design an
+attacker can still pad a macro body past 8192 chars to FORCE a real call to be dropped
+(a reachability-evasion primitive), now at least flagged via ``scan_truncated``. The limit
+is measured in Python string length (Unicode code points), not raw bytes.
+"""
+from __future__ import annotations
+
+import sys
+from typing import Tuple
+
+MAX_MACRO_SCAN_CHARS = 8192  # ~0.35s worst-case for the quadratic Rust regex; < the 1s DoS budget.
+MAX_MACRO_SCAN_BYTES = MAX_MACRO_SCAN_CHARS  # legacy alias (unit is code points, not bytes)
+
+
+def bound_macro_scan_text(text: str, context: str = "", *,
+                          limit: int = MAX_MACRO_SCAN_CHARS) -> Tuple[str, bool]:
+    """Return ``(bounded_text, truncated)``.
+
+    ``bounded_text`` is ``text`` unchanged if within ``limit``, else its first ``limit``
+    chars. ``truncated`` is True iff the input exceeded ``limit`` (callers record it into
+    the call-graph output as ``scan_truncated`` so the coverage gap is machine-readable,
+    not just a stderr line). A loud stderr warning is still emitted on truncation.
+    """
+    if len(text) <= limit:
+        return text, False
+    where = f" ({context})" if context else ""
+    print(
+        f"[scan-budget] WARNING: call-scan input{where} truncated "
+        f"{len(text)} -> {limit} chars; calls past the cut are not extracted "
+        f"(coverage gap, flagged as scan_truncated). This bounds a regex-ReDoS DoS vector.",
+        file=sys.stderr,
+    )
+    return text[:limit], True


### PR DESCRIPTION
## What
The Rust macro-body call scanner blanked string/char literals via a regex whose
repeated-`r#"` and unterminated-quote paths are O(n^2) (a real ReDoS: an untrusted
scanned repo with a large macro body stalls the parser). It also lost real call
edges when a large literal pushed a trailing call past the scan budget.

## Root cause
`_RUST_STR_LITERAL_RE.sub` in parsers/rust/call_graph_builder.py runs before the scan
budget and is quadratic on a repeated-`r#"` flood (each opener scans to EOF); and the
bound-then-strip order truncated a still-unstripped large literal, dropping a real call.

## Fix (subtractive + linear)
Replace the regex `.sub` with `_blank_rust_literals`, a single forward-cursor O(n)
stripper proven BYTE-IDENTICAL to `_RUST_STR_LITERAL_RE.sub(" ", text)` (the regex is
retained as the differential oracle). Strip first (linear, uncapped), then bound only
the still-quadratic `_MACRO_CALL_RE`. A monotonic short-circuit keeps the repeated-`r#"`
path linear. Reachability-neutral: the extracted call set is unchanged except it now
RECOVERS calls the bound-first order dropped (never fabricates one).

## Evidence (offline)
- Differential (test_rust_literal_stripper_differential.py): 21 fixtures + 4304 real-code
  windows + 200k fuzz, 0 divergence vs the regex oracle.
- Linearity: 7 adversarial flood shapes + a doubling-scaling regression test (repeated-`r#"`
  240KB: was ~1.8s O(n^2) -> 6ms linear). RED-verified against the pre-fix stripper.
- Recall: test asserts a call after a >8KB literal is recovered (was dropped).

## Scope / named residuals
Only parsers/rust + the shared scan_budget. A call after >8KB of NON-literal token soup
is still truncated by `_MACRO_CALL_RE`'s budget (disclosed via `scan_truncated`); the
tree-sitter token-tree walk that would retire both regexes is deferred. Zig's regex path
is a near-dead fallback, already budget-bounded, left unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
