### PR TITLE
fix(tests): cross-platform CI failures in two pre-existing tests

### DIFF
--- a/libs/openant-core/tests/test_fence_live_sites_escape.py
+++ b/libs/openant-core/tests/test_fence_live_sites_escape.py
@@ -201,14 +201,19 @@ def test_collapse_inline_has_a_single_home():
     core_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     offenders_oneline, offenders_inline = [], []
     for dp, _dn, files in os.walk(core_root):
-        if "/tests" in dp or "/.git" in dp or "__pycache__" in dp:
+        # Normalize separators: os.walk yields native separators, so a hardcoded
+        # "/tests" never matches on Windows (dp uses "\") and the tests/ dir is
+        # walked instead of skipped -> false offenders. (Same reason rel is
+        # normalized below so the prompts/_fence.py home exemption holds on Windows.)
+        dp_norm = dp.replace(os.sep, "/")
+        if "/tests" in dp_norm or "/.git" in dp_norm or "__pycache__" in dp_norm:
             continue
         for fn in files:
             if not fn.endswith(".py"):
                 continue
             p = os.path.join(dp, fn)
             txt = open(p, encoding="utf-8", errors="ignore").read()
-            rel = os.path.relpath(p, core_root)
+            rel = os.path.relpath(p, core_root).replace(os.sep, "/")
             if "def _oneline" in txt:
                 offenders_oneline.append(rel)
             # the raw inline collapse form, allowed ONLY inside _fence.py (the home)

--- a/libs/openant-core/tests/test_macro_scan_budget_redos.py
+++ b/libs/openant-core/tests/test_macro_scan_budget_redos.py
@@ -49,7 +49,11 @@ def test_bounded_scan_is_fast_where_raw_is_quadratic():
     t = time.time()
     list(RUST_RE.finditer(bound_macro_scan_text(adversarial, context="test")[0]))
     bounded_dt = time.time() - t
-    assert bounded_dt < 1.0, f"bounded scan still slow: {bounded_dt:.2f}s"
+    # The bound must keep this near-instant; the UNBOUNDED regex on this payload
+    # ReDoS-hangs for minutes. A tight sub-second wall-clock flakes on loaded CI
+    # runners (observed 1.03-1.20s on macos/windows) without catching a real
+    # regression any better than a generous ceiling that a true ReDoS blows past.
+    assert bounded_dt < 5.0, f"bounded scan still slow: {bounded_dt:.2f}s (bound not applied?)"
 
 
 def test_rust_and_zig_regex_unchanged():


### PR DESCRIPTION
## What

Two pre-existing tests fail on Windows/macOS CI **independently of any product change**, blocking every PR from a green required `Python tests` check (master's own windows run is red on #1).

### 1. `test_fence_live_sites_escape::test_collapse_inline_has_a_single_home` — deterministic Windows bug
The directory-skip used a hardcoded forward slash (`"/tests" in dp`), but `os.walk` yields **native** separators, so on Windows `dp` contains `\tests` and the `tests/` dir is walked instead of skipped → the scanner flags a test file as an offender (`['tests\\test_fence_live_sites_escape.py']`). The `prompts/_fence.py` home exemption had the same latent bug (`rel != "prompts/_fence.py"` never matches when `rel` uses `\`).
**Fix:** normalize `os.sep → "/"` before both comparisons. No behavior change on Linux/macOS.

### 2. `test_bounded_scan_is_fast_where_raw_is_quadratic` — timing flake
The absolute `< 1.0s` wall-clock has zero tolerance for loaded runners (observed 1.03s→1.20s on macos/windows; passes on ubuntu + master's macos). The test's purpose is to prove the bound prevents a ReDoS hang (minutes for the unbounded regex) — a generous `5.0s` ceiling still catches that.
**Fix:** raise the ceiling + document; intent preserved.

## Scope
Test-only; no product code touched. Local: 16 passed, ruff clean. Windows/macOS correctness is validated by CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
