### PR TITLE
fix(cost): unpriced models are loud in artifacts; registry gains the 5th-gen slugs

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -1,264 +1,503 @@
 {
-  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment — see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests.",
+  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment \u2014 see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests.",
   "schema_version": 1,
   "models": [
     {
-      "id": "claude-opus-4-8", "provider": "anthropic", "status": "current",
-      "price": {"input": 15.00, "output": 75.00},
+      "id": "claude-opus-4-8",
+      "provider": "anthropic",
+      "status": "current",
+      "price": {
+        "input": 15.0,
+        "output": 75.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Anthropic pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "claude-sonnet-4-6", "provider": "anthropic", "status": "current",
-      "price": {"input": 3.00, "output": 15.00},
+      "id": "claude-sonnet-4-6",
+      "provider": "anthropic",
+      "status": "current",
+      "price": {
+        "input": 3.0,
+        "output": 15.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Anthropic pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "claude-haiku-4-5-20251001", "provider": "anthropic", "status": "current",
-      "price": {"input": 1.00, "output": 5.00},
+      "id": "claude-haiku-4-5-20251001",
+      "provider": "anthropic",
+      "status": "current",
+      "price": {
+        "input": 1.0,
+        "output": 5.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Anthropic pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "claude-opus-4-20250514", "provider": "anthropic", "status": "retired",
+      "id": "claude-opus-4-20250514",
+      "provider": "anthropic",
+      "status": "retired",
       "price": null,
       "source": "labeled retired in openant source (model_config.py); no live verification in build env",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "claude-sonnet-4-20250514", "provider": "anthropic", "status": "retired",
+      "id": "claude-sonnet-4-20250514",
+      "provider": "anthropic",
+      "status": "retired",
       "price": null,
       "source": "labeled retired in openant source (model_config.py, cmd/setup.go); no live verification in build env",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "claude-opus-4-6", "provider": "anthropic", "status": "unknown",
+      "id": "claude-opus-4-6",
+      "provider": "anthropic",
+      "status": "unknown",
       "price": null,
       "source": "liveness contested and not verifiable in build env; asserted neither alive nor dead",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "us.anthropic.claude-opus-4-8", "provider": "bedrock", "status": "current",
-      "price": {"input": 15.00, "output": 75.00},
+      "id": "us.anthropic.claude-opus-4-8",
+      "provider": "bedrock",
+      "status": "current",
+      "price": {
+        "input": 15.0,
+        "output": 75.0
+      },
       "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record (Bedrock Claude token rates match the direct Anthropic API)",
       "retrieved": "2026-07-31"
     },
     {
-      "id": "global.anthropic.claude-opus-4-8", "provider": "bedrock", "status": "current",
-      "price": {"input": 15.00, "output": 75.00},
+      "id": "global.anthropic.claude-opus-4-8",
+      "provider": "bedrock",
+      "status": "current",
+      "price": {
+        "input": 15.0,
+        "output": 75.0
+      },
       "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record (Bedrock Claude token rates match the direct Anthropic API)",
       "retrieved": "2026-07-31"
     },
     {
-      "id": "us.anthropic.claude-sonnet-4-6", "provider": "bedrock", "status": "current",
-      "price": {"input": 3.00, "output": 15.00},
+      "id": "us.anthropic.claude-sonnet-4-6",
+      "provider": "bedrock",
+      "status": "current",
+      "price": {
+        "input": 3.0,
+        "output": 15.0
+      },
       "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-sonnet-4-6 record (Bedrock Claude token rates match the direct Anthropic API)",
       "retrieved": "2026-07-31"
     },
     {
-      "id": "global.anthropic.claude-sonnet-4-6", "provider": "bedrock", "status": "current",
-      "price": {"input": 3.00, "output": 15.00},
+      "id": "global.anthropic.claude-sonnet-4-6",
+      "provider": "bedrock",
+      "status": "current",
+      "price": {
+        "input": 3.0,
+        "output": 15.0
+      },
       "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-sonnet-4-6 record (Bedrock Claude token rates match the direct Anthropic API)",
       "retrieved": "2026-07-31"
     },
     {
-      "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0", "provider": "bedrock", "status": "current",
-      "price": {"input": 1.00, "output": 5.00},
+      "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "provider": "bedrock",
+      "status": "current",
+      "price": {
+        "input": 1.0,
+        "output": 5.0
+      },
       "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-haiku-4-5-20251001 record (Bedrock Claude token rates match the direct Anthropic API)",
       "retrieved": "2026-07-31"
     },
     {
-      "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0", "provider": "bedrock", "status": "current",
-      "price": {"input": 1.00, "output": 5.00},
+      "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+      "provider": "bedrock",
+      "status": "current",
+      "price": {
+        "input": 1.0,
+        "output": 5.0
+      },
       "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-haiku-4-5-20251001 record (Bedrock Claude token rates match the direct Anthropic API)",
       "retrieved": "2026-07-31"
     },
     {
-      "id": "gpt-4o", "provider": "openai", "status": "current",
-      "price": {"input": 2.50, "output": 10.00},
+      "id": "gpt-4o",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 2.5,
+        "output": 10.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gpt-4o-mini", "provider": "openai", "status": "current",
-      "price": {"input": 0.15, "output": 0.60},
+      "id": "gpt-4o-mini",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gpt-4.1", "provider": "openai", "status": "current",
-      "price": {"input": 2.00, "output": 8.00},
+      "id": "gpt-4.1",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 2.0,
+        "output": 8.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gpt-4.1-mini", "provider": "openai", "status": "current",
-      "price": {"input": 0.40, "output": 1.60},
+      "id": "gpt-4.1-mini",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 0.4,
+        "output": 1.6
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gpt-4.1-nano", "provider": "openai", "status": "current",
-      "price": {"input": 0.10, "output": 0.40},
+      "id": "gpt-4.1-nano",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 0.1,
+        "output": 0.4
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "o1", "provider": "openai", "status": "current",
-      "price": {"input": 15.00, "output": 60.00},
+      "id": "o1",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 15.0,
+        "output": 60.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "o3", "provider": "openai", "status": "current",
-      "price": {"input": 2.00, "output": 8.00},
+      "id": "o3",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 2.0,
+        "output": 8.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "o3-mini", "provider": "openai", "status": "current",
-      "price": {"input": 1.10, "output": 4.40},
+      "id": "o3-mini",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 1.1,
+        "output": 4.4
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "o4-mini", "provider": "openai", "status": "current",
-      "price": {"input": 1.10, "output": 4.40},
+      "id": "o4-mini",
+      "provider": "openai",
+      "status": "current",
+      "price": {
+        "input": 1.1,
+        "output": 4.4
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gemini-2.5-pro", "provider": "google", "status": "current",
-      "price": {"input": 1.25, "output": 10.00},
+      "id": "gemini-2.5-pro",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 1.25,
+        "output": 10.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gemini-2.5-flash", "provider": "google", "status": "current",
-      "price": {"input": 0.30, "output": 2.50},
+      "id": "gemini-2.5-flash",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 0.3,
+        "output": 2.5
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gemini-2.5-flash-lite", "provider": "google", "status": "current",
-      "price": {"input": 0.10, "output": 0.40},
+      "id": "gemini-2.5-flash-lite",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 0.1,
+        "output": 0.4
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gemini-2.0-flash", "provider": "google", "status": "current",
-      "price": {"input": 0.10, "output": 0.40},
+      "id": "gemini-2.0-flash",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 0.1,
+        "output": 0.4
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gemini-2.0-flash-lite", "provider": "google", "status": "current",
-      "price": {"input": 0.075, "output": 0.30},
+      "id": "gemini-2.0-flash-lite",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 0.075,
+        "output": 0.3
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gemini-1.5-pro", "provider": "google", "status": "current",
-      "price": {"input": 1.25, "output": 5.00},
+      "id": "gemini-1.5-pro",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 1.25,
+        "output": 5.0
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "gemini-1.5-flash", "provider": "google", "status": "current",
-      "price": {"input": 0.075, "output": 0.30},
+      "id": "gemini-1.5-flash",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 0.075,
+        "output": 0.3
+      },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
       "retrieved": "2026-07-23"
     },
     {
-      "id": "anthropic/claude-opus-4.8", "provider": "openrouter", "status": "current",
-      "price": {"input": 5.00, "output": 25.00},
+      "id": "anthropic/claude-opus-4.8",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 5.0,
+        "output": 25.0
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "anthropic/claude-sonnet-4.6", "provider": "openrouter", "status": "current",
-      "price": {"input": 3.00, "output": 15.00},
+      "id": "anthropic/claude-sonnet-4.6",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 3.0,
+        "output": 15.0
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "anthropic/claude-haiku-4.5", "provider": "openrouter", "status": "current",
-      "price": {"input": 1.00, "output": 5.00},
+      "id": "anthropic/claude-haiku-4.5",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 1.0,
+        "output": 5.0
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/gpt-4o", "provider": "openrouter", "status": "current",
-      "price": {"input": 2.50, "output": 10.00},
+      "id": "openai/gpt-4o",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 2.5,
+        "output": 10.0
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/gpt-4o-mini", "provider": "openrouter", "status": "current",
-      "price": {"input": 0.15, "output": 0.60},
+      "id": "openai/gpt-4o-mini",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 0.15,
+        "output": 0.6
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/gpt-4.1", "provider": "openrouter", "status": "current",
-      "price": {"input": 2.00, "output": 8.00},
+      "id": "openai/gpt-4.1",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 2.0,
+        "output": 8.0
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/gpt-4.1-mini", "provider": "openrouter", "status": "current",
-      "price": {"input": 0.40, "output": 1.60},
+      "id": "openai/gpt-4.1-mini",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 0.4,
+        "output": 1.6
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/gpt-4.1-nano", "provider": "openrouter", "status": "current",
-      "price": {"input": 0.10, "output": 0.40},
+      "id": "openai/gpt-4.1-nano",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 0.1,
+        "output": 0.4
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/o1", "provider": "openrouter", "status": "current",
-      "price": {"input": 15.00, "output": 60.00},
+      "id": "openai/o1",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 15.0,
+        "output": 60.0
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/o3", "provider": "openrouter", "status": "current",
-      "price": {"input": 2.00, "output": 8.00},
+      "id": "openai/o3",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 2.0,
+        "output": 8.0
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/o3-mini", "provider": "openrouter", "status": "current",
-      "price": {"input": 1.10, "output": 4.40},
+      "id": "openai/o3-mini",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 1.1,
+        "output": 4.4
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "openai/o4-mini", "provider": "openrouter", "status": "current",
-      "price": {"input": 1.10, "output": 4.40},
+      "id": "openai/o4-mini",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 1.1,
+        "output": 4.4
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "google/gemini-2.5-pro", "provider": "openrouter", "status": "current",
-      "price": {"input": 1.25, "output": 10.00},
+      "id": "google/gemini-2.5-pro",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 1.25,
+        "output": 10.0
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "google/gemini-2.5-flash", "provider": "openrouter", "status": "current",
-      "price": {"input": 0.30, "output": 2.50},
+      "id": "google/gemini-2.5-flash",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 0.3,
+        "output": 2.5
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
     },
     {
-      "id": "google/gemini-2.5-flash-lite", "provider": "openrouter", "status": "current",
-      "price": {"input": 0.10, "output": 0.40},
+      "id": "google/gemini-2.5-flash-lite",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 0.1,
+        "output": 0.4
+      },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-01"
+    },
+    {
+      "id": "anthropic/claude-opus-5",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 5.0,
+        "output": 25.0
+      },
+      "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
+      "retrieved": "2026-08-27"
+    },
+    {
+      "id": "anthropic/claude-sonnet-5",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 2.0,
+        "output": 10.0
+      },
+      "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
+      "retrieved": "2026-08-27"
+    },
+    {
+      "id": "anthropic/claude-fable-5",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 10.0,
+        "output": 50.0
+      },
+      "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
+      "retrieved": "2026-08-27"
     }
   ]
 }

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -568,6 +568,7 @@ def run_analysis(
     _summary_input_tokens = 0
     _summary_output_tokens = 0
     _summary_cost_usd = 0.0
+    _summary_unpriced: set[str] = set()
     for _uid, _cp in _existing.items():
         _r = _cp.get("result", {})
         if _r.get("verdict") == "ERROR" or _r.get("finding") == "error":
@@ -579,16 +580,27 @@ def run_analysis(
         _summary_input_tokens += _cp_usage.get("input_tokens", 0)
         _summary_output_tokens += _cp_usage.get("output_tokens", 0)
         _summary_cost_usd += _cp_usage.get("cost_usd", 0.0)
+        # #216: restore the incomplete-cost marker from per-unit records.
+        _summary_unpriced.update(_cp_usage.get("unpriced_models") or [])
 
     def _usage_dict():
-        return {"input_tokens": _summary_input_tokens,
-                "output_tokens": _summary_output_tokens,
-                "cost_usd": round(_summary_cost_usd, 6)}
+        usage = {"input_tokens": _summary_input_tokens,
+                 "output_tokens": _summary_output_tokens,
+                 "cost_usd": round(_summary_cost_usd, 6)}
+        # #216: persist the unpriced set into _summary.json so a resume of
+        # a resume keeps the marker (run-cumulative semantics).
+        _all_unpriced = set(_summary_unpriced) | set(
+            get_global_tracker().get_totals().get("unpriced_models") or [])
+        if _all_unpriced:
+            usage["cost_incomplete"] = True
+            usage["unpriced_models"] = sorted(_all_unpriced)
+        return usage
 
     # Inject prior usage into tracker so step_report captures the total
-    if _summary_input_tokens or _summary_output_tokens:
+    if _summary_input_tokens or _summary_output_tokens or _summary_unpriced:
         get_global_tracker().add_prior_usage(
-            _summary_input_tokens, _summary_output_tokens, _summary_cost_usd)
+            _summary_input_tokens, _summary_output_tokens, _summary_cost_usd,
+            unpriced_models=sorted(_summary_unpriced) or None)
 
     # Write initial summary
     checkpoint.write_summary(total, _summary_completed, _summary_errors,

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -1314,6 +1314,16 @@ def _write_scan_report(
             "input_tokens": total_input,
             "output_tokens": total_output,
             "total_tokens": total_input + total_output,
+            # #216: the aggregate rebuilds token_usage from the step
+            # reports — OR-aggregate the incomplete-cost marker across them
+            # (a rebuild must not drop the advisory).
+            **({
+                "cost_incomplete": True,
+                "unpriced_models": sorted({m for sr in step_reports
+                                           for m in (sr.get("token_usage", {})
+                                                     .get("unpriced_models") or [])}),
+            } if any(sr.get("token_usage", {}).get("cost_incomplete")
+                     for sr in step_reports) else {}),
         },
     )
 

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -91,6 +91,11 @@ class UsageInfo:
     total_output_tokens: int = 0
     total_tokens: int = 0
     total_cost_usd: float = 0.0
+    # #216: the cost figure is incomplete when any dispatched model had no
+    # pricing record (tokens counted, dollars $0). Deterministic advisory —
+    # flows into step reports and scan.report.json via tracking.get_usage.
+    cost_incomplete: bool = False
+    unpriced_models: list = field(default_factory=list)
 
     def to_dict(self) -> dict:
         return asdict(self)

--- a/libs/openant-core/core/step_report.py
+++ b/libs/openant-core/core/step_report.py
@@ -59,13 +59,20 @@ def step_context(step: str, output_dir: str, inputs: dict | None = None):
         report.duration_seconds = round(time.monotonic() - start, 2)
 
         # Capture cost delta
-        end_cost, end_tokens = _snapshot_usage()
+        end_cost, end_snapshot = _snapshot_usage()
         report.cost_usd = round(end_cost - start_cost, 6)
         report.token_usage = {
-            "input_tokens": end_tokens.get("input", 0) - start_tokens.get("input", 0),
-            "output_tokens": end_tokens.get("output", 0) - start_tokens.get("output", 0),
-            "total_tokens": end_tokens.get("total", 0) - start_tokens.get("total", 0),
+            "input_tokens": end_snapshot.get("input", 0) - start_tokens.get("input", 0),
+            "output_tokens": end_snapshot.get("output", 0) - start_tokens.get("output", 0),
+            "total_tokens": end_snapshot.get("total", 0) - start_tokens.get("total", 0),
         }
+        # #216: a step whose cost is incomplete (any call on an unpriced
+        # model) must say so IN the artifact — OR the end snapshot's marker
+        # (run-cumulative, so a step after unpriced spend also flags).
+        if end_snapshot.get("cost_incomplete"):
+            report.token_usage["cost_incomplete"] = True
+            report.token_usage["unpriced_models"] = end_snapshot.get(
+                "unpriced_models", [])
 
         report.write(output_dir)
         print(
@@ -76,7 +83,8 @@ def step_context(step: str, output_dir: str, inputs: dict | None = None):
 
 
 def _snapshot_usage() -> tuple[float, dict]:
-    """Return (cost_usd, {input, output, total}) from the global tracker.
+    """Return (cost_usd, {input, output, total, cost_incomplete,
+    unpriced_models}) from the global tracker.
 
     Returns zeroes if the tracker isn't available (e.g. for local-only steps).
     """
@@ -87,6 +95,9 @@ def _snapshot_usage() -> tuple[float, dict]:
             "input": usage.total_input_tokens,
             "output": usage.total_output_tokens,
             "total": usage.total_tokens,
+            "cost_incomplete": usage.cost_incomplete,
+            "unpriced_models": usage.unpriced_models,
         }
     except Exception:
-        return 0.0, {"input": 0, "output": 0, "total": 0}
+        return 0.0, {"input": 0, "output": 0, "total": 0,
+                     "cost_incomplete": False, "unpriced_models": []}

--- a/libs/openant-core/core/tracking.py
+++ b/libs/openant-core/core/tracking.py
@@ -26,6 +26,8 @@ def get_usage() -> UsageInfo:
         total_output_tokens=totals["total_output_tokens"],
         total_tokens=totals["total_tokens"],
         total_cost_usd=totals["total_cost_usd"],
+        cost_incomplete=totals.get("cost_incomplete", False),
+        unpriced_models=totals.get("unpriced_models", []),
     )
 
 

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -57,18 +57,25 @@ def _extract_usage(
         input_cost = (input_tokens / 1_000_000) * pricing["input"]
         output_cost = (output_tokens / 1_000_000) * pricing["output"]
         total_cost = input_cost + output_cost
-    return {
+    usage = {
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "total_tokens": input_tokens + output_tokens,
         "cost_usd": round(total_cost, 6),
     }
+    if pricing is None:
+        # #216: this fallback costs OUTSIDE the tracker — the usage dict
+        # must not claim a complete cost it does not have.
+        usage["cost_incomplete"] = True
+    return usage
 
 
 def _merge_usage(usages: list[dict]) -> dict:
     """Merge multiple usage dicts into one."""
     merged = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0, "cost_usd": 0.0}
     for u in usages:
+        if u.get("cost_incomplete"):
+            merged["cost_incomplete"] = True
         merged["input_tokens"] += u["input_tokens"]
         merged["output_tokens"] += u["output_tokens"]
         merged["total_tokens"] += u["total_tokens"]

--- a/libs/openant-core/tests/test_issue216_unpriced_models_loud.py
+++ b/libs/openant-core/tests/test_issue216_unpriced_models_loud.py
@@ -1,0 +1,271 @@
+"""Regression tests for issue #216 — unpriced models must be loud in artifacts.
+
+A model absent from config/models.json dispatched normally: every phase
+reported ``cost_usd: 0.0000`` with correct token counts (only money blind),
+and NOTHING in any artifact recorded that the cost was incomplete — the
+null-price convention's exact failure mode, reached via the missing-record
+path. A one-time stderr warning existed but is invisible in a 7-phase run's
+noise and leaves no durable trace.
+
+Contract locked here:
+- ``TokenTracker`` records every unpriced call and the unpriced model set;
+  ``get_totals``/``get_summary`` expose ``cost_incomplete`` + ``unpriced_models``;
+- ``UsageInfo`` carries the same two fields, so step reports and
+  ``scan.report.json`` surface them (the deterministic advisory surface —
+  same class as the #212 coverage headline);
+- the scanner's aggregate token_usage OR-aggregates ``cost_incomplete``
+  across step reports (a rebuild-from-parts must not drop the marker);
+- the report-generator's own costing fallback annotates the same marker
+  (it duplicates the tracker's miss path outside the tracker).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.llm_client import TokenTracker  # noqa: E402
+
+
+def test_tracker_records_unpriced_models():
+    t = TokenTracker()
+    t.record_call(model="totally/unknown-model", input_tokens=100,
+                  output_tokens=50)  # no pricing → $0 + unpriced
+    totals = t.get_totals()
+    assert totals["cost_incomplete"] is True
+    assert "totally/unknown-model" in totals["unpriced_models"]
+
+
+def test_tracker_priced_call_is_complete():
+    t = TokenTracker()
+    t.record_call(model="m", input_tokens=10, output_tokens=5,
+                  pricing={"input": 1.0, "output": 2.0})
+    totals = t.get_totals()
+    assert totals["cost_incomplete"] is False
+    assert totals["unpriced_models"] == []
+
+
+def test_mixed_run_incomplete_and_both_models_listed():
+    t = TokenTracker()
+    t.record_call(model="known/m", input_tokens=10, output_tokens=5,
+                  pricing={"input": 1.0, "output": 2.0})
+    t.record_call(model="unknown/a", input_tokens=10, output_tokens=5)
+    t.record_call(model="unknown/a", input_tokens=10, output_tokens=5)  # dedup
+    t.record_call(model="unknown/b", input_tokens=10, output_tokens=5)
+    totals = t.get_totals()
+    assert totals["cost_incomplete"] is True
+    assert sorted(totals["unpriced_models"]) == ["unknown/a", "unknown/b"]
+
+
+def test_usage_info_carries_the_marker():
+    from core.schemas import UsageInfo
+    from core import tracking
+    tracker = tracking.get_global_tracker()
+    tracker.reset()
+    tracker.record_call(model="unknown/x", input_tokens=1, output_tokens=1)
+    usage = tracking.get_usage()
+    assert isinstance(usage, UsageInfo)
+    assert usage.cost_incomplete is True
+    assert "unknown/x" in usage.unpriced_models
+    assert "cost_incomplete" in usage.to_dict()
+
+
+def test_step_report_serializes_the_marker(tmp_path: Path):
+    from core.step_report import step_context
+    from core import tracking
+    tracker = tracking.get_global_tracker()
+    tracker.reset()
+    tracker.record_call(model="unknown/x", input_tokens=1, output_tokens=1)
+    with step_context("analyze", str(tmp_path)):
+        pass
+    import json
+    report = json.loads((tmp_path / "analyze.report.json").read_text())
+    assert report["token_usage"]["cost_incomplete"] is True
+
+
+def test_registry_records_for_the_issue_slugs_exist():
+    """Data half: the three missing slugs from the issue now have
+    records with the live-catalogue source convention."""
+    import json
+    from pathlib import Path as P
+    registry = json.loads(
+        (P(__file__).parents[3] / "config" / "models.json").read_text())
+    ids = {m["id"] for m in registry["models"]}
+    for slug in ("anthropic/claude-opus-5", "anthropic/claude-sonnet-5",
+                 "anthropic/claude-fable-5"):
+        assert slug in ids, f"{slug} missing from config/models.json"
+        rec = next(m for m in registry["models"] if m["id"] == slug)
+        assert rec["price"]["input"] > 0 and rec["price"]["output"] > 0
+        assert "retrieved" in rec and "source" in rec
+
+
+def test_scan_report_aggregate_or_aggregates_marker(tmp_path, monkeypatch):
+    """_write_scan_report rebuilds token_usage from step reports — the
+    incomplete-cost marker must survive the rebuild (OR across steps)."""
+    import json
+    from core.scanner import _write_scan_report
+    from core.schemas import ScanResult, AnalysisMetrics
+
+    metrics = AnalysisMetrics(total=0, vulnerable=0, bypassable=0, inconclusive=0,
+                              protected=0, safe=0, errors=0)
+    result = ScanResult(output_dir=str(tmp_path), units_count=0,
+                        language="python", metrics=metrics)
+    step_reports = [
+        {"step": "parse", "cost_usd": 0.0, "duration_seconds": 1.0,
+         "token_usage": {"input_tokens": 5, "output_tokens": 5,
+                         "total_tokens": 10, "cost_incomplete": True,
+                         "unpriced_models": ["unknown/a"]}},
+        {"step": "analyze", "cost_usd": 0.1, "duration_seconds": 1.0,
+         "token_usage": {"input_tokens": 5, "output_tokens": 5,
+                         "total_tokens": 10}},
+    ]
+    path = _write_scan_report(str(tmp_path), result, step_reports)
+    agg = json.loads(Path(path).read_text())
+    tu = agg["token_usage"]
+    assert tu["cost_incomplete"] is True
+    assert tu["unpriced_models"] == ["unknown/a"]
+
+
+def test_scan_report_aggregate_clean_when_all_steps_clean(tmp_path):
+    import json
+    from core.scanner import _write_scan_report
+    from core.schemas import ScanResult, AnalysisMetrics
+    metrics = AnalysisMetrics(total=0, vulnerable=0, bypassable=0, inconclusive=0,
+                              protected=0, safe=0, errors=0)
+    result = ScanResult(output_dir=str(tmp_path), units_count=0,
+                        language="python", metrics=metrics)
+    step_reports = [{"step": "parse", "cost_usd": 0.1, "duration_seconds": 1.0,
+                     "token_usage": {"input_tokens": 5, "output_tokens": 5,
+                                     "total_tokens": 10}}]
+    path = _write_scan_report(str(tmp_path), result, step_reports)
+    agg = json.loads(Path(path).read_text())
+    assert "cost_incomplete" not in agg["token_usage"]
+
+
+# ---------------------------------------------------------------------------
+# Wave-1 additions: generator annotation, merge OR, unit-level + resume restore
+# ---------------------------------------------------------------------------
+
+def test_generator_fallback_annotates_incomplete():
+    """BLOCKER catch (3-seat convergence): _extract_usage with no pricing
+    must mark its OWN usage dict cost_incomplete (the commit claimed this
+    and it wasn't there)."""
+    from report.generator import _extract_usage
+    u = _extract_usage(100, 50, "totally/unknown")
+    assert u["cost_incomplete"] is True
+    priced = _extract_usage(100, 50, "m", pricing={"input": 1.0, "output": 2.0})
+    assert "cost_incomplete" not in priced
+
+
+def test_merge_usage_ors_incomplete():
+    from report.generator import _merge_usage
+    merged = _merge_usage([
+        {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15, "cost_usd": 0.01},
+        {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15, "cost_usd": 0.0,
+         "cost_incomplete": True},
+    ])
+    assert merged.get("cost_incomplete") is True
+
+
+def test_unit_usage_carries_own_unpriced_models():
+    t = TokenTracker()
+    t.start_unit_tracking()
+    t.record_call(model="unknown/u", input_tokens=1, output_tokens=1)
+    usage = t.get_unit_usage()
+    assert usage["cost_incomplete"] is True
+    assert usage["unpriced_models"] == ["unknown/u"]
+
+
+def test_add_prior_usage_restores_marker_across_resume():
+    """BLOCKER catch: a resumed run's tracker must not silently look
+    complete when the prior run had unpriced models."""
+    t = TokenTracker()
+    t.add_prior_usage(100, 50, 0.0, unpriced_models=["unknown/a"])
+    totals = t.get_totals()
+    assert totals["cost_incomplete"] is True
+    assert totals["unpriced_models"] == ["unknown/a"]
+
+
+def test_analyzer_resume_restores_marker(tmp_path, monkeypatch):
+    """The analyzer's checkpoint-restore path re-injects unpriced models
+    from per-unit records into the tracker."""
+    import json
+    from core import checkpoint as cp_mod
+    from core import tracking
+    from utilities.file_io import write_json
+    import tempfile, os
+
+    td = tempfile.mkdtemp()
+    # one per-unit checkpoint carrying the marker
+    write_json(os.path.join(td, "unit_a.json"),
+               {"result": {"verdict": "safe"}, "usage": {
+                   "input_tokens": 10, "output_tokens": 5, "cost_usd": 0.0,
+                   "cost_incomplete": True, "unpriced_models": ["unknown/a"]}})
+    tracker = tracking.get_global_tracker()
+    tracker.reset()
+    # drive the same accumulation the resume loop performs
+    _existing = {"unit_a": json.loads(
+        open(os.path.join(td, "unit_a.json")).read())}
+    unpriced = set()
+    for _uid, _cp in _existing.items():
+        unpriced.update(_cp.get("usage", {}).get("unpriced_models") or [])
+    tracker.add_prior_usage(10, 5, 0.0,
+                            unpriced_models=sorted(unpriced) or None)
+    totals = tracker.get_totals()
+    assert totals["cost_incomplete"] is True
+    assert totals["unpriced_models"] == ["unknown/a"]
+
+
+def test_agent_result_metadata_carries_unpriced_models():
+    """Confirm-round BLOCKER fix: the ENHANCER's per-unit record
+    (agent_metadata) must carry the marker — the #211-style real-loop test
+    with an unpriced (no-pricing) adapter."""
+    from utilities.agentic_enhancer.agent import ContextAgent
+    from utilities.llm.adapter import CompletionResult, TextBlock, ToolUseBlock
+    from utilities.llm.registry import PhaseBinding
+    from utilities.llm_client import TokenTracker
+    from utilities.agentic_enhancer.repository_index import RepositoryIndex
+
+    class _UnpricedAdapter:
+        name = "fake"
+        supports_tools = True
+        pricing = {}  # NO pricing for fake-model → unpriced path
+
+        def __init__(self):
+            self.turn = 0
+
+        def complete(self, *, model, max_tokens, system, tools, messages):
+            self.turn += 1
+            if self.turn == 1:
+                return CompletionResult(
+                    content=(ToolUseBlock(id="t1", name="finish",
+                                          input={"security_classification": "exploitable",
+                                                 "usage_context": "ctx",
+                                                 "include_functions": [],
+                                                 "classification_reasoning": "r",
+                                                 "confidence": 0.9}),),
+                    input_tokens=10, output_tokens=5, stop_reason="tool_use")
+            return CompletionResult(
+                content=(TextBlock("done"),),
+                input_tokens=8, output_tokens=4, stop_reason="end_turn")
+
+    tracker = TokenTracker()
+    binding = PhaseBinding(phase="enhance", adapter=_UnpricedAdapter(),
+                           model="fake-model", provider_name="fake")
+    agent = ContextAgent(index=RepositoryIndex({}, repo_path=None),
+                         binding=binding, tracker=tracker)
+    tracker.start_unit_tracking()
+    result = agent.analyze_unit(
+        unit_id="a.py:f", unit_type="function",
+        primary_code="def f(): ...", static_deps=[], static_callers=[])
+    d = result.to_dict()
+    meta = d["agent_metadata"]
+    assert meta.get("cost_incomplete") is True, (
+        f"agent_metadata must carry the incomplete-cost marker for an "
+        f"unpriced unit (got {meta!r})"
+    )
+    assert meta.get("unpriced_models") == ["fake-model"]

--- a/libs/openant-core/utilities/agentic_enhancer/agent.py
+++ b/libs/openant-core/utilities/agentic_enhancer/agent.py
@@ -99,6 +99,7 @@ class AgentResult:
         input_tokens: int = 0,
         output_tokens: int = 0,
         cost_usd: float = 0.0,
+        unpriced_models: Optional[list] = None,
     ):
         self.include_functions = include_functions
         self.usage_context = usage_context
@@ -113,6 +114,8 @@ class AgentResult:
         self.input_tokens = input_tokens
         self.output_tokens = output_tokens
         self.cost_usd = cost_usd
+        # #216: this unit's unpriced models (incomplete-cost marker).
+        self.unpriced_models = unpriced_models
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -128,6 +131,10 @@ class AgentResult:
                 "input_tokens": self.input_tokens,
                 "output_tokens": self.output_tokens,
                 "cost_usd": self.cost_usd,
+                # #216: the unit's unpriced models — flows into the
+                # per-unit checkpoint record so resume restores the marker.
+                **({"cost_incomplete": True, "unpriced_models": self.unpriced_models}
+                   if self.unpriced_models else {}),
             },
             "reachability": {
                 "is_entry_point": self.is_entry_point,
@@ -205,6 +212,16 @@ class ContextAgent:
         Returns:
             AgentResult with gathered context
         """
+        # #216: begin per-unit usage tracking on THIS thread — the unit's
+        # unpriced-model set (thread-local) is what the AgentResult
+        # construction sites read for agent_metadata. Without this call the
+        # getattr chain always sees the default empty set and the marker is
+        # dead code on the enhance path (union-checkpoint catch: no caller
+        # on the worker thread ever started tracking).
+        _start = getattr(self.tracker, "start_unit_tracking", None)
+        if _start is not None:
+            _start()
+
         is_entry_point = unit_id in self.entry_points
         reachable_from_entry: Optional[bool] = None
         entry_point_path: Optional[List[str]] = None
@@ -311,6 +328,9 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     cost_usd=call_record.get("cost_usd", 0.0),
+                    unpriced_models=sorted(getattr(
+                        getattr(self.tracker, "_thread_local", None),
+                        "unit_unpriced", set())) or None,
                 )
 
             tool_results: list[ToolResultBlock] = []
@@ -381,6 +401,9 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     cost_usd=call_record.get("cost_usd", 0.0),
+                    unpriced_models=sorted(getattr(
+                        getattr(self.tracker, "_thread_local", None),
+                        "unit_unpriced", set())) or None,
                 )
 
             # If finish was called, return result
@@ -407,6 +430,9 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     cost_usd=call_record.get("cost_usd", 0.0),
+                    unpriced_models=sorted(getattr(
+                        getattr(self.tracker, "_thread_local", None),
+                        "unit_unpriced", set())) or None,
                 )
 
             # Add assistant message and tool results to conversation.
@@ -444,6 +470,9 @@ class ContextAgent:
                     input_tokens=total_input_tokens,
                     output_tokens=total_output_tokens,
                     cost_usd=call_record.get("cost_usd", 0.0),
+                    unpriced_models=sorted(getattr(
+                        getattr(self.tracker, "_thread_local", None),
+                        "unit_unpriced", set())) or None,
                 )
 
         # Max iterations reached
@@ -472,6 +501,9 @@ class ContextAgent:
             input_tokens=total_input_tokens,
             output_tokens=total_output_tokens,
             cost_usd=call_record.get("cost_usd", 0.0),
+            unpriced_models=sorted(getattr(
+                getattr(self.tracker, "_thread_local", None),
+                "unit_unpriced", set())) or None,
         )
 
 

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -638,6 +638,7 @@ class ContextEnhancer:
         _summary_input_tokens = 0
         _summary_output_tokens = 0
         _summary_cost_usd = 0.0
+        _summary_unpriced: set[str] = set()
 
         if checkpoint_dir:
             SC = _get_step_checkpoint()
@@ -658,6 +659,8 @@ class ContextEnhancer:
                     _summary_input_tokens += cp_usage.get("input_tokens", 0)
                     _summary_output_tokens += cp_usage.get("output_tokens", 0)
                     _summary_cost_usd += cp_usage.get("cost_usd", 0.0)
+                    # #216: restore the incomplete-cost marker per unit.
+                    _summary_unpriced.update(cp_usage.get("unpriced_models") or [])
                     # Count errors for non-completed units
                     if uid not in processed_ids and cp_data.get("agent_context", {}).get("error"):
                         _summary_errors += 1
@@ -674,9 +677,10 @@ class ContextEnhancer:
                                              "cost_usd": round(_summary_cost_usd, 6)})
 
             # Inject prior usage into tracker so step_report captures the total
-            if _summary_input_tokens or _summary_output_tokens:
+            if _summary_input_tokens or _summary_output_tokens or _summary_unpriced:
                 self.tracker.add_prior_usage(
-                    _summary_input_tokens, _summary_output_tokens, _summary_cost_usd)
+                    _summary_input_tokens, _summary_output_tokens, _summary_cost_usd,
+                    unpriced_models=sorted(_summary_unpriced) or None)
 
         remaining = total - len(processed_ids)
         self._log("info", f"Enhancing {remaining} units with agentic analysis ({len(processed_ids)} already done)", units=remaining)
@@ -759,11 +763,16 @@ class ContextEnhancer:
             _summary_input_tokens += meta.get("input_tokens", 0)
             _summary_output_tokens += meta.get("output_tokens", 0)
             _summary_cost_usd += meta.get("cost_usd", 0.0)
+            _summary_unpriced.update(meta.get("unpriced_models") or [])
+            _usage = {"input_tokens": _summary_input_tokens,
+                      "output_tokens": _summary_output_tokens,
+                      "cost_usd": round(_summary_cost_usd, 6)}
+            if _summary_unpriced:
+                _usage["cost_incomplete"] = True
+                _usage["unpriced_models"] = sorted(_summary_unpriced)
             _summary_cp.write_summary(total, _summary_completed, _summary_errors,
                                       _summary_error_breakdown, phase="in_progress",
-                                      usage={"input_tokens": _summary_input_tokens,
-                                             "output_tokens": _summary_output_tokens,
-                                             "cost_usd": round(_summary_cost_usd, 6)})
+                                      usage=_usage)
 
         if workers <= 1:
             # Sequential mode

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -646,6 +646,7 @@ class FindingVerifier:
         _summary_input_tokens = 0
         _summary_output_tokens = 0
         _summary_cost_usd = 0.0
+        _summary_unpriced: set[str] = set()
 
         # Sum usage from ALL existing checkpoints (including errored ones
         # — their cost was already spent in a prior run)
@@ -654,16 +655,25 @@ class FindingVerifier:
             _summary_input_tokens += _cp_usage.get("input_tokens", 0)
             _summary_output_tokens += _cp_usage.get("output_tokens", 0)
             _summary_cost_usd += _cp_usage.get("cost_usd", 0.0)
+            # #216: restore the incomplete-cost marker per unit.
+            _summary_unpriced.update(_cp_usage.get("unpriced_models") or [])
 
         def _usage_dict():
-            return {"input_tokens": _summary_input_tokens,
-                    "output_tokens": _summary_output_tokens,
-                    "cost_usd": round(_summary_cost_usd, 6)}
+            usage = {"input_tokens": _summary_input_tokens,
+                     "output_tokens": _summary_output_tokens,
+                     "cost_usd": round(_summary_cost_usd, 6)}
+            # #216: persist the unpriced set into _summary.json (mirrors
+            # analyzer's — a resume-of-resume keeps the marker).
+            if _summary_unpriced:
+                usage["cost_incomplete"] = True
+                usage["unpriced_models"] = sorted(_summary_unpriced)
+            return usage
 
         # Inject prior usage into tracker so step_report captures the total
-        if _summary_input_tokens or _summary_output_tokens:
+        if _summary_input_tokens or _summary_output_tokens or _summary_unpriced:
             self.tracker.add_prior_usage(
-                _summary_input_tokens, _summary_output_tokens, _summary_cost_usd)
+                _summary_input_tokens, _summary_output_tokens, _summary_cost_usd,
+                unpriced_models=sorted(_summary_unpriced) or None)
 
         if checkpoint is not None:
             checkpoint.write_summary(total, _summary_completed, _summary_errors,

--- a/libs/openant-core/utilities/llm_client.py
+++ b/libs/openant-core/utilities/llm_client.py
@@ -80,6 +80,9 @@ class TokenTracker:
             self.total_input_tokens = 0
             self.total_output_tokens = 0
             self.total_cost_usd = 0.0
+            # #216: models dispatched without a pricing record (their cost
+            # contributes $0 — the run's cost figure is incomplete).
+            self._unpriced_models: set[str] = set()
 
     @property
     def total_tokens(self) -> int:
@@ -119,6 +122,15 @@ class TokenTracker:
         if pricing is None:
             _warn_unknown_pricing(model)
             total_cost = 0.0
+            # #216: an unpriced-but-dispatched model must be LOUD in the
+            # artifacts, not just stderr — record it so get_totals exposes
+            # cost_incomplete + unpriced_models (flows to UsageInfo → step
+            # reports → scan.report.json).
+            with self._lock:
+                self._unpriced_models.add(model)
+            tl = self._thread_local
+            if hasattr(tl, "unit_unpriced"):
+                tl.unit_unpriced.add(model)
         else:
             input_cost = (input_tokens / 1_000_000) * pricing["input"]
             output_cost = (output_tokens / 1_000_000) * pricing["output"]
@@ -147,16 +159,22 @@ class TokenTracker:
 
         return call_record
 
-    def add_prior_usage(self, input_tokens: int, output_tokens: int, cost_usd: float):
+    def add_prior_usage(self, input_tokens: int, output_tokens: int, cost_usd: float,
+                        unpriced_models: list[str] | None = None):
         """Inject usage from a prior run (e.g. restored checkpoints).
 
         This ensures step reports capture the total cost across all runs,
-        not just the current run's API calls.
+        not just the current run's API calls. ``unpriced_models`` restores
+        the #216 incomplete-cost marker across a resume (the tracker resets
+        per process; without this, a resumed run's cost silently looks
+        complete again).
         """
         with self._lock:
             self.total_input_tokens += input_tokens
             self.total_output_tokens += output_tokens
             self.total_cost_usd += cost_usd
+            if unpriced_models:
+                self._unpriced_models.update(unpriced_models)
 
     def start_unit_tracking(self):
         """Start tracking usage for the current unit on this thread.
@@ -169,15 +187,23 @@ class TokenTracker:
         tl.unit_input = 0
         tl.unit_output = 0
         tl.unit_cost = 0.0
+        tl.unit_unpriced: set[str] = set()
 
     def get_unit_usage(self) -> dict:
         """Return usage accumulated since ``start_unit_tracking()`` on this thread."""
         tl = self._thread_local
-        return {
+        usage = {
             "input_tokens": getattr(tl, "unit_input", 0),
             "output_tokens": getattr(tl, "unit_output", 0),
             "cost_usd": round(getattr(tl, "unit_cost", 0.0), 6),
         }
+        # #216: the unit's own unpriced models — persisted into the unit's
+        # checkpoint record so a resume restores the incomplete-cost marker.
+        unpriced = getattr(tl, "unit_unpriced", set())
+        if unpriced:
+            usage["cost_incomplete"] = True
+            usage["unpriced_models"] = sorted(unpriced)
+        return usage
 
     def get_summary(self) -> dict:
         """
@@ -193,6 +219,10 @@ class TokenTracker:
                 "total_output_tokens": self.total_output_tokens,
                 "total_tokens": self.total_input_tokens + self.total_output_tokens,
                 "total_cost_usd": round(self.total_cost_usd, 6),
+                # #216: the cost figure is INCOMPLETE when any dispatched
+                # model had no pricing (its tokens counted, its dollars $0).
+                "cost_incomplete": bool(self._unpriced_models),
+                "unpriced_models": sorted(self._unpriced_models),
                 "calls": list(self.calls),
             }
 
@@ -210,6 +240,8 @@ class TokenTracker:
                 "total_output_tokens": self.total_output_tokens,
                 "total_tokens": self.total_input_tokens + self.total_output_tokens,
                 "total_cost_usd": round(self.total_cost_usd, 6),
+                "cost_incomplete": bool(self._unpriced_models),
+                "unpriced_models": sorted(self._unpriced_models),
             }
 
 


### PR DESCRIPTION
## Summary

A model absent from `config/models.json` dispatched normally while **every phase reported `cost_usd: 0.0000`** (tokens correct, only money blind) — and nothing in any artifact recorded the incompleteness. This is the null-price convention's exact failure mode reached via the missing-record path (#216); the existing one-time stderr warning left no durable trace.

**Loud artifacts, end to end** (all three checkpoint-loop sites verified by adversarial review):
- `TokenTracker` records unpriced models (run-cumulative + per-unit via thread-local tracking); `get_totals`/`get_summary` expose `cost_incomplete` + `unpriced_models`; `add_prior_usage(unpriced_models=...)` restores the marker across resume
- `UsageInfo` carries both → each step report's `token_usage` (OR'd with the run-cumulative end snapshot); `scan.report.json` OR-aggregates across steps
- The report generator's tracker-external `_extract_usage` fallback marks its own usage dict; `_merge_usage` OR-merges
- Resume restores at **all three** sites (analyzer/verifier/enhancer checkpoint loops); analyzer + verifier `_summary.json` usage dicts persist the set; the enhancer's per-unit `agent_metadata` carries the marker (`AgentResult.unpriced_models`, serialized, all five construction sites)

**Data**: the three missing 5th-generation slugs the issue names (`anthropic/claude-opus-5` 5/25, `claude-sonnet-5` 2/10, `claude-fable-5` 10/50 per-M) added with live-OpenRouter-catalogue rates + the registry's `source`/`retrieved` provenance convention.

Deferred on the issue: the optional `expires` field (new schema, nothing consumes it); Go-side display of the marker (JSON artifacts carry it; the Go formatter doesn't render it yet).

## Test plan

14 hermetic tests incl. a real-loop enhancer integration test driving an unpriced adapter through `analyze_unit` into `agent_metadata`, resume-restore, unit-level tracking, merge OR, generator fallback annotation, aggregate OR, and the registry-record shape.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue216_unpriced_models_loud.py -q` | 14 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue216_unpriced_models_loud.py` | 14 passed |
| mutation smokes | remove tracker marker / scanner OR-aggregate / agent to_dict marker | each removal → test fails (restored → green) |
| full suite | `pytest tests/ -q` | 3009 passed, 2 failed (pre-existing zig local-env, stash-replay verified; CI green with them), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Adversarial loop: 4-seat wave → phantom generator-fix BLOCKER (3-seat convergence) + resume BLOCKERs found and fixed; confirm round → enhancer structural gap (agent_metadata never carried the marker) + verifier `_summary.json` gap found and fixed; the AgentResult kwarg break glm-5.3 caught in confirm was fixed before push.

</details>

Fixes #216
