### PR TITLE
fix(llm): capture provider usage detail fields verbatim (accounting fidelity)

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -904,6 +904,9 @@ def _record_usage_in_tracker(usage: dict, binding):
                 input_tokens=usage["input_tokens"],
                 output_tokens=usage["output_tokens"],
                 pricing=lookup_pricing(binding),
+                # #211 pass-through capture: verbatim when the generator's
+                # usage dict carries it; never in the cost math.
+                usage_details=usage.get("usage_details"),
             )
     except Exception:
         pass  # Best effort — don't break report generation

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -32,6 +32,7 @@ def _extract_usage(
     input_tokens: int,
     output_tokens: int,
     model: str,
+    usage_details: dict | None = None,
     pricing: dict[str, float] | None = None,
 ) -> dict:
     """Build the usage dict from token counts.
@@ -57,22 +58,34 @@ def _extract_usage(
         input_cost = (input_tokens / 1_000_000) * pricing["input"]
         output_cost = (output_tokens / 1_000_000) * pricing["output"]
         total_cost = input_cost + output_cost
-    return {
+    usage: dict = {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "total_tokens": input_tokens + output_tokens,
         "cost_usd": round(total_cost, 6),
     }
+    if usage_details is not None:
+        # #211 pass-through capture: verbatim, informational only.
+        usage["usage_details"] = usage_details
+    return usage
 
 
 def _merge_usage(usages: list[dict]) -> dict:
-    """Merge multiple usage dicts into one."""
+    """Merge multiple usage dicts into one.
+
+    #211 pass-through: per-completion ``usage_details`` (when any completion
+    captured provider detail fields) are carried VERBATIM as a list — same
+    shape the agentic loops record — never summed, never in cost.
+    """
     merged = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "cost_usd": 0.0}
     for u in usages:
         merged["input_tokens"] += u["input_tokens"]
         merged["output_tokens"] += u["output_tokens"]
         merged["total_tokens"] += u["total_tokens"]
         merged["cost_usd"] = round(merged["cost_usd"] + u["cost_usd"], 6)
+    details = [u.get("usage_details") for u in usages if u.get("usage_details") is not None]
+    if details:
+        merged["usage_details"] = details
     return merged
 
 
@@ -185,7 +198,9 @@ def generate_summary_report(
 
     Returns:
         (report_text, usage_dict) where usage_dict has input_tokens,
-        output_tokens, total_tokens, cost_usd.
+        output_tokens, total_tokens, cost_usd — plus a verbatim
+        ``usage_details`` key when the provider supplied usage detail
+        fields (#211 pass-through; never summed, never in cost).
     """
     from utilities.llm import Message, TextBlock
 
@@ -224,6 +239,7 @@ def generate_summary_report(
         result.output_tokens,
         binding.model,
         pricing=lookup_pricing(binding),
+        usage_details=result.usage_details,
     )
 
 
@@ -361,6 +377,7 @@ def generate_disclosure(
         result.output_tokens,
         binding.model,
         pricing=lookup_pricing(binding),
+        usage_details=result.usage_details,
     )
 
 

--- a/libs/openant-core/tests/test_disclosure_verdict_header.py
+++ b/libs/openant-core/tests/test_disclosure_verdict_header.py
@@ -23,6 +23,7 @@ class _Result:
         self.input_tokens = 10
         self.output_tokens = 5
         self.stop_reason = "end_turn"
+        self.usage_details = None  # matches CompletionResult (#211 capture)
 
 
 class _Adapter:

--- a/libs/openant-core/tests/test_issue211_usage_details_capture.py
+++ b/libs/openant-core/tests/test_issue211_usage_details_capture.py
@@ -1,0 +1,418 @@
+"""Regression tests for issue #211 — usage-detail capture (accounting fidelity).
+
+The cost meter dropped provider-supplied billing-relevant usage fields on the
+floor: no adapter read any reasoning-token or cache-token detail field, and
+``TokenTracker.record_call`` had nowhere to put them. A run could under-report
+cost against the provider's bill with no way to reconcile from the artifacts
+(#211's measurement: ~15% under, concentrated in the reasoning- and
+cache-heavy Opus-5 phases; the issue itself frames the mechanisms as leads).
+
+Contract locked here (PASS-THROUGH CAPTURE ONLY):
+- adapters copy provider-supplied detail fields into
+  ``CompletionResult.usage_details`` VERBATIM — present-only; a field the
+  provider did not report is ABSENT from the dict (never a fabricated 0);
+- ``record_call`` stores ``usage_details`` verbatim in the call record;
+- detail fields NEVER feed the cost formula and are NEVER summed into the
+  token totals — the reported cost number is UNCHANGED by this capture
+  (whether ``completion_tokens`` already includes reasoning differs by
+  provider/route; summing would double-count on including routes — the
+  cost-math question stays deferred per the issue's ruling);
+- multi-turn loops pass the per-turn detail dicts as a list (verbatim order).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.llm.adapter import CompletionResult  # noqa: E402
+from utilities.llm_client import TokenTracker  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Tracker: verbatim storage, no math
+# ---------------------------------------------------------------------------
+
+def test_record_call_stores_usage_details_verbatim():
+    t = TokenTracker()
+    details = {"reasoning_tokens": 1234, "cached_tokens": 800}
+    rec = t.record_call(
+        model="claude-opus-5", input_tokens=100, output_tokens=50,
+        pricing={"input": 1.0, "output": 2.0}, usage_details=details,
+    )
+    assert rec["usage_details"] == details, "details must be stored verbatim"
+    # Not summed anywhere: totals stay the plain token counts.
+    assert t.total_input_tokens == 100
+    assert t.total_output_tokens == 50
+
+
+def test_record_call_usage_details_absent_not_zero():
+    t = TokenTracker()
+    rec = t.record_call(
+        model="claude-opus-5", input_tokens=10, output_tokens=5,
+        pricing={"input": 1.0, "output": 2.0},
+    )
+    assert "usage_details" not in rec or rec["usage_details"] is None, (
+        "absent details must not become a fabricated 0-dict"
+    )
+
+
+def test_record_call_details_do_not_change_cost():
+    t = TokenTracker()
+    base_kwargs = dict(model="claude-opus-5", input_tokens=100, output_tokens=50,
+                       pricing={"input": 1.0, "output": 2.0})
+    t.record_call(**base_kwargs)
+    cost_without = t.total_cost_usd
+    t.record_call(**base_kwargs, usage_details={"reasoning_tokens": 999999})
+    cost_with = t.total_cost_usd
+    assert cost_with == 2 * cost_without, (
+        "details must not affect cost math (second call identical except details)"
+    )
+
+
+def test_record_call_accepts_per_turn_list():
+    t = TokenTracker()
+    turns = [{"reasoning_tokens": 10}, {"reasoning_tokens": 20}, None]
+    rec = t.record_call(
+        model="claude-opus-5", input_tokens=30, output_tokens=15,
+        pricing={"input": 1.0, "output": 2.0}, usage_details=turns,
+    )
+    assert rec["usage_details"] == turns
+
+
+# ---------------------------------------------------------------------------
+# CompletionResult field
+# ---------------------------------------------------------------------------
+
+def test_completion_result_has_usage_details_default_none():
+    r = CompletionResult(content=(), input_tokens=1, output_tokens=1,
+                         stop_reason="end_turn")
+    assert getattr(r, "usage_details", None) is None
+
+
+# ---------------------------------------------------------------------------
+# Adapter extraction: verbatim, present-only
+# ---------------------------------------------------------------------------
+
+def _fake_anthropic_usage(**kw):
+    return SimpleNamespace(**kw)
+
+
+def test_anthropic_extracts_cache_fields_verbatim():
+    from utilities.llm.providers.anthropic import _extract_usage_details
+    usage = _fake_anthropic_usage(
+        input_tokens=100, output_tokens=50,
+        cache_read_input_tokens=800, cache_creation_input_tokens=120,
+    )
+    d = _extract_usage_details(usage)
+    assert d == {"cache_read_input_tokens": 800,
+                 "cache_creation_input_tokens": 120}
+
+
+def test_anthropic_absent_fields_absent_not_zero():
+    from utilities.llm.providers.anthropic import _extract_usage_details
+    usage = _fake_anthropic_usage(input_tokens=100, output_tokens=50)
+    d = _extract_usage_details(usage)
+    assert d is None or d == {}, (
+        f"no cache fields supplied → no fabricated zeros (got {d!r})"
+    )
+
+
+def test_openai_chat_extracts_reasoning_and_cache_details():
+    from utilities.llm.providers.openai import _extract_usage_details_chat
+    usage = SimpleNamespace(
+        prompt_tokens=100, completion_tokens=50,
+        prompt_tokens_details=SimpleNamespace(
+            cached_tokens=64, cache_write_tokens=32),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=512),
+    )
+    d = _extract_usage_details_chat(usage)
+    assert d == {"reasoning_tokens": 512, "cached_tokens": 64,
+                 "cache_write_tokens": 32}
+
+
+def test_openai_chat_absent_details_absent():
+    from utilities.llm.providers.openai import _extract_usage_details_chat
+    usage = SimpleNamespace(prompt_tokens=100, completion_tokens=50)
+    d = _extract_usage_details_chat(usage)
+    assert d is None or d == {}
+
+
+def test_openai_responses_extracts_reasoning_and_cached_tokens():
+    """Field names verified against pinned openai SDK 2.37.0 ResponseUsage."""
+    from utilities.llm.providers.openai import _extract_usage_details_responses
+    usage = SimpleNamespace(
+        input_tokens=100, output_tokens=50,
+        input_tokens_details=SimpleNamespace(cached_tokens=64),
+        output_tokens_details=SimpleNamespace(reasoning_tokens=256),
+    )
+    d = _extract_usage_details_responses(usage)
+    assert d == {"reasoning_tokens": 256, "cached_tokens": 64}
+
+
+def test_google_extracts_thoughts_and_cached_content():
+    from utilities.llm.providers.google import _extract_usage_details
+    usage = SimpleNamespace(
+        prompt_token_count=100, candidates_token_count=50,
+        thoughts_token_count=256, cached_content_token_count=128)
+    d = _extract_usage_details(usage)
+    assert d == {"thoughts_token_count": 256, "cached_content_token_count": 128}
+
+
+def test_google_absent_details_absent():
+    from utilities.llm.providers.google import _extract_usage_details
+    usage = SimpleNamespace(prompt_token_count=100, candidates_token_count=50)
+    d = _extract_usage_details(usage)
+    assert d is None or d == {}
+
+
+# ---------------------------------------------------------------------------
+# simple_text pass-through
+# ---------------------------------------------------------------------------
+
+class _RecordingAdapter:
+    name = "fake"
+    supports_tools = False
+    pricing = {"fake-model": {"input": 1.0, "output": 2.0}}
+
+    def __init__(self, result):
+        self._result = result
+
+    def complete(self, **kwargs):
+        return self._result
+
+
+def test_simple_text_passes_usage_details_to_tracker():
+    from utilities.llm.helpers import simple_text
+    from utilities.llm.adapter import TextBlock
+    from utilities.llm.registry import PhaseBinding
+
+    details = {"reasoning_tokens": 42}
+    adapter = _RecordingAdapter(CompletionResult(
+        content=(TextBlock("ok"),), input_tokens=10, output_tokens=5,
+        stop_reason="end_turn", usage_details=details))
+    binding = PhaseBinding(phase="analyze", adapter=adapter, model="fake-model",
+                           provider_name="fake")
+    t = TokenTracker()
+    simple_text(binding, "hello", tracker=t)
+    assert t.calls[-1]["usage_details"] == details
+
+
+def test_genuine_zero_survives_not_dropped():
+    """A provider-reported 0 must be captured as 0 (absent ≠ zero ≠ dropped-zero)."""
+    from utilities.llm.providers.openai import _extract_usage_details_chat
+    usage = SimpleNamespace(
+        prompt_tokens=100, completion_tokens=50,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        completion_tokens_details=SimpleNamespace(reasoning_tokens=0),
+    )
+    d = _extract_usage_details_chat(usage)
+    assert d == {"reasoning_tokens": 0, "cached_tokens": 0}
+
+
+def test_merge_usage_carries_details_verbatim():
+    from report.generator import _merge_usage
+    merged = _merge_usage([
+        {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15,
+         "cost_usd": 0.01, "usage_details": {"reasoning_tokens": 3}},
+        {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15,
+         "cost_usd": 0.01},
+    ])
+    assert merged["usage_details"] == [{"reasoning_tokens": 3}]
+    assert merged["input_tokens"] == 20  # numerics still merged as before
+
+
+def test_merge_usage_no_details_no_key():
+    from report.generator import _merge_usage
+    merged = _merge_usage([
+        {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15, "cost_usd": 0.01},
+        {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15, "cost_usd": 0.01},
+    ])
+    assert "usage_details" not in merged
+
+
+def test_verifier_real_loop_persists_usage_details():
+    """Integration: the REAL Stage-2 loop records per-turn details to the
+    tracker AND serializes them into the unit's verification record."""
+    import json
+    from utilities.finding_verifier import FindingVerifier
+    from utilities.llm.adapter import TextBlock, ToolUseBlock
+    from utilities.llm.registry import PhaseBinding
+    from utilities.llm_client import TokenTracker
+
+    class _ToolLoopAdapter:
+        name = "fake"
+        supports_tools = True
+        pricing = {"fake-model": {"input": 1.0, "output": 2.0}}
+
+        def __init__(self):
+            self.turn = 0
+
+        def complete(self, *, model, max_tokens, system, tools, messages):
+            self.turn += 1
+            if self.turn == 1:
+                # One tool-use turn with details, then a finish turn.
+                return CompletionResult(
+                    content=(ToolUseBlock(id="t1", name="finish", input={}),),
+                    input_tokens=10, output_tokens=5, stop_reason="tool_use",
+                    usage_details={"reasoning_tokens": 11})
+            return CompletionResult(
+                content=(TextBlock("done"),),
+                input_tokens=8, output_tokens=4, stop_reason="end_turn")
+
+    tracker = TokenTracker()
+    adapter = _ToolLoopAdapter()
+    binding = PhaseBinding(phase="verify", adapter=adapter, model="fake-model",
+                           provider_name="fake")
+    from utilities.agentic_enhancer.repository_index import RepositoryIndex
+    verifier = FindingVerifier(index=RepositoryIndex({}, repo_path=None),
+                               binding=binding, tracker=tracker)
+    result = verifier.verify_result(
+        code="def f(): ...", finding="vulnerable",
+        attack_vector="x", reasoning="r")
+    # tracker record carries the per-turn list verbatim
+    assert tracker.calls[-1]["usage_details"] == [{"reasoning_tokens": 11}, None]
+    # the serialized unit record persists them (the reconcilable artifact)
+    d = result.to_dict()
+    assert d["usage_details"] == [{"reasoning_tokens": 11}, None]
+
+
+def test_agent_real_loop_persists_usage_details():
+    """Integration: the REAL enhancer loop serializes per-turn details into
+    agent_metadata (dataset_enhanced / checkpoints)."""
+    from utilities.agentic_enhancer.agent import ContextAgent
+    from utilities.llm.adapter import TextBlock, ToolUseBlock
+    from utilities.llm.registry import PhaseBinding
+    from utilities.llm_client import TokenTracker
+
+    class _ToolLoopAdapter:
+        name = "fake"
+        supports_tools = True
+        pricing = {"fake-model": {"input": 1.0, "output": 2.0}}
+
+        def __init__(self):
+            self.turn = 0
+
+        def complete(self, *, model, max_tokens, system, tools, messages):
+            self.turn += 1
+            if self.turn == 1:
+                return CompletionResult(
+                    content=(ToolUseBlock(id="t1", name="finish",
+                                          input={"security_classification": "exploitable",
+                                                 "usage_context": "ctx",
+                                                 "include_functions": [],
+                                                 "classification_reasoning": "r",
+                                                 "confidence": 0.9}),),
+                    input_tokens=10, output_tokens=5, stop_reason="tool_use",
+                    usage_details={"reasoning_tokens": 9})
+            return CompletionResult(
+                content=(TextBlock("done"),),
+                input_tokens=8, output_tokens=4, stop_reason="end_turn")
+
+    tracker = TokenTracker()
+    adapter = _ToolLoopAdapter()
+    binding = PhaseBinding(phase="enhance", adapter=adapter, model="fake-model",
+                           provider_name="fake")
+    from utilities.agentic_enhancer.repository_index import RepositoryIndex
+    agent = ContextAgent(index=RepositoryIndex({}, repo_path=None),
+                         binding=binding, tracker=tracker)
+    result = agent.analyze_unit(
+        unit_id="a.py:f", unit_type="function",
+        primary_code="def f(): ...", static_deps=[], static_callers=[])
+    d = result.to_dict()
+    # The finish arrives as a tool call in turn 1 → a single recorded turn.
+    assert d["agent_metadata"]["usage_details"] == [{"reasoning_tokens": 9}]
+
+
+# ---------------------------------------------------------------------------
+# Round-2 additions: cost-mutation locks (details must NEVER move a cost number)
+# ---------------------------------------------------------------------------
+
+def test_extract_usage_cost_immune_to_details():
+    """_extract_usage is where detail fields and cost math are adjacent —
+    lock that details cannot move the dollar figure (mutation guard)."""
+    from report.generator import _extract_usage
+    base = _extract_usage(100, 50, "m", pricing={"input": 1.0, "output": 2.0})
+    with_details = _extract_usage(
+        100, 50, "m", pricing={"input": 1.0, "output": 2.0},
+        usage_details={"reasoning_tokens": 10_000_000, "cached_tokens": 10_000_000})
+    assert with_details["cost_usd"] == base["cost_usd"], (
+        "usage_details must not change cost_usd (the deferred cost-math rule)"
+    )
+    assert with_details["usage_details"]["reasoning_tokens"] == 10_000_000
+
+
+def test_reporter_record_usage_forwards_details_to_tracker():
+    """core/reporter._record_usage_in_tracker (its except swallows errors)
+    must forward usage_details — a dropped kwarg would silently degrade."""
+    from core.reporter import _record_usage_in_tracker
+    import utilities.llm_client as llm_client
+
+    details = {"reasoning_tokens": 5}
+    usage = {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15,
+             "cost_usd": 0.01, "usage_details": details}
+
+    class _Adapter:
+        pricing = {"m": {"input": 1.0, "output": 2.0}}
+
+    class _B:
+        model = "m"
+        adapter = _Adapter()
+
+    tracker = llm_client.TokenTracker()
+    orig = llm_client.get_global_tracker
+    llm_client.get_global_tracker = lambda: tracker
+    try:
+        _record_usage_in_tracker(usage, _B())
+    finally:
+        llm_client.get_global_tracker = orig
+    assert tracker.calls[-1]["usage_details"] == details
+
+
+def test_verifier_loop_totals_immune_to_details():
+    """The REAL verifier loop: totals/cost must not move when details are
+    present (double-count mutation guard at the accumulation site)."""
+    from utilities.finding_verifier import FindingVerifier
+    from utilities.llm.adapter import TextBlock, ToolUseBlock
+    from utilities.llm.registry import PhaseBinding
+    from utilities.llm_client import TokenTracker
+    from utilities.agentic_enhancer.repository_index import RepositoryIndex
+
+    class _ToolLoopAdapter:
+        name = "fake"
+        supports_tools = True
+        pricing = {"fake-model": {"input": 1.0, "output": 2.0}}
+
+        def __init__(self):
+            self.turn = 0
+
+        def complete(self, *, model, max_tokens, system, tools, messages):
+            self.turn += 1
+            if self.turn == 1:
+                return CompletionResult(
+                    content=(ToolUseBlock(id="t1", name="finish", input={}),),
+                    input_tokens=10, output_tokens=5, stop_reason="tool_use",
+                    usage_details={"reasoning_tokens": 10_000_000})
+            return CompletionResult(
+                content=(TextBlock("done"),),
+                input_tokens=8, output_tokens=4, stop_reason="end_turn")
+
+    tracker = TokenTracker()
+    binding = PhaseBinding(phase="verify", adapter=_ToolLoopAdapter(),
+                           model="fake-model", provider_name="fake")
+    verifier = FindingVerifier(index=RepositoryIndex({}, repo_path=None),
+                               binding=binding, tracker=tracker)
+    result = verifier.verify_result(
+        code="def f(): ...", finding="vulnerable",
+        attack_vector="x", reasoning="r")
+    # Totals = plain token sums only: 10+8 input, 5+4 output — the
+    # 10M reasoning tokens in usage_details must NOT appear anywhere.
+    assert result.total_tokens == (10 + 8) + (5 + 4)
+    assert tracker.total_input_tokens == 18
+    assert tracker.total_output_tokens == 9
+    assert tracker.calls[-1]["usage_details"] == [{"reasoning_tokens": 10_000_000}, None]

--- a/libs/openant-core/tests/test_reporter_empty_summary_guard.py
+++ b/libs/openant-core/tests/test_reporter_empty_summary_guard.py
@@ -29,6 +29,7 @@ class _Result:
         self.input_tokens = 10
         self.output_tokens = 5 if has_text else 0
         self.stop_reason = "end_turn"
+        self.usage_details = None  # matches CompletionResult (#211 capture)
 
 
 class _Adapter:

--- a/libs/openant-core/utilities/agentic_enhancer/agent.py
+++ b/libs/openant-core/utilities/agentic_enhancer/agent.py
@@ -99,6 +99,7 @@ class AgentResult:
         input_tokens: int = 0,
         output_tokens: int = 0,
         cost_usd: float = 0.0,
+        usage_details: Optional[list] = None,
     ):
         self.include_functions = include_functions
         self.usage_context = usage_context
@@ -113,6 +114,8 @@ class AgentResult:
         self.input_tokens = input_tokens
         self.output_tokens = output_tokens
         self.cost_usd = cost_usd
+        # #211 pass-through capture: per-turn detail dicts, verbatim.
+        self.usage_details = usage_details
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -128,6 +131,9 @@ class AgentResult:
                 "input_tokens": self.input_tokens,
                 "output_tokens": self.output_tokens,
                 "cost_usd": self.cost_usd,
+                # #211: verbatim when captured; never summed, never in cost.
+                **({"usage_details": self.usage_details}
+                   if self.usage_details is not None else {}),
             },
             "reachability": {
                 "is_entry_point": self.is_entry_point,
@@ -239,6 +245,8 @@ class ContextAgent:
         iterations = 0
         total_input_tokens = 0
         total_output_tokens = 0
+        # #211 pass-through capture: per-turn usage detail dicts, verbatim.
+        per_turn_usage_details: list = []
 
         while iterations < MAX_ITERATIONS:
             iterations += 1
@@ -272,6 +280,7 @@ class ContextAgent:
 
             total_input_tokens += result.input_tokens
             total_output_tokens += result.output_tokens
+            per_turn_usage_details.append(result.usage_details)
 
             assistant_content = result.content
             stop_reason = result.stop_reason
@@ -296,6 +305,7 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     pricing=lookup_pricing(self.binding),
+                    usage_details=per_turn_usage_details,
                 )
                 return AgentResult(
                     include_functions=[],
@@ -311,6 +321,7 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     cost_usd=call_record.get("cost_usd", 0.0),
+                    usage_details=per_turn_usage_details,
                 )
 
             tool_results: list[ToolResultBlock] = []
@@ -366,6 +377,7 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     pricing=lookup_pricing(self.binding),
+                    usage_details=per_turn_usage_details,
                 )
                 return AgentResult(
                     include_functions=[],
@@ -381,6 +393,7 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     cost_usd=call_record.get("cost_usd", 0.0),
+                    usage_details=per_turn_usage_details,
                 )
 
             # If finish was called, return result
@@ -391,6 +404,7 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     pricing=lookup_pricing(self.binding),
+                    usage_details=per_turn_usage_details,
                 )
 
                 return AgentResult(
@@ -407,6 +421,7 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     cost_usd=call_record.get("cost_usd", 0.0),
+                    usage_details=per_turn_usage_details,
                 )
 
             # Add assistant message and tool results to conversation.
@@ -429,6 +444,7 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     pricing=lookup_pricing(self.binding),
+                    usage_details=per_turn_usage_details,
                 )
                 return AgentResult(
                     include_functions=[],
@@ -444,6 +460,7 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     cost_usd=call_record.get("cost_usd", 0.0),
+                    usage_details=per_turn_usage_details,
                 )
 
         # Max iterations reached
@@ -456,6 +473,7 @@ class ContextAgent:
             input_tokens=total_input_tokens,
             output_tokens=total_output_tokens,
             pricing=lookup_pricing(self.binding),
+            usage_details=per_turn_usage_details,
         )
 
         return AgentResult(
@@ -472,6 +490,7 @@ class ContextAgent:
             input_tokens=total_input_tokens,
             output_tokens=total_output_tokens,
             cost_usd=call_record.get("cost_usd", 0.0),
+            usage_details=per_turn_usage_details,
         )
 
 

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -273,6 +273,11 @@ class VerificationResult:
     # lets the reporter render "unverified" (not "rejected") and lets the
     # metrics bucket it as needs-review (not "safe").
     incomplete: bool = False
+    # #211 pass-through capture: per-turn provider usage detail dicts
+    # (verbatim; None entries for turns that reported none). Serialized
+    # into the unit's verification record so results_verified.json is
+    # reconcilable against a provider bill; never summed, never in cost.
+    usage_details: Optional[list] = None
 
     def to_dict(self) -> dict:
         result = {
@@ -282,6 +287,8 @@ class VerificationResult:
             "iterations": self.iterations,
             "total_tokens": self.total_tokens
         }
+        if self.usage_details is not None:
+            result["usage_details"] = self.usage_details
         if self.exploit_path:
             result["exploit_path"] = self.exploit_path.to_dict()
         if self.security_weakness:
@@ -395,6 +402,10 @@ class FindingVerifier:
         iterations = 0
         total_input_tokens = 0
         total_output_tokens = 0
+        # #211 pass-through capture: per-turn provider usage detail dicts,
+        # verbatim (None entries for turns whose provider reported none).
+        # Passed to record_call as a list; never summed, never in cost.
+        per_turn_usage_details: list = []
 
         while iterations < MAX_ITERATIONS:
             iterations += 1
@@ -412,6 +423,7 @@ class FindingVerifier:
 
             total_input_tokens += response.input_tokens
             total_output_tokens += response.output_tokens
+            per_turn_usage_details.append(response.usage_details)
 
             assistant_content = response.content
             stop_reason = response.stop_reason
@@ -420,7 +432,8 @@ class FindingVerifier:
             if stop_reason == "end_turn":
                 result = self._try_parse_text_response(
                     assistant_content, finding, iterations,
-                    total_input_tokens, total_output_tokens
+                    total_input_tokens, total_output_tokens,
+                    usage_details=per_turn_usage_details,
                 )
                 if result:
                     return result
@@ -442,10 +455,12 @@ class FindingVerifier:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     pricing=lookup_pricing(self.binding),
+                    usage_details=per_turn_usage_details,
                 )
                 return VerificationResult(
                     agree=False,
                     correct_finding=finding,
+                    usage_details=per_turn_usage_details,
                     explanation="Verification incomplete",
                     iterations=iterations,
                     total_tokens=total_input_tokens + total_output_tokens,
@@ -497,10 +512,12 @@ class FindingVerifier:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     pricing=lookup_pricing(self.binding),
+                    usage_details=per_turn_usage_details,
                 )
                 return VerificationResult(
                     agree=False,
                     correct_finding=finding,
+                    usage_details=per_turn_usage_details,
                     explanation="Verification incomplete (finish call truncated at max_tokens)",
                     iterations=iterations,
                     total_tokens=total_input_tokens + total_output_tokens,
@@ -513,10 +530,12 @@ class FindingVerifier:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     pricing=lookup_pricing(self.binding),
+                    usage_details=per_turn_usage_details,
                 )
                 return self._parse_finish_result(
                     finish_result, finding, iterations,
-                    total_input_tokens + total_output_tokens
+                    total_input_tokens + total_output_tokens,
+                    usage_details=per_turn_usage_details,
                 )
 
             # Echo only the block kinds the loop consumes (Text + ToolUse);
@@ -534,12 +553,14 @@ class FindingVerifier:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     pricing=lookup_pricing(self.binding),
+                    usage_details=per_turn_usage_details,
                 )
                 # Fail-safe (R4-7): see the :380 path above. Don't auto-agree;
                 # keep the Stage-1 verdict surfaced for human triage.
                 return VerificationResult(
                     agree=False,
                     correct_finding=finding,
+                    usage_details=per_turn_usage_details,
                     explanation="Verification incomplete (no tool calls)",
                     iterations=iterations,
                     total_tokens=total_input_tokens + total_output_tokens,
@@ -553,12 +574,14 @@ class FindingVerifier:
             input_tokens=total_input_tokens,
             output_tokens=total_output_tokens,
             pricing=lookup_pricing(self.binding),
+            usage_details=per_turn_usage_details,
         )
         # Fail-safe (R4-7): exhausting the iteration budget is not agreement.
         # Don't auto-agree; keep the Stage-1 verdict surfaced for human triage.
         return VerificationResult(
             agree=False,
             correct_finding=finding,
+            usage_details=per_turn_usage_details,
             explanation="Max iterations reached",
             iterations=iterations,
             total_tokens=total_input_tokens + total_output_tokens,
@@ -1058,7 +1081,8 @@ class FindingVerifier:
         finish_result: dict,
         original_finding: str,
         iterations: int,
-        total_tokens: int
+        total_tokens: int,
+        usage_details: list | None = None,
     ) -> VerificationResult:
         """Parse the finish tool result into VerificationResult."""
         # Parse exploit path if present
@@ -1119,6 +1143,7 @@ class FindingVerifier:
             explanation=finish_result.get("explanation", ""),
             iterations=iterations,
             total_tokens=total_tokens,
+            usage_details=usage_details,
             exploit_path=exploit_path,
             security_weakness=finish_result.get("security_weakness"),
             incomplete=incomplete,
@@ -1130,7 +1155,8 @@ class FindingVerifier:
         original_finding: str,
         iterations: int,
         total_input_tokens: int,
-        total_output_tokens: int
+        total_output_tokens: int,
+        usage_details: list | None = None,
     ) -> Optional[VerificationResult]:
         """Try to parse a text response as JSON."""
         for block in assistant_content:
@@ -1142,10 +1168,12 @@ class FindingVerifier:
                         input_tokens=total_input_tokens,
                         output_tokens=total_output_tokens,
                         pricing=lookup_pricing(self.binding),
+                        usage_details=usage_details,
                     )
                     return self._parse_finish_result(
                         result, original_finding, iterations,
-                        total_input_tokens + total_output_tokens
+                        total_input_tokens + total_output_tokens,
+                        usage_details=usage_details,
                     )
         return None
 

--- a/libs/openant-core/utilities/llm/adapter.py
+++ b/libs/openant-core/utilities/llm/adapter.py
@@ -191,6 +191,17 @@ class CompletionResult:
             ``Message.content`` already enforces).
         input_tokens: From the provider's usage metadata.
         output_tokens: Ditto.
+        usage_details: Provider-supplied billing-relevant usage DETAIL
+            fields (reasoning tokens; cache read/write tokens), copied
+            VERBATIM by the adapter — present-only, absent when the
+            provider reported none. Pass-through capture for #211:
+            these fields never feed the cost formula and are never
+            summed into token totals; they exist so the accounting
+            artifacts can be reconciled against a provider bill. (The
+            cost-math question — whether ``output_tokens`` already
+            includes reasoning on a given route — is deliberately
+            unresolved; summing here would double-count on routes
+            where it does.)
         stop_reason: Normalised across providers. The pipeline's
             agentic loops branch on ``"tool_use"`` to know whether
             to execute tools and continue.
@@ -204,6 +215,9 @@ class CompletionResult:
     output_tokens: int
     stop_reason: StopReason
     raw: Any = field(default=None, repr=False)
+    # After ``raw`` so the pre-existing positional contract
+    # (content, input, output, stop_reason, raw) is unchanged.
+    usage_details: dict | None = field(default=None, repr=False)
 
     def __post_init__(self):
         # Accept list for ergonomic construction by adapters; freeze

--- a/libs/openant-core/utilities/llm/helpers.py
+++ b/libs/openant-core/utilities/llm/helpers.py
@@ -87,6 +87,9 @@ def simple_text(
         input_tokens=result.input_tokens,
         output_tokens=result.output_tokens,
         pricing=lookup_pricing(binding),
+        # #211 pass-through capture: provider detail fields verbatim
+        # (never in the cost math — see TokenTracker.record_call).
+        usage_details=result.usage_details,
     )
 
     return "\n".join(

--- a/libs/openant-core/utilities/llm/providers/anthropic.py
+++ b/libs/openant-core/utilities/llm/providers/anthropic.py
@@ -308,6 +308,28 @@ def _tool_to_anthropic(tool: ToolDef) -> dict[str, Any]:
     }
 
 
+def _extract_usage_details(usage: Any) -> Optional[dict]:
+    """Pass-through capture (#211): provider-supplied cache billing fields.
+
+    Copies ``cache_read_input_tokens`` / ``cache_creation_input_tokens``
+    VERBATIM when the provider reported them; returns ``None`` when neither
+    is present (absent ≠ 0 — fabricated zeros would poison reconciliation
+    against a provider bill). These fields NEVER feed the cost formula:
+    ``TokenTracker`` stores them verbatim, unsummed. (Anthropic's
+    ``output_tokens`` includes thinking tokens; there is no separate
+    reasoning field to capture on this path.)
+    """
+    if usage is None:
+        return None
+    details: dict = {}
+    for field_name in ("cache_read_input_tokens",
+                       "cache_creation_input_tokens"):
+        value = getattr(usage, field_name, None)
+        if value is not None:
+            details[field_name] = value
+    return details or None
+
+
 def _response_to_unified(
     response: Any, *, adapter: str = "AnthropicAdapter"
 ) -> CompletionResult:
@@ -392,6 +414,7 @@ def _response_to_unified(
         content=content_blocks,
         input_tokens=getattr(usage, "input_tokens", 0),
         output_tokens=getattr(usage, "output_tokens", 0),
+        usage_details=_extract_usage_details(usage),
         # R2-C: an unknown/abnormal stop_reason defaults to "max_tokens" (not
         # "end_turn") — as the warning above notes, treating a refusal/abnormal
         # termination as end_turn masks false negatives. Known values (end_turn/

--- a/libs/openant-core/utilities/llm/providers/google.py
+++ b/libs/openant-core/utilities/llm/providers/google.py
@@ -144,6 +144,26 @@ def reset_warnings() -> None:
         _warned_finish_reasons.clear()
 
 
+def _extract_usage_details(usage: Any) -> Optional[dict]:
+    """Pass-through capture (#211): Gemini usage detail fields.
+
+    Copies ``thoughts_token_count`` / ``cached_content_token_count``
+    VERBATIM when present; ``None`` otherwise (absent ≠ 0). Never feeds
+    the cost formula — note ``thoughts_token_count`` is ALREADY summed
+    into ``output_tokens`` above (Gemini bills candidates + thoughts as
+    output), so these captured fields are informational for bill
+    reconciliation, not additional billed tokens.
+    """
+    if usage is None:
+        return None
+    details: dict = {}
+    for field_name in ("thoughts_token_count", "cached_content_token_count"):
+        value = getattr(usage, field_name, None)
+        if value is not None:
+            details[field_name] = value
+    return details or None
+
+
 class GoogleAdapter:
     """:class:`LLMAdapter` implementation backed by ``google.genai.Client``."""
 
@@ -428,6 +448,7 @@ def _response_to_unified(response: Any) -> CompletionResult:
             (getattr(usage, "candidates_token_count", 0) or 0)
             + (getattr(usage, "thoughts_token_count", 0) or 0)
         )
+    usage_details = _extract_usage_details(usage)
 
     # R4-2: a safety/blocked candidate finish reason is the more
     # specific signal — raise it regardless of whether the candidate
@@ -499,6 +520,7 @@ def _response_to_unified(response: Any) -> CompletionResult:
         content=content_blocks,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
+        usage_details=usage_details,
         stop_reason=stop_reason,
         raw=response,
     )

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -641,6 +641,57 @@ def _warn_unknown_output_item(kind: str) -> None:
         )
 
 
+def _extract_usage_details_chat(usage: Any) -> Optional[dict]:
+    """Pass-through capture (#211): chat-completions usage detail fields.
+
+    Copies ``completion_tokens_details.reasoning_tokens`` and
+    ``prompt_tokens_details.cached_tokens`` / ``cache_write_tokens``
+    VERBATIM when present; ``None`` when the provider reported none
+    (absent ≠ 0). NEVER feeds the cost formula: OpenAI documents
+    ``completion_tokens`` as already INCLUDING reasoning tokens, so
+    summing would double-count — the captured fields exist for
+    reconciliation against a provider bill, and OpenRouter (which
+    reuses this unifier) surfaces the same detail fields.
+    """
+    if usage is None:
+        return None
+    details: dict = {}
+    ctd = getattr(usage, "completion_tokens_details", None)
+    reasoning = getattr(ctd, "reasoning_tokens", None) if ctd is not None else None
+    if reasoning is not None:
+        details["reasoning_tokens"] = reasoning
+    ptd = getattr(usage, "prompt_tokens_details", None)
+    if ptd is not None:
+        for field_name in ("cached_tokens", "cache_write_tokens"):
+            value = getattr(ptd, field_name, None)
+            if value is not None:
+                details[field_name] = value
+    return details or None
+
+
+def _extract_usage_details_responses(usage: Any) -> Optional[dict]:
+    """Pass-through capture (#211): responses-API usage detail fields.
+
+    Same contract as :func:`_extract_usage_details_chat` but for the
+    Responses API field names (``output_tokens_details.reasoning_tokens``,
+    ``input_tokens_details.cached_tokens`` — field names verified against
+    the pinned openai SDK 2.37.0 ``ResponseUsage`` types). Verbatim,
+    present-only, never in the cost math.
+    """
+    if usage is None:
+        return None
+    details: dict = {}
+    otd = getattr(usage, "output_tokens_details", None)
+    reasoning = getattr(otd, "reasoning_tokens", None) if otd is not None else None
+    if reasoning is not None:
+        details["reasoning_tokens"] = reasoning
+    itd = getattr(usage, "input_tokens_details", None)
+    cached = getattr(itd, "cached_tokens", None) if itd is not None else None
+    if cached is not None:
+        details["cached_tokens"] = cached
+    return details or None
+
+
 def _responses_to_unified(response: Any) -> CompletionResult:
     """Translate an OpenAI ``Response`` (Responses API) into unified types.
 
@@ -736,6 +787,7 @@ def _responses_to_unified(response: Any) -> CompletionResult:
         content=content_blocks,
         input_tokens=getattr(usage, "input_tokens", 0) if usage else 0,
         output_tokens=getattr(usage, "output_tokens", 0) if usage else 0,
+        usage_details=_extract_usage_details_responses(usage),
         stop_reason=stop_reason,
         raw=response,
     )
@@ -838,6 +890,7 @@ def _response_to_unified(
         content=content_blocks,
         input_tokens=getattr(usage, "prompt_tokens", 0) if usage else 0,
         output_tokens=getattr(usage, "completion_tokens", 0) if usage else 0,
+        usage_details=_extract_usage_details_chat(usage),
         # BUG-7: an UNKNOWN finish_reason defaults to "max_tokens", not "end_turn" —
         # the chat-path analog of _responses_to_unified's abnormal-status handling, so
         # a proxy/future-value truncation isn't laundered into a clean completion.

--- a/libs/openant-core/utilities/llm_client.py
+++ b/libs/openant-core/utilities/llm_client.py
@@ -93,6 +93,7 @@ class TokenTracker:
         output_tokens: int,
         *,
         pricing: dict[str, float] | None = None,
+        usage_details: dict | list | None = None,
     ) -> dict:
         """
         Record a single LLM call.
@@ -110,6 +111,15 @@ class TokenTracker:
                 (with a one-time stderr warning on miss). New code
                 should always pass ``pricing`` via
                 ``binding.adapter.pricing.get(binding.model)``.
+            usage_details: Pass-through capture (#211): provider-supplied
+                billing-relevant DETAIL fields (reasoning tokens; cache
+                read/write tokens) VERBATIM — a dict for a single call,
+                or a list of per-turn dicts for an agentic loop. Stored
+                on the call record for reconciliation against a provider
+                bill; NEVER summed into totals and NEVER in the cost
+                formula (whether a provider's ``completion_tokens``
+                already includes reasoning differs by route — summing
+                would double-count on including routes).
 
         Returns:
             Dict with call details including cost.
@@ -128,7 +138,12 @@ class TokenTracker:
             "model": model,
             "input_tokens": input_tokens,
             "output_tokens": output_tokens,
-            "cost_usd": round(total_cost, 6)
+            "cost_usd": round(total_cost, 6),
+            # #211 pass-through capture: stored VERBATIM (absent when the
+            # provider supplied none — never a fabricated empty dict; in the
+            # per-turn list form, turns without details appear as None
+            # ENTRIES), never summed into the totals below, never in cost.
+            **({"usage_details": usage_details} if usage_details is not None else {}),
         }
 
         # Update totals (thread-safe)


### PR DESCRIPTION
## Summary

The cost meter dropped provider-supplied billing-relevant usage fields on the floor: no adapter read any reasoning-token or cache-token detail field, and `TokenTracker.record_call` had nowhere to put them. A run could under-report cost against the provider's bill (#211 measured ~15% under, concentrated in the reasoning- and cache-heavy Opus-5 phases) with no way to reconcile from the artifacts.

This adds **pass-through capture only**: adapters copy the provider-supplied detail fields VERBATIM into `CompletionResult.usage_details` — OpenAI/OpenRouter chat (`completion_tokens_details.reasoning_tokens`, `prompt_tokens_details.cached_tokens`), OpenAI Responses (`output_tokens_details.reasoning_tokens`, `input_tokens_details.cached_tokens` — names verified against the pinned openai 2.37.0 SDK types), Anthropic/Bedrock (`cache_read_input_tokens`, `cache_creation_input_tokens`), Google (`thoughts_token_count`, `cached_content_token_count`, informational there). The capture persists where reconciliation needs it: per-unit verification records (`results_verified.json`), per-unit agent metadata (enhance checkpoints/dataset), the tracker's call records, and the report path (including the multi-completion disclosure merge).

**Scope boundary (per the issue's own framing — mechanisms were leads, not diagnoses):** the cost-math change is deliberately NOT here. Whether a provider's `completion_tokens` already includes reasoning differs by route; summing would double-count on including routes. Hard constraints held: details never feed the cost formula, never sum into totals, absent stays `None` (never fabricated zeros), and the reported cost number is unchanged — locked by cost-mutation tests. This PR makes the artifacts reconcilable against a provider bill; the deferred cost-math question needs route-level verification (one authorized probe per route, or provider documentation) and is recorded on the issue.

## Test plan

21 hermetic tests covering the constraint matrix: verbatim capture per provider (4 extractor shapes), absent-not-zero, genuine-zero-survives, cost-immunity at `_extract_usage` / `record_call` / the real verifier loop (totals unchanged with 10M reasoning tokens present), real-loop integration through the Stage-2 verifier and enhancer `ContextAgent` (persistence + per-turn list), disclosure merge carry, and reporter forwarding.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue211_usage_details_capture.py -q` | 21 passed (offline) |
| full suite | `pytest tests/ -q` | 3013 passed, 2 failed (pre-existing `tests/parsers/zig/test_callgraph_funcptr_field.py`, verified failing on clean master via stash-replay), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |
| CodeQL base-vs-fix | `codeql database analyze` (python-security-and-quality) | 269→271 raw; after test-import cleanup the only deltas vs base are pre-existing findings moved by line shifts; 0 new production findings |
| Semgrep | `semgrep scan --config p/python --config p/owasp-top-ten --config p/bandit` on changed surfaces | 0 findings |

</details>

Fixes #211 (accounting-fidelity half; cost-math half explicitly deferred — see issue comment)
