### PR TITLE
fix(scanner): --limit bounds the enhance phase, not just analyze

### DIFF
--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -75,7 +75,7 @@ func registerScanFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&scanEnhanceMode, "enhance-mode", "agentic", "Enhancement mode: agentic (thorough) or single-shot (fast)")
 	cmd.Flags().BoolVar(&scanNoReport, "no-report", false, "Skip report generation")
 	cmd.Flags().BoolVar(&scanSkipDynamicTest, "skip-dynamic-test", false, "Skip Docker-isolated dynamic testing (default: run dynamic tests)")
-	cmd.Flags().IntVar(&scanLimit, "limit", 0, "Max units to analyze (0 = no limit)")
+	cmd.Flags().IntVar(&scanLimit, "limit", 0, "Max units to analyze and enhance, 0 = no limit (the LLM reachability pass still reviews the full codebase)")
 	cmd.Flags().StringVar(&scanLLMConfig, "llm-config", "", "Name of the llm-config in ~/.config/openant/config.json (defaults to the file's default_llm, or the built-in 'openant-default' if no config file exists).")
 	cmd.Flags().IntVar(&scanWorkers, "workers", 8, "Number of parallel workers for LLM steps (default: 8)")
 	cmd.Flags().IntVar(&scanBackoff, "backoff", 30, "Seconds to wait when rate-limited (default: 30)")

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -6,7 +6,7 @@ for both agentic and single-shot enhancement modes.
 
 Checkpoints are always enabled for agentic mode. Per-unit progress is saved
 to ``{output_dir}/enhance_checkpoints/`` so interrupted runs can resume
-automatically. On successful completion the checkpoint dir is removed.
+automatically. Checkpoints are preserved alongside results (see the scanner's enhance step).
 """
 
 import json
@@ -99,6 +99,18 @@ def enhance_dataset(
     print(f"[Enhance] Loading dataset: {dataset_path}", file=sys.stderr)
     dataset = read_json(dataset_path)
     units = dataset.get("units", [])
+    # #213: apply --limit to the INTENDED population, not the raw head. When
+    # diff-mode annotated the dataset (diff_selected markers), analyze's own
+    # order is filter-then-limit (analyzer.py:523-557); a raw head-slice here
+    # would slice ALPHABETICALLY first and silently drop diff-selected units
+    # outside the head — the run would enhance/analyze ~0 units and exit
+    # clean (a false-coverage regression glm-5.3 caught in review). Match
+    # analyze's population semantics EXACTLY, including its key-presence
+    # predicate (analyzer.py:523): a diff that selected ZERO units still
+    # counts as annotated — filtering to 0 beats spending the limit on
+    # unrelated units (sonnet confirm-round catch).
+    if any("diff_selected" in u for u in units if isinstance(u, dict)):
+        units = [u for u in units if isinstance(u, dict) and u.get("diff_selected")]
     if limit:
         units = units[:limit]
         dataset["units"] = units  # so the agentic/single-shot paths enhance only these

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -166,7 +166,8 @@ def scan_repository(
         generate_context: If True, generate application context (reduces FP).
         generate_report: If True, generate summary + disclosure reports.
         skip_tests: If True, exclude test files from parsing (default: True).
-        limit: Max number of units to analyze.
+        limit: Max number of units to analyze and enhance (the LLM
+            reachability pass still reviews the full codebase).
         enhance: If True, run agentic/single-shot context enhancement.
         enhance_mode: ``"agentic"`` (thorough) or ``"single-shot"`` (fast).
         dynamic_test: If True, run Docker-isolated dynamic testing (requires Docker).
@@ -512,9 +513,9 @@ def scan_repository(
                         )
                         app_ctx_payload = None
 
-                # --limit governs the analyze stage, not how many units the
-                # LLM reachability pass reviews — it must see the full
-                # codebase to find missed entry points.
+                # --limit governs the analyze AND enhance stages, not how
+                # many units the LLM reachability pass reviews — it must see
+                # the full codebase to find missed entry points.
                 signals = analyze_reachability(
                     dataset=dataset,
                     app_context=app_ctx_payload,
@@ -761,6 +762,17 @@ def scan_repository(
                     workers=workers,
                     backoff_seconds=backoff_seconds,
                     # checkpoint_path auto-derived from output_path
+                    # #213: --limit bounds the enhance phase too — the
+                    # scan's cheapest-mode flag must bound the run's spend,
+                    # and enhance is a high-volume per-unit LLM phase. NOTE
+                    # the ordering trade-off (deliberate, per the issue's
+                    # ruling): a limited run selects units BEFORE the
+                    # enhancer writes security_classification, so analyze's
+                    # classification-priority re-sort no-ops on the
+                    # pre-limited set — bounded runs choose cost-bound over
+                    # classification-priority coverage. (LLM reachability
+                    # stays unbounded: it needs the full corpus.)
+                    limit=limit,
                 )
 
                 ctx.summary = {

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -1420,7 +1420,7 @@ def build_parser() -> argparse.ArgumentParser:
     scan_p.add_argument("--no-skip-tests", action="store_true", help="Include test files in parsing (default: tests are skipped)")
     scan_p.add_argument("--library-mode", action="store_true",
                         help="Seed the exported public API as entry points (for libraries with no main/route/CLI entry point)")
-    scan_p.add_argument("--limit", type=int, help="Max units to analyze")
+    scan_p.add_argument("--limit", type=int, help="Max units to analyze and enhance (the LLM reachability pass still reviews the full codebase)")
     scan_p.add_argument(
         "--llm-config",
         default=None,

--- a/libs/openant-core/tests/test_issue213_limit_bounds_enhance.py
+++ b/libs/openant-core/tests/test_issue213_limit_bounds_enhance.py
@@ -1,0 +1,231 @@
+"""Regression tests for issue #213 — ``--limit`` bounds the enhance phase.
+
+``scan --limit 2`` ran the agentic enhancer across the ENTIRE dataset before
+analyzing 2 units — the cheapest-looking way to try OpenAnt on a real repo
+incurred near-full cost, with no warning (the reporter measured 1351 units
+enhanced on a ``--limit 2`` run).
+
+The plumbing already existed: ``enhance_dataset(limit=...)`` ("Mirrors
+``analyze --limit``", applied as a head-slice). The scanner simply never
+threaded the scan's ``--limit`` into it. Contract locked here: the scan's
+``--limit`` bounds BOTH the enhance phase and the analyze phase; the LLM
+reachability pass deliberately remains unbounded (scanner's documented
+rationale — it must see the full codebase to find missed entry points).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.schemas import AnalysisMetrics, ParseResult  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _offline_registry(monkeypatch):
+    """Hermetic: neuter the credential probe + config resolution offline."""
+    import utilities.llm as llm_mod
+
+    monkeypatch.setattr(
+        llm_mod, "probe_registry_or_raise", lambda *a, **k: None, raising=True)
+    orig_resolve = llm_mod.resolve_llm_config
+    monkeypatch.setattr(
+        llm_mod, "resolve_llm_config",
+        lambda cf, name: orig_resolve(cf, None), raising=True)
+
+
+def _install_pipeline(monkeypatch, tmp_path, *, enhance_calls):
+    """Offline parse → enhance → analyze scaffold (the pr69 pattern)."""
+    import core.parser_adapter as parser_adapter
+    import core.analyzer as analyzer
+    import core.tracking as tracking
+
+    class _ParseResult:
+        def __init__(self, output_dir):
+            self.dataset_path = str(Path(output_dir) / "dataset.json")
+            self.analyzer_output_path = str(Path(output_dir) / "analyzer.json")
+            self.units_count = 5
+            self.language = "python"
+            self.processing_level = "all"
+
+    def _fake_parse(*, output_dir, **kwargs):
+        pr = _ParseResult(output_dir)
+        Path(pr.dataset_path).write_text('{"units": []}')
+        Path(pr.analyzer_output_path).write_text("{}")
+        return pr
+
+    metrics = AnalysisMetrics(total=5, vulnerable=1, bypassable=0, inconclusive=0,
+                              protected=0, safe=4, errors=0)
+
+    class _AnalyzeResult:
+        def __init__(self, output_dir):
+            self.results_path = str(Path(output_dir) / "results.json")
+            Path(self.results_path).write_text("[]")
+            self.metrics = metrics
+
+    def _fake_analysis(*, output_dir, **kwargs):
+        return _AnalyzeResult(output_dir)
+
+    def _fake_build_output(*, results_path, output_path, **kwargs):
+        Path(output_path).write_text("{}")
+        return output_path
+
+    def _fake_enhance(*, dataset_path, output_path, limit=None, **kwargs):
+        enhance_calls.append({"limit": limit,
+                              "dataset_path": dataset_path})
+        Path(output_path).write_text(Path(dataset_path).read_text())
+        class _ER:
+            enhanced_dataset_path = output_path
+            units_enhanced = limit or 5
+            error_count = 0
+            classifications = {}
+            error_summary = None
+        return _ER()
+
+    monkeypatch.setattr(parser_adapter, "parse_repository", _fake_parse)
+    monkeypatch.setattr(analyzer, "run_analysis", _fake_analysis)
+    import core.enhancer as enhancer
+    monkeypatch.setattr(enhancer, "enhance_dataset", _fake_enhance)
+    import core.reporter as reporter
+    monkeypatch.setattr(reporter, "build_pipeline_output", _fake_build_output)
+    tracking.reset_tracking()
+
+
+def _scan(tmp_path, monkeypatch, *, limit):
+    from core import scanner as scanner_mod
+    calls = []
+    _install_pipeline(monkeypatch, tmp_path, enhance_calls=calls)
+    scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(tmp_path / "out"),
+        generate_context=False,
+        enhance=True,
+        verify=False,
+        generate_report=False,
+        dynamic_test=False,
+        limit=limit,
+    )
+    return calls
+
+
+def test_scan_limit_threads_into_enhance(tmp_path, monkeypatch):
+    """The scan's --limit must bound the enhance phase (#213)."""
+    calls = _scan(tmp_path, monkeypatch, limit=2)
+    assert calls, "enhance must have run"
+    assert calls[0]["limit"] == 2, (
+        f"scan --limit 2 must thread limit=2 into enhance_dataset "
+        f"(got {calls[0]['limit']!r}) — the unbounded enhance was #213's "
+        "near-full-cost surprise"
+    )
+
+
+def test_scan_without_limit_enhances_all(tmp_path, monkeypatch):
+    calls = _scan(tmp_path, monkeypatch, limit=None)
+    assert calls[0]["limit"] is None
+
+
+def test_scan_help_text_states_enhance_bounded():
+    """#213 ask: the help text must state exactly what --limit bounds —
+    locked on the ACTUAL argparse help string of the scan verb's --limit
+    (not a source-substring match, which a comment could satisfy)."""
+    import argparse
+    from openant.cli import build_parser
+
+    parser = build_parser()
+    subparsers_actions = [
+        a for a in parser._actions if isinstance(a, argparse._SubParsersAction)]
+    scan_parser = subparsers_actions[0].choices["scan"]
+    # Lock the --limit ACTION's OWN help string — a whole-block render could
+    # be satisfied by a sibling flag's text (sonnet confirm-round catch).
+    limit_action = next(
+        a for a in scan_parser._actions if "--limit" in (a.option_strings or []))
+    help_text = limit_action.help or ""
+    assert "Max units to analyze and enhance" in help_text
+    assert "full codebase" in help_text
+
+
+def test_enhance_limit_slices_diff_selected_population():
+    """glm-5.3 MAJOR: --limit + --diff markers must slice the DIFF-SELECTED
+    population (analyze's semantics: filter-then-limit), never the raw
+    alphabetical head — else a limited diff run enhances/analyzes ~0 units
+    and exits clean (false coverage). Observes the dataset actually handed
+    to the enhancer (the post-slice population)."""
+    import os
+    import tempfile
+    from pathlib import Path
+    import unittest.mock as mock
+
+    from core.enhancer import enhance_dataset
+    from utilities.file_io import write_json
+
+    units = ([{"unit_id": f"a.py:f{i}", "diff_selected": False} for i in range(5)]
+             + [{"unit_id": f"z.py:g{i}", "diff_selected": True} for i in range(5)])
+
+    captured = {}
+
+    class _StubEnhancer:
+        def __init__(self, *a, **k):
+            pass
+
+        def enhance_dataset_agentic(self, dataset=None, **kwargs):
+            captured["unit_ids"] = [u["unit_id"] for u in dataset.get("units", [])]
+            return {"units": dataset.get("units", [])}
+
+    with tempfile.TemporaryDirectory() as td:
+        ds = os.path.join(td, "dataset.json")
+        write_json(ds, {"units": units})
+        out = os.path.join(td, "enhanced.json")
+        import utilities.context_enhancer as ctx_mod
+        with mock.patch.object(ctx_mod, "ContextEnhancer", _StubEnhancer):
+            enhance_dataset(dataset_path=ds, output_path=out,
+                            analyzer_output_path=os.path.join(td, "ao.json"),
+                            repo_path=td, mode="agentic", limit=2)
+    assert captured["unit_ids"] == ["z.py:g0", "z.py:g1"], (
+        f"limit must slice the DIFF-SELECTED population (analyze's "
+        f"filter-then-limit order), got {captured['unit_ids']!r} — a raw "
+        "alphabetical head-slice silently drops diff-selected units and "
+        "produces a false-coverage empty scan"
+    )
+
+
+def test_enhance_limit_zero_diff_selection_spends_nothing():
+    """A diff that selected ZERO units is still an annotated dataset
+    (key-presence predicate, analyzer.py:523's mirror): enhance filters to
+    0 units rather than spending the limit on unrelated units."""
+    import os
+    import tempfile
+    import unittest.mock as mock
+
+    from core.enhancer import enhance_dataset
+    from utilities.file_io import write_json
+
+    units = [{"unit_id": f"a.py:f{i}", "diff_selected": False} for i in range(5)]
+    captured = {}
+
+    class _StubEnhancer:
+        def __init__(self, *a, **k):
+            pass
+
+        def enhance_dataset_agentic(self, dataset=None, **kwargs):
+            captured["unit_ids"] = [u["unit_id"] for u in dataset.get("units", [])]
+            return {"units": dataset.get("units", [])}
+
+    with tempfile.TemporaryDirectory() as td:
+        ds = os.path.join(td, "dataset.json")
+        write_json(ds, {"units": units})
+        import utilities.context_enhancer as ctx_mod
+        with mock.patch.object(ctx_mod, "ContextEnhancer", _StubEnhancer):
+            enhance_dataset(dataset_path=ds,
+                            output_path=os.path.join(td, "e.json"),
+                            analyzer_output_path=os.path.join(td, "ao.json"),
+                            repo_path=td, mode="agentic", limit=2)
+    assert captured["unit_ids"] == [], (
+        f"a zero-selection diff must enhance 0 units, not spend the limit on "
+        f"unrelated units (got {captured['unit_ids']!r})"
+    )


### PR DESCRIPTION
## Summary

`scan --limit 2` ran the agentic enhancer across the **entire dataset** before analyzing 2 units — the cheapest-looking way to try OpenAnt on a real repo incurred near-full cost with no warning (#213's reporter measured 1351 units enhanced on a `--limit 2` run). The plumbing already existed — `enhance_dataset(limit=...)` — but the scanner never threaded the scan's limit into it.

This threads `limit=limit` into the scanner's enhance call and amends the `--limit` help (Python CLI **and** Go CLI) to state it bounds analyze **and** enhance, with the LLM reachability pass deliberately still reviewing the full codebase (it needs the corpus to find missed entry points).

**Population semantics** (two review-caught regressions fixed before they shipped): the limit is applied to the *intended* population, never the raw alphabetical head. When diff-mode annotated the dataset, enhance filters `diff_selected` **before** slicing — using analyzer's exact key-presence predicate (a zero-selection diff still counts as annotated: filtering to 0 beats spending the limit on unrelated units). A raw head-slice would have silently dropped diff-selected units outside the head: a `--limit + --diff-manifest` run would enhance/analyze ~0 units and exit 0 clean — a false-coverage regression.

**Deliberate ordering trade-off** (per the issue's ruling): a limited run selects units *before* the enhancer writes `security_classification`, so analyze's classification-priority re-sort no-ops on the pre-limited set — bounded runs choose cost-bound over classification-priority coverage. A static priority basis is recorded as a follow-up on the issue.

## Test plan

5 hermetic tests: scan-level limit threading (RED on the pre-fix tree via the offline scaffold); no-limit passes `None`; an action-level help lock (asserts the `--limit` action's **own** help string, not a block render a sibling flag could satisfy); the diff-selected-population test observing the post-slice dataset handed to the enhancer; and a zero-selection-diff test (enhances 0 units, not the limit's worth of unrelated ones).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue213_limit_bounds_enhance.py -q` | 5 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue213_limit_bounds_enhance.py` | 5 passed |
| mutation smoke (thread) | remove `limit=limit` from the scanner call | threading test fails |
| mutation smoke (filter) | remove the diff-filter from enhancer | 2 tests fail (population + zero-selection) |
| full suite | `pytest tests/ -q` | 3000 passed, 2 failed (pre-existing `tests/parsers/zig/test_callgraph_funcptr_field.py`, local-env tree-sitter, stash-replay verified; CI green with them), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Adversarial loop: 4-seat wave (sonnet×2, glm-5.3, kimi) → 1 false-coverage MAJOR + 2 help/test MAJORs fixed; confirm round → 2 more MAJORs fixed (predicate mismatch, help-lock isolation); re-confirm **DRY** from the original finding's seat.

</details>

Fixes #213
