### PR TITLE
fix(context): oversized docs are truncated, not skipped; the degradation is visible in the artifact

### DIFF
--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -303,6 +303,8 @@ def gather_context_sources(repo_path: Path) -> dict[str, str]:
         Dictionary mapping filename to content.
     """
     sources = {}
+    skipped: list[str] = []
+    truncated: list[str] = []
 
     # Read priority files
     for filename in CONTEXT_FILES:
@@ -311,15 +313,46 @@ def gather_context_sources(repo_path: Path) -> dict[str, str]:
             # Guarded, and bounded at the syscall rather than after the fact: the
             # old form read the whole file and *then* truncated to 10 000 chars, so
             # a README symlinked to /dev/zero or a multi-GB file was fully resident
-            # before the cap ever applied.
-            content = read_repo_file(filepath, max_bytes=10_000)
+            # before the cap ever applied. ``oversize="truncate"`` is the intended
+            # semantics here (#217 — exploration reads take the bounded prefix,
+            # per read_repo_file's own caller guidance); the default "raise" made
+            # every doc above the ceiling vanish while the truncation handler
+            # below was dead code.
+            # Read one char PAST the cap: len > 10_000 is the only precise
+            # truncation signal (chars are what the model consumes; a
+            # byte-based stat check false-positives on multi-byte files
+            # whose whole char count fits, and a bare >= misfires at the
+            # exact boundary — confirm-round catches on both sides).
+            content = read_repo_file(filepath, max_bytes=10_001,
+                                     oversize="truncate")
             if content is None:
                 continue
-            if len(content) >= 10_000:
-                content = content + "\n\n[... truncated ...]"
+            if len(content) > 10_000:
+                content = content[:10_000] + "\n\n[... truncated ...]"
+                truncated.append(filename)
             sources[filename] = content
         except Exception as e:  # noqa: BLE001 - context gathering is best-effort
             print(f"Warning: Could not read {filename}: {e}", file=sys.stderr)
+            skipped.append(filename)
+
+    # #217: the degradation must be VISIBLE to the context generator (and so
+    # to the artifact) — the generator prices the gap into its confidence via
+    # its existing "based on how much information was available" instruction;
+    # no post-hoc arithmetic on the model's number.
+    if skipped:
+        # String-valued (the sources dict is dict[str, str] and every prompt
+        # builder does text assembly on its values — a list here crashed both
+        # builders the moment the bookkeeping first fired; 4-seat wave catch).
+        sources["[skipped_sources]"] = (
+            "Documentation files that could NOT be read and were excluded "
+            "from the sources below: " + ", ".join(skipped)
+        )
+    if truncated:
+        sources["[truncated_sources]"] = (
+            "Documentation files read only as a bounded 10 000-character "
+            "prefix (content may continue past the truncation marker): "
+            + ", ".join(truncated)
+        )
 
     # Get directory structure (top 2 levels)
     dir_structure = get_directory_structure(repo_path, max_depth=2)

--- a/libs/openant-core/tests/test_issue217_doc_oversize.py
+++ b/libs/openant-core/tests/test_issue217_doc_oversize.py
@@ -35,8 +35,8 @@ from context.application_context import gather_context_sources  # noqa: E402
 
 
 def _doc_repo(tmp_path: Path):
-    (tmp_path / "README.md").write_text("# Big doc\n" + ("x" * 20_000))
-    (tmp_path / "pyproject.toml").write_text("[project]\nname='t'\n")
+    (tmp_path / "README.md").write_text("# Big doc\n" + ("x" * 20_000), encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='t'\n", encoding="utf-8")
     return tmp_path
 
 
@@ -78,8 +78,8 @@ def test_skipped_unreadable_docs_listed(tmp_path, monkeypatch):
 
 
 def test_small_docs_unaffected(tmp_path: Path):
-    (tmp_path / "README.md").write_text("# small\n")
-    (tmp_path / "pyproject.toml").write_text("[project]\nname='t'\n")
+    (tmp_path / "README.md").write_text("# small\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='t'\n", encoding="utf-8")
     sources = gather_context_sources(tmp_path)
     assert sources["README.md"] == "# small\n"
     assert "[truncated_sources]" not in sources
@@ -90,7 +90,7 @@ def test_exactly_at_ceiling_not_marked_truncated(tmp_path: Path):
     """A doc of exactly 10 000 bytes fits whole — nothing was lost, so no
     false truncation entry (the inherited >= off-by-one, now feeding a
     visible artifact record, had to go)."""
-    (tmp_path / "README.md").write_text("x" * 10_000)
+    (tmp_path / "README.md").write_text("x" * 10_000, encoding="utf-8")
     sources = gather_context_sources(tmp_path)
     assert "[truncated_sources]" not in sources
     assert "[... truncated ...]" not in sources["README.md"]
@@ -115,7 +115,7 @@ def test_multibyte_file_under_char_cap_not_marked_truncated(tmp_path: Path):
     but whose CHAR count fits under the cap is COMPLETE — a byte-based
     check false-positives; the char basis (what the model consumes) is the
     truthful signal."""
-    (tmp_path / "README.md").write_text("日" * 5_000)  # 5,000 chars, ~15,000 bytes
+    (tmp_path / "README.md").write_text("日" * 5_000, encoding="utf-8")  # 5,000 chars, ~15,000 bytes
     sources = gather_context_sources(tmp_path)
     assert "[truncated_sources]" not in sources
     assert "[... truncated ...]" not in sources["README.md"]
@@ -123,7 +123,7 @@ def test_multibyte_file_under_char_cap_not_marked_truncated(tmp_path: Path):
 
 
 def test_one_char_over_cap_is_truncated(tmp_path: Path):
-    (tmp_path / "README.md").write_text("x" * 10_001)
+    (tmp_path / "README.md").write_text("x" * 10_001, encoding="utf-8")
     sources = gather_context_sources(tmp_path)
     assert "[truncated_sources]" in sources
     assert sources["README.md"].count("x") == 10_000

--- a/libs/openant-core/tests/test_issue217_doc_oversize.py
+++ b/libs/openant-core/tests/test_issue217_doc_oversize.py
@@ -1,0 +1,129 @@
+"""Regression tests for issue #217 — oversized docs degrade the context
+silently.
+
+The context phase called ``read_repo_file(max_bytes=10_000)`` WITHOUT
+``oversize="truncate"`` — the default ``"raise"`` made every doc above
+10 KB raise → caught → warned → SKIPPED, while the truncation handler
+three lines down (append ``[... truncated ...]``) was dead code the
+author clearly intended. On the reporter's target BOTH top-level docs
+(README ~3x the limit) were dropped and the context reported high
+confidence from manifests alone — degradation invisible in artifacts.
+
+Contract locked here:
+- docs above the ceiling are READ as a bounded prefix with the truncation
+  marker (the intended semantics; the guard itself stays — repo content
+  is attacker-controlled, the read stays syscall-bounded);
+- unreadable (skipped) docs are listed in a ``[skipped_sources]`` entry
+  inside ``sources`` so the context generator — and the artifact — see
+  the gap (the LLM prices it into confidence via its existing
+  "based on how much information was available" instruction; NO
+  post-hoc arithmetic on the model's number);
+- truncated docs are listed in ``[truncated_sources]``;
+- no new configuration: the 10_000 ceiling stays hard-coded.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from context.application_context import gather_context_sources  # noqa: E402
+
+
+def _doc_repo(tmp_path: Path):
+    (tmp_path / "README.md").write_text("# Big doc\n" + ("x" * 20_000))
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='t'\n")
+    return tmp_path
+
+
+def test_oversize_doc_is_truncated_not_skipped(tmp_path: Path):
+    """A README above the 10 KB ceiling is READ (bounded prefix + marker),
+    never dropped — the issue's both-docs-dropped symptom. The prefix is
+    pinned to exactly 10 000 chars + marker (not just 'some prefix')."""
+    sources = gather_context_sources(_doc_repo(tmp_path))
+    readme = sources.get("README.md")
+    assert readme is not None, "oversize README must not be skipped"
+    assert "[... truncated ...]" in readme
+    assert len(readme) == 10_000 + len("\n\n[... truncated ...]")
+
+
+def test_truncated_sources_listed_in_artifact_inputs(tmp_path: Path):
+    sources = gather_context_sources(_doc_repo(tmp_path))
+    entry = sources.get("[truncated_sources]")
+    assert isinstance(entry, str) and "README.md" in entry, (
+        f"entry must be a STRING (the sources dict is dict[str, str]; a list "
+        f"crashes both prompt builders — 4-seat wave catch). Got {entry!r}"
+    )
+
+
+def test_skipped_unreadable_docs_listed(tmp_path, monkeypatch):
+    """An unreadable doc (guard raises for another reason) is listed in
+    [skipped_sources] so the gap is visible to the generator + artifact."""
+    import context.application_context as ac
+
+    real = ac.read_repo_file
+    def _flaky(path, **kw):
+        if str(path).endswith("README.md"):
+            raise PermissionError("nope")
+        return real(path, **kw)
+    monkeypatch.setattr(ac, "read_repo_file", _flaky)
+    sources = gather_context_sources(_doc_repo(tmp_path))
+    entry = sources.get("[skipped_sources]")
+    assert isinstance(entry, str) and "README.md" in entry
+    assert "README.md" not in {k for k in sources if not k.startswith("[")}
+
+
+def test_small_docs_unaffected(tmp_path: Path):
+    (tmp_path / "README.md").write_text("# small\n")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='t'\n")
+    sources = gather_context_sources(tmp_path)
+    assert sources["README.md"] == "# small\n"
+    assert "[truncated_sources]" not in sources
+    assert "[skipped_sources]" not in sources
+
+
+def test_exactly_at_ceiling_not_marked_truncated(tmp_path: Path):
+    """A doc of exactly 10 000 bytes fits whole — nothing was lost, so no
+    false truncation entry (the inherited >= off-by-one, now feeding a
+    visible artifact record, had to go)."""
+    (tmp_path / "README.md").write_text("x" * 10_000)
+    sources = gather_context_sources(tmp_path)
+    assert "[truncated_sources]" not in sources
+    assert "[... truncated ...]" not in sources["README.md"]
+
+
+def test_sources_survive_prompt_builder(tmp_path: Path):
+    """The BLOCKER catch: drive the REAL prompt assembly (the fence loop at
+    generate_application_context:689) over sources containing both new
+    entries — no TypeError, entries rendered as text."""
+    from prompts._fence import safe_code_fence
+    sources = gather_context_sources(_doc_repo(tmp_path))
+    sources_text = ""
+    for name, content in sources.items():
+        _sf = safe_code_fence(content)
+        sources_text += f"\n### {name}\n{_sf}\n{content}\n{_sf}\n"
+    assert "[truncated_sources]" in sources_text
+    assert "README.md" in sources_text
+
+
+def test_multibyte_file_under_char_cap_not_marked_truncated(tmp_path: Path):
+    """Confirm-round MAJOR: a multi-byte file whose BYTE size exceeds 10 KB
+    but whose CHAR count fits under the cap is COMPLETE — a byte-based
+    check false-positives; the char basis (what the model consumes) is the
+    truthful signal."""
+    (tmp_path / "README.md").write_text("日" * 5_000)  # 5,000 chars, ~15,000 bytes
+    sources = gather_context_sources(tmp_path)
+    assert "[truncated_sources]" not in sources
+    assert "[... truncated ...]" not in sources["README.md"]
+    assert len(sources["README.md"]) == 5_000
+
+
+def test_one_char_over_cap_is_truncated(tmp_path: Path):
+    (tmp_path / "README.md").write_text("x" * 10_001)
+    sources = gather_context_sources(tmp_path)
+    assert "[truncated_sources]" in sources
+    assert sources["README.md"].count("x") == 10_000


### PR DESCRIPTION
## Summary

The context phase called `read_repo_file(max_bytes=10_000)` **without** `oversize="truncate"` — the default `"raise"` made every documentation file above 10 KB raise, get caught, and be **skipped**, while the truncation handler three lines down (append `[... truncated ...]`) was dead code the author clearly intended. On #217's reporter target **both** top-level docs (README ~3× the limit, CLAUDE.md ~3.1×) were dropped and the context was generated from dependency manifests alone, with a high confidence score and no artifact-level trace of the withheld primary evidence.

- Pass `oversize="truncate"` (the codebase's own documented semantics for exploration reads). The guard itself is unchanged — repo content is attacker-controlled; no new configuration; the 10,000 ceiling stays hard-coded.
- Unreadable docs are listed in a `[skipped_sources]` entry inside `sources`; truncated docs in `[truncated_sources]` — **string-valued** (the sources dict is `dict[str, str]`; a list-valued entry crashed both prompt builders the moment the bookkeeping first fired — a 4-seat wave catch, fixed pre-ship with a prompt-builder integration test). The generator prices the gap into its confidence via its existing instruction; no post-hoc arithmetic on the model's number.
- Truncation is detected on the **char basis** (read one past the cap: `len > 10_000` is the only precise signal) — a byte-based check false-positives on multi-byte files whose whole char count fits; a bare `>=` misfires at the exact boundary. Both edges test-locked (exact-fit, multi-byte, one-over).

## Test plan

8 hermetic tests: truncate-not-skip (prefix pinned to exactly 10,000 chars + marker); truncated/skipped listed as strings; small docs unaffected; exact-10,000 not marked; multi-byte file under the char cap complete; one-char-over truncated; the prompt-builder integration test driving the real fence loop over both new entries.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue217_doc_oversize.py -q` | 8 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue217_doc_oversize.py` | 8 passed |
| mutation smoke | drop `oversize="truncate"` | 2 tests fail (restored → green) |
| full suite | `pytest tests/ -q` | 3003 passed, 2 failed (pre-existing zig local-env, stash-replay verified; CI green with them), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Adversarial loop: 4-seat wave → list-valued-entry crash BLOCKER (4-seat convergence) + boundary off-by-one, fixed; confirm round → byte-vs-char false-positive edge + weak length assertion, fixed — truncation now on the precise char basis.

</details>

Fixes #217
