### PR TITLE
fix(reporter): surface real skipped/failed steps in pipeline_output (verify visibility)

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -245,6 +245,8 @@ def build_pipeline_output(
     context_source: str = "none",
     threat_model_sha256: str | None = None,
     threat_model_warnings: list | None = None,
+    skipped_steps: list | None = None,
+    skipped_step_reasons: dict | None = None,
 ) -> tuple[str, int]:
     """Build ``pipeline_output.json`` from analysis results.
 
@@ -452,7 +454,6 @@ def build_pipeline_output(
     # Compute costs and durations from step reports
     costs = {}
     durations = {}
-    skipped_steps = []
     if step_reports:
         for sr in step_reports:
             step = sr.get("step", "unknown")
@@ -460,6 +461,20 @@ def build_pipeline_output(
                 costs[step] = {"actual": sr["cost_usd"]}
             if sr.get("duration_seconds"):
                 durations[step] = sr["duration_seconds"]
+
+    # Populate skipped_steps from the authoritative ScanResult skip data. The
+    # reporter is otherwise blind to skips (it reads only cost/duration above),
+    # so pipeline_stats.skipped_steps was always [] — a crashed/skipped step
+    # (most importantly a non-aborting Stage-2 verify failure) then rendered in
+    # the human summary as "No steps were skipped", indistinguishable from a
+    # clean fully-verified scan. Report-fidelity only: per-finding disclosure is
+    # unchanged (unverified findings stay included, labeled stage2_verdict
+    # 'vulnerable' vs 'confirmed'); this does NOT gate disclosure.
+    _skip_reasons = skipped_step_reasons or {}
+    skipped_steps_detail = [
+        {"step": s, "reason": _skip_reasons.get(s, "")}
+        for s in (skipped_steps or [])
+    ]
 
     total_units = metrics.get("total", len(all_results))
 
@@ -542,7 +557,7 @@ def build_pipeline_output(
             "processing_level": processing_level,
             "costs": costs,
             "durations": durations,
-            "skipped_steps": skipped_steps,
+            "skipped_steps": skipped_steps_detail,
         },
         "results": {
             "vulnerable": metrics.get("vulnerable", 0) + metrics.get("bypassable", 0),

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -407,6 +407,7 @@ def scan_repository(
                     print(f"  WARNING: App context generation failed: {e}",
                           file=sys.stderr)
                     print("  Continuing without app context.", file=sys.stderr)
+                    ctx.status = "skipped"
                     ctx.summary = {"skipped": True, "reason": str(e)}
 
         collected_step_reports.append(_load_step_report(output_dir, "app-context"))
@@ -461,6 +462,7 @@ def scan_repository(
                 dataset = read_json(active_dataset_path)
             except (OSError, json.JSONDecodeError) as exc:
                 print(f"  WARNING: failed to load dataset: {exc}", file=sys.stderr)
+                ctx.status = "skipped"
                 ctx.summary = {"skipped": True, "reason": str(exc)}
                 dataset = None
 
@@ -663,6 +665,7 @@ def scan_repository(
             except Exception as e:
                 print(f"  WARNING: Enhancement failed: {e}", file=sys.stderr)
                 print("  Continuing with the un-enhanced dataset.", file=sys.stderr)
+                ctx.status = "skipped"
                 ctx.summary = {"skipped": True, "reason": str(e)}
                 _record_skip(result, "enhance", "failed")
 
@@ -796,6 +799,7 @@ def scan_repository(
             except Exception as e:
                 print(f"  WARNING: Verification failed: {e}", file=sys.stderr)
                 print("  Continuing with unverified Stage 1 results.", file=sys.stderr)
+                ctx.status = "skipped"
                 ctx.summary = {"skipped": True, "reason": str(e)}
                 _record_skip(result, "verify", "failed")
 
@@ -837,6 +841,13 @@ def scan_repository(
             context_source=result.context_source,
             threat_model_sha256=result.threat_model_sha256,
             threat_model_warnings=result.threat_model_warnings,
+            # Authoritative skip data so pipeline_output.json reflects real
+            # pipeline status (esp. a non-aborting verify failure) instead of
+            # always reporting "nothing skipped". At this point (Step 6) all
+            # pre-build skips incl. verify are already recorded; dynamic-test/
+            # report skips are recorded later and remain in scan.report.json.
+            skipped_steps=list(result.skipped_steps),
+            skipped_step_reasons=dict(result.skipped_step_reasons),
         )
 
         ctx.outputs = {"pipeline_output_path": pipeline_output_path}
@@ -890,6 +901,7 @@ def scan_repository(
                 except Exception as e:
                     print(f"  WARNING: Dynamic test failed: {e}", file=sys.stderr)
                     print("  Continuing without dynamic-test results.", file=sys.stderr)
+                    ctx.status = "skipped"
                     ctx.summary = {"skipped": True, "reason": str(e)}
                     _record_skip(result, "dynamic-test", "failed")
 

--- a/libs/openant-core/tests/test_reporter_status_fidelity.py
+++ b/libs/openant-core/tests/test_reporter_status_fidelity.py
@@ -1,0 +1,113 @@
+"""Tests for ``core.reporter`` pipeline-status fidelity.
+
+Regression coverage for a report-correctness class: ``build_pipeline_output``
+hand-assembled ``pipeline_stats`` from a subset of telemetry and fabricated a
+clean constant for status it wasn't handed — ``pipeline_stats.skipped_steps``
+was always ``[]`` (the reporter received no ``result`` and read only
+cost/duration from the step reports). So a scan where a step was skipped — most
+importantly a **crashed Stage-2 verify** (caught, non-aborting) — rendered in
+the human summary (``report/prompts/summary.txt``) as "No steps were skipped",
+indistinguishable from a clean fully-verified scan.
+
+The fix plumbs the authoritative ``ScanResult.skipped_steps`` /
+``skipped_step_reasons`` into ``build_pipeline_output`` and emits them as
+``[{step, reason}]`` (the shape summary.txt already expects). This is
+report-fidelity ONLY — per-finding disclosure is unchanged: unverified findings
+stay included, distinguishable by ``stage2_verdict`` ('vulnerable' vs
+'confirmed'). It does NOT gate disclosure (that would drop findings = FN).
+
+The last test is the completeness guard (mirrors parsers' schema-completeness
+tests): a skipped/failed verify MUST surface in ``pipeline_output.json`` — the
+gap that existing ``tests/test_scanner.py`` misses because it asserts the
+``ScanResult`` object, never the artifact.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.reporter import build_pipeline_output
+from utilities.file_io import write_json
+
+
+def _run(tmp_path: Path, *, skipped_steps=None, skipped_step_reasons=None,
+         findings=None, metrics=None) -> dict:
+    results = {
+        "dataset": "t",
+        "code_by_route": {"a.py:f": "def f(): ..."},
+        "metrics": metrics or {"total": len(findings or []), "errors": 0},
+        "confirmed_findings": findings or [],
+    }
+    write_json(tmp_path / "results.json", results)
+    out = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(tmp_path / "results.json"),
+        output_path=str(out),
+        language="python",
+        repo_name="t/r",
+        processing_level="reachable",
+        skipped_steps=skipped_steps,
+        skipped_step_reasons=skipped_step_reasons,
+    )
+    return json.loads(out.read_text())
+
+
+def test_skipped_steps_populated_from_scanresult(tmp_path: Path):
+    """pipeline_stats.skipped_steps mirrors ScanResult skips as [{step,reason}]."""
+    out = _run(
+        tmp_path,
+        skipped_steps=["verify", "enhance"],
+        skipped_step_reasons={"verify": "failed", "enhance": "not_requested"},
+    )
+    assert out["pipeline_stats"]["skipped_steps"] == [
+        {"step": "verify", "reason": "failed"},
+        {"step": "enhance", "reason": "not_requested"},
+    ]
+
+
+def test_crashed_verify_is_visible_not_masked(tmp_path: Path):
+    """The security-relevant core: a crashed verify surfaces in the artifact."""
+    out = _run(
+        tmp_path,
+        skipped_steps=["verify"],
+        skipped_step_reasons={"verify": "failed"},
+        findings=[{"route_key": "a.py:f", "unit_id": "a.py:f",
+                   "finding": "vulnerable", "name": "SQLi"}],
+        metrics={"total": 1, "vulnerable": 1, "errors": 0},
+    )
+    stats = out["pipeline_stats"]
+    skipped = [s["step"] for s in stats["skipped_steps"]]
+    assert "verify" in skipped, "a crashed verify must not render as 'nothing skipped'"
+    # disclosure unchanged: the finding is still included, labeled Stage-1
+    assert out["findings"][0]["stage2_verdict"] == "vulnerable"
+
+
+def test_no_skips_stays_empty(tmp_path: Path):
+    """No false positives: a clean scan reports no skipped steps."""
+    out = _run(tmp_path, skipped_steps=[], skipped_step_reasons={})
+    assert out["pipeline_stats"]["skipped_steps"] == []
+
+
+def test_missing_reason_degrades_to_empty_string(tmp_path: Path):
+    """A skip with no recorded reason still surfaces (reason='')."""
+    out = _run(tmp_path, skipped_steps=["dynamic-test"], skipped_step_reasons=None)
+    assert out["pipeline_stats"]["skipped_steps"] == [
+        {"step": "dynamic-test", "reason": ""}
+    ]
+
+
+def test_step_context_swallow_path_records_skipped_status(tmp_path: Path):
+    """The scanner's catch-and-continue (verify/enhance/etc.) must record
+    status='skipped' on the step report — not the default 'success' — so the
+    HTML step table (success->green, else->grey) stops rendering a crashed
+    verify as green. Mirrors the scanner pattern without running a full scan."""
+    import os
+    from core.step_report import step_context
+    with step_context("verify", str(tmp_path)) as ctx:
+        # simulate run_verification raising and being caught locally (no re-raise)
+        ctx.status = "skipped"
+        ctx.summary = {"skipped": True, "reason": "Anthropic 529 overloaded"}
+    rep = json.loads((tmp_path / "verify.report.json").read_text())
+    assert rep["status"] == "skipped"          # not the default "success"
+    assert rep["summary"]["skipped"] is True


### PR DESCRIPTION
## What
`pipeline_stats.skipped_steps` was always `[]` — `build_pipeline_output` received no `ScanResult` and read only cost/duration from step reports. So a skipped or **crashed** step rendered in the human summary (`report/prompts/summary.txt`) as "No steps were skipped". Worst case: a **Stage-2 verify failure** is caught non-abortingly and recorded only in `result.skipped_step_reasons → scan.report.json`; `pipeline_output.json` showed `skipped_steps:[]` + `durations.verify`, making a crashed verify indistinguishable from a clean fully-verified scan.

## Change (report-fidelity ONLY — does NOT gate disclosure)
- `build_pipeline_output` gains `skipped_steps` + `skipped_step_reasons` params; scanner passes `result.*`. `pipeline_stats.skipped_steps` emits `[{step,reason}]` (the shape `summary.txt:58/111` already expects).
- The 5 catch-and-continue sites (app-context/llm-reachability/enhance/verify/dynamic-test) that already set `ctx.summary.skipped` now also set `ctx.status="skipped"`, so the step report — and HTML step table (success=green, else=grey) — no longer renders a crashed step green. Non-abort catch preserved.
- Disclosure unchanged: unverified findings stay included, distinguishable by `stage2_verdict` (`vulnerable` vs `confirmed`). Gating would drop findings = FN.

## Bound (stated)
`build_pipeline_output` runs at Step 6 → verify + earlier skips captured; dynamic-test/report skips are recorded later and remain in `scan.report.json`+stderr (follow-up). Backward-compat: new params default `None`→`[]`, ~15 existing callers unaffected.

## Tests
5 in `tests/test_reporter_status_fidelity.py` (`grep -c 'def test_' = 5`), incl. the crashed-verify-visible guard + `ctx.status` mechanism. Full suite **2784 passed**. Guard proven: reverting the fix to constant `[]` fails 3 of them. Old-vs-new differential: only `pipeline_stats.skipped_steps` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
