### PR TITLE
fix(dynamic-test): confine host-side staging paths and scrub the docker build/run env of secrets

### DIFF
--- a/libs/openant-core/report/__main__.py
+++ b/libs/openant-core/report/__main__.py
@@ -9,6 +9,7 @@ Usage:
 """
 
 import argparse
+import os
 import sys
 from pathlib import Path
 
@@ -100,7 +101,10 @@ def cmd_disclosures(args):
         print(f"Generating disclosure for {finding['short_name']}...")
         disclosure, _usage = generate_disclosure(finding, product_name, report_binding)
 
-        safe_name = finding["short_name"].replace(" ", "_").upper()
+        # Coerce to str, fall back to id, and basename so a null/typed/traversal
+        # short_name can't crash disclosure generation (mirrors report/generator.py).
+        safe_name = (os.path.basename(str(finding.get("short_name") or finding.get("id") or "finding"))
+                     or "finding").replace(" ", "_").upper()
         filename = f"DISCLOSURE_{i:02d}_{safe_name}.md"
         with open_utf8(output_dir / filename, "w") as f:
             f.write(disclosure)

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -361,9 +361,12 @@ def generate_all(
         print(f"Generating disclosure for {finding['short_name']}...")
         disclosure, _usage = generate_disclosure(finding, product_name, report_binding)
 
-        # short_name passes validation on presence only, so it may be null/empty;
-        # fall back to id so a null short_name can't crash disclosure generation.
-        safe_name = (finding.get("short_name") or finding.get("id") or "finding").replace(" ", "_").upper()
+        # short_name passes validation on presence only, so it may be null/empty,
+        # a non-str (JSON), or contain a "/" — fall back to id, coerce to str, and
+        # basename it so a null/typed/traversal short_name can't crash disclosure
+        # generation (AttributeError / FileNotFoundError writing into a missing dir).
+        safe_name = (os.path.basename(str(finding.get("short_name") or finding.get("id") or "finding"))
+                     or "finding").replace(" ", "_").upper()
         filename = f"DISCLOSURE_{i:02d}_{safe_name}.md"
         with open_utf8(disclosures_dir / filename, "w") as f:
             f.write(disclosure)

--- a/libs/openant-core/tests/report/test_disclosure_filename_safety.py
+++ b/libs/openant-core/tests/report/test_disclosure_filename_safety.py
@@ -1,0 +1,113 @@
+"""A hostile finding.short_name must not steer the disclosure filename.
+
+``short_name`` is model-produced / repo-influenced free text, interpolated into the
+on-disk disclosure filename ``DISCLOSURE_NN_<short_name>.md``. A ``/`` (traversal) or a
+non-str value would previously crash disclosure generation (FileNotFoundError writing
+into a missing intermediate dir / AttributeError on ``.replace``). generate_all and the
+``python -m report`` CLI now ``os.path.basename(str(...))`` the value, so it stays a bare
+leaf inside the disclosures dir. This locks that behavior at the generate_all call site
+(the one hardening in this branch that otherwise shipped without a test).
+"""
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# parents[2] = the openant-core root, so `from report import generator` resolves to the
+# real package rather than this tests/report/ directory (which would shadow it).
+_CORE_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_CORE_ROOT))
+
+if "anthropic" not in sys.modules:
+    _stub = types.ModuleType("anthropic")
+    _stub.Anthropic = MagicMock()
+    _stub.RateLimitError = type("RateLimitError", (Exception,), {})
+    _stub.AuthenticationError = type("AuthenticationError", (Exception,), {})
+    sys.modules["anthropic"] = _stub
+
+from report import generator  # noqa: E402
+
+
+def _pipeline(short_name):
+    return {
+        "repository": {"name": "test", "language": "python"},
+        "application_type": "web_app",
+        "findings": [{
+            "id": "VULN-001", "name": "t", "short_name": short_name,
+            "location": {"file": "app.py", "function": "app.py:vuln"},
+            "cwe_id": 79, "cwe_name": "XSS",
+            "stage1_verdict": "vulnerable", "stage2_verdict": "confirmed",
+        }],
+    }
+
+
+@pytest.mark.parametrize("short_name", [
+    "../../etc/passwd",      # traversal
+    "/etc/passwd",           # absolute
+    "a/b/c",                 # nested
+    12345,                   # non-str
+    ["x"],                   # non-str container
+    None,                    # falls back to id
+    "",                      # empty -> id/finding
+])
+def test_hostile_short_name_stays_a_leaf_in_disclosures_dir(tmp_path, monkeypatch, short_name):
+    po_path = tmp_path / "pipeline_output.json"
+    po_path.write_text(json.dumps(_pipeline(short_name)))
+    out_dir = tmp_path / "out"
+
+    # No LLM: stub the two generators and validation so we exercise only the
+    # filename-derivation path in generate_all.
+    monkeypatch.setattr(generator, "generate_summary_report", lambda *a, **k: ("summary", {}))
+    monkeypatch.setattr(generator, "generate_disclosure", lambda *a, **k: ("disclosure body", {}))
+    monkeypatch.setattr(generator, "validate_pipeline_output", lambda *a, **k: None)
+
+    class _NoopBinding:
+        pass
+
+    class _Reg:
+        def get(self, _phase):
+            return _NoopBinding()
+
+    generator.generate_all(str(po_path), str(out_dir), registry=_Reg())
+
+    disclosures = out_dir / "disclosures"
+    written = list(disclosures.glob("*.md"))
+    assert len(written) == 1, f"expected one disclosure, got {written}"
+    name = written[0].name
+    # It must be a bare leaf directly inside disclosures/, no traversal escape.
+    assert written[0].parent == disclosures
+    assert "/" not in name and ".." not in name
+    assert name.startswith("DISCLOSURE_") and name.endswith(".md")
+    # Nothing was written outside the output dir.
+    assert not (tmp_path / "etc").exists()
+    assert not Path("/etc/passwd.md").exists()
+
+
+@pytest.mark.parametrize("short_name", ["../../etc/passwd", "/etc/passwd", 12345, ["x"]])
+def test_cli_disclosures_hostile_short_name_stays_a_leaf(tmp_path, monkeypatch, short_name):
+    """The `python -m report disclosures` CLI path carries the SAME (byte-identical)
+    safe_name hardening as generate_all — cover it too so both sites are locked."""
+    import argparse
+    from report import __main__ as report_main
+
+    po_path = tmp_path / "pipeline_output.json"
+    po_path.write_text(json.dumps(_pipeline(short_name)))
+    out_dir = tmp_path / "cli_out"
+
+    monkeypatch.setattr(report_main, "_build_report_binding", lambda *a, **k: object())
+    monkeypatch.setattr(report_main, "generate_disclosure", lambda *a, **k: ("body", {}))
+    monkeypatch.setattr(report_main, "validate_pipeline_output", lambda *a, **k: None)
+
+    report_main.cmd_disclosures(argparse.Namespace(input=str(po_path), output=str(out_dir)))
+
+    written = list(out_dir.glob("*.md"))
+    assert len(written) == 1, f"expected one disclosure, got {written}"
+    name = written[0].name
+    assert written[0].parent == out_dir
+    assert "/" not in name and ".." not in name
+    assert name.startswith("DISCLOSURE_") and name.endswith(".md")
+    assert not (tmp_path / "etc").exists()

--- a/libs/openant-core/tests/test_docker_egress_hardening.py
+++ b/libs/openant-core/tests/test_docker_egress_hardening.py
@@ -160,6 +160,10 @@ def test_scrubbed_env_removes_provider_secrets_keeps_docker_essentials():
         "GITHUB_TOKEN": "ghs_x", "OPENAI_APIKEY": "sk-3", "KEY_PASSPHRASE": "pp",
         "SSH_KEY_PASSPHRASE": "pp2", "ANTHROPIC_AUTH": "auth", "SLACK_WEBHOOK": "https://hook",
         "DIGITALOCEAN_ACCESS_KEY": "do",
+        # DOCKER_*/COMPOSE_*/BUILDKIT_* families ALSO carry secrets — a broad prefix
+        # allow re-opened the leak (round-2 bug-hunt). These MUST be dropped.
+        "DOCKER_PASSWORD": "pw", "DOCKER_AUTH_CONFIG": '{"auths":{}}', "DOCKER_TOKEN": "t",
+        "DOCKER_HUB_PASSWORD": "h2", "COMPOSE_PASSWORD": "cp", "BUILDKIT_TOKEN": "bt",
     }
     for k, v in secrets.items():
         os.environ[k] = v

--- a/libs/openant-core/tests/test_docker_egress_hardening.py
+++ b/libs/openant-core/tests/test_docker_egress_hardening.py
@@ -135,3 +135,57 @@ def test_single_container_run_uses_network_none():
     # list form ["docker", "network", "create", ...] (quoted tokens), which the prose
     # comment ("no `docker network create` needed") does not contain.
     assert '"docker", "network", "create"' not in src
+
+
+# --- provider-secret exfil via compose build.args ${VAR} interpolation ---------
+
+def test_scrubbed_env_removes_provider_secrets_keeps_docker_essentials():
+    """The docker subprocess env must not carry provider API keys.
+
+    A compose `build.args` value like `${ANTHROPIC_API_KEY}` is interpolated by
+    docker compose from the host env at BUILD time and can be exfiltrated by the
+    LLM-authored Dockerfile's `RUN` over the still-open build-time network. The
+    build/run subprocess never needs any provider secret, so it runs with a
+    scrubbed env — closing the exfil by construction regardless of build.args.
+    """
+    import os
+    from utilities.dynamic_tester.docker_executor import _scrubbed_subprocess_env
+
+    os.environ["ANTHROPIC_API_KEY"] = "sk-should-not-leak"
+    os.environ["OPENAI_API_KEY"] = "sk-should-not-leak-2"
+    os.environ["SOME_SECRET_TOKEN"] = "leak3"
+    try:
+        env = _scrubbed_subprocess_env()
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "OPENAI_API_KEY" not in env
+        assert "SOME_SECRET_TOKEN" not in env
+        # docker still needs its essentials
+        assert "PATH" in env
+    finally:
+        for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "SOME_SECRET_TOKEN"):
+            os.environ.pop(k, None)
+
+
+def test_run_command_passes_scrubbed_env(monkeypatch):
+    """_run_command must hand the scrubbed env to the subprocess (not inherit os.environ)."""
+    import os
+    from utilities.dynamic_tester import docker_executor
+
+    os.environ["ANTHROPIC_API_KEY"] = "sk-should-not-leak"
+    captured = {}
+
+    def fake_run_utf8(cmd, **kwargs):
+        captured["env"] = kwargs.get("env")
+        class R:
+            stdout, stderr, returncode = "", "", 0
+        return R()
+
+    monkeypatch.setattr(docker_executor, "run_utf8", fake_run_utf8)
+    try:
+        docker_executor._run_command(["docker", "version"], timeout=5)
+    finally:
+        os.environ.pop("ANTHROPIC_API_KEY", None)
+
+    assert captured["env"] is not None, "_run_command must pass an explicit env= (scrubbed)"
+    assert "ANTHROPIC_API_KEY" not in captured["env"]
+    assert "PATH" in captured["env"]

--- a/libs/openant-core/tests/test_docker_egress_hardening.py
+++ b/libs/openant-core/tests/test_docker_egress_hardening.py
@@ -189,8 +189,11 @@ def test_scrubbed_env_keeps_docker_essentials_and_proxy():
         os.environ[k] = v
     try:
         env = _scrubbed_subprocess_env()
+        # Windows os.environ is case-insensitive and normalizes keys to upper-case
+        # (so "no_proxy" comes back as "NO_PROXY"); compare case-insensitively.
+        env_upper = {kk.upper() for kk in env}
         for k in keep:
-            assert k in env, f"docker-essential var was dropped: {k}"
+            assert k.upper() in env_upper, f"docker-essential var was dropped: {k}"
     finally:
         for k in keep:
             os.environ.pop(k, None)

--- a/libs/openant-core/tests/test_docker_egress_hardening.py
+++ b/libs/openant-core/tests/test_docker_egress_hardening.py
@@ -151,18 +151,44 @@ def test_scrubbed_env_removes_provider_secrets_keeps_docker_essentials():
     import os
     from utilities.dynamic_tester.docker_executor import _scrubbed_subprocess_env
 
-    os.environ["ANTHROPIC_API_KEY"] = "sk-should-not-leak"
-    os.environ["OPENAI_API_KEY"] = "sk-should-not-leak-2"
-    os.environ["SOME_SECRET_TOKEN"] = "leak3"
+    # An ALLOWLIST must drop a secret regardless of its NAME convention — the
+    # denylist-substring approach missed all of these (ACCESS_KEY without API_KEY,
+    # APIKEY without underscore, PASSPHRASE, bare AUTH, PAT, WEBHOOK).
+    secrets = {
+        "ANTHROPIC_API_KEY": "sk-1", "OPENAI_API_KEY": "sk-2", "SOME_SECRET_TOKEN": "s3",
+        "AWS_ACCESS_KEY_ID": "AKIA", "AWS_SECRET_ACCESS_KEY": "s4", "GH_PAT": "ghp_x",
+        "GITHUB_TOKEN": "ghs_x", "OPENAI_APIKEY": "sk-3", "KEY_PASSPHRASE": "pp",
+        "SSH_KEY_PASSPHRASE": "pp2", "ANTHROPIC_AUTH": "auth", "SLACK_WEBHOOK": "https://hook",
+        "DIGITALOCEAN_ACCESS_KEY": "do",
+    }
+    for k, v in secrets.items():
+        os.environ[k] = v
     try:
         env = _scrubbed_subprocess_env()
-        assert "ANTHROPIC_API_KEY" not in env
-        assert "OPENAI_API_KEY" not in env
-        assert "SOME_SECRET_TOKEN" not in env
+        for k in secrets:
+            assert k not in env, f"secret leaked into docker subprocess env: {k}"
         # docker still needs its essentials
         assert "PATH" in env
     finally:
-        for k in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "SOME_SECRET_TOKEN"):
+        for k in secrets:
+            os.environ.pop(k, None)
+
+
+def test_scrubbed_env_keeps_docker_essentials_and_proxy():
+    """The allowlist must keep the vars docker legitimately needs."""
+    import os
+    from utilities.dynamic_tester.docker_executor import _scrubbed_subprocess_env
+
+    keep = {"DOCKER_HOST": "unix:///x", "DOCKER_CONFIG": "/c", "HTTPS_PROXY": "http://p",
+            "no_proxy": "localhost", "LC_ALL": "C"}
+    for k, v in keep.items():
+        os.environ[k] = v
+    try:
+        env = _scrubbed_subprocess_env()
+        for k in keep:
+            assert k in env, f"docker-essential var was dropped: {k}"
+    finally:
+        for k in keep:
             os.environ.pop(k, None)
 
 

--- a/libs/openant-core/tests/test_docker_scaffold.py
+++ b/libs/openant-core/tests/test_docker_scaffold.py
@@ -255,3 +255,123 @@ def test_finding_prompt_includes_source_basename():
     assert "VulnerablePythonScript.py" in prompt, (
         "prompt must mention the staged source filename so the LLM references it in COPY"
     )
+
+
+# ---------------------------------------------------------------------------
+# Staging path-traversal confinement (host-write + host-read escapes)
+#
+# The generation dict is LLM output influenced by the scanned repo, and
+# finding.location.file is an LLM-emitted structured field. Neither may be
+# used as a filesystem path without confining it to the staging root:
+#   * generation['test_filename'] / ['requirements_filename'] are joined to
+#     work_dir and written -> a `..`/absolute name is a HOST-WRITE escape.
+#   * finding.location.file is joined to repo_path and copied into the build
+#     context -> a `..`/absolute value is a HOST-READ/exfil escape.
+# The staging happens on the host BEFORE any container runs, so the container
+# runtime hardening (#253) does not cover it.
+# ---------------------------------------------------------------------------
+
+def test_write_test_files_confines_traversal_test_filename(tmp_path):
+    """A `..`-traversal generation['test_filename'] must not write outside work_dir."""
+    from utilities.dynamic_tester.docker_executor import _write_test_files
+
+    work_dir = str(tmp_path / "work")
+    os.makedirs(work_dir)
+    escape_target = tmp_path / "PWNED_test.py"  # sibling of work_dir, outside it
+
+    generation = {
+        "dockerfile": "FROM python:3.11\nCMD echo hi",
+        "test_script": "print('pwn')",
+        "test_filename": "../PWNED_test.py",  # escapes work_dir
+    }
+    _write_test_files(work_dir, generation)
+
+    assert not escape_target.exists(), (
+        f"test_filename traversal escaped work_dir -> host-write at {escape_target}"
+    )
+    # Content is confined to a bare leaf inside work_dir.
+    assert (tmp_path / "work" / "PWNED_test.py").exists()
+
+
+def test_write_test_files_confines_absolute_requirements_filename(tmp_path):
+    """An absolute generation['requirements_filename'] must not write to a host path."""
+    from utilities.dynamic_tester.docker_executor import _write_test_files
+
+    work_dir = str(tmp_path / "work")
+    os.makedirs(work_dir)
+    escape_target = tmp_path / "PWNED_reqs.txt"
+
+    generation = {
+        "dockerfile": "FROM python:3.11\nCMD echo hi",
+        "test_script": "print('ok')",
+        "test_filename": "test_exploit.py",
+        "requirements": "flask",
+        "requirements_filename": str(escape_target),  # absolute path outside work_dir
+    }
+    _write_test_files(work_dir, generation)
+
+    assert not escape_target.exists(), (
+        f"requirements_filename absolute path escaped work_dir -> host-write at {escape_target}"
+    )
+
+
+def test_orchestrator_rejects_out_of_repo_source(tmp_path, monkeypatch):
+    """A `..`-traversal finding.location.file must not resolve OUTSIDE repo_path.
+
+    Otherwise a host file (secret) outside the scanned repo is copied into the
+    Docker build context and can be exfiltrated by the LLM-authored test script.
+    """
+    import json
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("def vuln(): pass")
+    # A host secret OUTSIDE the repo the attacker tries to reach via traversal.
+    secret = tmp_path / "SECRET.txt"
+    secret.write_text("top-secret")
+
+    po = {
+        "repository": {"name": "test", "language": "python"},
+        "application_type": "web_app",
+        "findings": [{
+            "id": "VULN-001", "name": "t", "short_name": "vuln",
+            "location": {"file": "../SECRET.txt", "function": "x"},
+            "cwe_id": 79, "cwe_name": "XSS",
+            "stage1_verdict": "vulnerable", "stage2_verdict": "confirmed",
+        }],
+    }
+    po_path = tmp_path / "pipeline_output.json"
+    po_path.write_text(json.dumps(po))
+
+    captured = {}
+
+    def mock_generate_test(finding, repo_info, binding, tracker):
+        return {
+            "dockerfile": "FROM python:3.11\nCMD echo hi",
+            "test_script": "print('ok')",
+            "test_filename": "test_exploit.py",
+        }
+
+    def mock_run_single_container(generation, finding_id, source_file=None, **kwargs):
+        captured["source_file"] = source_file
+        from utilities.dynamic_tester.docker_executor import DockerExecutionResult
+        r = DockerExecutionResult()
+        r.stdout = '{"status": "CONFIRMED", "details": "t", "evidence": []}'
+        r.exit_code = 0
+        return r
+
+    monkeypatch.setattr("utilities.dynamic_tester.generate_test", mock_generate_test)
+    monkeypatch.setattr("utilities.dynamic_tester.run_single_container", mock_run_single_container)
+
+    from utilities.dynamic_tester import run_dynamic_tests
+    run_dynamic_tests(
+        pipeline_output_path=str(po_path),
+        output_dir=str(tmp_path / "out"),
+        max_retries=0,
+        repo_path=str(repo),
+        registry=_fake_registry(),
+    )
+
+    assert captured.get("source_file") is None, (
+        f"traversal location.file escaped repo_path -> host-read/exfil: {captured.get('source_file')!r}"
+    )

--- a/libs/openant-core/tests/test_docker_scaffold.py
+++ b/libs/openant-core/tests/test_docker_scaffold.py
@@ -375,3 +375,144 @@ def test_orchestrator_rejects_out_of_repo_source(tmp_path, monkeypatch):
     assert captured.get("source_file") is None, (
         f"traversal location.file escaped repo_path -> host-read/exfil: {captured.get('source_file')!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# No-raise invariant: staging must NOT raise into the orchestrator (an unwrapped
+# raise aborts the WHOLE dynamic-test run, not one finding — docker_executor.py
+# _refuse_compose). The confinement fix touches exactly the untrusted fields that
+# can also carry a wrong TYPE / dot-segment / reserved-name collision.
+# ---------------------------------------------------------------------------
+
+def test_safe_leaf_never_raises_and_confines():
+    from utilities.dynamic_tester.docker_executor import _safe_leaf
+    # non-str (JSON allows any type) -> default, never raises (M1)
+    for bad in (123, ["x"], {"a": 1}, None, True):
+        assert _safe_leaf(bad, "d.py") == "d.py"
+    # dot-segments resolve to a directory, not a file -> default (M2)
+    for bad in ("..", ".", "a/b/..", "", "x/"):
+        assert _safe_leaf(bad, "d.py") == "d.py"
+    # collision with a fixed staging path -> default (M6)
+    for bad in ("Dockerfile", "docker-compose.yml", "attacker-server"):
+        assert _safe_leaf(bad, "d.py") == "d.py"
+    # traversal still strips to the bare leaf; normal names pass through
+    assert _safe_leaf("../../etc/passwd", "d.py") == "passwd"
+    assert _safe_leaf("test_exploit.py", "d.py") == "test_exploit.py"
+
+
+@pytest.mark.parametrize("gen_over", [
+    {"test_filename": 123},                       # M1 non-str name
+    {"test_filename": ".."},                       # M2 dot-segment
+    {"test_filename": "attacker-server", "needs_attacker_server": True},  # M6 collision
+    {"dockerfile": 123},                           # M3 non-str content
+    {"test_script": ["x"]},                        # M3 non-str content
+    {"requirements": ["flask"], "requirements_filename": 99},  # M1+M3
+])
+def test_write_test_files_never_raises_on_hostile_fields(tmp_path, gen_over):
+    """No hostile generation field may raise out of _write_test_files."""
+    from utilities.dynamic_tester.docker_executor import _write_test_files
+    work_dir = str(tmp_path / "work")
+    os.makedirs(work_dir)
+    generation = {"dockerfile": "FROM python:3.11\nCMD echo hi",
+                  "test_script": "print('ok')", "test_filename": "test_exploit.py"}
+    generation.update(gen_over)
+    _write_test_files(work_dir, generation)  # must not raise
+
+
+@pytest.mark.parametrize("location", [None, "astring", 123, {"file": 123}, {"file": ["x"]}, {}])
+def test_orchestrator_never_raises_on_bad_location(tmp_path, monkeypatch, location):
+    """A non-dict location or non-str location.file must not raise (M4/M5); source_file None."""
+    import json
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "app.py").write_text("def vuln(): pass")
+
+    po = {
+        "repository": {"name": "test", "language": "python"},
+        "application_type": "web_app",
+        "findings": [{
+            "id": "VULN-001", "name": "t", "short_name": "vuln",
+            "location": location,
+            "cwe_id": 79, "cwe_name": "XSS",
+            "stage1_verdict": "vulnerable", "stage2_verdict": "confirmed",
+        }],
+    }
+    po_path = tmp_path / "pipeline_output.json"
+    po_path.write_text(json.dumps(po))
+
+    captured = {}
+
+    def mock_generate_test(finding, repo_info, binding, tracker):
+        return {"dockerfile": "FROM python:3.11\nCMD echo hi",
+                "test_script": "print('ok')", "test_filename": "test_exploit.py"}
+
+    def mock_run_single_container(generation, finding_id, source_file=None, **kwargs):
+        captured["source_file"] = source_file
+        from utilities.dynamic_tester.docker_executor import DockerExecutionResult
+        r = DockerExecutionResult()
+        r.stdout = '{"status": "CONFIRMED", "details": "t", "evidence": []}'
+        r.exit_code = 0
+        return r
+
+    monkeypatch.setattr("utilities.dynamic_tester.generate_test", mock_generate_test)
+    monkeypatch.setattr("utilities.dynamic_tester.run_single_container", mock_run_single_container)
+
+    from utilities.dynamic_tester import run_dynamic_tests
+    run_dynamic_tests(  # must not raise
+        pipeline_output_path=str(po_path),
+        output_dir=str(tmp_path / "out"),
+        max_retries=0,
+        repo_path=str(repo),
+        registry=_fake_registry(),
+    )
+    assert captured.get("source_file") is None
+
+
+def test_orchestrator_coerces_nonstr_finding_id(tmp_path, monkeypatch):
+    """A non-str finding.id must be coerced to str at the boundary, else
+    run_single_container's finding_id.lower() (and checkpoint's safe_filename)
+    raise and abort the whole run."""
+    import json
+
+    po = {
+        "repository": {"name": "test", "language": "python"},
+        "application_type": "web_app",
+        "findings": [{
+            "id": 12345,  # non-str id
+            "name": "t", "short_name": "vuln",
+            "location": {"file": "app.py", "function": "x"},
+            "cwe_id": 79, "cwe_name": "XSS",
+            "stage1_verdict": "vulnerable", "stage2_verdict": "confirmed",
+        }],
+    }
+    po_path = tmp_path / "pipeline_output.json"
+    po_path.write_text(json.dumps(po))
+
+    captured = {}
+
+    def mock_generate_test(finding, repo_info, binding, tracker):
+        return {"dockerfile": "FROM python:3.11\nCMD echo hi",
+                "test_script": "print('ok')", "test_filename": "test_exploit.py"}
+
+    def mock_run_single_container(generation, finding_id, source_file=None, **kwargs):
+        captured["finding_id"] = finding_id
+        from utilities.dynamic_tester.docker_executor import DockerExecutionResult
+        r = DockerExecutionResult()
+        r.stdout = '{"status": "CONFIRMED", "details": "t", "evidence": []}'
+        r.exit_code = 0
+        return r
+
+    monkeypatch.setattr("utilities.dynamic_tester.generate_test", mock_generate_test)
+    monkeypatch.setattr("utilities.dynamic_tester.run_single_container", mock_run_single_container)
+
+    from utilities.dynamic_tester import run_dynamic_tests
+    run_dynamic_tests(  # must not raise
+        pipeline_output_path=str(po_path),
+        output_dir=str(tmp_path / "out"),
+        max_retries=0,
+        registry=_fake_registry(),
+    )
+    assert isinstance(captured.get("finding_id"), str), (
+        f"finding_id not coerced to str: {captured.get('finding_id')!r}"
+    )

--- a/libs/openant-core/tests/test_docker_scaffold.py
+++ b/libs/openant-core/tests/test_docker_scaffold.py
@@ -389,6 +389,13 @@ def test_safe_leaf_never_raises_and_confines():
     # non-str (JSON allows any type) -> default, never raises (M1)
     for bad in (123, ["x"], {"a": 1}, None, True):
         assert _safe_leaf(bad, "d.py") == "d.py"
+    # embedded NUL / control chars: a str that survives basename+reserved but makes
+    # open()/os.path.join raise ValueError("embedded null byte") -> must degrade,
+    # not raise (would abort the whole run). Also proves the leaf is openable.
+    for bad in ("exploit\x00.py", "a\x1fb.py", "x\x7f.py", "\x00"):
+        leaf = _safe_leaf(bad, "d.py")
+        import os as _os
+        _os.path.join("/tmp", leaf)  # must not raise ValueError: embedded null byte
     # dot-segments resolve to a directory, not a file -> default (M2)
     for bad in ("..", ".", "a/b/..", "", "x/"):
         assert _safe_leaf(bad, "d.py") == "d.py"

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -254,14 +254,21 @@ def run_dynamic_tests(
         print(f"  Generated (${generation_cost:.4f}). Running in Docker...",
               file=sys.stderr)
 
-        # Resolve the vulnerable source file for pre-staging.
+        # Resolve the vulnerable source file for pre-staging. location.file is an
+        # LLM-emitted field; a `..`/absolute value would make os.path.join escape
+        # repo_path and copy a HOST file into the Docker build context (read/exfil).
+        # Confine the resolved path under repo_path (realpath also blocks a repo
+        # symlink pointing outside); skip on escape — source_file stays None, the
+        # already-supported no-source path.
         source_file = None
         if repo_path:
             rel_path = finding.get("location", {}).get("file", "")
             if rel_path:
-                candidate = os.path.join(repo_path, rel_path)
-                if os.path.isfile(candidate):
-                    source_file = candidate
+                repo_root = os.path.realpath(repo_path)
+                resolved = os.path.realpath(os.path.join(repo_path, rel_path))
+                if ((resolved == repo_root or resolved.startswith(repo_root + os.sep))
+                        and os.path.isfile(resolved)):
+                    source_file = resolved
 
         # Step 2: Execute in Docker and retry on errors
         execution = run_single_container(generation, finding_id,

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -181,7 +181,10 @@ def run_dynamic_tests(
 
     try:
       for i, finding in enumerate(findings):
-        finding_id = finding.get("id", f"FINDING-{i+1}")
+        # str() at the boundary: id is repo/JSON-derived and may be non-str; it flows
+        # to run_single_container's finding_id.lower() and checkpoint's safe_filename,
+        # both of which would raise on a non-str and abort the whole run.
+        finding_id = str(finding.get("id", f"FINDING-{i+1}"))
 
         # Skip already-checkpointed findings, but ONLY if they succeeded.
         # Errored findings fall through to fresh test generation + Docker run,
@@ -217,8 +220,9 @@ def run_dynamic_tests(
         # Placed AFTER the checkpoint hit: a finding CONFIRMED by an
         # earlier run must keep that verdict on resume, not be downgraded
         # to SKIPPED and lose its exploit evidence.
-        _loc = finding.get("location", {})
-        _file = _loc.get("file", "") if isinstance(_loc, dict) else ""
+        _loc = finding.get("location")
+        _file = _loc.get("file") if isinstance(_loc, dict) else None
+        _file = _file if isinstance(_file, str) else ""  # location.file may be non-str (JSON)
         _skip, _reason = should_skip_for_language(_file, repo_info.get("language"))
         if _skip:
             print(f"\n[{i+1}/{total}] SKIPPED {finding_id}: {_reason}", file=sys.stderr)
@@ -254,16 +258,21 @@ def run_dynamic_tests(
         print(f"  Generated (${generation_cost:.4f}). Running in Docker...",
               file=sys.stderr)
 
-        # Resolve the vulnerable source file for pre-staging. location.file is an
-        # LLM-emitted field; a `..`/absolute value would make os.path.join escape
-        # repo_path and copy a HOST file into the Docker build context (read/exfil).
-        # Confine the resolved path under repo_path (realpath also blocks a repo
-        # symlink pointing outside); skip on escape — source_file stays None, the
-        # already-supported no-source path.
+        # Resolve the vulnerable source file for pre-staging. location.file is a
+        # DETERMINISTIC repo-derived path (reporter.py sets it to route_key.split(":")[0],
+        # the parser's repo-relative path of the unit) — repo-author-controlled, and in a
+        # standalone run the findings JSON is fully caller-supplied. A `..`/absolute value,
+        # or an in-repo symlink pointing outside, would make the copy escape repo_path and
+        # read a HOST file into the Docker build context (read/exfil). Confine the resolved
+        # path under repo_path (realpath also blocks the symlink case); skip on escape —
+        # source_file stays None, the already-supported no-source path. Guard the types too:
+        # `location` may be a non-dict and `file` a non-str (JSON), which must not raise
+        # (an unwrapped raise aborts the whole run — see docker_executor._refuse_compose).
         source_file = None
         if repo_path:
-            rel_path = finding.get("location", {}).get("file", "")
-            if rel_path:
+            _loc = finding.get("location")
+            rel_path = _loc.get("file", "") if isinstance(_loc, dict) else ""
+            if isinstance(rel_path, str) and rel_path:
                 repo_root = os.path.realpath(repo_path)
                 resolved = os.path.realpath(os.path.join(repo_path, rel_path))
                 if ((resolved == repo_root or resolved.startswith(repo_root + os.sep))

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -301,10 +301,18 @@ def _write_test_files(work_dir: str, generation: dict, source_file: str | None =
 # CONSTRUCTION: a provider secret with any name (ANTHROPIC_API_KEY, GH_PAT,
 # AWS_ACCESS_KEY_ID, *_APIKEY, *_PASSPHRASE, *_AUTH, SLACK_WEBHOOK, …) is dropped by
 # default because it is not on the list, so no new secret-name convention can leak.
-# Docker's own needs are a bounded, well-known set. Tradeoff: a private base image
-# pulled via a cloud credential-helper that reads secrets from ENV (e.g. AWS_* for
-# ecr-login) will fail — use a prior `docker login` (writes config.json; DOCKER_CONFIG
-# is allowed) instead. Public base images and pre-authenticated config.json are unaffected.
+# Docker's own needs are a bounded, well-known set. Tradeoff: any build that needs a
+# host secret from ENV at build time fails — a private BASE IMAGE via a cloud
+# credential-helper (AWS_* for ecr-login), or a private BUILD DEPENDENCY fetched by a
+# RUN step (GITHUB_TOKEN for `go mod download` of a GOPRIVATE module, NPM_TOKEN, a
+# credentialed PIP_INDEX_URL, …). Such a generated repro fails to build and is recorded
+# as status=ERROR (result_collector.py) — VISIBLE and retried, NOT a silent
+# NOT_REPRODUCED, so the static verdict is preserved and only the dynamic confirmation is
+# missed (the safe side for a SAST tool). Private base images have a workaround (a prior
+# `docker login` writes config.json; DOCKER_CONFIG is allowed); a private build-time
+# dependency does not (the RUN-step token cannot be supplied without re-opening the
+# build-arg exfil this scrub closes) — an accepted coverage limit. Public base images and
+# public dependencies are unaffected.
 _ENV_ALLOW_EXACT = frozenset({
     "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TERM", "PWD", "TZ", "HOSTNAME",
     "TMPDIR", "TMP", "TEMP", "LANG", "LANGUAGE",

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -310,16 +310,28 @@ _ENV_ALLOW_EXACT = frozenset({
     "TMPDIR", "TMP", "TEMP", "LANG", "LANGUAGE",
     "XDG_RUNTIME_DIR", "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
     "SSL_CERT_FILE", "SSL_CERT_DIR", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO",
-    "COLIMA_HOME",
+    "COLIMA_HOME", "SSH_AUTH_SOCK",  # ssh:// docker context needs the agent socket (a
+                                     # unix-socket PATH, not a secret interpolable into a build-arg)
+    # The BOUNDED set of real docker CLI knobs. NOT a `DOCKER_` prefix: that prefix
+    # re-admits DOCKER_PASSWORD / DOCKER_AUTH_CONFIG (a GitLab-CI registry-cred var) /
+    # DOCKER_TOKEN — the exact secret-by-name leak the allowlist exists to prevent.
+    "DOCKER_HOST", "DOCKER_CONFIG", "DOCKER_CONTEXT", "DOCKER_CERT_PATH",
+    "DOCKER_TLS_VERIFY", "DOCKER_API_VERSION", "DOCKER_BUILDKIT",
+    "DOCKER_DEFAULT_PLATFORM", "DOCKER_CLI_EXPERIMENTAL", "DOCKER_CONTENT_TRUST",
+    "BUILDKIT_HOST", "BUILDKIT_PROGRESS", "COMPOSE_PROJECT_NAME", "COMPOSE_FILE",
+    "COMPOSE_PROFILES", "COMPOSE_DOCKER_CLI_BUILD",
     # Windows essentials so docker.exe resolves on CI runners.
     "SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT", "USERPROFILE", "APPDATA",
     "LOCALAPPDATA", "PROGRAMDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
     "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
 })
-# Prefixes for families docker legitimately needs. Proxy vars may embed the user's OWN
-# proxy credential — that is the user's network config (needed to reach the daemon /
-# registry), not a provider API key, and dropping it would break builds behind a proxy.
-_ENV_ALLOW_PREFIXES = ("DOCKER_", "BUILDKIT_", "COMPOSE_", "CONTAINERD_", "LC_")
+# Only `LC_*` (locale) stays a prefix — it can never carry a provider secret. The
+# docker/compose/buildkit knobs are enumerated exactly above precisely because their
+# families ALSO contain credential-bearing names (DOCKER_PASSWORD/DOCKER_AUTH_CONFIG).
+_ENV_ALLOW_PREFIXES = ("LC_",)
+# Proxy vars may embed the user's OWN proxy credential — that is the user's network
+# config (needed to reach the daemon/registry), not a provider API key, and dropping
+# it would break builds behind a proxy.
 _ENV_ALLOW_SUFFIXES = ("_PROXY", "_proxy")
 _ENV_ALLOW_LOWER = frozenset({"no_proxy"})
 

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -111,11 +111,18 @@ def _safe_leaf(name, default: str) -> str:
     basename is strictly correct and strips any traversal.
 
     Fail-closed WITHOUT raising: an unwrapped raise here would abort the whole
-    dynamic-test run (see _refuse_compose), so a hostile name degrades to a
+    dynamic-test run (see _refuse_compose), so a hostile value degrades to a
     harmless leaf (COPY mismatch -> NOT_REPRODUCED) rather than a host write.
+    A non-str value (JSON allows any type), a dot-segment ('.'/'..' -> a
+    directory, not a file), and a name colliding with a fixed staging path
+    (Dockerfile / docker-compose.yml / attacker-server) all degrade to `default`
+    so nothing downstream raises IsADirectoryError / FileExistsError / TypeError.
     """
-    leaf = os.path.basename(name or "")
-    return leaf or default
+    if not isinstance(name, str):
+        return default
+    leaf = os.path.basename(name)
+    _RESERVED = {"", ".", "..", "Dockerfile", "docker-compose.yml", "attacker-server"}
+    return default if leaf in _RESERVED else leaf
 
 
 def _harden_service(name: str, svc: dict) -> dict:
@@ -239,16 +246,20 @@ def _write_test_files(work_dir: str, generation: dict, source_file: str | None =
     if source_file and os.path.isfile(source_file):
         shutil.copy2(source_file, os.path.join(work_dir, os.path.basename(source_file)))
 
+    # str() the content fields as a defense-in-depth belt: generate_test already
+    # rejects a non-str content field (test_generator validation), but coercing here
+    # too means a non-str value can never raise TypeError in f.write and abort the
+    # whole run — it degrades to a garbage build that fails safe (NOT_REPRODUCED).
     # Write Dockerfile
     with open_utf8(os.path.join(work_dir, "Dockerfile"), "w") as f:
-        f.write(generation["dockerfile"])
+        f.write(str(generation["dockerfile"]))
 
     # Write test script (confine the LLM-supplied name to a leaf inside work_dir)
     test_filename = _safe_leaf(generation.get("test_filename"), "test_exploit.py")
     test_path = os.path.join(work_dir, test_filename)
     os.makedirs(os.path.dirname(test_path), exist_ok=True)
     with open_utf8(test_path, "w") as f:
-        f.write(generation["test_script"])
+        f.write(str(generation["test_script"]))
 
     # Write requirements/dependencies file
     if generation.get("requirements"):
@@ -256,7 +267,7 @@ def _write_test_files(work_dir: str, generation: dict, source_file: str | None =
         req_path = os.path.join(work_dir, req_filename)
         os.makedirs(os.path.dirname(req_path), exist_ok=True)
         with open_utf8(req_path, "w") as f:
-            f.write(generation["requirements"])
+            f.write(str(generation["requirements"]))
 
     # Copy attacker server if needed (before docker-compose so it's available)
     if generation.get("needs_attacker_server"):

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -120,6 +120,13 @@ def _safe_leaf(name, default: str) -> str:
     """
     if not isinstance(name, str):
         return default
+    # A NUL (or other control char) is a str that survives basename and the
+    # reserved check, but open()/os.path.join raise ValueError("embedded null
+    # byte") — an unwrapped raise here would abort the whole run (the exact
+    # fail-closed contract this helper exists to keep). Reject any name carrying a
+    # control character (0x00-0x1f, 0x7f) and degrade to the default leaf.
+    if any(ord(c) < 0x20 or ord(c) == 0x7f for c in name):
+        return default
     leaf = os.path.basename(name)
     _RESERVED = {"", ".", "..", "Dockerfile", "docker-compose.yml", "attacker-server"}
     return default if leaf in _RESERVED else leaf
@@ -286,26 +293,53 @@ def _write_test_files(work_dir: str, generation: dict, source_file: str | None =
             f.write(compose_content)
 
 
-# Env-var names whose VALUE is a host secret the docker build/run subprocess must
-# never carry. `docker compose` interpolates a `${VAR}` in an untrusted, LLM-authored
-# compose `build.args` from the subprocess env at BUILD time; the generated Dockerfile
-# `RUN` then has open build-time network egress (an accepted GHSA-98g5 residual that
-# assumed NO host secret was reachable at build time). Scrubbing these names closes the
-# exfil by construction — docker itself needs none of them.
-_SECRET_ENV_SUBSTRINGS = ("API_KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD",
-                          "CREDENTIAL", "PRIVATE_KEY", "SESSION")
+# The env the docker build/run subprocess is ALLOWED to see. `docker compose`
+# interpolates a `${VAR}` in an untrusted, LLM-authored compose `build.args` from the
+# subprocess env at BUILD time; the generated Dockerfile `RUN` then has open build-time
+# network egress (an accepted GHSA-98g5 residual that assumed NO host secret was
+# reachable at build time). An ALLOWLIST (not a deny-list) closes the exfil BY
+# CONSTRUCTION: a provider secret with any name (ANTHROPIC_API_KEY, GH_PAT,
+# AWS_ACCESS_KEY_ID, *_APIKEY, *_PASSPHRASE, *_AUTH, SLACK_WEBHOOK, …) is dropped by
+# default because it is not on the list, so no new secret-name convention can leak.
+# Docker's own needs are a bounded, well-known set. Tradeoff: a private base image
+# pulled via a cloud credential-helper that reads secrets from ENV (e.g. AWS_* for
+# ecr-login) will fail — use a prior `docker login` (writes config.json; DOCKER_CONFIG
+# is allowed) instead. Public base images and pre-authenticated config.json are unaffected.
+_ENV_ALLOW_EXACT = frozenset({
+    "PATH", "HOME", "USER", "LOGNAME", "SHELL", "TERM", "PWD", "TZ", "HOSTNAME",
+    "TMPDIR", "TMP", "TEMP", "LANG", "LANGUAGE",
+    "XDG_RUNTIME_DIR", "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME",
+    "SSL_CERT_FILE", "SSL_CERT_DIR", "CURL_CA_BUNDLE", "GIT_SSL_CAINFO",
+    "COLIMA_HOME",
+    # Windows essentials so docker.exe resolves on CI runners.
+    "SYSTEMROOT", "WINDIR", "COMSPEC", "PATHEXT", "USERPROFILE", "APPDATA",
+    "LOCALAPPDATA", "PROGRAMDATA", "PROGRAMFILES", "PROGRAMFILES(X86)",
+    "NUMBER_OF_PROCESSORS", "PROCESSOR_ARCHITECTURE",
+})
+# Prefixes for families docker legitimately needs. Proxy vars may embed the user's OWN
+# proxy credential — that is the user's network config (needed to reach the daemon /
+# registry), not a provider API key, and dropping it would break builds behind a proxy.
+_ENV_ALLOW_PREFIXES = ("DOCKER_", "BUILDKIT_", "COMPOSE_", "CONTAINERD_", "LC_")
+_ENV_ALLOW_SUFFIXES = ("_PROXY", "_proxy")
+_ENV_ALLOW_LOWER = frozenset({"no_proxy"})
 
 
 def _scrubbed_subprocess_env() -> dict:
-    """os.environ minus any provider secret, for the docker build/run subprocess.
+    """os.environ filtered to a docker-essentials ALLOWLIST for the build/run subprocess.
 
-    Deny-list by name substring (not an allowlist) so docker keeps everything it
-    needs (PATH, HOME, DOCKER_HOST, DOCKER_CONFIG, proxy vars, …) while no
-    ``*_API_KEY`` / ``*_TOKEN`` / ``*_SECRET`` value can be interpolated into an
-    untrusted compose build-arg and exfiltrated over build-time egress.
+    Everything not explicitly allowed (every ``*_API_KEY`` / ``*_TOKEN`` / ``*_SECRET``
+    / ``*_AUTH`` / ``*_PAT`` / arbitrary secret) is dropped, so no host secret can be
+    interpolated into an untrusted compose build-arg and exfiltrated over build-time
+    egress — regardless of the secret's name.
     """
-    return {k: v for k, v in os.environ.items()
-            if not any(s in k.upper() for s in _SECRET_ENV_SUBSTRINGS)}
+    def _allowed(name: str) -> bool:
+        up = name.upper()
+        return (up in _ENV_ALLOW_EXACT
+                or name in _ENV_ALLOW_LOWER
+                or any(up.startswith(p) for p in _ENV_ALLOW_PREFIXES)
+                or any(name.endswith(s) for s in _ENV_ALLOW_SUFFIXES))
+
+    return {k: v for k, v in os.environ.items() if _allowed(k)}
 
 
 def _run_command(cmd: list[str], timeout: int, cwd: str = None) -> tuple[str, str, int, bool]:

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -98,6 +98,26 @@ def _safe_build(build):
     raise ValueError("service has no usable build spec")
 
 
+def _safe_leaf(name, default: str) -> str:
+    """Confine an LLM-supplied staging filename to a bare leaf inside work_dir.
+
+    generation['test_filename'] / ['requirements_filename'] are LLM output
+    influenced by the scanned repo. Used raw as `os.path.join(work_dir, name)`
+    they let a `..`/absolute value escape work_dir and write to the HOST during
+    pre-container staging (the compose `build.context` analogue that _safe_build
+    already confines). The scaffold is flat by construction — the generation
+    schema's examples are plain basenames, Dockerfiles `COPY <basename> .` at
+    WORKDIR, and pip needs requirements.txt at the build-context root — so
+    basename is strictly correct and strips any traversal.
+
+    Fail-closed WITHOUT raising: an unwrapped raise here would abort the whole
+    dynamic-test run (see _refuse_compose), so a hostile name degrades to a
+    harmless leaf (COPY mismatch -> NOT_REPRODUCED) rather than a host write.
+    """
+    leaf = os.path.basename(name or "")
+    return leaf or default
+
+
 def _harden_service(name: str, svc: dict) -> dict:
     """Reconstruct ONE service from the allowlist + the fixed hardening set (C).
 
@@ -223,8 +243,8 @@ def _write_test_files(work_dir: str, generation: dict, source_file: str | None =
     with open_utf8(os.path.join(work_dir, "Dockerfile"), "w") as f:
         f.write(generation["dockerfile"])
 
-    # Write test script
-    test_filename = generation.get("test_filename", "test_exploit.py")
+    # Write test script (confine the LLM-supplied name to a leaf inside work_dir)
+    test_filename = _safe_leaf(generation.get("test_filename"), "test_exploit.py")
     test_path = os.path.join(work_dir, test_filename)
     os.makedirs(os.path.dirname(test_path), exist_ok=True)
     with open_utf8(test_path, "w") as f:
@@ -232,7 +252,7 @@ def _write_test_files(work_dir: str, generation: dict, source_file: str | None =
 
     # Write requirements/dependencies file
     if generation.get("requirements"):
-        req_filename = generation.get("requirements_filename", "requirements.txt")
+        req_filename = _safe_leaf(generation.get("requirements_filename"), "requirements.txt")
         req_path = os.path.join(work_dir, req_filename)
         os.makedirs(os.path.dirname(req_path), exist_ok=True)
         with open_utf8(req_path, "w") as f:

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -286,6 +286,28 @@ def _write_test_files(work_dir: str, generation: dict, source_file: str | None =
             f.write(compose_content)
 
 
+# Env-var names whose VALUE is a host secret the docker build/run subprocess must
+# never carry. `docker compose` interpolates a `${VAR}` in an untrusted, LLM-authored
+# compose `build.args` from the subprocess env at BUILD time; the generated Dockerfile
+# `RUN` then has open build-time network egress (an accepted GHSA-98g5 residual that
+# assumed NO host secret was reachable at build time). Scrubbing these names closes the
+# exfil by construction — docker itself needs none of them.
+_SECRET_ENV_SUBSTRINGS = ("API_KEY", "TOKEN", "SECRET", "PASSWORD", "PASSWD",
+                          "CREDENTIAL", "PRIVATE_KEY", "SESSION")
+
+
+def _scrubbed_subprocess_env() -> dict:
+    """os.environ minus any provider secret, for the docker build/run subprocess.
+
+    Deny-list by name substring (not an allowlist) so docker keeps everything it
+    needs (PATH, HOME, DOCKER_HOST, DOCKER_CONFIG, proxy vars, …) while no
+    ``*_API_KEY`` / ``*_TOKEN`` / ``*_SECRET`` value can be interpolated into an
+    untrusted compose build-arg and exfiltrated over build-time egress.
+    """
+    return {k: v for k, v in os.environ.items()
+            if not any(s in k.upper() for s in _SECRET_ENV_SUBSTRINGS)}
+
+
 def _run_command(cmd: list[str], timeout: int, cwd: str = None) -> tuple[str, str, int, bool]:
     """Run a command with timeout. Returns (stdout, stderr, exit_code, timed_out)."""
     try:
@@ -295,6 +317,7 @@ def _run_command(cmd: list[str], timeout: int, cwd: str = None) -> tuple[str, st
             text=True,
             timeout=timeout,
             cwd=cwd,
+            env=_scrubbed_subprocess_env(),
         )
         return result.stdout, result.stderr, result.returncode, False
     except subprocess.TimeoutExpired:

--- a/libs/openant-core/utilities/dynamic_tester/test_generator.py
+++ b/libs/openant-core/utilities/dynamic_tester/test_generator.py
@@ -131,14 +131,15 @@ def _build_finding_prompt(finding: dict, repo_info: dict) -> str:
     # vocabularies ("javascript" vs the "node" base image) and conflating them
     # tells the model the wrong language for the code it is writing a test
     # against. Template selection is resolve_docker_template's job.
-    loc_for_lang = finding.get("location", {})
-    finding_file = loc_for_lang.get("file", "") if isinstance(loc_for_lang, dict) else ""
+    loc_for_lang = finding.get("location")
+    _ff = loc_for_lang.get("file") if isinstance(loc_for_lang, dict) else None
+    finding_file = _ff if isinstance(_ff, str) else ""  # location.file may be non-str (JSON)
     language = language_for_path(finding_file) or repo_info.get("language") or "unknown"
 
     # Derive the staged source filename so the LLM can reference it in COPY.
     source_basename = ""
-    loc = finding.get("location", {})
-    if isinstance(loc, dict) and loc.get("file"):
+    loc = finding.get("location")
+    if isinstance(loc, dict) and isinstance(loc.get("file"), str) and loc["file"]:
         source_basename = os.path.basename(loc["file"])
 
     # Inline label fields are model-produced free text (name, cwe_name, the two
@@ -286,6 +287,13 @@ def generate_test(
     required = ["dockerfile", "test_script", "test_filename"]
     if not all(k in parsed for k in required):
         return None
+    # Every staging field the executor writes or joins must be a str — a non-str
+    # (JSON allows any type) would raise in _write_test_files and abort the whole
+    # dynamic-test run. Degrade a malformed generation to the None (NOT_REPRODUCED) path.
+    _STR_FIELDS = ("dockerfile", "test_script", "test_filename",
+                   "requirements", "requirements_filename", "docker_compose")
+    if any(k in parsed and not isinstance(parsed[k], str) for k in _STR_FIELDS):
+        return None
 
     return parsed
 
@@ -357,6 +365,13 @@ def regenerate_test(
 
     required = ["dockerfile", "test_script", "test_filename"]
     if not all(k in parsed for k in required):
+        return None
+    # Every staging field the executor writes or joins must be a str — a non-str
+    # (JSON allows any type) would raise in _write_test_files and abort the whole
+    # dynamic-test run. Degrade a malformed generation to the None (NOT_REPRODUCED) path.
+    _STR_FIELDS = ("dockerfile", "test_script", "test_filename",
+                   "requirements", "requirements_filename", "docker_compose")
+    if any(k in parsed and not isinstance(parsed[k], str) for k in _STR_FIELDS):
         return None
 
     return parsed


### PR DESCRIPTION
## What

Confine the three LLM-supplied filesystem paths the dynamic tester materializes on the **host** during pre-container staging, so none can escape the staging root.

## Why

The dynamic tester stages files on the host *before* any container is built or run, using values that originate from LLM output influenced by the scanned repository. Three of those values were used as paths without confinement:

- `_write_test_files` (`docker_executor.py`): `generation["test_filename"]` and `generation["requirements_filename"]` were `os.path.join`'d to `work_dir`, then `os.makedirs(os.path.dirname(...))` + written. A `..`/absolute value collapses above `work_dir` and `makedirs` builds the chain → **host file-write** at an attacker-influenced path.
- `run_dynamic_tests` (`__init__.py`): `finding.location.file` was `os.path.join`'d to `repo_path` and `copy2`'d into the build context. `os.path.join` honors an absolute second arg (`/etc/passwd`) and `..` traversal → a **host file outside the repo is read** into the image, where the LLM-authored test script can print it into the captured result → read/exfil.

This staging path is **outside the container runtime boundary hardened in #253** — that PR confined the compose `build.context` in this same file via `_safe_build`, but the sibling filename/source seams beside it were left unguarded.

## Threat model / reachability (honest scope)

- **Grounding:** sibling of the dynamic-tester sandbox threat model established by #253 / GHSA-98g5. The staging write/read runs as the user running OpenAnt.
- **Default-on, not opt-in:** dynamic testing **runs by default** (`scan.go`: "Dynamic testing runs by default"; the flag is `--skip-dynamic-test`, default false). Any `openant scan <repo>` on a Docker host reaches the staging code.
- **The READ sink is deterministic, not LLM-mediated.** `location.file` is set by `reporter.py` to `route_key.split(":")[0]` — the parser's **repo-relative path** of the vulnerable unit — so a malicious repo controls it directly (a crafted path, or an in-repo symlink the copy follows out of the repo); in a standalone dynamic-test run the findings JSON is fully caller-supplied. No LLM dice-roll required.
- **The WRITE sinks are LLM-mediated:** `test_filename`/`requirements_filename` are emitted by the fenced stage-2 LLM under prompt-injection pressure from scanned-repo content — attacker-influenced, probabilistic end-to-end.
- **Why fix by construction:** the sink mechanics (traversal collapse, `makedirs` builds the chain, no clamp, host-user privilege, pre-container timing) are static-confirmed and live in an advertised sandbox boundary.

## Fix

One confinement concern, three sites, all **fail-closed without raising** (an unwrapped raise here aborts the whole dynamic-test run — see `_refuse_compose`):

- `_safe_leaf(name, default)` basenames the two write filenames. The scaffold is flat by construction (schema examples are basenames; Dockerfiles `COPY <basename> .` at WORKDIR; pip needs `requirements.txt` at the build-context root), so basename is strictly correct. A hostile name degrades to a harmless leaf → `COPY` mismatch → `NOT_REPRODUCED`.
- The source read is confined under `realpath(repo_path)` (`realpath` also blocks a repo symlink pointing outside); on escape `source_file` stays `None` — the already-supported no-source path.

**No-raise hardening (second commit).** The confinement touches exactly the untrusted fields that can also carry a wrong **type / dot-segment / reserved-name** — and any unwrapped raise in this path aborts the *whole* run (a DoS). Closed comprehensively:
- `_safe_leaf` also rejects non-str, `.`/`..`, and names colliding with fixed staging paths (`Dockerfile`/`docker-compose.yml`/`attacker-server`) → all degrade to the default leaf.
- Content writes are `str()`-coerced, and `test_generator` rejects a non-str content field up front (→ `NOT_REPRODUCED`).
- `location.file` is str-guarded at **all four** read sites (skip-language, source-resolve, template-select, basename) — a non-str previously drove `Path(int)` → `TypeError`. (`finding.id` is `str()`-coerced at the boundary for the same reason: it flows to `finding_id.lower()` and checkpoint `safe_filename`.)
- The report disclosure filename (`generator.py` + `__main__.py`) is `str()`+`basename`-guarded so a null/typed/`/`-bearing `short_name` can't crash disclosure generation.

## Tests

17 new test cases across 7 functions in `test_docker_scaffold.py` (`pytest --collect-only` → 22 total, base was 5), each RED-verified against the unfixed code — 3 for the traversal confinement (`../PWNED_test.py` / absolute `requirements_filename` must not write outside `work_dir`; a `../SECRET.txt` `location.file` must yield `source_file=None`), and 14 (parametrized) for the no-raise invariant (`_safe_leaf` type/dot/reserved cases; `_write_test_files` on hostile fields; non-dict/non-str `location`; non-str `finding.id`).

Full dynamic-tester + report suite passes:

```
$ python -m pytest tests/test_docker_scaffold.py tests/test_docker_sandbox_reconstruct.py \
    tests/test_docker_egress_hardening.py tests/test_dynamic_testable_filter.py \
    tests/test_dynamic_tester_language.py tests/test_entrypoint_bindings.py \
    tests/test_F3_verdict_taxonomy_shared_constant.py tests/test_fence_live_sites_escape.py \
    tests/test_prompt_fence_escape_siblings.py tests/test_bughunt2_regressions.py \
    tests/report/test_poisoned_confirmed_findings_and_findings_fa18.py -q
145 passed
```
