### PR TITLE
fix(core): step report status must be error when errors are recorded

### DIFF
--- a/libs/openant-core/core/step_report.py
+++ b/libs/openant-core/core/step_report.py
@@ -29,7 +29,11 @@ def step_context(step: str, output_dir: str, inputs: dict | None = None):
     - timestamp (UTC ISO 8601)
     - duration (wall-clock seconds)
     - cost / token usage (from ``core.tracking`` if available)
-    - errors (any exception that propagates)
+    - errors (any exception that propagates, or any error appended to
+      ``report.errors`` inside the block — in which case the step's status
+      is derived as ``"error"`` at exit rather than left at ``"success"``.
+      Errors also win over an explicitly-set ``"skipped"``: a step that
+      both marks itself skipped and records errors reports ``"error"``.)
 
     The caller should set ``ctx.summary`` and ``ctx.outputs`` inside the
     ``with`` block. On exit the report is written to ``{output_dir}/{step}.report.json``.
@@ -56,6 +60,19 @@ def step_context(step: str, output_dir: str, inputs: dict | None = None):
         traceback.print_exc(file=sys.stderr)
         raise
     finally:
+        # Issue #209: a step that records errors via ``ctx.errors.append(...)``
+        # (exception caught BY DESIGN — e.g. the report phase's summary and
+        # disclosure handlers in ``core/scanner.py``) must not report success.
+        # Derive the status from the errors list at exit: non-empty errors
+        # means "error", idempotently with the propagating-exception path
+        # above. Errors also WIN over an explicitly-set ``"skipped"`` (a
+        # skipped step that recorded errors is more error than skipped — no
+        # current call site produces that combination; locked by test). The
+        # scanner's degrade idiom (status="skipped" with the reason in
+        # ``summary``, no errors) is unaffected.
+        if report.errors and report.status != "error":
+            report.status = "error"
+
         report.duration_seconds = round(time.monotonic() - start, 2)
 
         # Capture cost delta

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -205,9 +205,12 @@ def generate_summary_report(
     text = "\n".join(b.text for b in result.content if isinstance(b, TextBlock))
     # #209: refuse to bless an empty summary. An empty/whitespace completion
     # (e.g. the Claude-5 thinking/empty-completion path) otherwise produces a
-    # summary-free SUMMARY_REPORT.md that the report step records as
-    # status=success with summary_path in its outputs — asserting a deliverable
-    # it never produced. Guard the raw LLM output HERE, before the deterministic
+    # summary-free SUMMARY_REPORT.md — an empty deliverable is wrong regardless
+    # of what status it is recorded under. (Historically this also left the
+    # report step's status="success" with summary_path in its outputs; that
+    # half is now fixed by core/step_report.py's #209 errors->status
+    # derivation, so the report step correctly reports "error" when this guard
+    # fires.) Guard the raw LLM output HERE, before the deterministic
     # provenance banner is prepended: on a threat-model scan the banner is
     # non-empty, so a guard on the banner+text combination would miss exactly
     # this case. Raising here also covers the standalone `python -m report
@@ -215,7 +218,7 @@ def generate_summary_report(
     if not text.strip():
         raise RuntimeError(
             "summary report generation returned empty output; refusing to write "
-            "a summary-free SUMMARY_REPORT.md and report success"
+            "a summary-free SUMMARY_REPORT.md"
         )
     # Prepend the provenance banner deterministically (see helper docstring).
     text = _context_provenance_header(pipeline_data) + text

--- a/libs/openant-core/tests/test_issue209_step_report_status.py
+++ b/libs/openant-core/tests/test_issue209_step_report_status.py
@@ -1,0 +1,265 @@
+"""Regression tests for issue #209 (per-step status half).
+
+``step_context`` only set ``status="error"`` when an exception PROPAGATED out
+of the ``with`` block. A step that catches its own exception by design and
+records it via ``ctx.errors.append(...)`` — exactly what the scan's report
+phase does for summary/disclosure generation (``core/scanner.py`` handlers,
+paired with PR #279's empty-summary producer guard) — wrote
+``status: "success"`` next to a non-empty ``errors`` list. ``report.report.json``
+claimed success while the primary human-readable deliverable was missing.
+
+Contract locked here: a step report with a non-empty ``errors`` list can never
+claim ``status: "success"`` — the status is derived from the errors at context
+exit. The existing 3-value vocabulary is unchanged (success / error / skipped);
+``skipped`` is the scanner's degrade idiom and never records errors.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from core.step_report import step_context
+
+
+def _read_report(tmp_path: Path, step: str) -> dict:
+    return json.loads((tmp_path / f"{step}.report.json").read_text())
+
+
+def test_errors_recorded_without_exception_yield_error_status(tmp_path: Path):
+    """The #209 shape: handler catches by design, appends to ctx.errors.
+
+    Mirrors the report phase's exact handler shape (try/except INSIDE the
+    with-block, exception swallowed, error recorded, scan continues): the step
+    report must not claim success.
+    """
+    with step_context("report", str(tmp_path)) as ctx:
+        outputs = {}
+        try:
+            raise ValueError("SUMMARY_REPORT.md is empty (0 bytes)")
+        except Exception as e:  # mirrors core/scanner.py report-phase handler
+            ctx.errors.append(f"Summary report: {e}")
+        ctx.summary = {"formats_generated": list(outputs.keys())}
+        ctx.outputs = outputs
+
+    report = _read_report(tmp_path, "report")
+    assert report["errors"], "errors list must be recorded"
+    assert report["status"] == "error", (
+        f"a step with recorded errors must not claim success (got {report['status']!r})"
+    )
+
+
+def test_clean_step_still_success(tmp_path: Path):
+    with step_context("parse", str(tmp_path)) as ctx:
+        ctx.summary = {"total_units": 1}
+    assert _read_report(tmp_path, "parse")["status"] == "success"
+
+
+def test_propagated_exception_still_error(tmp_path: Path):
+    with pytest.raises(RuntimeError):
+        with step_context("analyze", str(tmp_path)):
+            raise RuntimeError("boom")
+    report = _read_report(tmp_path, "analyze")
+    assert report["status"] == "error"
+    assert any("boom" in e for e in report["errors"])
+
+
+def test_explicit_skipped_without_errors_unchanged(tmp_path: Path):
+    """scanner.py's degrade idiom (status='skipped', no ctx.errors) is unaffected."""
+    with step_context("enhance", str(tmp_path)) as ctx:
+        ctx.status = "skipped"
+        ctx.summary = {"skipped": True, "reason": "api down"}
+    assert _read_report(tmp_path, "enhance")["status"] == "skipped"
+
+
+def test_errors_recorded_override_explicit_skipped(tmp_path: Path):
+    """Discriminates the shipped rule from the '== success' variant.
+
+    A step that BOTH marks itself skipped AND records an error (no current
+    scanner.py call site produces this, but the API does not forbid it):
+    errors win — status must be "error", not "skipped". Without this test a
+    future refactor to the conservative-looking
+    ``report.status == "success"`` guard would silently change the artifact
+    and no test would fail.
+    """
+    with step_context("weird", str(tmp_path)) as ctx:
+        ctx.status = "skipped"
+        ctx.errors.append("boom")
+    assert _read_report(tmp_path, "weird")["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Integration: the actual reachable code path from the issue — the scan's
+# report-phase handlers (core/scanner.py) driving step_context with a caught
+# exception. Scaffold mirrors tests/test_pr69_report_llmconfig_forwarding.py.
+# ---------------------------------------------------------------------------
+
+import sys  # noqa: E402
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core import scanner as scanner_mod  # noqa: E402
+from core.schemas import AnalysisMetrics  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _offline_registry(monkeypatch):
+    """Neuter the credential probe and accept any llm-config name offline.
+
+    MUST be autouse: without it ``scan_repository`` runs the real registry
+    probe (a live 1-token provider API call) and the tests stop being
+    hermetic — passing on machines with credentials, failing on keyless CI
+    (mirrors tests/test_pr69_report_llmconfig_forwarding.py's fixture).
+    """
+    import utilities.llm as llm_mod
+
+    monkeypatch.setattr(
+        llm_mod, "probe_registry_or_raise", lambda *a, **k: None, raising=True
+    )
+    orig_resolve = llm_mod.resolve_llm_config
+    monkeypatch.setattr(
+        llm_mod, "resolve_llm_config",
+        lambda cf, name: orig_resolve(cf, None), raising=True,
+    )
+
+
+def _install_minimal_pipeline(monkeypatch):
+    import core.parser_adapter as parser_adapter
+    import core.analyzer as analyzer
+    import core.reporter as reporter
+    import core.tracking as tracking
+
+    class _ParseResult:
+        def __init__(self, output_dir):
+            self.dataset_path = str(Path(output_dir) / "dataset.json")
+            self.analyzer_output_path = str(Path(output_dir) / "analyzer.json")
+            self.units_count = 3
+            self.language = "python"
+            self.processing_level = "all"
+
+    def _fake_parse(*, output_dir, **kwargs):
+        pr = _ParseResult(output_dir)
+        Path(pr.dataset_path).write_text('{"units": []}')
+        Path(pr.analyzer_output_path).write_text("{}")
+        return pr
+
+    metrics = AnalysisMetrics(
+        total=3, vulnerable=1, bypassable=0, inconclusive=0,
+        protected=0, safe=2, errors=0,
+    )
+
+    class _AnalyzeResult:
+        def __init__(self, output_dir):
+            self.results_path = str(Path(output_dir) / "results.json")
+            Path(self.results_path).write_text("[]")
+            self.metrics = metrics
+
+    def _fake_analysis(*, output_dir, **kwargs):
+        return _AnalyzeResult(output_dir)
+
+    def _fake_build_output(*, results_path, output_path, **kwargs):
+        Path(output_path).write_text("{}")
+        return output_path
+
+    monkeypatch.setattr(parser_adapter, "parse_repository", _fake_parse)
+    monkeypatch.setattr(analyzer, "run_analysis", _fake_analysis)
+    monkeypatch.setattr(reporter, "build_pipeline_output", _fake_build_output)
+    tracking.reset_tracking()
+
+
+def _scan_with_report_failures(monkeypatch, tmp_path, *, summary_fails, disclosures_fail):
+    _install_minimal_pipeline(monkeypatch)
+    import core.reporter as reporter
+
+    def _fake_summary(results_path, output_path, llm_config_name=None):
+        if summary_fails:
+            raise RuntimeError(
+                "summary report generation returned empty output; refusing "
+                "to write a summary-free SUMMARY_REPORT.md and report success"
+            )
+        Path(output_path).write_text("# summary")
+        return None
+
+    def _fake_disclosure(results_path, output_dir, llm_config_name=None):
+        if disclosures_fail:
+            raise RuntimeError("disclosure generation failed (test)")
+        Path(output_dir).mkdir(parents=True, exist_ok=True)
+        return None
+
+    monkeypatch.setattr(reporter, "generate_summary_report", _fake_summary)
+    monkeypatch.setattr(reporter, "generate_disclosure_docs", _fake_disclosure)
+
+    out = tmp_path / "out"
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(out),
+        generate_context=False,
+        enhance=False,
+        verify=False,
+        generate_report=True,
+        dynamic_test=False,
+    )
+    report = json.loads((out / "report.report.json").read_text())
+    return result, report
+
+
+def test_scan_report_step_error_status_when_summary_fails(
+    monkeypatch, tmp_path
+):
+    """The #209 end-to-end shape: summary raises (#279's guard), handler
+    catches by design, scan continues — and report.report.json must say
+    status="error" with the recorded error, not success."""
+    result, report = _scan_with_report_failures(
+        monkeypatch, tmp_path, summary_fails=True, disclosures_fail=False
+    )
+    assert result is not None, "scan must COMPLETE (report failure must not abort)"
+    assert report["status"] == "error"
+    assert len(report["errors"]) == 1
+    assert "Summary report" in report["errors"][0]
+
+
+def test_scan_report_step_error_status_when_both_fail(monkeypatch, tmp_path):
+    """Both deliverables fail: two recorded errors, still status="error",
+    scan still completes (multiple-errors shape)."""
+    result, report = _scan_with_report_failures(
+        monkeypatch, tmp_path, summary_fails=True, disclosures_fail=True
+    )
+    assert result is not None
+    assert report["status"] == "error"
+    assert len(report["errors"]) == 2
+
+
+def test_scan_report_step_error_status_when_only_disclosures_fail(
+    monkeypatch, tmp_path
+):
+    """Partial-failure shape: summary OK, disclosures fail — the step still
+    reports error (disclosures are a deliverable), with exactly the
+    disclosure error recorded."""
+    result, report = _scan_with_report_failures(
+        monkeypatch, tmp_path, summary_fails=False, disclosures_fail=True
+    )
+    assert result is not None
+    assert report["status"] == "error"
+    assert len(report["errors"]) == 1
+    assert "Disclosure docs" in report["errors"][0]
+
+
+def test_scan_report_step_success_when_both_deliverables_succeed(
+    monkeypatch, tmp_path
+):
+    """Clean-success path through the REAL report phase: both deliverables
+    succeed ⇒ status stays "success" with an empty errors list. Guards the
+    false-positive direction — a stray errors.append on a non-exceptional
+    branch in the report handlers would flip a clean scan's report step to
+    error, and nothing else in the suite drives this path."""
+    result, report = _scan_with_report_failures(
+        monkeypatch, tmp_path, summary_fails=False, disclosures_fail=False
+    )
+    assert result is not None
+    assert report["status"] == "success"
+    assert report["errors"] == []
+    assert set(report.get("outputs", {})) == {"summary_path", "disclosures_dir"}

--- a/libs/openant-core/tests/test_scanner.py
+++ b/libs/openant-core/tests/test_scanner.py
@@ -4,7 +4,7 @@ Covers two areas:
 
 - error-handling: the OPTIONAL stages (enhance, verify, dynamic-test) were
   wrapped in ``step_context`` but had NO inner try/except. ``step_context``
-  re-raises (core/step_report.py:57), so an optional-stage error escaped
+  re-raises (core/step_report.py:61), so an optional-stage error escaped
   ``scan_repository`` to cli.py's blanket ``except`` and discarded all completed
   parse/analyze work. The fix adds an inner warn-and-continue try/except around
   each optional stage, matching the existing app-context / llm-reachability


### PR DESCRIPTION
## Summary

`step_context` only set `status: "error"` when an exception **propagated** out of the
`with` block. A step that catches its own exception by design and records it via
`ctx.errors.append(...)` — exactly what the scan's report phase does for summary and
disclosure generation — wrote `status: "success"` next to a non-empty `errors` list.
`report.report.json` claimed success while the primary human-readable deliverable was
missing.

This fixes the per-step status half of #209 at the root: the status is now **derived from
the errors list at context exit** — non-empty errors means `error`, idempotently with the
propagating-exception path. `core/scanner.py` is untouched. Errors also win over an
explicitly-set `skipped` (documented in the docstring, discriminated by test); the
scanner's degrade idiom (`status="skipped"`, reason in `summary`, no errors) is unaffected.

Scope boundaries: the 0-byte producer half was fixed by #279 (its guard now raises, and
this PR makes the step report that raise honestly); the aggregate `scan.report.json` half
that never reads step statuses is #285 and is deliberately not touched here.

## Test plan

9 tests, all hermetic (the integration harness neuters the credential probe via an
`autouse` fixture, mirroring `test_pr69_report_llmconfig_forwarding.py` — nothing touches
a live provider):

- 4 unit: defect shape, clean-success, propagated-error, skipped-idiom guard
- 1 discriminator: errors override an explicit `skipped` — kills a silent
  `== "success"`-variant refactor
- 4 integration through the REAL scan report phase: summary-fails / both-fail /
  disclosures-only-fail / both-succeed

<details>
<summary>Verification evidence (commands + results)</summary>

RED → GREEN on `fix/issue-209-step-status` (base `f332660`):

| check | command | result |
|---|---|---|
| RED (pre-fix) | `pytest tests/test_issue209_step_report_status.py -q` on clean master | 1 failed — `assert 'error' == 'success'` (the defect) |
| GREEN (post-fix) | same | 9 passed (0.32s, offline) |
| adjacent suites | `pytest tests/test_scanner.py tests/test_reporter_status_fidelity.py tests/test_analyze_verify_chain_llm_config.py tests/test_llm_round5_fixes.py tests/test_artifact_serialization_contract.py tests/test_schemas_multilang.py -q` | 61 passed |
| full suite | `pytest tests/ -q` | 3001 passed, 2 failed (pre-existing `tests/parsers/zig/test_callgraph_funcptr_field.py`, verified failing on clean master via stash-replay), 32 skipped |
| lint | `ruff check` (4 touched files) | clean |
| CodeQL base-vs-fix | `codeql database analyze` (python-security-and-quality) | 269→270; the 1 new = `py/unreachable-statement` on test code (CodeQL does not model `pytest.raises` as catching — false positive); 0 new production findings |
| Semgrep | `semgrep scan --config p/python --config p/owasp-top-ten --config p/r2c-security-audit --config p/bandit` on changed files | 0 findings (base: 0) |

</details>

Also includes a doc-accuracy pass (found by a pre-submission archaeology sweep):
`report/generator.py`'s #279-guard comment and `RuntimeError` message described the
pre-fix `status=success` behavior in the present tense; `tests/test_scanner.py`'s
`step_report.py:57` line-ref drifted to `:61`.

Fixes #209
