### PR TITLE
fix(reporter): thread finding-semantic transit fields (confidence, json_corrected) into the finding record

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -443,6 +443,20 @@ def build_pipeline_output(
             "cwe_name": vuln.get("cwe_name") or finding.get("cwe_name") or full_result.get("cwe_name", "Unknown"),
             "stage1_verdict": finding.get("verdict", finding.get("finding", "vulnerable")),
             "stage2_verdict": stage2_verdict,
+            # #215 (partial repair): the two FINDING-SEMANTIC transit
+            # fields — confidence (float 0.0-1.0 per the verdict schema,
+            # json_corrector.py:32; NOT analysis_core.py:181's error-shape
+            # default) and json_corrected (provenance: the finding's JSON
+            # was model-repaired, json_corrector.py:278) — populated
+            # upstream, surviving into results_verified.json, previously
+            # DROPPED by this fixed-key record. Present-only: absent
+            # upstream stays absent (never a fabricated 0/False — a REAL
+            # falsy value threads through). elapsed_seconds/prompt_length
+            # stay OUT (per-unit step telemetry, not finding metadata).
+            **({"confidence": finding["confidence"]}
+               if finding.get("confidence") is not None else {}),
+            **({"json_corrected": finding["json_corrected"]}
+               if finding.get("json_corrected") is not None else {}),
             "description": description,
             "vulnerable_code": vulnerable_code,
             "vulnerable_code_section": vulnerable_code_section,

--- a/libs/openant-core/tests/test_issue215_transit_fields.py
+++ b/libs/openant-core/tests/test_issue215_transit_fields.py
@@ -1,0 +1,148 @@
+"""Regression tests for issue #215 (partial repair — dropped-in-transit fields).
+
+#215's headline (76 of 82 findings with ``cwe_id: 0``, no severity field)
+needs schema-constrained prompts + a new severity field — deferred on the
+issue as beyond a fixes-only campaign. The maintainer comment's
+repair-shaped sub-finding is in scope: per-unit fields populated upstream
+and surviving into ``results_verified.json`` were DROPPED by
+``build_pipeline_output``'s fixed 14-key finding record.
+
+Contract locked here: the finding record carries the two FINDING-SEMANTIC
+transit fields — ``confidence`` (triage weight) and ``json_corrected``
+(provenance: this finding's JSON was model-repaired). ``elapsed_seconds``
+and ``prompt_length`` stay OUT (per-unit step telemetry, not finding
+metadata — surface-growth dressed as repair).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.reporter import build_pipeline_output  # noqa: E402
+from utilities.file_io import write_json  # noqa: E402
+
+
+def _run(tmp_path: Path, finding_extra: dict | None = None) -> dict:
+    finding = {
+        "finding": "vulnerable",
+        "verdict": "vulnerable",
+        "confidence": 0.9,
+        "json_corrected": True,
+        "cwe_id": 79,
+        "cwe_name": "XSS",
+        "description": "d",
+        "reasoning": "r",
+        "vulnerabilities": [{"name": "XSS", "short_name": "XSS",
+                             "description": "d", "impact": "i",
+                             "suggested_fix": "s",
+                             "steps_to_reproduce": "steps"}],
+    }
+    if finding_extra:
+        finding.update(finding_extra)
+    results = {
+        "dataset": "t",
+        "code_by_route": {"a.py:f": "def f(): ..."},
+        "metrics": {"total": 1, "errors": 0},
+        "confirmed_findings": [finding],
+        "results": [finding],
+    }
+    write_json(tmp_path / "results.json", results)
+    out = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(tmp_path / "results.json"),
+        output_path=str(out),
+        language="python", repo_name="t/r", processing_level="reachable",
+    )
+    return json.loads(out.read_text())
+
+
+def test_finding_record_carries_confidence(tmp_path: Path):
+    """confidence is finding-semantic (triage weight) — must survive
+    transit with its REAL upstream type (float 0.0-1.0 per the verdict
+    schema, json_corrector.py:32 — never a hand-invented string)."""
+    out = _run(tmp_path)
+    rec = out["findings"][0]
+    assert rec.get("confidence") == 0.9, (
+        f"confidence populated upstream must reach the finding record "
+        f"(got {rec.get('confidence')!r})"
+    )
+    assert isinstance(rec["confidence"], float)
+
+
+def test_finding_record_carries_json_corrected(tmp_path: Path):
+    """json_corrected is a provenance/trust signal — must survive transit."""
+    out = _run(tmp_path)
+    rec = out["findings"][0]
+    assert rec.get("json_corrected") is True
+
+
+def test_absent_upstream_stays_absent_not_fabricated(tmp_path: Path):
+    """Present-only threading: a unit whose record NEVER CARRIED the keys
+    (absent — not None) must not get fabricated values."""
+    import json as _json
+    _run(tmp_path)  # writes results.json with default fixture
+    rp = tmp_path / "results.json"
+    data = _json.loads(rp.read_text())
+    for f in data["confirmed_findings"]:
+        f.pop("confidence", None)
+        f.pop("json_corrected", None)
+    for f in data.get("results", []):
+        f.pop("confidence", None)
+        f.pop("json_corrected", None)
+    rp.write_text(_json.dumps(data))
+    out2_path = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(rp), output_path=str(out2_path),
+        language="python", repo_name="t/r", processing_level="reachable")
+    rec = _json.loads(out2_path.read_text())["findings"][0]
+    assert "confidence" not in rec, "key-absent upstream must stay key-absent"
+    assert "json_corrected" not in rec
+
+
+def test_falsy_present_values_thread_through(tmp_path: Path):
+    """The is-not-None guard's actual purpose: a REAL falsy value (0.0
+    confidence, False json_corrected) threads — only absence suppresses."""
+    out = _run(tmp_path, finding_extra={"confidence": 0.0, "json_corrected": False})
+    rec = out["findings"][0]
+    assert rec.get("confidence") == 0.0
+    assert rec.get("json_corrected") is False
+
+
+def test_step_telemetry_stays_out_of_the_finding_record(tmp_path: Path):
+    """elapsed_seconds/prompt_length are per-unit STEP telemetry, not
+    finding metadata — deliberately NOT threaded (surface-growth)."""
+    out = _run(tmp_path, finding_extra={"elapsed_seconds": 1.5, "prompt_length": 100})
+    rec = out["findings"][0]
+    assert "elapsed_seconds" not in rec
+    assert "prompt_length" not in rec
+
+
+def test_unverified_findings_path_threads_the_fields(tmp_path: Path):
+    """The no-Stage-2 path (unverified findings, filtered from results
+    rather than confirmed_findings) must thread the fields too."""
+    import json as _json
+    finding = {
+        "route_key": "a.py:f", "finding": "vulnerable", "verdict": "vulnerable",
+        "confidence": 0.75, "json_corrected": False, "cwe_id": 79,
+        "description": "d", "reasoning": "r",
+        "vulnerabilities": [{"name": "X", "short_name": "X", "description": "d",
+                             "impact": "i", "suggested_fix": "s",
+                             "steps_to_reproduce": "s"}],
+    }
+    results = {"dataset": "t", "code_by_route": {"a.py:f": "code"},
+               "metrics": {"total": 1, "errors": 0},
+               "results": [finding]}  # NO confirmed_findings -> filter path
+    write_json(tmp_path / "results.json", results)
+    out = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(tmp_path / "results.json"), output_path=str(out),
+        language="python", repo_name="t/r", processing_level="reachable")
+    rec = _json.loads(out.read_text())["findings"][0]
+    assert rec.get("confidence") == 0.75
+    assert rec.get("json_corrected") is False


### PR DESCRIPTION
## Summary

#215's maintainer comment found per-unit fields **populated upstream and dropped in transit**: `confidence` (float 0.0–1.0 per the verdict schema) and `json_corrected` (provenance: the finding's JSON was model-repaired) survive into `results_verified.json`, then get dropped by `build_pipeline_output`'s fixed 14-key finding record. This threads those two **finding-semantic** fields through — present-only: absent upstream stays absent (never a fabricated 0/False — a real falsy value threads through, test-locked). `elapsed_seconds`/`prompt_length` deliberately stay out (per-unit step telemetry, not finding metadata — noted on the issue as `pipeline_stats` material if ever wanted). Both finding-construction paths (verified `confirmed_findings` and the unverified filter) thread the fields.

**Refs #215 (partial), by design**: this moves the issue's dropped-in-transit finding, not its headline (76 of 82 findings with `cwe_id: 0`) — that half asks for a severity field and schema-constrained prompts, a new-capability/design change deferred on the issue.

## Test plan

6 hermetic tests: confidence transit with the **real** float type; `json_corrected` transit; key-absent-stays-absent (not a None-in-disguise test); falsy-present (0.0/False) threads; telemetry stays out with populated source values; the unverified-filter path.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue215_transit_fields.py -q` | 6 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue215_transit_fields.py` | 6 passed |
| mutation smoke | remove the threading from `build_pipeline_output` | 4 tests fail (restored → green) |
| full suite | `pytest tests/ -q` | 3001 passed, 2 failed (pre-existing zig local-env, stash-replay verified; CI green with them), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Adversarial loop: 4-seat wave found test-fidelity gaps (wrong confidence type pinned; two vacuous guards; falsy-present untested; filter path untested) — all fixed pre-ship; confirm round **DRY** from both finding seats.

</details>

Refs #215
