### PR TITLE
fix(reporter): report true reachable_units from the filter record, not total

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -202,6 +202,36 @@ def _dedup_caller_callee(
 # Pipeline output builder
 # ---------------------------------------------------------------------------
 
+def _load_reachability_metadata(scan_dir: str) -> dict | None:
+    """Return the reachability-filter record for this scan, if one exists.
+
+    The parse step (``core/parser_adapter.apply_reachability_filter``) stamps
+    the true kept-unit count onto ``<scan_dir>/dataset.json`` under
+    ``metadata.reachability_filter``. The reporter reads it so
+    ``pipeline_stats.reachable_units`` reflects reality instead of assuming
+    every analyzed unit is reachable. Returns ``None`` when the dataset or the
+    record is absent/unreadable (an unfiltered scan, or a parser that recorded
+    none). NOTE: on a multi-language scan the merged ``dataset.json`` currently
+    carries only the first-parsed language's record (see ``dataset_merge`` /
+    BUG-2b); this reader surfaces that record and warns — full per-language
+    accounting is deferred to a follow-up.
+    """
+    dataset_path = os.path.join(scan_dir, "dataset.json")
+    if not os.path.exists(dataset_path):
+        return None
+    try:
+        dataset = read_json(dataset_path)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(dataset, dict):
+        return None
+    metadata = dataset.get("metadata")
+    if not isinstance(metadata, dict):
+        return None
+    rf = metadata.get("reachability_filter")
+    return rf if isinstance(rf, dict) else None
+
+
 def build_pipeline_output(
     results_path: str,
     output_path: str,
@@ -433,6 +463,52 @@ def build_pipeline_output(
 
     total_units = metrics.get("total", len(all_results))
 
+    # F1: report the TRUE reachable count from the reachability filter's record
+    # (persisted to <scan_dir>/dataset.json by the parse step) instead of
+    # fabricating reachable_units = total_units. Surfacing original_units +
+    # the reduction makes the pruning visible (a report that showed only the
+    # kept count gave no hint units were pruned — the neqo misdiagnosis vector).
+    # When no record exists but a filtering level was requested, warn rather
+    # than silently assert full reachability (the free-function-parser /
+    # not-recorded blind spot); also surface any blackout warning the filter
+    # recorded (previously written to metadata only, with no report consumer).
+    _reach = _load_reachability_metadata(
+        os.path.dirname(os.path.abspath(results_path))
+    )
+    reachability_warnings: list[str] = []
+    reachability_filter_applied = _reach is not None
+    reachable_units = total_units
+    original_units = total_units
+    reachability_reduction_percentage = None
+    if _reach is not None:
+        if isinstance(_reach.get("reachable_units"), int):
+            reachable_units = _reach["reachable_units"]
+        if isinstance(_reach.get("original_units"), int):
+            original_units = _reach["original_units"]
+        if isinstance(_reach.get("reduction_percentage"), (int, float)):
+            reachability_reduction_percentage = _reach["reduction_percentage"]
+        _rf_warning = _reach.get("warning")
+        if isinstance(_rf_warning, str) and _rf_warning:
+            reachability_warnings.append(_rf_warning)
+    elif total_units > 0 and (processing_level or "").lower() not in ("", "all", "none"):
+        reachability_warnings.append(
+            f"Reachability filtering was requested (level={processing_level!r}) "
+            "but no reachability_filter record was found; reachable_units falls "
+            "back to total_units and may overstate reachability."
+        )
+
+    # reachable_units is a parse-stage count (units the filter kept); total_units
+    # is the analyze-stage total (which --limit / subset runs can truncate below
+    # the kept set). Guard the cross-stage case so the report never silently
+    # shows reachable_units > total_units without explanation.
+    if isinstance(reachable_units, int) and reachable_units > total_units:
+        reachability_warnings.append(
+            f"reachable_units ({reachable_units}) exceeds analyzed total_units "
+            f"({total_units}): analysis covered a subset of the reachable units "
+            "(e.g. --limit). reachable_units is the reachability filter's kept "
+            "count; units_analyzed reflects what was actually analyzed."
+        )
+
     pipeline_output = {
         "repository": {
             "name": repo_name or experiment.get("dataset", "unknown"),
@@ -455,7 +531,13 @@ def build_pipeline_output(
         "threat_model_warnings": list(threat_model_warnings or []),
         "pipeline_stats": {
             "total_units": total_units,
-            "reachable_units": total_units,
+            "reachable_units": reachable_units,
+            # Additive reachability provenance (all tolerated by the untyped
+            # pipeline_stats dict in report/schema.py):
+            "original_units": original_units,
+            "reachability_filter_applied": reachability_filter_applied,
+            "reachability_reduction_percentage": reachability_reduction_percentage,
+            "reachability_warnings": reachability_warnings,
             "units_analyzed": total_units - metrics.get("errors", 0),
             "processing_level": processing_level,
             "costs": costs,

--- a/libs/openant-core/report/prompts/summary.txt
+++ b/libs/openant-core/report/prompts/summary.txt
@@ -30,6 +30,7 @@ OUTPUT FORMAT:
 - Parsed: {n} functions from {n} files
 - Total units: {pipeline_stats.total_units}
 - Reachable units: {pipeline_stats.reachable_units}
+- Reachability warnings: {pipeline_stats.reachability_warnings}
 - After CodeQL filter: {n} units
 - Analyzed in Stage 1: {n} units
 - Verified in Stage 2: {n} findings
@@ -103,7 +104,8 @@ INSTRUCTIONS:
   - When the scan was incremental, ALSO add a paragraph immediately after the metadata block:
     `> This is an incremental scan. Only the {diff.units_in_diff}/{diff.units_total_parsed} unit(s) overlapping changes between {diff.base_sha[:8]} and {diff.head_sha[:8]} were analyzed. Findings on unchanged units inherit the most recent prior verdict and are not re-examined here.`
 - Processing Level comes from pipeline_stats.processing_level; if null or missing, write "Not available"
-- Reachable units comes from pipeline_stats.reachable_units; total units from pipeline_stats.total_units
+- Reachable units comes from pipeline_stats.reachable_units; total units from pipeline_stats.total_units. When pipeline_stats.reachability_filter_applied is true, append " ({pipeline_stats.reachable_units} of {pipeline_stats.original_units} parsed, {pipeline_stats.reachability_reduction_percentage}% pruned by the reachability filter)" to the Reachable units line so the pruning is visible; when false, append " (reachability filtering not applied/recorded)"
+- Reachability warnings: iterate pipeline_stats.reachability_warnings; if non-empty, render each entry as its own bullet under the Reachable units line; if empty, OMIT the "Reachability warnings" line entirely
 - Per-Step Costs: iterate pipeline_stats.costs; compute totals by summing estimated and actual
 - Per-Step Durations: iterate pipeline_stats.durations; format seconds as "Xm Ys" (e.g., "2m 31s"); the "total" key is the overall duration
 - Skipped Steps: iterate pipeline_stats.skipped_steps; if the array is empty, write "No steps were skipped."

--- a/libs/openant-core/tests/test_reporter_reachable_units.py
+++ b/libs/openant-core/tests/test_reporter_reachable_units.py
@@ -1,0 +1,200 @@
+"""Tests for ``core.reporter`` honest ``reachable_units`` reporting (F1).
+
+Regression coverage for a report-correctness bug: ``build_pipeline_output``
+hardcoded ``pipeline_stats.reachable_units = total_units`` — i.e. it asserted
+that *every* analyzed unit was reachable, even though the reachability filter
+(``core/parser_adapter.apply_reachability_filter``) may have pruned most of
+them. The true reachable count is persisted by the parse step into
+``<scan_dir>/dataset.json`` under ``metadata.reachability_filter.reachable_units``;
+the reporter simply never read it. On a real scan (e.g. neqo: 2883 -> 892) the
+human-facing summary report (``report/prompts/summary.txt`` interpolates
+``pipeline_stats.reachable_units``) therefore stated a falsehood — the exact
+artifact that misled a reviewer into a "reachability is broken" misdiagnosis.
+
+These tests pin the fix:
+1. When a reachability-filter record exists, the report's ``reachable_units``
+   reflects the TRUE filtered count, not ``total_units``.
+2. When units were analyzed but NO reachability-filter record exists and a
+   filtering level was requested (the free-function-parser / not-recorded
+   blind spot), the report does not silently assert full reachability — it
+   carries a warning and flags that filtering was not recorded.
+3. Absent/unfiltered scans keep the safe fallback without a spurious warning.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.reporter import build_pipeline_output
+from utilities.file_io import write_json
+
+
+def _run_build(
+    tmp_path: Path,
+    *,
+    metrics: dict,
+    reachability_filter: dict | None,
+    processing_level: str | None = "reachable",
+    dataset_metadata_extra: dict | None = None,
+) -> dict:
+    """Invoke ``build_pipeline_output`` with a controlled results.json +
+    sibling dataset.json, returning the parsed ``pipeline_output.json``.
+    """
+    results = {
+        "dataset": "test",
+        "code_by_route": {"app.py:foo": "def foo(): pass"},
+        "metrics": metrics,
+        "confirmed_findings": [],
+    }
+    results_path = tmp_path / "results.json"
+    write_json(results_path, results)
+
+    # The parse step writes dataset.json as a sibling of results.json; the
+    # reachability filter stamps metadata.reachability_filter onto it.
+    if reachability_filter is not None or dataset_metadata_extra is not None:
+        metadata: dict = {}
+        if reachability_filter is not None:
+            metadata["reachability_filter"] = reachability_filter
+        if dataset_metadata_extra:
+            metadata.update(dataset_metadata_extra)
+        write_json(tmp_path / "dataset.json", {"units": [], "metadata": metadata})
+
+    out_path = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(results_path),
+        output_path=str(out_path),
+        language="python",
+        repo_name="test/repo",
+        processing_level=processing_level,
+    )
+    return json.loads(out_path.read_text())
+
+
+def test_reachable_units_reflects_true_filtered_count(tmp_path: Path):
+    """reachable_units == the filter's real kept count, not total_units."""
+    out = _run_build(
+        tmp_path,
+        metrics={"total": 10, "errors": 0},
+        reachability_filter={
+            "original_units": 10,
+            "reachable_units": 2,
+            "reduction_percentage": 80,
+        },
+    )
+    stats = out["pipeline_stats"]
+    assert stats["total_units"] == 10
+    # The bug: this was hardcoded to total_units (10). Truth is 2.
+    assert stats["reachable_units"] == 2, (
+        f"expected true filtered count 2, got {stats['reachable_units']} "
+        "(reporter fabricated reachable_units = total_units)"
+    )
+    assert stats.get("reachability_filter_applied") is True
+
+
+def test_missing_reachability_record_warns_not_asserts(tmp_path: Path):
+    """Filtering requested but no rf record -> warn, don't claim full reach."""
+    out = _run_build(
+        tmp_path,
+        metrics={"total": 10, "errors": 0},
+        reachability_filter=None,               # e.g. rust/zig: no rf metadata
+        dataset_metadata_extra={"language": "rust"},
+        processing_level="reachable",
+    )
+    stats = out["pipeline_stats"]
+    assert stats.get("reachability_filter_applied") is False
+    warnings = stats.get("reachability_warnings") or []
+    assert warnings, "expected a reachability warning when no rf record exists"
+    assert any("reachab" in w.lower() for w in warnings)
+
+
+def test_malformed_dataset_json_degrades_safely(tmp_path: Path):
+    """A corrupt dataset.json must not crash the report; it degrades to fallback."""
+    results = {"dataset": "t", "code_by_route": {}, "metrics": {"total": 5, "errors": 0},
+               "confirmed_findings": []}
+    write_json(tmp_path / "results.json", results)
+    (tmp_path / "dataset.json").write_text("{not valid json")
+    out_path = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(tmp_path / "results.json"), output_path=str(out_path),
+        language="python", repo_name="t/r", processing_level="reachable",
+    )
+    stats = json.loads(out_path.read_text())["pipeline_stats"]
+    assert stats["reachable_units"] == 5           # safe fallback, no crash
+    assert stats["reachability_filter_applied"] is False
+
+
+def test_rf_record_present_but_no_count_keeps_fallback(tmp_path: Path):
+    """rf record exists but lacks reachable_units -> applied True, count fallback, no warning."""
+    out = _run_build(
+        tmp_path,
+        metrics={"total": 7, "errors": 0},
+        reachability_filter={"reduction_percentage": 0},   # no reachable_units key
+        processing_level="reachable",
+    )
+    stats = out["pipeline_stats"]
+    assert stats["reachability_filter_applied"] is True
+    assert stats["reachable_units"] == 7
+    assert not (stats.get("reachability_warnings") or [])
+
+
+def test_blackout_warning_surfaced_from_rf_record(tmp_path: Path):
+    """A blackout warning recorded on the rf record reaches the report."""
+    out = _run_build(
+        tmp_path,
+        metrics={"total": 100, "errors": 0},
+        reachability_filter={"original_units": 100, "reachable_units": 100,
+                             "reduction_percentage": 0,
+                             "warning": "No entry points detected; keeping all units"},
+        processing_level="reachable",
+    )
+    stats = out["pipeline_stats"]
+    assert any("entry point" in w.lower() for w in stats.get("reachability_warnings") or [])
+
+
+def test_original_units_and_reduction_surfaced(tmp_path: Path):
+    """The pruning is made visible (original + reduction), not just the kept count."""
+    out = _run_build(
+        tmp_path,
+        metrics={"total": 892, "errors": 0},
+        reachability_filter={"original_units": 2883, "reachable_units": 892,
+                             "reduction_percentage": 69},
+        processing_level="reachable",
+    )
+    stats = out["pipeline_stats"]
+    assert stats["reachable_units"] == 892
+    assert stats["original_units"] == 2883
+    assert stats["reachability_reduction_percentage"] == 69
+
+
+def test_limit_run_reachable_exceeds_total_warns(tmp_path: Path):
+    """--limit truncates analysis below the kept set: keep the true reachable
+    count but warn so reachable_units > total_units is never silently shown."""
+    out = _run_build(
+        tmp_path,
+        metrics={"total": 100, "errors": 0},          # analysis limited to 100
+        reachability_filter={"original_units": 2883, "reachable_units": 892,
+                             "reduction_percentage": 69},
+        processing_level="reachable",
+    )
+    stats = out["pipeline_stats"]
+    assert stats["reachable_units"] == 892            # true kept count preserved
+    assert stats["total_units"] == 100
+    warnings = stats.get("reachability_warnings") or []
+    assert any("exceeds analyzed total_units" in w for w in warnings), (
+        "expected a warning explaining reachable_units > total_units under --limit"
+    )
+
+
+def test_unfiltered_level_has_no_spurious_warning(tmp_path: Path):
+    """processing_level='all' means no filter by design -> no warning."""
+    out = _run_build(
+        tmp_path,
+        metrics={"total": 10, "errors": 0},
+        reachability_filter=None,
+        processing_level="all",
+    )
+    stats = out["pipeline_stats"]
+    assert not (stats.get("reachability_warnings") or []), (
+        "unfiltered scans must not emit a reachability warning"
+    )


### PR DESCRIPTION
## What

`build_pipeline_output` hardcoded `pipeline_stats.reachable_units = total_units`, asserting every analyzed unit is reachable even when the reachability filter pruned units (or never ran). The true kept count is persisted by the parse step to `<scan_dir>/dataset.json` (`metadata.reachability_filter`); the reporter never read it. The summary report (`report/prompts/summary.txt`, an LLM prompt handed `pipeline_stats`) therefore stated a falsehood and **hid the pruning entirely** — a report showing `reachable == total` gives no hint that e.g. 2883 units were pruned to 892, the exact artifact that can misread as "reachability broken".

## Change (report-only, coverage-neutral — no filter/verdict/seed change)

- Read `metadata.reachability_filter` from `<scan_dir>/dataset.json` (mirrors the existing `_load_diff_metadata` sidecar reader; parse writes `dataset.json` beside `results.json` at `output_dir`).
- `reachable_units` now reflects the filter's real kept count; add additive keys `original_units`, `reachability_reduction_percentage`, `reachability_filter_applied`, `reachability_warnings` to `pipeline_output.json` (the machine-readable product artifact — so the keys are not write-only).
- Reference those keys in `report/prompts/summary.txt` so the summary LLM renders the pruning + any warnings. Summary prose is LLM-rendered (not deterministic); `pipeline_output.json` carries the exact values.
- Surface the filter's blackout `warning` (previously metadata-only) into `reachability_warnings`; when a filtering level was requested but no record exists, warn rather than assert full reachability.
- Guard the cross-stage case: `reachable_units` (parse-stage kept) vs `total_units` (analyze-stage, `--limit`-truncatable) — warn instead of silently showing `reachable > total`.
- Degrades safely (missing/corrupt `dataset.json` → fallback, no crash).

## Scope honesty

- **Multi-language:** the merged `dataset.json` carries only the first-parsed language's record (`dataset_merge` spreads `first.metadata`); this reads that record and does not yet do full per-language accounting — deferred to a follow-up.
- **Sibling deferred:** `pipeline_stats.skipped_steps` is hardcoded `[]` while step reports carry the real skip data (same class) — left for a follow-up PR to keep this one atomic.

## Tests

8 new in `tests/test_reporter_reachable_units.py` (`grep -c 'def test_' = 8`): malformed-json degrade, rf-without-count fallback, blackout-warning surfaced, original/reduction surfaced, `--limit reachable>total` guard. Reporter + report suite green (117 passed). Mechanically red/green-validated on the git blobs (base `75e6461` vs fix) via rebugz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
