### PR TITLE
ci: least-privilege hardening of the gitleaks and test workflows

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -2,7 +2,7 @@ name: gitleaks
 on:
   push:
     branches: [master]
-  pull_request_target:
+  pull_request:
 jobs:
   scan:
     name: gitleaks
@@ -10,14 +10,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      # Fork PRs need pull_request_target so GITLEAKS_LICENSE is available
-      # (regular pull_request from a fork has no access to repo secrets).
-      # gitleaks-action@v2 rejects pull_request_target ("event is not yet
-      # supported"), so we run the gitleaks CLI directly. Pattern mirrors
-      # kirin_auto/.github/workflows/gitleaks.yaml.
-      #
-      # Safety with pull_request_target: explicitly check out the fork's HEAD
-      # SHA, drop persisted credentials, restrict permissions to contents:read.
+      # We run the open-source gitleaks CLI directly (not gitleaks-action@v2,
+      # which is the only thing that consumes GITLEAKS_LICENSE). The CLI needs
+      # no license and no repo secret, so plain `pull_request` is sufficient and
+      # avoids the privileged `pull_request_target` token alongside fork content.
       # Gitleaks only reads files — no fork code is executed.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4.2.2
         with:
@@ -34,7 +30,7 @@ jobs:
           FORCED: ${{ github.event.forced }}
         run: |
           NULL_SHA="0000000000000000000000000000000000000000"
-          if [ "$EVENT" = "pull_request_target" ]; then
+          if [ "$EVENT" = "pull_request" ]; then
             echo "log_opts=${BASE_SHA}..HEAD" >> "$GITHUB_OUTPUT"
           elif [ "$BEFORE_SHA" = "$NULL_SHA" ] || [ -z "$BEFORE_SHA" ] || [ "$FORCED" = "true" ]; then
             echo "log_opts=" >> "$GITHUB_OUTPUT"
@@ -54,7 +50,6 @@ jobs:
           gitleaks version
       - name: Run gitleaks
         env:
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
           LOG_OPTS: ${{ steps.range.outputs.log_opts }}
         run: |
           if [ -n "$LOG_OPTS" ]; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint (Python)


### PR DESCRIPTION
Hardening / least-privilege, not a vulnerability fix — the flagged gitleaks
untrusted-checkout is not exploitable (gitleaks only reads files; no fork code
is executed). Resolves CodeQL alerts #1 (untrusted-checkout) and #2/#3/#4
(missing-workflow-permissions) at the root.

## gitleaks.yaml — drop the unnecessary privileged trigger
- `pull_request_target` -> `pull_request`. The only stated reason for the
  privileged trigger was to expose `GITLEAKS_LICENSE` to fork PRs — but this
  workflow runs the open-source gitleaks CLI directly, and the CLI ignores that
  secret (only `gitleaks-action@v2` consumes it). So the license env was a no-op
  and the privileged trigger bought nothing. Drop both, and the stale comment.
- The scan still runs on fork PRs (the CLI needs no secret), the range logic is
  unchanged (`github.event.pull_request.base.sha` is populated on `pull_request`),
  and the checkout still targets the PR head. Removes the privileged-token +
  fork-content foot-gun that alert #1 flags. `EVENT` check updated to match.

## test.yaml — add least-privilege token scope
- Add top-level `permissions: contents: read`. All three jobs (lint /
  python-tests / go-tests) only read the repo — none comments, uploads
  artifacts, pushes, or writes a status. `actions/cache` save is unaffected
  (it uses ACTIONS_RUNTIME_TOKEN, not GITHUB_TOKEN). Resolves #2/#3/#4.

## Notes for reviewers
- Under `pull_request`, a brand-new fork contributor's run needs a maintainer
  "Approve and run" (the intended safety gate), and the workflow YAML comes from
  the PR — if "gitleaks" is a required status check, a weakening edit leaves the
  check pending under branch protection.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
