### PR TITLE
feat(agentic-enhancer): get_static_dependencies tool + DI-aware forward tracing

### DIFF
--- a/libs/openant-core/tests/test_enhancer_tools.py
+++ b/libs/openant-core/tests/test_enhancer_tools.py
@@ -1,0 +1,127 @@
+"""Tests for the agentic enhancer tools, specifically the get_static_dependencies tool."""
+import pytest
+
+from utilities.agentic_enhancer.repository_index import RepositoryIndex
+from utilities.agentic_enhancer.tools import ToolExecutor
+
+
+def _make_index(functions: dict) -> RepositoryIndex:
+    """Create a RepositoryIndex from a minimal functions dict."""
+    return RepositoryIndex({"functions": functions})
+
+
+SAMPLE_FUNCTIONS = {
+    "src/user.controller.ts:UserController.getUser": {
+        "name": "UserController.getUser",
+        "code": "async getUser(id) { return this.userService.findById(id); }",
+        "className": "UserController",
+        "unitType": "class_method",
+        "startLine": 10,
+        "endLine": 12,
+    },
+    "src/user.service.ts:UserService.findById": {
+        "name": "UserService.findById",
+        "code": "async findById(id) { return this.repo.findOne(id); }",
+        "className": "UserService",
+        "unitType": "class_method",
+        "startLine": 5,
+        "endLine": 7,
+    },
+    "src/auth.guard.ts:AuthGuard.canActivate": {
+        "name": "AuthGuard.canActivate",
+        "code": "canActivate(context) { return this.validate(context); }",
+        "className": "AuthGuard",
+        "unitType": "class_method",
+        "startLine": 3,
+        "endLine": 5,
+    },
+}
+
+
+class TestResolveDependencies:
+    """Test RepositoryIndex.resolve_dependencies."""
+
+    def test_resolves_by_function_id(self):
+        index = _make_index(SAMPLE_FUNCTIONS)
+        result = index.resolve_dependencies([
+            "src/user.service.ts:UserService.findById"
+        ])
+        assert len(result) == 1
+        assert result[0]["id"] == "src/user.service.ts:UserService.findById"
+        assert result[0]["className"] == "UserService"
+
+    def test_resolves_by_qualified_name(self):
+        """Resolve using Class.method format when full ID is unknown."""
+        index = _make_index(SAMPLE_FUNCTIONS)
+        result = index.resolve_dependencies(["AuthGuard.canActivate"])
+        assert len(result) == 1
+        assert "AuthGuard.canActivate" in result[0]["id"]
+
+    def test_returns_empty_for_unknown(self):
+        index = _make_index(SAMPLE_FUNCTIONS)
+        result = index.resolve_dependencies(["nonExistentFunction"])
+        assert result == []
+
+    def test_deduplicates_results(self):
+        index = _make_index(SAMPLE_FUNCTIONS)
+        result = index.resolve_dependencies([
+            "src/user.service.ts:UserService.findById",
+            "src/user.service.ts:UserService.findById",
+        ])
+        assert len(result) == 1
+
+
+class TestGetStaticDependenciesTool:
+    """Test the get_static_dependencies tool via ToolExecutor."""
+
+    def test_returns_resolved_deps(self):
+        index = _make_index(SAMPLE_FUNCTIONS)
+        executor = ToolExecutor(index)
+        executor.set_unit_context(
+            static_deps=["src/user.service.ts:UserService.findById"],
+            static_callers=[],
+        )
+
+        result = executor.execute("get_static_dependencies", {})
+        assert result["dependencies"]["count"] == 1
+        assert len(result["dependencies"]["resolved"]) == 1
+        assert result["dependencies"]["resolved"][0]["className"] == "UserService"
+        assert result["callers"]["count"] == 0
+
+    def test_returns_resolved_callers(self):
+        index = _make_index(SAMPLE_FUNCTIONS)
+        executor = ToolExecutor(index)
+        executor.set_unit_context(
+            static_deps=[],
+            static_callers=["src/user.controller.ts:UserController.getUser"],
+        )
+
+        result = executor.execute("get_static_dependencies", {})
+        assert result["callers"]["count"] == 1
+        assert result["callers"]["resolved"][0]["className"] == "UserController"
+
+    def test_empty_context(self):
+        index = _make_index(SAMPLE_FUNCTIONS)
+        executor = ToolExecutor(index)
+        executor.set_unit_context([], [])
+
+        result = executor.execute("get_static_dependencies", {})
+        assert result["dependencies"]["count"] == 0
+        assert result["callers"]["count"] == 0
+
+    def test_context_resets_between_units(self):
+        index = _make_index(SAMPLE_FUNCTIONS)
+        executor = ToolExecutor(index)
+
+        # First unit
+        executor.set_unit_context(
+            static_deps=["src/user.service.ts:UserService.findById"],
+            static_callers=[],
+        )
+        result1 = executor.execute("get_static_dependencies", {})
+        assert result1["dependencies"]["count"] == 1
+
+        # Second unit - different context
+        executor.set_unit_context(static_deps=[], static_callers=[])
+        result2 = executor.execute("get_static_dependencies", {})
+        assert result2["dependencies"]["count"] == 0

--- a/libs/openant-core/utilities/agentic_enhancer/agent.py
+++ b/libs/openant-core/utilities/agentic_enhancer/agent.py
@@ -216,6 +216,9 @@ class ContextAgent:
                 entry_point_path = self.reachability.get_entry_point_path(unit_id)
                 reaching_entry_point = self.reachability.get_reaching_entry_point(unit_id)
 
+        # Set static deps on tool executor for get_static_dependencies tool
+        self.tool_executor.set_unit_context(static_deps, static_callers)
+
         # Build initial prompt with reachability info
         user_prompt = get_user_prompt(
             unit_id=unit_id,

--- a/libs/openant-core/utilities/agentic_enhancer/prompts.py
+++ b/libs/openant-core/utilities/agentic_enhancer/prompts.py
@@ -76,15 +76,15 @@ Code that HANDLES dangerous patterns is often a SECURITY CONTROL:
    - Look for validation/sanitization in called code
    - A function may delegate security to its callees (e.g., service-layer auth)
    - For `this.someService.method()` patterns, search for the method name definition
+   - A control found in a callee reduces severity ONLY if it PROVABLY guards the
+     tainted path; when unsure, keep EXPLOITABLE — never hide a reachable sink (over-seed)
 
 5. **Apply Classification Logic**
    ```
    Has dangerous sink?
    ├─ No  → NEUTRAL or SECURITY_CONTROL
    └─ Yes → Is reachable from entry point?
-            ├─ Yes → Are there security controls in called functions?
-            │        ├─ Yes → May be SECURITY_CONTROL or lower severity
-            │        └─ No  → EXPLOITABLE
+            ├─ Yes → EXPLOITABLE
             └─ No  → VULNERABLE_INTERNAL
    ```
 
@@ -199,11 +199,12 @@ def get_user_prompt(
    - If this is an entry point or reachable from one: vulnerabilities are EXPLOITABLE
    - If not reachable: vulnerabilities are VULNERABLE_INTERNAL
 
-4. **Trace forward**: Check called functions for authorization, validation, or security controls.
-   A function may delegate security to its service layer.
+4. **Trace forward**: Check called functions for authorization, validation, or security controls
+   for context. A callee control reduces severity ONLY if it provably guards the tainted path;
+   when unsure, keep EXPLOITABLE — never hide a reachable sink (over-seed).
 
 5. **Classify the code**:
-   - **EXPLOITABLE**: Dangerous ops + user input can reach them + no security controls in callees
+   - **EXPLOITABLE**: Dangerous ops + user input can reach them
    - **VULNERABLE_INTERNAL**: Dangerous ops but no user input path
    - **SECURITY_CONTROL**: Defensive code (validators, sanitizers)
    - **NEUTRAL**: No security relevance

--- a/libs/openant-core/utilities/agentic_enhancer/prompts.py
+++ b/libs/openant-core/utilities/agentic_enhancer/prompts.py
@@ -55,25 +55,40 @@ Code that HANDLES dangerous patterns is often a SECURITY CONTROL:
 
 ## Your Analysis Process
 
-1. **Identify Dangerous Operations**
+1. **Get Static Dependencies First**
+   Call `get_static_dependencies` to see what functions this code calls and what calls it.
+   Then use `read_function` to examine key dependencies — especially service methods
+   that may contain authorization, validation, or sanitization.
+
+2. **Identify Dangerous Operations**
    Look for: eval, exec, SQL queries, file I/O, deserialization, command execution, innerHTML
 
-2. **Trace User Input Reachability**
+3. **Trace User Input Reachability (Backward)**
    If dangerous operations exist, trace BACKWARDS:
    - Who calls this function?
    - Who calls those callers?
    - Does the chain lead to an entry point (route handler, CLI parser, stdin)?
 
-3. **Apply Classification Logic**
+4. **Trace Forward Into Called Functions**
+   Check what the function CALLS — especially service/repository methods:
+   - Use `search_definitions` to find implementations of called methods
+   - Look for authorization checks (auth, permission, guard, can, allow, authorize)
+   - Look for validation/sanitization in called code
+   - A function may delegate security to its callees (e.g., service-layer auth)
+   - For `this.someService.method()` patterns, search for the method name definition
+
+5. **Apply Classification Logic**
    ```
    Has dangerous sink?
    ├─ No  → NEUTRAL or SECURITY_CONTROL
    └─ Yes → Is reachable from entry point?
-            ├─ Yes → EXPLOITABLE
+            ├─ Yes → Are there security controls in called functions?
+            │        ├─ Yes → May be SECURITY_CONTROL or lower severity
+            │        └─ No  → EXPLOITABLE
             └─ No  → VULNERABLE_INTERNAL
    ```
 
-4. **Complete with finish tool**
+6. **Complete with finish tool**
    Provide classification, reasoning, and confidence level.
 
 ## Entry Point Examples
@@ -175,19 +190,25 @@ def get_user_prompt(
 
 ## Your Task
 
-1. **Analyze for dangerous operations**: eval, exec, SQL, file I/O, deserialization, etc.
+1. **Start with `get_static_dependencies`** to see resolved callees and callers.
+   Then use `read_function` to examine called service/repository methods.
 
-2. **Consider reachability**: Can user input reach any dangerous operations?
+2. **Analyze for dangerous operations**: eval, exec, SQL, file I/O, deserialization, etc.
+
+3. **Consider reachability**: Can user input reach any dangerous operations?
    - If this is an entry point or reachable from one: vulnerabilities are EXPLOITABLE
    - If not reachable: vulnerabilities are VULNERABLE_INTERNAL
 
-3. **Classify the code**:
-   - **EXPLOITABLE**: Dangerous ops + user input can reach them
+4. **Trace forward**: Check called functions for authorization, validation, or security controls.
+   A function may delegate security to its service layer.
+
+5. **Classify the code**:
+   - **EXPLOITABLE**: Dangerous ops + user input can reach them + no security controls in callees
    - **VULNERABLE_INTERNAL**: Dangerous ops but no user input path
    - **SECURITY_CONTROL**: Defensive code (validators, sanitizers)
    - **NEUTRAL**: No security relevance
 
-4. Call the `finish` tool with your classification and reasoning.
+6. Call the `finish` tool with your classification and reasoning.
 
 Begin your analysis."""
 

--- a/libs/openant-core/utilities/agentic_enhancer/repository_index.py
+++ b/libs/openant-core/utilities/agentic_enhancer/repository_index.py
@@ -14,10 +14,11 @@ Functions:
     load_index_from_file: Load index from analyzer_output.json file
 """
 
-import json
 import re
 from pathlib import Path
 from typing import Optional
+
+from utilities.file_io import read_json
 
 
 class RepositoryIndex:
@@ -338,7 +339,6 @@ def load_index_from_file(analyzer_output_path: str, repo_path: str = None) -> Re
     Returns:
         RepositoryIndex instance
     """
-    with open(analyzer_output_path, 'r') as f:
-        analyzer_output = json.load(f)
+    analyzer_output = read_json(analyzer_output_path)
 
     return RepositoryIndex(analyzer_output, repo_path)

--- a/libs/openant-core/utilities/agentic_enhancer/repository_index.py
+++ b/libs/openant-core/utilities/agentic_enhancer/repository_index.py
@@ -14,11 +14,10 @@ Functions:
     load_index_from_file: Load index from analyzer_output.json file
 """
 
+import json
 import re
 from pathlib import Path
 from typing import Optional
-
-from utilities.file_io import read_json
 
 
 class RepositoryIndex:
@@ -254,6 +253,54 @@ class RepositoryIndex:
         except Exception:
             return None
 
+    def resolve_dependencies(self, dep_names: list[str]) -> list[dict]:
+        """
+        Resolve dependency names from static analysis to function entries.
+
+        Handles both full function IDs (file:Class.method) and simple names.
+
+        Args:
+            dep_names: List of function IDs or names from static analysis
+
+        Returns:
+            List of {name, id, file, className} for each resolved dependency
+        """
+        results = []
+        seen_ids = set()
+
+        for name in dep_names:
+            # First try as a direct function ID
+            func = self.functions.get(name)
+            if func and name not in seen_ids:
+                seen_ids.add(name)
+                results.append({
+                    "name": name,
+                    "id": name,
+                    "file": name.rsplit(":", 1)[0] if ":" in name else "",
+                    "className": func.get("className")
+                })
+                continue
+
+            # Try exact name match
+            matches = self.search_by_name(name, exact=True)
+            if not matches:
+                # Try just the method part (e.g., "Class.method" -> "method")
+                parts = name.rsplit(".", 1)
+                if len(parts) == 2:
+                    matches = self.search_by_name(parts[1], exact=True)
+
+            for m in matches:
+                if m["id"] not in seen_ids:
+                    seen_ids.add(m["id"])
+                    results.append({
+                        "name": name,
+                        "id": m["id"],
+                        "file": m["id"].rsplit(":", 1)[0] if ":" in m["id"] else "",
+                        "className": m.get("className")
+                    })
+
+        return results
+
     def get_all_function_ids(self) -> list[str]:
         """
         Get list of all function IDs.
@@ -291,6 +338,7 @@ def load_index_from_file(analyzer_output_path: str, repo_path: str = None) -> Re
     Returns:
         RepositoryIndex instance
     """
-    analyzer_output = read_json(analyzer_output_path)
+    with open(analyzer_output_path, 'r') as f:
+        analyzer_output = json.load(f)
 
     return RepositoryIndex(analyzer_output, repo_path)

--- a/libs/openant-core/utilities/agentic_enhancer/tools.py
+++ b/libs/openant-core/utilities/agentic_enhancer/tools.py
@@ -103,6 +103,15 @@ TOOL_DEFINITIONS = [
         }
     },
     {
+        "name": "get_static_dependencies",
+        "description": "Get the statically-analyzed dependencies (functions called) and callers for the unit being analyzed. Returns resolved function IDs that can be read with read_function. Use this first to understand what the code calls and to trace into service methods for auth/validation checks.",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": []
+        }
+    },
+    {
         "name": "finish",
         "description": "Complete the analysis and return the final result. Call this when you have gathered enough context to understand the code's intent and security implications.",
         "input_schema": {
@@ -165,6 +174,13 @@ class ToolExecutor:
             index: RepositoryIndex instance for searching
         """
         self.index = index
+        self._unit_static_deps: list[str] = []
+        self._unit_static_callers: list[str] = []
+
+    def set_unit_context(self, static_deps: list[str], static_callers: list[str]):
+        """Set static dependency data for the current unit being analyzed."""
+        self._unit_static_deps = static_deps or []
+        self._unit_static_callers = static_callers or []
 
     def execute(self, tool_name: str, tool_input: dict) -> dict:
         """
@@ -188,6 +204,8 @@ class ToolExecutor:
                 return self._list_functions(tool_input)
             elif tool_name == "read_file_section":
                 return self._read_file_section(tool_input)
+            elif tool_name == "get_static_dependencies":
+                return self._get_static_dependencies(tool_input)
             elif tool_name == "finish":
                 return self._finish(tool_input)
             else:
@@ -313,6 +331,24 @@ class ToolExecutor:
             "start_line": start_line,
             "end_line": end_line,
             "content": content
+        }
+
+    def _get_static_dependencies(self, input: dict) -> dict:
+        """Get resolved static dependencies and callers for the current unit."""
+        resolved_deps = self.index.resolve_dependencies(self._unit_static_deps)
+        resolved_callers = self.index.resolve_dependencies(self._unit_static_callers)
+
+        return {
+            "dependencies": {
+                "raw": self._unit_static_deps[:20],
+                "resolved": resolved_deps[:20],
+                "count": len(self._unit_static_deps)
+            },
+            "callers": {
+                "raw": self._unit_static_callers[:20],
+                "resolved": resolved_callers[:20],
+                "count": len(self._unit_static_callers)
+            }
         }
 
     def _finish(self, input: dict) -> dict:


### PR DESCRIPTION
## `get_static_dependencies` tool + DI-aware forward tracing — fork-minimal replacement for #60

Full credit to **@joshbouncesecurity**: this carries their `get_static_dependencies` tool and DI-aware forward-tracing capability from #60 verbatim (their original commit is preserved with authorship intact), rebased onto current `master`. DI frameworks (`this.someService.method()`) are a real call-graph blind spot for a reachability tool, and resolving them to concrete function IDs is a genuinely valuable addition. Thank you.

### What this fork changes vs #60
#60 bundled the capability with two changes this drops, because both trade a false-positive for a false-negative — the one thing a reachability-SAST tool must never do:

1. **Dropped the `EXPLOITABLE → SECURITY_CONTROL` downgrade.** The classification prompt routed a *reachable* dangerous sink to "May be SECURITY_CONTROL or lower severity" whenever a callee "has security controls." A control in a callee does not prove the tainted path is guarded (it may be reachable-around, off-path, or — via the resolver's bare-name fallback — a *different* class's same-named method), so this could hide a real EXPLOITABLE finding. Reverted the classification to EXPLOITABLE-when-reachable. The forward-tracing guidance is **kept as context**, with an explicit over-seed guard: a callee control lowers severity only if it *provably* guards the tainted path; when unsure, keep EXPLOITABLE.

2. **Restored `read_json`.** #60 swapped `read_json` for a bare `open()` + `json.load` in `repository_index.py`, dropping the UTF-8 forcing (`read_json` uses `open_utf8`). Under a non-UTF-8 default locale this raises `UnicodeDecodeError` on any non-ASCII identifier/path in `analyzer_output.json`. Restored `read_json`.

### Evidence
- **Downgrade removed:** grep for the downgrade wording across the enhancer dir → 0 occurrences.
- **read_json regression:** reproduced under an ASCII default locale (bare `open()` → `UnicodeDecodeError` on `validación`/`café.py`; `read_json` reads it correctly).
- **Capability intact:** `tests/test_enhancer_tools.py` → 8 passed (end-to-end exercise of `get_static_dependencies` + the resolver).
- **Merge-tree:** clean against current `master`, no conflicts.

Fork-minimal replacement for #60 — recommend landing this and closing #60. A human should click merge; never on red CI.
