### PR TITLE
fix(scanner): record crashed context steps; broaden reachability reads

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -409,6 +409,11 @@ def scan_repository(
                     print("  Continuing without app context.", file=sys.stderr)
                     ctx.status = "skipped"
                     ctx.summary = {"skipped": True, "reason": str(e)}
+                    # Record the crash like the enhance/verify/dynamic-test
+                    # handlers do — otherwise the degraded scan (default threat
+                    # model) leaves no artifact record and the summary claims
+                    # "No steps were skipped".
+                    _record_skip(result, "app-context", "failed")
 
         collected_step_reports.append(_load_step_report(output_dir, "app-context"))
     elif generate_context:
@@ -464,6 +469,10 @@ def scan_repository(
                 print(f"  WARNING: failed to load dataset: {exc}", file=sys.stderr)
                 ctx.status = "skipped"
                 ctx.summary = {"skipped": True, "reason": str(exc)}
+                # Record the crash so the degraded reachability pass (no
+                # LLM-promoted entry points -> potential missed vulns) is
+                # visible in the artifacts, not only on CI-discarded stderr.
+                _record_skip(result, "llm-reachability", "failed")
                 dataset = None
 
             if dataset is not None:

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -467,11 +467,14 @@ def scan_repository(
             try:
                 dataset = read_json(active_dataset_path)
             except Exception as exc:
-                # Broad like the other optional-stage crash handlers
-                # (app-context/enhance/verify/dynamic-test): read_json opens
-                # strict UTF-8, so a bad-encoding dataset raises
-                # UnicodeDecodeError (a ValueError, not OSError/JSONDecodeError)
-                # which previously escaped and aborted the whole scan.
+                # Broaden beyond (OSError, json.JSONDecodeError): read_json opens
+                # strict UTF-8, so a bad-encoding dataset raises UnicodeDecodeError
+                # (a ValueError) which previously escaped and aborted the whole
+                # scan. NOTE: this guards only the dataset READ. The stage's LLM
+                # call (analyze_reachability, below) is NOT wrapped here, so a
+                # provider error there still aborts the scan — a separate gap
+                # tracked as a follow-up (wrap the whole stage body like
+                # enhance/verify do).
                 print(f"  WARNING: failed to load dataset: {exc}", file=sys.stderr)
                 ctx.status = "skipped"
                 ctx.summary = {"skipped": True, "reason": str(exc)}
@@ -486,7 +489,21 @@ def scan_repository(
                 if app_context_path and os.path.exists(app_context_path):
                     try:
                         app_ctx_payload = read_json(app_context_path)
-                    except (OSError, json.JSONDecodeError):
+                    except Exception as exc:
+                        # Broad like the dataset load above: this optional
+                        # app-context read must never abort the scan. read_json
+                        # opens strict UTF-8, so a bad-encoding self-written file
+                        # raises UnicodeDecodeError (not OSError/JSONDecodeError);
+                        # a missing payload just means the reachability prompt
+                        # runs without the extra app-context hint. Warn (like the
+                        # dataset-load sibling) so this recall-affecting
+                        # degradation is visible, not silent.
+                        print(
+                            f"  WARNING: could not read app context for "
+                            f"reachability ({exc}); continuing without the "
+                            f"app-context hint.",
+                            file=sys.stderr,
+                        )
                         app_ctx_payload = None
 
                 # --limit governs the analyze stage, not how many units the

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -411,8 +411,9 @@ def scan_repository(
                     ctx.summary = {"skipped": True, "reason": str(e)}
                     # Record the crash like the enhance/verify/dynamic-test
                     # handlers do — otherwise the degraded scan (default threat
-                    # model) leaves no artifact record and the summary claims
-                    # "No steps were skipped".
+                    # model) is absent from result.skipped_steps / scan.report.json
+                    # / pipeline_output.json and the summary claims "No steps were
+                    # skipped" (only the per-step report + stderr carried it).
                     _record_skip(result, "app-context", "failed")
 
         collected_step_reports.append(_load_step_report(output_dir, "app-context"))
@@ -465,7 +466,12 @@ def scan_repository(
         }) as ctx:
             try:
                 dataset = read_json(active_dataset_path)
-            except (OSError, json.JSONDecodeError) as exc:
+            except Exception as exc:
+                # Broad like the other optional-stage crash handlers
+                # (app-context/enhance/verify/dynamic-test): read_json opens
+                # strict UTF-8, so a bad-encoding dataset raises
+                # UnicodeDecodeError (a ValueError, not OSError/JSONDecodeError)
+                # which previously escaped and aborted the whole scan.
                 print(f"  WARNING: failed to load dataset: {exc}", file=sys.stderr)
                 ctx.status = "skipped"
                 ctx.summary = {"skipped": True, "reason": str(exc)}

--- a/libs/openant-core/tests/test_scanner.py
+++ b/libs/openant-core/tests/test_scanner.py
@@ -305,3 +305,65 @@ def test_skipped_step_reasons_serialized_in_scan_report(monkeypatch, tmp_path):
     # New disambiguated map present.
     assert "steps_skipped_reasons" in summary
     assert "verify" in summary["steps_skipped_reasons"]
+
+
+# ---------------------------------------------------------------------------
+# Crashed context steps must be RECORDED, not silently dropped.
+#
+# enhance/verify/dynamic-test crashes already call _record_skip(..., "failed").
+# app-context and llm-reachability crashes set ctx.status="skipped" but did NOT
+# _record_skip, so a degraded scan (wrong/absent threat model -> FP inflation;
+# no LLM-promoted entry points -> potential missed vulns) left ZERO record in
+# result.skipped_steps / scan.report.json / pipeline_output.json — the summary
+# then affirmatively claimed "No steps were skipped". These pin the invariant.
+# ---------------------------------------------------------------------------
+
+def test_app_context_crash_is_recorded_as_failed(monkeypatch, tmp_path):
+    """A crashed app-context step must land in result.skipped_steps (reason
+    'failed'), so the degraded (default-model) scan is visible in the artifacts,
+    not only on CI-discarded stderr."""
+    _install_minimal_pipeline(monkeypatch)
+
+    def _boom(*a, **k):
+        raise RuntimeError("app-context blew up")
+
+    monkeypatch.setattr(scanner_mod, "generate_application_context", _boom,
+                        raising=False)
+
+    out = tmp_path / "out"
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out),
+        generate_context=True, enhance=False, verify=False,
+        generate_report=False, dynamic_test=False,
+    )
+    assert isinstance(result, ScanResult)
+    assert "app-context" in result.skipped_steps, \
+        "a crashed app-context step was silently dropped from skipped_steps"
+    assert result.skipped_step_reasons.get("app-context") == "failed"
+
+
+def test_llm_reachability_crash_is_recorded_as_failed(monkeypatch, tmp_path):
+    """A crashed llm-reachability dataset-load must land in result.skipped_steps
+    (reason 'failed') — same invariant. The crash silently disables the
+    LLM-promoted entry points (potential missed vulns) for an opt-in feature."""
+    _install_minimal_pipeline(monkeypatch)
+
+    _orig_read = scanner_mod.read_json
+
+    def _raise_on_dataset(path, *a, **k):
+        if "dataset" in str(path):
+            raise OSError("dataset unreadable")
+        return _orig_read(path, *a, **k)
+
+    monkeypatch.setattr(scanner_mod, "read_json", _raise_on_dataset)
+
+    out = tmp_path / "out"
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out),
+        generate_context=False, enhance=False, verify=False,
+        generate_report=False, dynamic_test=False, llm_reachability=True,
+    )
+    assert isinstance(result, ScanResult)
+    assert "llm-reachability" in result.skipped_steps, \
+        "a crashed llm-reachability step was silently dropped from skipped_steps"
+    assert result.skipped_step_reasons.get("llm-reachability") == "failed"

--- a/libs/openant-core/tests/test_scanner.py
+++ b/libs/openant-core/tests/test_scanner.py
@@ -367,3 +367,31 @@ def test_llm_reachability_crash_is_recorded_as_failed(monkeypatch, tmp_path):
     assert "llm-reachability" in result.skipped_steps, \
         "a crashed llm-reachability step was silently dropped from skipped_steps"
     assert result.skipped_step_reasons.get("llm-reachability") == "failed"
+
+
+def test_llm_reachability_non_oserror_crash_is_recorded(monkeypatch, tmp_path):
+    """read_json opens strict UTF-8, so a bad-encoding dataset raises
+    UnicodeDecodeError (a ValueError subclass) — NOT OSError/JSONDecodeError.
+    The handler must catch it (like the other 4 crash handlers' broad except),
+    record the skip, and let the scan complete — not abort the whole scan."""
+    _install_minimal_pipeline(monkeypatch)
+
+    _orig_read = scanner_mod.read_json
+
+    def _raise_unicode(path, *a, **k):
+        if "dataset" in str(path):
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        return _orig_read(path, *a, **k)
+
+    monkeypatch.setattr(scanner_mod, "read_json", _raise_unicode)
+
+    out = tmp_path / "out"
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out),
+        generate_context=False, enhance=False, verify=False,
+        generate_report=False, dynamic_test=False, llm_reachability=True,
+    )
+    assert isinstance(result, ScanResult), \
+        "a non-OSError dataset crash aborted the whole scan"
+    assert "llm-reachability" in result.skipped_steps
+    assert result.skipped_step_reasons.get("llm-reachability") == "failed"

--- a/libs/openant-core/tests/test_scanner.py
+++ b/libs/openant-core/tests/test_scanner.py
@@ -328,7 +328,7 @@ def test_app_context_crash_is_recorded_as_failed(monkeypatch, tmp_path):
         raise RuntimeError("app-context blew up")
 
     monkeypatch.setattr(scanner_mod, "generate_application_context", _boom,
-                        raising=False)
+                        raising=True)
 
     out = tmp_path / "out"
     result = scanner_mod.scan_repository(
@@ -337,9 +337,17 @@ def test_app_context_crash_is_recorded_as_failed(monkeypatch, tmp_path):
         generate_report=False, dynamic_test=False,
     )
     assert isinstance(result, ScanResult)
+    # Pin that the injected generate-branch crash (not some other path / a real
+    # API failure) produced the skip: a real success would set "generated".
+    assert result.context_source == "none"
     assert "app-context" in result.skipped_steps, \
         "a crashed app-context step was silently dropped from skipped_steps"
     assert result.skipped_step_reasons.get("app-context") == "failed"
+    # ...and it must reach the machine-readable artifact, not just the object.
+    import json
+    summary = json.loads((out / "scan.report.json").read_text())["summary"]
+    assert "app-context" in summary["steps_skipped"]
+    assert summary["steps_skipped_reasons"].get("app-context") == "failed"
 
 
 def test_llm_reachability_crash_is_recorded_as_failed(monkeypatch, tmp_path):
@@ -367,6 +375,11 @@ def test_llm_reachability_crash_is_recorded_as_failed(monkeypatch, tmp_path):
     assert "llm-reachability" in result.skipped_steps, \
         "a crashed llm-reachability step was silently dropped from skipped_steps"
     assert result.skipped_step_reasons.get("llm-reachability") == "failed"
+    # ...and it must reach the machine-readable artifact, not just the object.
+    import json
+    summary = json.loads((out / "scan.report.json").read_text())["summary"]
+    assert "llm-reachability" in summary["steps_skipped"]
+    assert summary["steps_skipped_reasons"].get("llm-reachability") == "failed"
 
 
 def test_llm_reachability_non_oserror_crash_is_recorded(monkeypatch, tmp_path):
@@ -395,3 +408,42 @@ def test_llm_reachability_non_oserror_crash_is_recorded(monkeypatch, tmp_path):
         "a non-OSError dataset crash aborted the whole scan"
     assert "llm-reachability" in result.skipped_steps
     assert result.skipped_step_reasons.get("llm-reachability") == "failed"
+
+
+def test_llm_reachability_appctx_read_bad_encoding_does_not_abort(monkeypatch, tmp_path, capsys):
+    """The optional app_ctx_payload read inside the llm-reachability stage reads
+    a self-written application_context.json; a bad-encoding file raises
+    UnicodeDecodeError. That read is a defensive fallback (app_ctx_payload=None)
+    and must NOT abort the whole scan — same strict-UTF-8 hazard as the dataset
+    load directly above it."""
+    _install_minimal_pipeline(monkeypatch)
+
+    # Make app-context generation succeed so app_context_path is set + file written.
+    class _Ctx:
+        application_type = "web_app"
+
+    monkeypatch.setattr(scanner_mod, "generate_application_context",
+                        lambda *a, **k: _Ctx(), raising=True)
+    monkeypatch.setattr(scanner_mod, "save_context",
+                        lambda ctx, path: Path(path).write_text("{}"), raising=True)
+
+    _orig_read = scanner_mod.read_json
+
+    def _raise_on_appctx(path, *a, **k):
+        if "application_context" in str(path):
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+        return _orig_read(path, *a, **k)
+
+    monkeypatch.setattr(scanner_mod, "read_json", _raise_on_appctx)
+
+    out = tmp_path / "out"
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path), output_dir=str(out),
+        generate_context=True, enhance=False, verify=False,
+        generate_report=False, dynamic_test=False, llm_reachability=True,
+    )
+    assert isinstance(result, ScanResult), \
+        "a bad-encoding application_context.json read aborted the whole scan"
+    # The degradation must be visible on stderr, not silent (it lowers the
+    # reachability prompt's recall). Mirrors the dataset-load sibling's warning.
+    assert "could not read app context for reachability" in capsys.readouterr().err


### PR DESCRIPTION
## What

Record the two optional-stage crash handlers (app-context, llm-reachability) that
were setting `ctx.status="skipped"` without calling `_record_skip`, and broaden the
two narrow file-read `except` clauses in the llm-reachability stage so a bad-encoding
input degrades the stage instead of aborting the whole scan. Report-fidelity +
crash-safety; no change to findings, verdicts, disclosure, or exit codes.

## Why

Of the five optional-stage crash handlers in `scan_repository`, three
(enhance/verify/dynamic-test) call `_record_skip(result, <step>, "failed")` on a
caught crash; app-context and llm-reachability did not. A crash there left no entry
in `result.skipped_steps`, `scan.report.json`, or `pipeline_output.json`, so the
generated summary rendered "No steps were skipped" for a scan that in fact ran
degraded — and both degrade scan quality: a failed app-context step makes analyze and
verify run with `app_context=None` (the default threat model, which drops the local-only
suppression rules → more false positives, plus a fabricated `Application Type: web_app`
in the summary), and a failed llm-reachability dataset load skips the LLM-promoted
entry points, reducing reachability coverage for an opt-in stage. Only stderr and the
per-step report carried the truth, and per `core/scanner.py`'s own R5 comment those are
not the machine-readable surfaces (CI discards stderr).

Separately, `read_json` opens strict UTF-8, so a bad-encoding input raises
`UnicodeDecodeError` (a `ValueError`, not `OSError`/`json.JSONDecodeError`). The
llm-reachability dataset load was the only crash handler using the narrow
`except (OSError, json.JSONDecodeError)`, so such an input escaped and aborted the
entire scan; the same narrow clause sat 20 lines below on the app-context payload read.

## How

Three commits, each with its own RED→GREEN test (kept separate: report-only vs
abort-semantics are distinct stories):

- `6adcf0c` — add `_record_skip(result, "app-context", "failed")` and
  `_record_skip(result, "llm-reachability", "failed")` in the two crash handlers,
  matching the enhance/verify/dynamic-test siblings (`core/scanner.py`). Two
  real-scanner tests drive the crash paths and assert the step lands in
  `result.skipped_steps` with reason `"failed"`.
- `11e5028` — broaden the llm-reachability dataset-*load* `except` to `except Exception`,
  so a `UnicodeDecodeError` (a `ValueError`, which `read_json`'s strict-UTF-8 open can
  raise) is recorded and the scan completes rather than aborting. Adds a
  `UnicodeDecodeError` test.
- `f32446e` — broaden the app-context payload read (`app_ctx_payload`, a defensive
  fallback) in the same stage to `except Exception`; adds a bad-encoding test, plus
  test-robustness (`raising=True`, a `context_source` pin, and `scan.report.json`
  artifact-surface assertions). No narrow-except **file read** remains in the
  llm-reachability stage.

## Tests

Four new tests in `tests/test_scanner.py`, each RED on the pre-fix state and GREEN
after (verified per-commit — each commit is independently necessary):

    python -m pytest libs/openant-core/tests/test_scanner.py -q   -> 11 passed
    python -m pytest libs/openant-core/tests/ -q                  -> 2919 passed, 30 skipped

`git diff origin/master...HEAD -- '**/test_scanner.py' | grep -cE '^\+def test_'` -> 4.
ruff: clean. Semgrep (p/python, 151 rules): 0 findings on `core/scanner.py`. CodeQL
(python-queries): 0 findings in `core/scanner.py`.

## Compatibility

None. `skipped_steps` is consumed only by the summary-report prompt and the reporter's
serialization; the Go CLI reads the flat scan-envelope `skipped_steps` list, which is
unchanged. No exit-code, disclosure, or per-finding verdict change.

Reviewer note: broadening the reachability dataset-load `except` moves the abort point
for a rare `MemoryError`/`RecursionError` there from immediate to degrade-and-continue.
This is safe because the mandatory analyze stage re-reads the same dataset path with no
`except`, so a persistent dataset failure still aborts loudly one stage later; the
broadening only stops the optional stage from being the abort point.

Known follow-ups, out of scope for this PR (each is a separate mechanism):
- **the llm-reachability LLM call (`analyze_reachability`) is not wrapped**, so a
  provider error (429/529/empty completion) there still aborts the whole scan with no
  artifacts — the higher-frequency failure. The right fix wraps the whole stage body in
  the same warn→`_record_skip`→continue pattern `enhance`/`verify` use; deferred to keep
  this PR scoped to the file-read + skip-recording change.
- report-step summary/disclosure failure leaves `status="success"` (`core/scanner.py`),
- dynamic-test/report skips are recorded after the pipeline_output snapshot so remain
  absent from the summary,
- the `or "web_app"` app-type fallback fabricates a type when context is absent,
- a parallel narrow-except JSON read in `core/reporter.py`.

## Author notes

- **Which lines implement the fix?** `core/scanner.py`: the two added
  `_record_skip(result, <step>, "failed")` calls in the app-context and
  llm-reachability crash handlers; the `except (OSError, json.JSONDecodeError)`
  → `except Exception` change on the reachability dataset load; and the same
  change on the `app_ctx_payload` read below it.
- **One input the old code handled wrong:** a `dataset.json` with an invalid
  UTF-8 byte. Old code raised `UnicodeDecodeError` out of the optional
  llm-reachability stage and aborted the entire scan; new code records the skip
  and completes. (Test: `test_llm_reachability_non_oserror_crash_is_recorded`.)
- **Most likely reviewer pushback:** "why broaden to `except Exception` — isn't
  that too wide?" Answer: each broadened `try` wraps a **single `read_json` call**,
  so the blast radius is exactly what one well-understood call raises;
  `BaseException` (KeyboardInterrupt/SystemExit) is still not caught; and a
  persistent dataset failure still aborts loudly at the mandatory analyze stage
  (which re-reads the same path unguarded) — the broadening only stops the
  *optional* file read from being the abort point. (It does not wrap the stage's
  LLM call — see the follow-up note above.)
