### PR TITLE
fix(core): correct resume ETA, per-phase usage, and step-counter telemetry

### DIFF
--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -462,6 +462,9 @@ def run_analysis(
     Returns:
         AnalyzeResult with results path, metrics, and usage.
     """
+    # #214: snapshot cumulative usage at phase start so the "Stage 1" summary
+    # below reports this phase's delta, not the prior phases' total.
+    _phase_baseline = tracking.get_usage()
     os.makedirs(output_dir, exist_ok=True)
 
     # Configure global rate limiter
@@ -670,7 +673,7 @@ def run_analysis(
                              _summary_error_breakdown, phase="done",
                              usage=_usage_dict())
 
-    tracking.log_usage("Stage 1")
+    tracking.log_usage("Stage 1", _phase_baseline)
 
     # Compute verdict counts from results
     counts = _count_verdicts(results)

--- a/libs/openant-core/core/dynamic_tester.py
+++ b/libs/openant-core/core/dynamic_tester.py
@@ -43,6 +43,9 @@ def run_tests(
         RuntimeError: If Docker is not available.
         FileNotFoundError: If pipeline_output_path doesn't exist.
     """
+    # #214: snapshot cumulative usage at phase start so the "Dynamic Test"
+    # summary below reports this phase's delta, not the prior phases' total.
+    _phase_baseline = tracking.get_usage()
     # Check Docker availability
     if not shutil.which("docker"):
         raise RuntimeError(
@@ -124,7 +127,7 @@ def run_tests(
     if not os.path.exists(results_md_path):
         results_md_path = None
 
-    tracking.log_usage("Dynamic Test")
+    tracking.log_usage("Dynamic Test", _phase_baseline)
 
     print(f"\n[Dynamic Test] Results: {confirmed} confirmed, "
           f"{not_reproduced} not reproduced, {blocked} blocked, "

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -115,7 +115,10 @@ def enhance_dataset(
         )
 
     def _on_restored(count: int):
-        progress.completed = count
+        # #218: rebase BOTH the counter and the session baseline, else the
+        # restored units dilute the per-unit rate (Enhance/Verify learn the
+        # restored count here, not via the `completed=` constructor arg).
+        progress.mark_restored(count)
 
     # Run enhancement
     if mode == "agentic":

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -140,6 +140,7 @@ def enhance_dataset(
             progress_callback=_on_unit_done,
             workers=workers,
             checkpoint_path=checkpoint_path,
+            restored_callback=_on_restored,
         )
     else:
         raise ValueError(f"Unknown enhancement mode: {mode}. Use 'agentic' or 'single-shot'.")

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -61,6 +61,9 @@ def enhance_dataset(
     Returns:
         EnhanceResult with output path, stats, and usage.
     """
+    # #214: snapshot cumulative usage at phase start so the "Enhance" summary
+    # below reports this phase's delta, not the prior phases' total.
+    _phase_baseline = tracking.get_usage()
     # Configure global rate limiter
     configure_rate_limiter(backoff_seconds=float(backoff_seconds))
 
@@ -171,7 +174,7 @@ def enhance_dataset(
     if error_count:
         print(f"[Enhance] Errors: {error_count} ({error_summary})", file=sys.stderr)
 
-    tracking.log_usage("Enhance")
+    tracking.log_usage("Enhance", _phase_baseline)
 
     usage = tracking.get_usage()
 

--- a/libs/openant-core/core/progress.py
+++ b/libs/openant-core/core/progress.py
@@ -60,6 +60,9 @@ class ProgressReporter:
         self.tracker = tracker
         self.start_time = time.monotonic()
         self.completed = completed
+        # Units restored from a checkpoint: they consumed no session time, so
+        # they must be excluded from the per-unit rate (#218).
+        self._initial_completed = completed
         self._lock = threading.Lock()
         self._last_cost = self._get_cost()  # snapshot for per-unit delta
 
@@ -81,10 +84,17 @@ class ProgressReporter:
         return totals.get("total_cost_usd", 0.0)
 
     def _estimate_remaining(self, elapsed: float) -> str:
-        """Estimate time remaining based on average per-unit time."""
-        if self.completed == 0:
+        """Estimate time remaining based on average per-unit time.
+
+        The rate is measured over units processed IN THIS SESSION only. Units
+        restored from a checkpoint (``_initial_completed``) consumed none of
+        ``elapsed``, so dividing session-elapsed by the cumulative count made a
+        resumed run's ETA wildly optimistic (~25x on the reported run, #218).
+        """
+        session_done = self.completed - self._initial_completed
+        if session_done <= 0:
             return "~?"
-        avg = elapsed / self.completed
+        avg = elapsed / session_done
         # Floor at 0: retries can double-count `completed` past `total`, which would otherwise
         # make remaining_units negative and render the ETA as a negative duration.
         remaining_units = max(0, self.total - self.completed)

--- a/libs/openant-core/core/progress.py
+++ b/libs/openant-core/core/progress.py
@@ -83,6 +83,28 @@ class ProgressReporter:
         totals = self.tracker.get_totals()
         return totals.get("total_cost_usd", 0.0)
 
+    def mark_restored(self, count: int) -> None:
+        """Rebase progress to a checkpoint-restored count AFTER construction.
+
+        The Detect phase passes ``completed=`` at construction, but Enhance and
+        Verify learn their restored count later via a callback. Set BOTH the
+        live counter and the session baseline, so restored units are excluded
+        from the per-unit rate exactly as ``completed=`` does — the callback
+        path previously set only ``completed`` and left the rate diluted (#218).
+        """
+        with self._lock:
+            self.completed = count
+            self._initial_completed = count
+
+    def _session_done(self) -> int:
+        """Units processed in THIS session (excludes checkpoint-restored units).
+
+        Every rate/average divides session ``elapsed`` by this, never the
+        cumulative ``completed`` — the restored units consumed no session time,
+        so cumulative division dilutes the per-unit rate on a resumed run (#218).
+        """
+        return self.completed - self._initial_completed
+
     def _estimate_remaining(self, elapsed: float) -> str:
         """Estimate time remaining based on average per-unit time.
 
@@ -91,7 +113,7 @@ class ProgressReporter:
         ``elapsed``, so dividing session-elapsed by the cumulative count made a
         resumed run's ETA wildly optimistic (~25x on the reported run, #218).
         """
-        session_done = self.completed - self._initial_completed
+        session_done = self._session_done()
         if session_done <= 0:
             return "~?"
         avg = elapsed / session_done
@@ -155,7 +177,8 @@ class ProgressReporter:
     def _print_summary(self, elapsed: float, cost: float) -> None:
         """Print a highlighted summary line."""
         pct = (self.completed / self.total) * 100
-        avg = elapsed / self.completed if self.completed else 0
+        session_done = self._session_done()
+        avg = elapsed / session_done if session_done > 0 else 0
         eta = self._estimate_remaining(elapsed)
 
         line = (
@@ -174,7 +197,8 @@ class ProgressReporter:
         with self._lock:
             elapsed = time.monotonic() - self.start_time
             cost = self._get_cost()
-            avg = elapsed / self.completed if self.completed else 0
+            session_done = self._session_done()
+            avg = elapsed / session_done if session_done > 0 else 0
 
             line = (
                 f"[{self.step_name}] Done: "

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -213,6 +213,12 @@ def scan_repository(
 
     def _step_label(name: str) -> str:
         nonlocal step_num
+        # #219: a "Skipping ..." notice is not a performed step; the denominator
+        # (_count_steps) counts only steps that RUN, so numbering skips too
+        # pushed the numerator past the total (e.g. the report step printed as
+        # [8/7]). Render skips without a step number.
+        if name.startswith("Skipping"):
+            return f"  - {name}"
         step_num += 1
         return f"[{step_num}/{total_steps}] {name}"
 

--- a/libs/openant-core/core/tracking.py
+++ b/libs/openant-core/core/tracking.py
@@ -29,13 +29,27 @@ def get_usage() -> UsageInfo:
     )
 
 
-def log_usage(prefix: str = ""):
-    """Log current usage summary to stderr."""
+def log_usage(prefix: str = "", baseline: "UsageInfo | None" = None):
+    """Log a usage summary to stderr.
+
+    With ``baseline`` (a ``get_usage()`` snapshot taken at the phase's start),
+    the line reports THIS PHASE's delta instead of the cumulative run totals.
+    The per-phase callers ("Stage 1"/"Stage 2"/"Enhance") log the global
+    cumulative tracker, so a "Stage 2:" line summed every prior phase and
+    overstated the phase's own calls/tokens/cost (#214). Without a baseline the
+    behaviour is unchanged (cumulative).
+    """
     usage = get_usage()
+    if baseline is not None:
+        calls = usage.total_calls - baseline.total_calls
+        tokens = usage.total_tokens - baseline.total_tokens
+        cost = usage.total_cost_usd - baseline.total_cost_usd
+    else:
+        calls, tokens, cost = (
+            usage.total_calls, usage.total_tokens, usage.total_cost_usd,
+        )
     label = f"{prefix}: " if prefix else ""
     print(
-        f"  {label}{usage.total_calls} API calls, "
-        f"{usage.total_tokens:,} tokens, "
-        f"${usage.total_cost_usd:.4f}",
+        f"  {label}{calls} API calls, {tokens:,} tokens, ${cost:.4f}",
         file=sys.stderr,
     )

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -200,7 +200,10 @@ def run_verification(
         )
 
     def _on_restored(count: int):
-        progress.completed = count
+        # #218: rebase BOTH the counter and the session baseline, else the
+        # restored units dilute the per-unit rate (Enhance/Verify learn the
+        # restored count here, not via the `completed=` constructor arg).
+        progress.mark_restored(count)
 
     try:
         verified_results = verifier.verify_batch(

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -75,6 +75,9 @@ def run_verification(
     Returns:
         VerifyResult with paths, counts, and usage info.
     """
+    # #214: snapshot cumulative usage at phase start so the "Stage 2" summary
+    # below reports this phase's delta, not every prior phase's total.
+    _phase_baseline = tracking.get_usage()
     os.makedirs(output_dir, exist_ok=True)
 
     # Configure global rate limiter
@@ -230,7 +233,7 @@ def run_verification(
     # Checkpoints are preserved as a permanent artifact alongside results
     # (final summary with phase="done" is written inside verify_batch).
 
-    tracking.log_usage("Stage 2")
+    tracking.log_usage("Stage 2", _phase_baseline)
 
     # Merge verified results back into the full result set
     verified_ids = {r.get("unit_id") or r.get("route_key") for r in verified_results}

--- a/libs/openant-core/tests/test_enhance_singleshot_resume_callback.py
+++ b/libs/openant-core/tests/test_enhance_singleshot_resume_callback.py
@@ -1,0 +1,54 @@
+"""#218: single-shot enhance resume must rebase the progress session baseline.
+
+`enhance_dataset` (single-shot mode) resumes from a checkpoint directory — it
+loads `processed_ids` and skips finished units — but it did not accept a
+`restored_callback`, so on resume the shared ProgressReporter never learned the
+restored count. Its counter ended at (remaining)/(total) instead of total/total
+and the ETA counted the restored units as phantom remaining work: the same #218
+defect the agentic path already fixes via `mark_restored`. This test drives the
+real single-shot `enhance_dataset` with every unit already restored (no LLM
+call) and asserts the callback fires with the restored count.
+"""
+
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utilities.context_enhancer import ContextEnhancer  # noqa: E402
+
+
+class _NoLLMEnhancer(ContextEnhancer):
+    """Pretends both units were already checkpointed; never calls the LLM."""
+
+    def _load_completed_units(self, checkpoint_dir, context_key="llm_context"):
+        return {"u1", "u2"}
+
+    def enhance_unit(self, unit, all_units):  # pragma: no cover - must not run
+        raise AssertionError("enhance_unit called — restored units were re-enhanced")
+
+
+def _unit(uid):
+    return {
+        "id": uid,
+        "unit_type": "function",
+        "code": {"primary_origin": {"file_path": "a.py", "function_name": uid}},
+        "metadata": {"direct_calls": [], "direct_callers": []},
+    }
+
+
+def test_singleshot_resume_invokes_restored_callback(tmp_path):
+    dataset = {"units": [_unit("u1"), _unit("u2")]}
+    enh = _NoLLMEnhancer(SimpleNamespace(provider_name="test", model="test"))
+    seen = []
+    enh.enhance_dataset(
+        dataset,
+        workers=1,
+        checkpoint_path=str(tmp_path / "cp"),
+        restored_callback=lambda n: seen.append(n),
+    )
+    assert seen == [2], (
+        f"single-shot resume did not report the restored count to the progress "
+        f"reporter (restored_callback calls: {seen!r})"
+    )

--- a/libs/openant-core/tests/test_progress_resume_eta.py
+++ b/libs/openant-core/tests/test_progress_resume_eta.py
@@ -14,6 +14,11 @@ the SAME ETA — one starting fresh, one resumed with a large restored count. On
 the buggy cumulative-rate code the resumed reporter's ETA is far smaller.
 """
 
+import re
+import time
+
+import pytest
+
 from core.progress import ProgressReporter
 
 
@@ -21,6 +26,29 @@ def _eta(total, initial_completed, session_units, elapsed):
     p = ProgressReporter("step", total, tracker=None, completed=initial_completed)
     p.completed = initial_completed + session_units
     return p._estimate_remaining(elapsed)
+
+
+def _eta_via_restore(total, restored, session_units, elapsed):
+    """Mirror the Enhance/Verify resume path: construct with NO ``completed=``,
+    then apply the restored count via the ``mark_restored`` callback (the way
+    enhancer.py / verifier.py do it), not the constructor arg."""
+    p = ProgressReporter("step", total, tracker=None)
+    p.mark_restored(restored)
+    p.completed = restored + session_units
+    return p._estimate_remaining(elapsed)
+
+
+def _finish_avg(capsys, total, restored, session_units, elapsed):
+    """The 'avg N.Ns/unit' float that finish() prints for a resumed run."""
+    p = ProgressReporter("step", total, tracker=None)
+    p.mark_restored(restored)
+    p.completed = restored + session_units
+    p.start_time = time.monotonic() - elapsed  # pin elapsed deterministically
+    capsys.readouterr()
+    p.finish()
+    m = re.search(r"avg ([\d.]+)s/unit", capsys.readouterr().err)
+    assert m, "finish() printed no avg s/unit line"
+    return float(m.group(1))
 
 
 class TestResumeETA:
@@ -45,3 +73,23 @@ class TestResumeETA:
         p = ProgressReporter("step", 100, tracker=None, completed=40)
         # nothing processed this session yet
         assert p._estimate_remaining(5.0) == "~?"
+
+    def test_callback_restore_path_excludes_restored_units(self):
+        # Enhance/Verify resume via mark_restored (a runtime callback), NOT the
+        # completed= constructor arg the Detect path uses. Same invariant: a
+        # fresh and a large-restored reporter with the same session work + same
+        # units remaining must show the same ETA.
+        fresh = _eta_via_restore(total=100, restored=0, session_units=10, elapsed=10.0)
+        resumed = _eta_via_restore(total=190, restored=90, session_units=10, elapsed=10.0)
+        assert fresh == resumed, (
+            f"resumed ETA {resumed!r} != fresh {fresh!r} — mark_restored did not "
+            "rebase the session baseline, so restored units still dilute the rate"
+        )
+
+    def test_finish_avg_reflects_session_pace_not_cumulative(self, capsys):
+        # 100 restored, 5 units in 25s → true session pace 5.0 s/unit; the
+        # cumulative rate (25/105) would print ~0.2 s/unit on the Done line.
+        avg = _finish_avg(capsys, total=200, restored=100, session_units=5, elapsed=25.0)
+        assert avg == pytest.approx(5.0, abs=0.5), (
+            f"finish() avg {avg}s/unit is diluted by the restored count"
+        )

--- a/libs/openant-core/tests/test_progress_resume_eta.py
+++ b/libs/openant-core/tests/test_progress_resume_eta.py
@@ -1,0 +1,47 @@
+"""#218: ETA must be based on the per-unit rate of THIS session, not the
+cumulative count including checkpoint-restored units.
+
+`_estimate_remaining` computed `avg = elapsed / self.completed`, but on a
+checkpoint-resumed run `self.completed` is seeded with the restored count
+(`ProgressReporter(..., completed=len(checkpointed))`, analyzer.py) while
+`elapsed` is measured from session start — so the average was diluted by units
+that took zero session time, making the ETA ~25x too optimistic on the reported
+run.
+
+Invariant test (format-independent): two reporters that process the SAME number
+of units in the SAME session time and have the SAME number remaining must show
+the SAME ETA — one starting fresh, one resumed with a large restored count. On
+the buggy cumulative-rate code the resumed reporter's ETA is far smaller.
+"""
+
+from core.progress import ProgressReporter
+
+
+def _eta(total, initial_completed, session_units, elapsed):
+    p = ProgressReporter("step", total, tracker=None, completed=initial_completed)
+    p.completed = initial_completed + session_units
+    return p._estimate_remaining(elapsed)
+
+
+class TestResumeETA:
+    def test_eta_depends_on_session_rate_not_restored_count(self):
+        # fresh: 0 restored, 10 processed this session, 90 remaining
+        fresh = _eta(total=100, initial_completed=0, session_units=10, elapsed=10.0)
+        # resumed: 90 restored, 10 processed this session, 90 remaining
+        resumed = _eta(total=190, initial_completed=90, session_units=10, elapsed=10.0)
+        assert fresh == resumed, (
+            f"resumed ETA {resumed!r} != fresh ETA {fresh!r} — the restored "
+            "count is still diluting the per-unit rate"
+        )
+
+    def test_resumed_eta_reflects_real_session_pace(self):
+        # 100 restored, 5 processed in 25s (=5s/unit), 95 remaining → ~475s.
+        # The buggy cumulative rate (25/105) would give ~22s.
+        eta = _eta(total=200, initial_completed=100, session_units=5, elapsed=25.0)
+        # 475s has a minutes component; 22s does not — a clean discriminator.
+        assert "m" in eta, f"ETA {eta!r} looks like the diluted cumulative rate"
+
+    def test_no_session_units_yet_is_unknown(self):
+        p = ProgressReporter("step", 100, tracker=None, completed=40)
+        # nothing processed this session yet
+        assert p._estimate_remaining(5.0) == "~?"

--- a/libs/openant-core/tests/test_step_counter_no_overflow.py
+++ b/libs/openant-core/tests/test_step_counter_no_overflow.py
@@ -17,10 +17,12 @@ import re
 from pathlib import Path
 
 import core.scanner as scanner_mod
-from test_pr69_report_llmconfig_forwarding import _install_minimal_pipeline
+from tests.test_pr69_report_llmconfig_forwarding import _install_minimal_pipeline
 
-# brings the autouse _offline_registry fixture (probe neutered, config resolves)
-pytest_plugins = ("test_pr69_report_llmconfig_forwarding",)
+# brings the autouse _offline_registry fixture (probe neutered, config resolves).
+# Package-qualified so the file also collects when run in isolation, not only
+# under a whole-`tests/` run (bare sibling names resolve only mid-suite).
+pytest_plugins = ("tests.test_pr69_report_llmconfig_forwarding",)
 
 
 def test_step_counter_never_overflows_when_optional_steps_skipped(

--- a/libs/openant-core/tests/test_step_counter_no_overflow.py
+++ b/libs/openant-core/tests/test_step_counter_no_overflow.py
@@ -1,0 +1,60 @@
+"""#219: the step counter must never overflow (e.g. the report step printed as
+`[8/7]`).
+
+`_count_steps` (the denominator) counts only steps that RUN, but `_step_label`
+incremented the numerator for every emitted line — including the "Skipping ..."
+notices for disabled optional steps — so a run with several steps skipped pushed
+the numerator past the total. Skips are notices, not performed steps, and must
+not consume a step number.
+
+Drives `scan_repository` fully offline (parse/analyze/build/report stubbed,
+credential probe neutered via the reused pr69 fixtures) with every optional step
+disabled but report on — the exact shape that produced `[8/7]` — and asserts no
+`[n/N]` label has n > N. Fully offline ($0).
+"""
+
+import re
+from pathlib import Path
+
+import core.scanner as scanner_mod
+from test_pr69_report_llmconfig_forwarding import _install_minimal_pipeline
+
+# brings the autouse _offline_registry fixture (probe neutered, config resolves)
+pytest_plugins = ("test_pr69_report_llmconfig_forwarding",)
+
+
+def test_step_counter_never_overflows_when_optional_steps_skipped(
+    monkeypatch, tmp_path, capsys
+):
+    _install_minimal_pipeline(monkeypatch)
+    import core.reporter as reporter
+
+    monkeypatch.setattr(
+        reporter, "generate_summary_report",
+        lambda results_path, output_path, llm_config_name=None: Path(
+            output_path
+        ).write_text("# summary"),
+    )
+    monkeypatch.setattr(
+        reporter, "generate_disclosure_docs",
+        lambda results_path, output_dir, llm_config_name=None: Path(
+            output_dir
+        ).mkdir(parents=True, exist_ok=True),
+    )
+
+    scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(tmp_path / "out"),
+        generate_context=False,   # -> "Skipping application context"
+        enhance=False,            # -> "Skipping enhancement"
+        verify=False,             # -> "Skipping verification"
+        generate_report=True,
+        dynamic_test=False,       # -> "Skipping dynamic test"
+        llm_config_name="x",
+    )
+
+    err = capsys.readouterr().err
+    labels = re.findall(r"\[(\d+)/(\d+)\]", err)
+    assert labels, f"no [n/N] step labels captured in stderr:\n{err}"
+    overflow = [(n, t) for n, t in labels if int(n) > int(t)]
+    assert not overflow, f"step counter overflowed: {overflow} in:\n{err}"

--- a/libs/openant-core/tests/test_tracking_phase_delta.py
+++ b/libs/openant-core/tests/test_tracking_phase_delta.py
@@ -1,0 +1,40 @@
+"""#214: a per-phase usage line must report the phase's own usage, not the
+cumulative run total.
+
+`log_usage("Stage 2")` printed `get_usage()` — the global cumulative tracker —
+so the console "Stage 2:" line summed every prior phase (parse/context/enhance/
+Stage 1) and overstated Stage 2's calls/tokens/cost. With a start-of-phase
+baseline it reports the delta; without one it stays cumulative (back-compat).
+"""
+
+import core.tracking as tracking
+from utilities.llm_client import get_global_tracker
+
+_PRICE = {"input": 1.0, "output": 1.0}
+
+
+def _record(n):
+    tr = get_global_tracker()
+    for _ in range(n):
+        tr.record_call("m", 100, 50, pricing=_PRICE)
+
+
+class TestPhaseDelta:
+    def test_baseline_reports_phase_delta_not_cumulative(self, capsys):
+        tracking.reset_tracking()
+        _record(3)                       # prior phases: 3 calls
+        baseline = tracking.get_usage()  # cumulative-so-far
+        _record(2)                       # this phase: 2 calls
+        tracking.log_usage("Stage 2", baseline)
+        err = capsys.readouterr().err
+        assert "Stage 2: 2 API calls" in err, (
+            f"expected the phase delta (2), got: {err.strip()!r}"
+        )
+        assert "5 API calls" not in err   # not the cumulative total
+
+    def test_no_baseline_is_cumulative_backcompat(self, capsys):
+        tracking.reset_tracking()
+        _record(4)
+        tracking.log_usage("Total")
+        err = capsys.readouterr().err
+        assert "Total: 4 API calls" in err

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -378,6 +378,7 @@ class ContextEnhancer:
         progress_callback: Optional[Callable] = None,
         workers: int = 10,
         checkpoint_path: str = None,
+        restored_callback: Optional[Callable] = None,
     ) -> dict:
         """
         Enhance all units in a dataset (single-shot mode).
@@ -397,6 +398,9 @@ class ContextEnhancer:
             workers: Number of parallel workers (default: 10).
             checkpoint_path: Path to a checkpoint directory (enables resume).
                 When None, no checkpoints are written (prior behavior).
+            restored_callback: Optional callback(count) invoked once with the
+                number of units restored from a checkpoint, so the progress
+                reporter can exclude them from the session rate (#218).
 
         Returns:
             Enhanced dataset
@@ -442,6 +446,11 @@ class ContextEnhancer:
                 self._log("info",
                           f"Restored {len(processed_ids)} already-processed units from checkpoints",
                           units=len(processed_ids))
+                # #218: rebase the progress reporter's session baseline so the
+                # restored units are excluded from the per-unit rate — the
+                # single-shot resume path needs this exactly as the agentic one.
+                if restored_callback:
+                    restored_callback(len(processed_ids))
 
         self._log("info", f"Enhancing {total} units with LLM context (single-shot mode)", units=total)
         self._log("info", f"Provider: {self.binding.provider_name}, Model: {self.binding.model}")


### PR DESCRIPTION
## What

Three console-telemetry counter fixes surfaced from one production run: resume ETA based on the session's own rate rather than the restored count (#218), per-phase usage lines that show the phase delta rather than the cumulative run total (#214), and a step counter that no longer overflows past its denominator (#219).

## Why

- **#218**: on a checkpoint-resumed run the per-unit rate divided session elapsed by the cumulative completed count — which includes restored units that took no session time — making the ETA wildly optimistic.
- **#214**: the `Stage 2:` (and sibling) usage lines printed cumulative run totals, so each phase appeared to cost the sum of all prior phases.
- **#219**: "Skipping ..." notices consumed a step number, so an optional-step skip pushed the counter past its total (for example `[8/7]`).

## How

- **#218**: `ProgressReporter` records the count it started this session with and rates over session-processed units only. `mark_restored(count)` rebases both the counter and the session baseline for the resume paths that learn their restored count via a callback (agentic Enhance, Verify, and single-shot Enhance); Detect already passed it at construction. All three rate/average sites route through one `_session_done()` helper.
- **#214**: `log_usage` takes an optional phase-start baseline and prints the delta; each phase snapshots the baseline as its first statement (Stage 1, Stage 2, Enhance, Dynamic Test).
- **#219**: skip notices render without consuming a step number.

## Tests

Adds `tests/test_progress_resume_eta.py`, `tests/test_tracking_phase_delta.py`, `tests/test_step_counter_no_overflow.py`, and `tests/test_enhance_singleshot_resume_callback.py`, each driving the real code offline.

## Compatibility

Display-only: no change to persisted `pipeline_output.json`, token totals, or `cost_usd`. Known scope: (1) on a resumed run the first phase-delta line still includes prior-session tokens/cost injected into the tracker after the baseline snapshot (a follow-up); (2) when a flag-enabled phase is skipped at runtime the final counter can read one below its total (`[M-1/M]`), each such skip printing an explicit "Skipping" line.

Fixes #218
Fixes #214
Fixes #219
