### PR TITLE
docs(readme): document the exit-code contract with a CI gating snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,34 @@ Or run the full pipeline in one command:
 openant scan --verify
 ```
 
+#### Exit codes (important for CI)
+
+`openant scan` — and each step verb (`analyze`, `verify`, …) when run step-by-step —
+exits **1 when it finds vulnerabilities** — that is the tool working, not failing. The
+contract:
+
+| Exit code | Meaning |
+|---|---|
+| 0 | Clean scan — no vulnerabilities found |
+| 1 | **Vulnerabilities found** (a successful run) |
+| 2 | Error — the scan itself failed (check `errors` in the JSON envelope on stdout) |
+
+Generic CI steps and process supervisors treat any non-zero exit as a failure, which
+misclassifies a healthy findings run. Gate on the contract instead of parsing stdout:
+
+```bash
+rc=0
+openant scan --verify /path/to/repo || rc=$?   # || captures: set -e safe
+if [ "$rc" -gt 1 ]; then
+  echo "scan FAILED (exit $rc)" >&2; exit "$rc"
+fi
+# rc 0 = clean, rc 1 = findings found — both are successful runs
+```
+
+The `|| rc=$?` form matters: CI defaults to `set -e` (GitHub Actions `run:`, Jenkins `sh`),
+where a bare `openant scan` exiting 1 would terminate the script before the capture line —
+reproducing exactly the misclassification this section exists to prevent.
+
 ### Web UI
 
 `openant serve` starts a local web UI over the same scan pipeline: submit a


### PR DESCRIPTION
## Summary

A successful scan that finds vulnerabilities exits 1 (the documented contract: 0 clean / 1 findings / 2 error) — so generic CI steps and process supervisors report a healthy findings run as **failed** (#220's reporter had a completed run with `errors: []` and every step `success`, reported as failed by the supervisor). The contract was documented only in contributor-facing `ARCHITECTURE.md`; no user-facing statement existed (`rg -in 'exit.?code|exit 1' README.md` → 0 contract hits).

This adds an **"Exit codes (important for CI)"** section to the README's run-the-pipeline area: the contract table, the warning that exit 1 = the tool working (for `scan` **and** each step verb run step-by-step — each also exits 1 on findings), and a **`set -e`-safe gating snippet** (`rc=0; openant scan … || rc=$?`) — the bare `rc=$?` form would terminate the script before the capture line under GitHub Actions/Jenkins defaults, reproducing exactly the misclassification the section exists to prevent (both caught in review).

Deferred on the issue: an `--exit-zero-on-findings` flag (new config surface; the gating idiom covers the use case) and a one-line exit-code note in the Go terminal summary.

<details>
<summary>Verification evidence</summary>

| check | command | result |
|---|---|---|
| docs-only claim | `git diff origin/master --stat` → README.md only | 1 file, no code paths |
| full suite (unchanged) | `pytest tests/ -q` | 2994 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| lint | `ruff check .` | clean |
| review | 2-seat docs check | both MAJORs (set -e safety; step-verb coverage) folded pre-ship |

</details>

Fixes #220
