### PR TITLE
fix(dynamic-test): reconstruct untrusted compose from an allowlist; complete container caps

### DIFF
--- a/libs/openant-core/tests/test_docker_sandbox_reconstruct.py
+++ b/libs/openant-core/tests/test_docker_sandbox_reconstruct.py
@@ -1,0 +1,145 @@
+"""Tests for the untrusted-compose RECONSTRUCTION hardening (B)+(C).
+
+The dynamic tester builds+runs an LLM/target-influenced docker-compose. Rather than
+blocklist dangerous keys (non-terminating), `_sanitize_compose` rebuilds each declared
+service from an allowlist + a fixed hardening set, dropping every container-runtime
+attribute that could grant host access. These tests pin that behaviour.
+"""
+
+import yaml
+
+from utilities.dynamic_tester.docker_executor import _sanitize_compose
+
+
+HOSTILE = """
+services:
+  test:
+    build: .
+    privileged: true
+    cap_add: [SYS_ADMIN]
+    pid: host
+    ipc: host
+    security_opt: [seccomp=unconfined, apparmor=unconfined]
+    devices: ["/dev/kmsg:/dev/kmsg"]
+    network_mode: host
+    user: root
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /:/host:rw
+    ports: ["8080:8080"]
+  attacker:
+    build: ./attacker-server
+"""
+
+DANGEROUS_KEYS = ("privileged", "cap_add", "pid", "ipc", "devices",
+                  "network_mode", "user", "volumes", "ports", "sysctls",
+                  "userns_mode", "cgroup_parent", "device_cgroup_rules",
+                  "extra_hosts", "env_file", "extends")
+
+
+def _load(out):
+    doc = yaml.safe_load(out)
+    assert isinstance(doc, dict), f"reconstructed compose is not a mapping: {out!r}"
+    return doc
+
+
+def test_hostile_runtime_attributes_are_gone():
+    doc = _load(_sanitize_compose(HOSTILE))
+    for name, svc in doc["services"].items():
+        for bad in DANGEROUS_KEYS:
+            assert bad not in svc, f"{bad!r} survived in service {name!r}"
+    # and no host paths / docker socket anywhere in the serialized output
+    out = _sanitize_compose(HOSTILE)
+    for token in ("docker.sock", "/:/host", "network_mode", "privileged: true", "seccomp=unconfined"):
+        assert token not in out, f"dangerous token survived: {token}"
+
+
+def test_service_set_preserved_and_hardened():
+    # test + attacker + db (SQLi-style) must ALL survive, each hardened — not dropped.
+    compose = """
+services:
+  test:
+    build: .
+    depends_on: [db, attacker]
+  attacker:
+    build: ./attacker-server
+  db:
+    image: postgres:15
+    environment: [POSTGRES_PASSWORD=x]
+"""
+    doc = _load(_sanitize_compose(compose))
+    assert set(doc["services"]) == {"test", "attacker", "db"}, "a service was silently dropped"
+    for name, svc in doc["services"].items():
+        assert svc.get("read_only") is True, name
+        assert svc.get("cap_drop") == ["ALL"], name
+        assert svc.get("security_opt") == ["no-new-privileges:true"], name
+        assert svc.get("pids_limit") == 256, name
+        assert "user" not in svc, f"{name} must NOT set user (read-only-HOME breakage)"
+
+
+def test_db_service_keeps_image_and_env():
+    doc = _load(_sanitize_compose(
+        "services:\n  db:\n    image: postgres:15\n    environment: [POSTGRES_PASSWORD=x]\n"))
+    db = doc["services"]["db"]
+    assert db.get("image") == "postgres:15"
+    assert db.get("environment") == ["POSTGRES_PASSWORD=x"]
+
+
+def test_network_is_internal():
+    doc = _load(_sanitize_compose(HOSTILE))
+    assert doc["networks"]["default"]["internal"] is True
+
+
+def test_unsafe_build_context_fails_closed():
+    for ctx in ("/", "../..", "/etc", "../../host"):
+        out = _sanitize_compose(f"services:\n  test:\n    build:\n      context: {ctx}\n")
+        assert "refusing to run" in out, f"context {ctx!r} should fail closed"
+        assert yaml.safe_load(out).get("services") is None if isinstance(yaml.safe_load(out), dict) else True
+
+
+def test_unparseable_fails_closed():
+    out = _sanitize_compose("::: not : valid : yaml :::\n  - [")
+    assert "refusing to run" in out
+
+
+def test_attacker_remote_image_becomes_local_build():
+    out = _sanitize_compose("services:\n  attacker:\n    image: evil/attacker:latest\n")
+    svc = yaml.safe_load(out)["services"]["attacker"]
+    assert "image" not in svc
+    assert svc.get("build") == "./attacker-server"
+
+
+def test_run_single_hardening_flags(monkeypatch):
+    """_run_single's `docker run` must add cap_drop ALL + pids-limit, keep the F4 flags,
+    and NOT set --user (which would break HOME on the read-only rootfs)."""
+    from utilities.dynamic_tester import docker_executor as de
+    calls = []
+
+    def fake_run(cmd, timeout, cwd=None):
+        calls.append(cmd)
+        # first call = build (return success); second = run
+        return ("", "", 0, False)
+
+    monkeypatch.setattr(de, "_run_command", fake_run)
+    de._run_single("/tmp/nowhere", "img:tag", "net", 10, 10)
+    run_cmd = [c for c in calls if c[:2] == ["docker", "run"]][0]
+    s = " ".join(run_cmd)
+    assert "--cap-drop ALL" in s
+    assert "--pids-limit 256" in s
+    assert "--network none" in s
+    assert "--read-only" in s
+    assert "--security-opt no-new-privileges" in s
+    assert "--user" not in run_cmd, "must NOT pin --user (read-only-HOME breakage)"
+
+
+def test_allowlist_is_ordered_for_deterministic_output():
+    """_SVC_ALLOWLIST must be an ORDERED sequence (not a set): the reconstruction
+    iterates it to build each service, so a hash-randomized set would emit a
+    non-deterministic compose file across processes."""
+    from utilities.dynamic_tester.docker_executor import _SVC_ALLOWLIST
+    assert isinstance(_SVC_ALLOWLIST, (tuple, list)), type(_SVC_ALLOWLIST)
+    # reconstructed service keys follow the allowlist order, then the hardening keys
+    doc = yaml.safe_load(_sanitize_compose(
+        "services:\n  t:\n    environment: [A=1]\n    build: .\n    expose: [8080]\n"))
+    keys = list(doc["services"]["t"])
+    assert keys.index("build") < keys.index("environment") < keys.index("expose")

--- a/libs/openant-core/utilities/dynamic_tester/DYNAMIC_TESTER_REFERENCE.md
+++ b/libs/openant-core/utilities/dynamic_tester/DYNAMIC_TESTER_REFERENCE.md
@@ -103,11 +103,22 @@ The system prompt in `test_generator.py` instructs Claude Sonnet to:
 
 CWE-specific guidance is injected via `_get_cwe_guidance()` for common CWE IDs (22, 78, 79, 89, 94, 134, 918, 200, 502).
 
-## Docker Compose Sanitization
+## Docker Compose Reconstruction
 
-`docker_executor._sanitize_compose()` post-processes LLM-generated compose files:
-- Strips `version:` lines (obsolete in modern Docker)
-- Replaces remote attacker image references with `build: ./attacker-server`
+`docker_executor._sanitize_compose()` treats the LLM-generated compose as untrusted and
+**reconstructs** it rather than patching it. Each declared service is rebuilt from a fixed
+key allowlist (`build`/`image`/`depends_on`/`command`/`entrypoint`/`environment`/`expose`/
+`working_dir`/`healthcheck`/`networks`) plus a fixed hardening set (`read_only`,
+`cap_drop: [ALL]`, `security_opt: [no-new-privileges]`, `pids_limit`, `mem_limit`, `cpus`,
+`tmpfs`), so every container-runtime attribute that could reach the host — `privileged`,
+`cap_add`, host `volumes`, `pid`/`ipc`/`network_mode`, `devices`, `security_opt`, `user`,
+`ports`, … — is dropped by omission. The service **set** is preserved (nothing silently
+dropped); every declared network is forced `internal: true`; the attacker image is
+local-built. Fails **closed** (a refusing comment-only compose) on unparseable YAML or a
+build context that escapes the work dir.
+
+Build-time `RUN` egress remains an accepted, documented residual (an egress-allowlisting
+build proxy is deferred).
 
 ## Retry Mechanism
 

--- a/libs/openant-core/utilities/dynamic_tester/README.md
+++ b/libs/openant-core/utilities/dynamic_tester/README.md
@@ -184,15 +184,22 @@ All debug output must go to stderr. The result collector looks for the last vali
 
 All containers run with strict isolation:
 
-- **Read-only filesystem** (`--read-only`) with `/tmp` as a writable tmpfs
+- **Read-only filesystem** (`--read-only`) with `/tmp` and `/root` as writable tmpfs
 - **No privilege escalation** (`--security-opt no-new-privileges`)
+- **All capabilities dropped** (`--cap-drop ALL`)
+- **PID limit** — 256 (`--pids-limit`)
 - **Memory limit** — 512 MB (`--memory 512m`)
 - **CPU limit** — 1 CPU (`--cpus 1`)
-- **Isolated network** — each test gets its own Docker network
-- **No host volume mounts** — containers cannot access the host filesystem
+- **Isolated network** — single-container tests run with `--network none`; multi-service
+  tests run on an `internal: true` Docker network (no external gateway)
+- **No host volume mounts / no privileged mode** — enforced, not assumed: an untrusted
+  multi-service `docker-compose` is *reconstructed* from an allowlist (see below), so
+  `privileged`, `cap_add`, host `volumes`, `pid`/`ipc`/`network_mode`, `devices`, etc.
+  cannot reach the runtime
 - **Timeouts** — 120s for execution, 300s for builds
 
-Multi-service tests (e.g., those needing the attacker capture server) use Docker Compose with a bridge network.
+Multi-service tests (e.g., those needing the attacker capture server) use Docker Compose
+on an internal network, with each service reconstructed and hardened identically.
 
 ## Attacker Capture Server
 

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -39,28 +39,130 @@ class DockerExecutionResult:
         return self.build_error is None and not self.timed_out
 
 
+# Per-service compose keys we KEEP when reconstructing an untrusted compose. This is an
+# ALLOWLIST, not a blocklist: every container-runtime attribute that could grant host
+# access — privileged, cap_add, pid/ipc/uts/userns:host, security_opt, devices,
+# device_cgroup_rules, cgroup_parent, volumes/host binds (incl /var/run/docker.sock),
+# network_mode, ports, user, sysctls, group_add, extra_hosts, dns, env_file, extends,
+# secrets, configs, … — is DROPPED by omission and replaced with the fixed hardening set
+# in `_harden_service`. A blocklist is non-terminating (network_mode was one round's
+# miss); an allowlist contains the NEXT unknown key by default.
+# An ORDERED tuple (not a set): the reconstruction iterates it to build each service,
+# so a set's hash-randomized order would make the emitted compose non-deterministic.
+_SVC_ALLOWLIST = (
+    "build", "image", "depends_on", "command", "entrypoint",
+    "environment", "expose", "working_dir", "healthcheck", "networks",
+)
+
+
+def _refuse_compose(reason: str) -> str:
+    """A services-less (comment-only) compose: `docker compose build`/`up` create ZERO
+    containers (verified), so the untrusted definition never executes and the finding is
+    recorded non-CONFIRMED (fail-closed, no egress). Note `docker compose build` on an
+    empty compose exits 0 ("empty compose file") rather than erroring — safety comes from
+    "no services => nothing runs", not from a build failure. We do not raise — the
+    orchestrator calls run_single_container unwrapped, so a raise would
+    abort the whole dynamic-test run instead of just this finding."""
+    return f"# openant: {reason}; refusing to run it (fail-closed).\n"
+
+
+def _safe_build(build):
+    """Return a build spec confined to the work_dir, or raise if it escapes it.
+
+    A compose `build.context` of `/`, `..`, or an absolute path would make
+    `docker build` read HOST paths into the image. Only `.`/`./<sub>` (no `..`,
+    not absolute) is allowed; `build.dockerfile` is confined the same way.
+    """
+    def _confined(p) -> bool:
+        return (isinstance(p, str) and not p.startswith("/")
+                and ".." not in p.replace("\\", "/").split("/"))
+
+    if isinstance(build, str):
+        if not _confined(build):
+            raise ValueError(f"unsafe build context: {build!r}")
+        return build
+    if isinstance(build, dict):
+        ctx = build.get("context", ".")
+        if not _confined(ctx):
+            raise ValueError(f"unsafe build context: {ctx!r}")
+        out = {"context": ctx}
+        df = build.get("dockerfile")
+        if df is not None:
+            if not _confined(df):
+                raise ValueError(f"unsafe dockerfile path: {df!r}")
+            out["dockerfile"] = df
+        args = build.get("args")
+        if isinstance(args, (dict, list)):
+            out["args"] = args
+        return out
+    raise ValueError("service has no usable build spec")
+
+
+def _harden_service(name: str, svc: dict) -> dict:
+    """Reconstruct ONE service from the allowlist + the fixed hardening set (C).
+
+    Runtime-privilege keys are dropped by omission (allowlist). No `user`: the container
+    runs as its image default (root) with a writable HOME via the /root tmpfs — dropping
+    `user` avoids the read-only-`$HOME` breakage that flips HOME-cache-writing tests to
+    ERROR, while cap_drop ALL + no-new-privileges + read_only + the internal-only network
+    still prevent privilege escalation and host access.
+    """
+    out = {k: svc[k] for k in _SVC_ALLOWLIST if k in svc}
+
+    # Attacker capture sidecar: a remote "attacker" image is replaced by the bundled,
+    # OpenAnt-owned build context (preserves the prior behaviour).
+    img = out.get("image")
+    if isinstance(img, str) and "attacker" in img.lower():
+        out.pop("image", None)
+        out["build"] = "./attacker-server"
+
+    if "build" in out:
+        out["build"] = _safe_build(out["build"])
+    if "build" not in out and "image" not in out:
+        raise ValueError(f"service {name!r} declares neither a safe build nor an image")
+
+    # Service network membership is preserved (from the allowlist) and every declared
+    # network is forced `internal: true` at the doc level below, so service-name
+    # resolution (test -> attacker:9999) keeps working with no external gateway.
+
+    # (C) fixed per-service hardening — applied uniformly to EVERY service, attacker
+    # sidecar included (it keeps captures in memory, so read_only is safe; :9999 > 1024
+    # so cap_drop ALL does not break its bind).
+    out["read_only"] = True
+    out["cap_drop"] = ["ALL"]
+    out["security_opt"] = ["no-new-privileges:true"]
+    out["pids_limit"] = 256
+    out["mem_limit"] = "512m"
+    out["cpus"] = 1.0
+    # Writable scratch + a writable HOME (=/root, image default user) on the RO rootfs.
+    out["tmpfs"] = ["/tmp", "/root"]
+    return out
+
+
 def _sanitize_compose(content: str) -> str:
-    """Fix LLM-generated docker-compose issues AND enforce network isolation (F4).
+    """RECONSTRUCT an untrusted LLM/target-influenced docker-compose from an allowlist.
 
-    The compose file is UNTRUSTED LLM output and is built+run (executed). Force every
-    network `internal: true` (no external egress) so an executing test cannot exfiltrate
-    at RUNTIME, while intra-network service-to-service (the attacker capture server at
-    `attacker:9999`, CWE-918 pattern) keeps working — an internal Docker network still
-    resolves + routes service names, it only loses the external gateway.
+    The compose is UNTRUSTED and is built+run (executed). Rather than blocklist the
+    dangerous keys (non-terminating — network_mode was one round's miss, then
+    privileged/cap_add/volumes/pid/ipc/security_opt/devices), this DISCARDS the LLM's
+    per-service runtime attributes entirely and rebuilds each declared service from a
+    fixed allowlist (`_SVC_ALLOWLIST`) + a fixed hardening set (`_harden_service`): no
+    privileged, no added caps (cap_drop ALL), no host mounts/volumes, no host namespaces,
+    no devices, no host network, no `ports` publish, read-only rootfs, no-new-privileges,
+    pids/mem/cpu caps — on an `internal: true` network with no external gateway.
 
-    `internal: true` ALONE is bypassable, so this also, structurally (via PyYAML, not
-    regex — a hostile file defeats textual patching):
-      * strips every service `network_mode` (host/bridge would escape the internal net);
-      * drops host `ports:` publishes (incompatible with an internal net anyway);
-      * sets `internal: true` on every declared network AND injects an internal `default`
-        so a service that omits `networks:` (implicit default) is still contained.
-    Also removes obsolete `version:` and local-builds any remote attacker image.
+    The SERVICE SET is preserved (test + attacker capture server + any extra service the
+    generation legitimately needs, e.g. a DB for a SQLi test), so a multi-service test is
+    not silently dropped; each service is reconstructed re-hardened.
 
-    RESIDUAL (documented, NOT closed here): `docker build`/`compose build` run untrusted
-    `RUN` steps with full egress, so build-time exfil/beaconing is still possible. The
-    build context is minimal (generated test files + one pre-staged source file, no host
-    secrets), and the exploit executes at RUNTIME where this policy applies — so runtime
-    isolation is worth it, but this whole change is sandbox HARDENING, not a vuln fix.
+    Fails CLOSED (returns a refusing comment-only compose) on unparseable YAML, a build
+    context that escapes the work dir, or a service with neither a safe build nor an image.
+
+    RESIDUAL (documented, NOT closed here): build-time `RUN` egress — `docker build`
+    still runs the generated Dockerfile's RUN steps with network (an egress-allowlisting
+    build proxy is deferred, an accepted residual). This change is RUNTIME sandbox
+    hardening that makes the code enforce its stated "no host volume mounts or privileged
+    mode" contract.
     """
     try:
         import yaml
@@ -68,54 +170,39 @@ def _sanitize_compose(content: str) -> str:
         if not isinstance(data, dict):
             raise ValueError("compose root is not a mapping")
     except Exception:
-        # FAIL CLOSED. If PyYAML cannot parse+structure the compose we cannot prove
-        # network isolation — and `docker compose` (compose-go, a DIFFERENT YAML impl)
-        # might still parse+run the untrusted original with full egress. So we must NOT
-        # return the untrusted content (nor a regex-patched copy, which cannot reliably
-        # strip network_mode/external). Replace it with a refusing comment-only compose:
-        # `docker compose build` then fails ("no services") -> build_error -> the finding
-        # is recorded as ERROR and never executed. No egress. (We do not raise: the
-        # orchestrator calls run_single_container unwrapped, so a raise would abort the
-        # whole dynamic-test run instead of just this finding.)
-        return ("# openant: docker-compose could not be safely parsed/sanitized; "
-                "refusing to run it (fail-closed).\n")
+        return _refuse_compose("docker-compose could not be parsed")
 
-    data.pop("version", None)
+    services_in = data.get("services")
+    if not isinstance(services_in, dict) or not services_in:
+        return _refuse_compose("docker-compose declares no services")
 
-    networks = data.get("networks")
-    if not isinstance(networks, dict):
-        networks = {}
-    for name, cfg in list(networks.items()):
-        cfg = cfg if isinstance(cfg, dict) else {}
-        # Drop `external`/`name`: an external network is one Compose does NOT create,
-        # so it attaches services to a PRE-EXISTING network by name (e.g. `bridge`,
-        # which has egress) and ignores our `internal: true`. Forcing Compose to
-        # create the network fresh is what makes `internal` actually apply.
-        cfg.pop("external", None)
-        cfg.pop("name", None)
-        cfg["internal"] = True
-        networks[name] = cfg
-    default = networks.get("default")
-    default = default if isinstance(default, dict) else {}
-    default.pop("external", None)
-    default.pop("name", None)
-    default["internal"] = True
-    networks["default"] = default
-    data["networks"] = networks
-
-    services = data.get("services")
-    if isinstance(services, dict):
-        for svc in services.values():
+    services_out = {}
+    try:
+        for name, svc in services_in.items():
             if not isinstance(svc, dict):
-                continue
-            svc.pop("network_mode", None)   # host/bridge escapes the internal network
-            svc.pop("ports", None)          # host publish incompatible with internal
-            img = svc.get("image")
-            if isinstance(img, str) and "attacker" in img.lower():
-                svc.pop("image", None)
-                svc["build"] = "./attacker-server"
+                raise ValueError(f"service {name!r} is not a mapping")
+            services_out[name] = _harden_service(name, svc)
+    except Exception as exc:
+        return _refuse_compose(f"docker-compose could not be safely reconstructed ({exc})")
 
-    return yaml.safe_dump(data, default_flow_style=False, sort_keys=False)
+    # Rebuild the networks: every DECLARED network is forced `internal: true` with
+    # `external`/`name` stripped (an external net attaches services to a pre-existing,
+    # egress-capable net by name and ignores `internal`), plus an injected internal
+    # `default` so a service that omits `networks:` is still contained. Named top-level
+    # `volumes:`/`secrets:`/`configs:`/`version:` are dropped by omission (services can
+    # no longer reference them — host-bind `volumes:` were stripped per-service above).
+    networks_in = data.get("networks")
+    networks_out = {}
+    if isinstance(networks_in, dict):
+        for net_name, cfg in networks_in.items():
+            cfg = cfg if isinstance(cfg, dict) else {}
+            cfg = {k: v for k, v in cfg.items() if k not in ("external", "name")}
+            cfg["internal"] = True
+            networks_out[net_name] = cfg
+    networks_out["default"] = {"internal": True}
+
+    out = {"services": services_out, "networks": networks_out}
+    return yaml.safe_dump(out, default_flow_style=False, sort_keys=False)
 
 
 def _write_test_files(work_dir: str, generation: dict, source_file: str | None = None) -> None:
@@ -279,10 +366,16 @@ def _run_single(
             "--network", "none",
             "--memory", "512m",
             "--cpus", "1",
+            "--pids-limit", "256",
+            "--cap-drop", "ALL",
             "--read-only",
             "--tmpfs", "/tmp:size=256m",
             "--tmpfs", "/root:size=128m",
             "--security-opt", "no-new-privileges",
+            # No --user: the container runs as its image default (root) with a writable
+            # HOME via the /root tmpfs above. cap_drop ALL + no-new-privileges + read_only
+            # + --network none contain it; a non-root --user on a read-only rootfs would
+            # instead move $HOME to an unwritable `/` and flip HOME-cache tests to ERROR.
             image_tag,
         ],
         timeout=container_timeout,


### PR DESCRIPTION
## What

Hardening of the dynamic-tester's Docker sandbox: the untrusted multi-service
`docker-compose` is now **reconstructed from a key allowlist** instead of
patched, and the single-container path gains the caps it was missing. Runtime
sandbox hardening — **not** an exploitable-today vuln fix (see Scope).

## Root cause

`docker_executor._sanitize_compose()` forced networks `internal: true` and
stripped `network_mode`/`ports` (F4/#247), but it did **not** strip the
container-escape keys: `privileged`, `cap_add`, host `volumes` (incl.
`/var/run/docker.sock`), `pid`/`ipc`, `security_opt`, `devices`, `user`. The
compose path (`docker_executor.py`, `_run_compose`) adds **zero** runtime flags,
so an injected generation with `needs_attacker_server: true` + a compose carrying
`privileged: true` + `volumes: ['/:/host:rw']` reached `_run_compose` intact —
container-root with the host bind-mounted. This also contradicts the module's own
stated contract (`docker_executor.py:5`, `README.md`: "No host volume mounts / no
privileged mode"). Dynamic testing runs **by default** on `openant scan`
(`--skip-dynamic-test` to opt out), so the sink is on the default path.

## Fix (tighten containment, not refuse)

Running the target-influenced container **is** the tester's documented purpose
(the `attacker:9999` capture server exists to test SSRF/exfil), so refusing is
wrong; and a bigger blocklist is non-terminating (`network_mode` was last round's
miss). Instead:

- **`_sanitize_compose` reconstructs** each declared service from a fixed key
  allowlist + a fixed hardening set (`read_only`, `cap_drop: [ALL]`,
  `security_opt: [no-new-privileges]`, `pids_limit`, `mem_limit`, `cpus`,
  `tmpfs: [/tmp, /root]`). Every runtime-privilege attribute is dropped **by
  omission**, so the next unknown key is contained too. The **service set is
  preserved** (a `test`+`attacker`+`db` generation is not silently dropped);
  every network forced `internal`; **fail-closed** on unparseable YAML or a build
  context escaping the work dir. No `user`: the container stays root with a
  writable HOME via the `/root` tmpfs — a non-root `user` on a read-only rootfs
  moves `$HOME` to an unwritable `/` and flips HOME-cache-writing tests to ERROR.
- **`_run_single`** gains `--cap-drop ALL` + `--pids-limit 256` (unchanged:
  `--network none`, `--read-only`, `no-new-privileges`, mem/cpu, `/tmp`+`/root`
  tmpfs).

## Evidence

- **RED→GREEN:** new `tests/test_docker_sandbox_reconstruct.py` (8 tests) — 3
  failed on the pre-fix code (hostile attrs survived, service-set not hardened,
  unsafe-build not fail-closed), all pass after. `grep -c "def test_"` = 8.
- **No regression:** `pytest tests/` → **0 failed** (2909 passed / 30 skipped with
  Docker present; 2787 / 151-skipped without — the delta is Docker-gated tests, not
  regressions).
- **Real-docker e2e** (through `run_single_container`): a hostile
  `privileged`+`/:/host`+docker.sock compose was reconstructed hardened (those
  keys gone), then **built + ran, exit 0**, the test **reached `attacker:9999`
  over the internal net**, and HOME was writable (`uid=0 home=/root`) — i.e. the
  escape is closed **and** multi-service function is preserved.

## Scope / residuals

- **Build-time `RUN` egress** stays an accepted, documented residual (an
  egress-allowlisting build proxy is deferred) — unchanged by this PR.
- Related to **GHSA-98g5** (dynamic-test sandbox): this closes the runtime
  host-mount/privileged half; it does not add rootless/gVisor isolation.
- Not exploitable end-to-end today without a successful second-order prompt
  injection past the prompt fences; framed as hardening accordingly.

## Author notes

- **Q1 (which lines):** `docker_executor.py` `_sanitize_compose`/`_harden_service`/
  `_safe_build` (reconstruction) + `_run_single` docker-run argv (`--cap-drop ALL`,
  `--pids-limit`).
- **Q2 (input handled right now):** a compose with `privileged: true` +
  `volumes: ['/:/host:rw']` previously ran with the host mounted; it now runs with
  those keys absent, cap-dropped, read-only, on an internal net.
- **Q3 (likely pushback):** "does reconstruction break real tests?" — no: the e2e
  above and the preserved service set show multi-service tests still build, run,
  and reach the sidecar; `--user` was deliberately **not** added (it breaks
  read-only `$HOME`).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
