### PR TITLE
fix(scanner): persist per-language reachability_filter after LLM re-filter

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -548,6 +548,13 @@ def scan_repository(
                         )
                         kept: list[dict] = []
                         unfilterable: dict[str, int] = {}
+                        # Per-language reachability_filter stats, aggregated back
+                        # onto the rebuilt dataset below. Without this the rebuild
+                        # at `dataset = {**dataset, "units": kept}` carried the
+                        # ORIGINAL (pre-LLM) metadata, so the reporter rendered
+                        # "reachability filtering not applied" on a scan that DID
+                        # prune via the LLM-seeded re-filter.
+                        refilter_by_language: dict[str, dict] = {}
 
                         for lang, lang_units in partitions.items():
                             lang_dir = cg_dirs.get(lang)
@@ -583,8 +590,83 @@ def scan_repository(
                                 library_mode=library_mode,
                             )
                             kept.extend(filtered.get("units", []))
+                            _rf = (filtered.get("metadata") or {}).get(
+                                "reachability_filter"
+                            )
+                            if _rf:
+                                refilter_by_language[lang or "unknown"] = _rf
 
-                        dataset = {**dataset, "units": kept}
+                        # Rebuild the dataset, aggregating the per-language filter
+                        # stats into metadata so the reporter reads a real record
+                        # instead of the stale pre-LLM one. Unfilterable languages
+                        # (no call graph) are folded in as pass-throughs so the
+                        # aggregate reconciles with len(kept).
+                        _new_md = dict(dataset.get("metadata") or {})
+                        # Only stamp a record when a real per-language filter ran.
+                        # If every language was unfilterable (no call graph), the
+                        # units passed through untouched, so leaving no record —
+                        # the honest "not applied" signal — is correct; a "0%
+                        # reduction" record would falsely claim filtering happened.
+                        if refilter_by_language:
+                            _per_lang = dict(refilter_by_language)
+                            _unfiltered = 0
+                            for _lang, _cnt in unfilterable.items():
+                                _unfiltered += _cnt
+                                _per_lang[_lang] = {
+                                    "original_units": _cnt,
+                                    "entry_points": 0,
+                                    "reachable_units": _cnt,
+                                    "filtered_out": 0,
+                                    "reduction_percentage": 0,
+                                    "unfilterable": True,
+                                }
+                            _orig = sum(
+                                r.get("original_units", 0) for r in _per_lang.values()
+                            )
+                            _reach = sum(
+                                r.get("reachable_units", 0) for r in _per_lang.values()
+                            )
+                            _agg = {
+                                "original_units": _orig,
+                                "entry_points": sum(
+                                    r.get("entry_points", 0) for r in _per_lang.values()
+                                ),
+                                "reachable_units": _reach,
+                                "filtered_out": _orig - _reach,
+                                # Units that flowed through unfiltered (no call
+                                # graph for their language) — folded into the
+                                # totals above but surfaced explicitly so the
+                                # record never silently claims they were filtered.
+                                "unfiltered_units": _unfiltered,
+                                "reduction_percentage": (
+                                    round((1 - _reach / _orig) * 100, 1)
+                                    if _orig
+                                    else 0
+                                ),
+                                "per_language": _per_lang,
+                            }
+                            # Lift any per-language advisory (e.g. an empty-seed
+                            # blackout — a language that flowed through unfiltered
+                            # because it had no real entry points) to the top
+                            # level, where the reporter reads it (reporter.py:505).
+                            # Without this the record reads "filter applied, N%
+                            # reduction" while hiding that a language blacked out —
+                            # the exact fidelity gap this record exists to close.
+                            _warnings = [
+                                f"{_lang}: {_r['warning']}"
+                                for _lang, _r in _per_lang.items()
+                                if _r.get("warning")
+                            ]
+                            if _warnings:
+                                _agg["warning"] = "; ".join(_warnings)
+                            _new_md["reachability_filter"] = _agg
+                        else:
+                            # No real filter ran (every language unfilterable):
+                            # honour the "not applied" contract by clearing any
+                            # record inherited from an upstream merge, so a stale
+                            # record can never misdescribe the passed-through units.
+                            _new_md.pop("reachability_filter", None)
+                        dataset = {**dataset, "units": kept, "metadata": _new_md}
                         post_filter_count = len(kept)
                         result.units_count = post_filter_count
                         refilter_supported = True

--- a/libs/openant-core/tests/test_scanner_refilter_metadata.py
+++ b/libs/openant-core/tests/test_scanner_refilter_metadata.py
@@ -1,0 +1,127 @@
+"""The post-LLM re-filter must persist its per-language stats onto the dataset.
+
+BUG-2: the loop rebuilds ``dataset = {**dataset, "units": kept}`` from the
+ORIGINAL (pre-LLM) metadata, discarding the ``reachability_filter`` record each
+``apply_reachability_filter`` call stamped. The reporter then reads no record
+and renders "reachability filtering not applied" on a scan that DID prune via
+the LLM-seeded re-filter — a machine-readable artifact stating the opposite of
+what happened.
+
+This drives the real loop end-to-end (fully offline, LLM stubbed) and asserts
+the persisted metadata carries a real, per-language, reconciling record.
+
+Reuses the offline multi-language harness from
+``test_scanner_refilter_loop_executes`` so both files exercise ONE loop.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+import core.scanner as scanner_mod
+
+# Reuse the exact offline fixtures that already drive the loop body (repo,
+# fake_parsers, stub_llm_reachability, _offline). Loading the module as a
+# fixture plugin makes them available without a by-name import (which would
+# shadow the fixture parameters and trip ruff F811).
+pytest_plugins = ("test_scanner_refilter_loop_executes",)
+
+
+@pytest.fixture(autouse=True)
+def _stub_analyze(monkeypatch):
+    """Keep this test $0. The offline harness stubs ``analyze_reachability`` but
+    NOT the Stage-1 analyze LLM: ``scan_repository`` calls
+    ``core.analyzer.run_analysis`` unconditionally against the live key, so an
+    un-stubbed run bills real API on every CI invocation. The refilter record
+    this test asserts on is produced BEFORE analyze, so a no-op stub is faithful.
+    """
+    import core.analyzer as analyzer_mod
+    from core.schemas import AnalyzeResult
+
+    def _fake(*a, **k):
+        out = k["output_dir"]
+        rp = os.path.join(out, "results.json")
+        with open(rp, "w") as fh:
+            json.dump({"results": [], "code_by_route": {}, "metrics": {}}, fh)
+        return AnalyzeResult(results_path=rp)
+
+    monkeypatch.setattr(analyzer_mod, "run_analysis", _fake)
+
+
+def _run(repo, out):
+    return scanner_mod.scan_repository(
+        repo_path=str(repo), output_dir=str(out),
+        languages=["python", "javascript"],
+        processing_level="reachable",
+        llm_reachability=True,
+        generate_context=False, generate_report=False,
+        enhance=False, verify=False,
+    )
+
+
+class TestRefilterMetadataPersisted:
+    def test_reachability_filter_record_is_stamped(self, repo, tmp_path,
+                                                   fake_parsers,
+                                                   stub_llm_reachability):
+        """RED on base: line 587 rebuilds from stale metadata -> no record."""
+        out = tmp_path / "out"
+        result = _run(repo, out)
+        dataset = json.loads(Path(result.dataset_path).read_text())
+        rf = (dataset.get("metadata") or {}).get("reachability_filter")
+        assert rf is not None, (
+            "the post-LLM re-filter pruned units but stamped NO "
+            "reachability_filter record — reporter will say 'not applied'"
+        )
+
+    def test_record_is_per_language(self, repo, tmp_path, fake_parsers,
+                                    stub_llm_reachability):
+        """A merged multi-language scan must not collapse to one language's stats."""
+        out = tmp_path / "out"
+        result = _run(repo, out)
+        dataset = json.loads(Path(result.dataset_path).read_text())
+        rf = (dataset.get("metadata") or {}).get("reachability_filter") or {}
+        per_lang = rf.get("per_language") or {}
+        assert set(per_lang) >= {"python", "javascript"}, (
+            f"per_language should cover both languages, got {set(per_lang)} "
+            "(overfit to the first-parsed language?)"
+        )
+
+    def test_aggregate_reconciles_with_kept_units(self, repo, tmp_path,
+                                                  fake_parsers,
+                                                  stub_llm_reachability):
+        """The stamped reachable_units MUST equal the units that survived."""
+        out = tmp_path / "out"
+        result = _run(repo, out)
+        dataset = json.loads(Path(result.dataset_path).read_text())
+        rf = (dataset.get("metadata") or {}).get("reachability_filter") or {}
+        assert rf.get("reachable_units") == len(dataset["units"]), (
+            "the aggregate reachable_units does not match the surviving unit "
+            "count — a fabricated/miscomputed record is worse than none"
+        )
+
+    def test_blackout_warning_is_lifted_to_top_level(self, repo, tmp_path,
+                                                     fake_parsers,
+                                                     stub_llm_reachability):
+        """A language that blacks out (no entry points -> flows through
+        unfiltered) stamps a per-language ``warning``. The aggregate MUST lift it
+        to the top-level ``warning`` the reporter reads (reporter.py:505), or the
+        report claims 'filter applied, N% reduction' while hiding the blackout.
+        The harness's javascript has NO entry point, so it blacks out.
+        """
+        out = tmp_path / "out"
+        result = _run(repo, out)
+        dataset = json.loads(Path(result.dataset_path).read_text())
+        rf = (dataset.get("metadata") or {}).get("reachability_filter") or {}
+        per_lang = rf.get("per_language") or {}
+        # Precondition: javascript did produce a per-language warning.
+        assert (per_lang.get("javascript") or {}).get("warning"), (
+            "expected the javascript blackout to stamp a per-language warning"
+        )
+        # The fix under test: it must be surfaced at the top level.
+        assert isinstance(rf.get("warning"), str) and rf["warning"], (
+            "per-language blackout warning was not lifted to the top-level "
+            "'warning' the reporter reads — the record hides the blackout"
+        )
+        assert "javascript" in rf["warning"]


### PR DESCRIPTION
## What

The post-LLM per-language reachability re-filter discarded the `reachability_filter` metadata it computed. In `scan_repository`'s re-filter loop, the dataset was rebuilt as `dataset = {**dataset, "units": kept}` — keeping the units but dropping the record each `apply_reachability_filter()` had stamped. The reporter (`build_pipeline_output`) then found no record and rendered "reachability filtering not applied" (and `reachable_units = total_units`) on a scan that **did** prune via the LLM-seeded re-filter. The machine-readable artifact asserted the opposite of what happened.

## Fix

Aggregate the per-language records into `metadata.reachability_filter`:
- a `per_language` breakdown (each language's original/reachable/filtered counts);
- languages with no call graph folded in as `unfiltered_units` (surfaced explicitly, never silently counted as "filtered");
- the record is stamped **only when a real per-language filter ran**; on the no-real-filter path any record inherited from an upstream merge is cleared so it cannot misdescribe the passed-through units;
- any per-language blackout advisory (a language with no entry points that flowed through unfiltered) is lifted to the top-level `warning` the reporter reads, so a blackout is not hidden behind a "filter applied, N% reduction" record.

This is report-fidelity only — a correctness fix for a machine-readable field. It changes **no** reachability computation: units, seeds, edges, and the call graphs are byte-identical before/after (the change is metadata-only; `"units": kept` is unchanged).

Net effect: on the `--llm-reachability` path the previous code dropped the whole `reachability_filter` record at the rebuild, so the reporter fell back to "no record found" and PR #251's real `reachable_units` / reduction reporting silently reverted in exactly the mode that prunes most. This restores it — and additionally surfaces per-language blackout advisories (a language with no entry points, whose units flow through unfiltered) that were previously discarded along with the record.

## Tests

`tests/test_scanner_refilter_metadata.py` (new) drives the real re-filter loop fully offline:
- the record is stamped with a per-language breakdown that reconciles (`reachable_units == len(units)`);
- a language that blacks out has its warning lifted to the top level;
- RED on the pre-fix base (no record stamped) → GREEN on the fix.

The test stubs the Stage-1 analyze call so it runs at no cost. (Note: the shared offline harness `test_scanner_refilter_loop_executes.py` does **not** stub that call, so it makes real API calls in CI — a pre-existing issue, out of scope for this PR, worth a separate follow-up.)

## Known residuals (not addressed here)

- **Plain multi-language parse+merge** still emits a first-language-only `reachability_filter` because `dataset_merge.merge_datasets` uses first-writer-wins for `metadata`. This PR fixes the record only on the `--llm-reachability` re-filter path; the merge path is a separate follow-up.
- The aggregate `reduction_percentage` is diluted by folded-in pass-through languages; the blackout itself is disclosed via the lifted `warning`.
- The record and its warning surface in the report artifact (`pipeline_output.json` → `pipeline_stats.reachability_warnings`, rendered in the summary), **not** the CLI stdout exit envelope (`ScanResult` / Go `ScanData` carry no reachability field, unlike `threat_model_warnings`). An envelope-only CI consumer still won't see a blackout — a separate, pre-existing gap.
