### PR TITLE
chore(deps): drop redundant pydantic_core pin

### DIFF
--- a/libs/openant-core/requirements.txt
+++ b/libs/openant-core/requirements.txt
@@ -17,7 +17,6 @@ truststore==0.10.4
 idna==3.19
 jiter==0.16.0
 pydantic==2.13.4
-pydantic_core==2.46.4
 python-dotenv==1.2.3
 sniffio==1.3.1
 typing-inspection==0.4.4


### PR DESCRIPTION
## What
Removes the `pydantic_core==2.46.4` line from `requirements.txt`.

## Why
- pydantic pins its core **exactly** (`2.13.4` → `pydantic-core==2.46.4`); nothing in the repo imports `pydantic_core` directly, and CI installs with plain `pip install -r` — the resolver already determines the core version deterministically from pydantic's own `==` constraint. The explicit pin adds zero reproducibility.
- It creates a real failure class: when pydantic-core releases without a paired stable pydantic (as just happened — core 2.48.0 vs pydantic 2.13.4), renovate proposes an unpaired core bump that is permanently unresolvable (closed #338). Dropping the pin makes pydantic bumps self-contained and ends that PR class structurally.

## Verification
- `grep -rn pydantic_core --include='*.py'` → zero hits; GitHub code search → requirements.txt only
- No lockfile / constraints file / `--no-deps` / `--require-hashes` anywhere in CI or docs; `pyproject.toml` declares only `pydantic>=2.0.0`
- CI on this branch exercises the install (tests workflow installs from this file)