### PR TITLE
fix(scanner): llm-reachability stage body degrades instead of aborting the scan

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -28,6 +28,7 @@ from core.schemas import (
 from core.step_report import step_context
 from core import tracking
 from utilities.file_io import read_json, write_json
+from utilities.llm.adapter import LLMAuthError
 
 # Import app context generator (optional)
 try:
@@ -475,12 +476,10 @@ def scan_repository(
             except Exception as exc:
                 # Broaden beyond (OSError, json.JSONDecodeError): read_json opens
                 # strict UTF-8, so a bad-encoding dataset raises UnicodeDecodeError
-                # (a ValueError) which previously escaped and aborted the whole
-                # scan. NOTE: this guards only the dataset READ. The stage's LLM
-                # call (analyze_reachability, below) is NOT wrapped here, so a
-                # provider error there still aborts the scan — a separate gap
-                # tracked as a follow-up (wrap the whole stage body like
-                # enhance/verify do).
+                # (a ValueError). NOTE: this inner guard predates the whole-body
+                # wrap below (#268) and stays for its precise skip reason; the
+                # body wrap catches everything else (corrupt call_graph.json in
+                # the re-filter, failed writes) and degrades the same way.
                 print(f"  WARNING: failed to load dataset: {exc}", file=sys.stderr)
                 ctx.status = "skipped"
                 ctx.summary = {"skipped": True, "reason": str(exc)}
@@ -490,239 +489,272 @@ def scan_repository(
                 _record_skip(result, "llm-reachability", "failed")
                 dataset = None
 
-            if dataset is not None:
-                app_ctx_payload = None
-                if app_context_path and os.path.exists(app_context_path):
-                    try:
-                        app_ctx_payload = read_json(app_context_path)
-                    except Exception as exc:
-                        # Broad like the dataset load above: this optional
-                        # app-context read must never abort the scan. read_json
-                        # opens strict UTF-8, so a bad-encoding self-written file
-                        # raises UnicodeDecodeError (not OSError/JSONDecodeError);
-                        # a missing payload just means the reachability prompt
-                        # runs without the extra app-context hint. Warn (like the
-                        # dataset-load sibling) so this recall-affecting
-                        # degradation is visible, not silent.
-                        print(
-                            f"  WARNING: could not read app context for "
-                            f"reachability ({exc}); continuing without the "
-                            f"app-context hint.",
-                            file=sys.stderr,
-                        )
-                        app_ctx_payload = None
-
-                # --limit governs the analyze stage, not how many units the
-                # LLM reachability pass reviews — it must see the full
-                # codebase to find missed entry points.
-                signals = analyze_reachability(
-                    dataset=dataset,
-                    app_context=app_ctx_payload,
-                    binding=llm_reach_binding,
-                    max_code_bytes=llm_reachability_max_code_bytes,
-                )
-                summary = apply_signals(dataset, signals)
-
-                signals_path = os.path.join(output_dir, "llm_reachability.json")
-                write_json(signals_path, {"signals": signals_to_json(signals)}, indent=2)
-
-                pre_filter_count = len(dataset.get("units", []))
-                post_filter_count = pre_filter_count
-                refilter_supported = False
-
-                # Re-apply the structural reachability filter using
-                # LLM-promoted entry points as additional BFS seeds.
-                # Only possible when the parser persisted call_graph.json.
-                # Which parsers do so is determined by PROBING THE FILESYSTEM
-                # below, not by a hardcoded language list — an earlier comment
-                # here claimed only Python and Zig persist it, which is wrong
-                # (JavaScript writes a fully-formed call_graph.json too). Keep
-                # this probe-based: parsers gain and lose the behaviour over
-                # time, and a stale list here would silently skip re-filtering
-                # for a language that actually supports it.
-                if processing_level != "all":
-                    cg_dirs = resolve_call_graph_dirs(output_dir)
-                    if cg_dirs:
-                        from core.parser_adapter import apply_reachability_filter
-
-                        llm_promoted_ids = {
-                            u["id"] for u in dataset.get("units", [])
-                            if u.get("is_entry_point") and u.get("id")
-                        }
-                        partitions = partition_units_by_language(
-                            dataset.get("units", [])
-                        )
-                        kept: list[dict] = []
-                        unfilterable: dict[str, int] = {}
-                        # Per-language reachability_filter stats, aggregated back
-                        # onto the rebuilt dataset below. Without this the rebuild
-                        # at `dataset = {**dataset, "units": kept}` carried the
-                        # ORIGINAL (pre-LLM) metadata, so the reporter rendered
-                        # "reachability filtering not applied" on a scan that DID
-                        # prune via the LLM-seeded re-filter.
-                        refilter_by_language: dict[str, dict] = {}
-
-                        for lang, lang_units in partitions.items():
-                            lang_dir = cg_dirs.get(lang)
-                            if lang_dir is None and None in cg_dirs:
-                                # Legacy flat layout: one graph covers everything.
-                                lang_dir = cg_dirs[None]
-                            if lang_dir is None:
-                                # This language's parser persisted no call graph,
-                                # so its units pass through unfiltered — the
-                                # pre-existing behaviour, now scoped per language
-                                # instead of disabling the filter for the whole
-                                # scan just because the primary lacked a graph.
-                                unfilterable[lang or "unknown"] = len(lang_units)
-                                kept.extend(lang_units)
-                                continue
-
-                            # Deep-copy metadata: the shallow {**dataset} copy
-                            # shares the nested metadata dict across every
-                            # per-language call, so each filter's stats
-                            # overwrote the previous language's.
-                            lang_dataset = {
-                                **dataset,
-                                "units": lang_units,
-                                "metadata": dict(dataset.get("metadata") or {}),
-                            }
-                            filtered = apply_reachability_filter(
-                                lang_dataset,
-                                lang_dir,
-                                processing_level,
-                                extra_entry_points=scope_entry_points_to_units(
-                                    llm_promoted_ids, lang_units
-                                ),
-                                library_mode=library_mode,
-                            )
-                            kept.extend(filtered.get("units", []))
-                            _rf = (filtered.get("metadata") or {}).get(
-                                "reachability_filter"
-                            )
-                            if _rf:
-                                refilter_by_language[lang or "unknown"] = _rf
-
-                        # Rebuild the dataset, aggregating the per-language filter
-                        # stats into metadata so the reporter reads a real record
-                        # instead of the stale pre-LLM one. Unfilterable languages
-                        # (no call graph) are folded in as pass-throughs so the
-                        # aggregate reconciles with len(kept).
-                        _new_md = dict(dataset.get("metadata") or {})
-                        # Only stamp a record when a real per-language filter ran.
-                        # If every language was unfilterable (no call graph), the
-                        # units passed through untouched, so leaving no record —
-                        # the honest "not applied" signal — is correct; a "0%
-                        # reduction" record would falsely claim filtering happened.
-                        if refilter_by_language:
-                            _per_lang = dict(refilter_by_language)
-                            _unfiltered = 0
-                            for _lang, _cnt in unfilterable.items():
-                                _unfiltered += _cnt
-                                _per_lang[_lang] = {
-                                    "original_units": _cnt,
-                                    "entry_points": 0,
-                                    "reachable_units": _cnt,
-                                    "filtered_out": 0,
-                                    "reduction_percentage": 0,
-                                    "unfilterable": True,
-                                }
-                            _orig = sum(
-                                r.get("original_units", 0) for r in _per_lang.values()
-                            )
-                            _reach = sum(
-                                r.get("reachable_units", 0) for r in _per_lang.values()
-                            )
-                            _agg = {
-                                "original_units": _orig,
-                                "entry_points": sum(
-                                    r.get("entry_points", 0) for r in _per_lang.values()
-                                ),
-                                "reachable_units": _reach,
-                                "filtered_out": _orig - _reach,
-                                # Units that flowed through unfiltered (no call
-                                # graph for their language) — folded into the
-                                # totals above but surfaced explicitly so the
-                                # record never silently claims they were filtered.
-                                "unfiltered_units": _unfiltered,
-                                "reduction_percentage": (
-                                    round((1 - _reach / _orig) * 100, 1)
-                                    if _orig
-                                    else 0
-                                ),
-                                "per_language": _per_lang,
-                            }
-                            # Lift any per-language advisory (e.g. an empty-seed
-                            # blackout — a language that flowed through unfiltered
-                            # because it had no real entry points) to the top
-                            # level, where the reporter reads it (reporter.py:505).
-                            # Without this the record reads "filter applied, N%
-                            # reduction" while hiding that a language blacked out —
-                            # the exact fidelity gap this record exists to close.
-                            _warnings = [
-                                f"{_lang}: {_r['warning']}"
-                                for _lang, _r in _per_lang.items()
-                                if _r.get("warning")
-                            ]
-                            if _warnings:
-                                _agg["warning"] = "; ".join(_warnings)
-                            _new_md["reachability_filter"] = _agg
-                        else:
-                            # No real filter ran (every language unfilterable):
-                            # honour the "not applied" contract by clearing any
-                            # record inherited from an upstream merge, so a stale
-                            # record can never misdescribe the passed-through units.
-                            _new_md.pop("reachability_filter", None)
-                        dataset = {**dataset, "units": kept, "metadata": _new_md}
-                        post_filter_count = len(kept)
-                        result.units_count = post_filter_count
-                        refilter_supported = True
-
-                        for lang, count in unfilterable.items():
+            # #268: guard the WHOLE stage body (the pattern enhance/verify
+            # use), not just the dataset read — a non-LLM failure below
+            # (corrupt call_graph.json in the re-filter at parser_adapter,
+            # a failed write_json) previously aborted the whole scan via
+            # step_context re-raise instead of degrading to a recorded skip.
+            # Provider errors are NOT at issue: analyze_reachability already
+            # skips failed batches, re-raising only LLMAuthError by design —
+            # and that one MUST still abort (bad credentials must not be
+            # silently skipped into a "successful" degraded scan).
+            pre_llmreach_units_count = result.units_count
+            try:
+                if dataset is not None:
+                    app_ctx_payload = None
+                    if app_context_path and os.path.exists(app_context_path):
+                        try:
+                            app_ctx_payload = read_json(app_context_path)
+                        except Exception as exc:
+                            # Broad like the dataset load above: this optional
+                            # app-context read must never abort the scan. read_json
+                            # opens strict UTF-8, so a bad-encoding self-written file
+                            # raises UnicodeDecodeError (not OSError/JSONDecodeError);
+                            # a missing payload just means the reachability prompt
+                            # runs without the extra app-context hint. Warn (like the
+                            # dataset-load sibling) so this recall-affecting
+                            # degradation is visible, not silent.
                             print(
-                                f"\n  WARNING: {lang} persisted no call_graph.json; "
-                                f"{count} unit(s) skip post-LLM re-filtering and "
-                                f"flow to downstream stages unfiltered.",
+                                f"  WARNING: could not read app context for "
+                                f"reachability ({exc}); continuing without the "
+                                f"app-context hint.",
                                 file=sys.stderr,
                             )
-                    else:
-                        # Parser doesn't persist call_graph.json — the full
-                        # unfiltered dataset will flow to downstream stages.
-                        # Warn loudly so the cost impact is visible.
-                        print(
-                            f"\n  WARNING: --llm-reachability with "
-                            f"--level {processing_level}: "
-                            f"{parse_result.language} does not yet support "
-                            f"post-LLM re-filtering (call_graph.json not found). "
-                            f"Downstream stages will process all "
-                            f"{pre_filter_count} units instead of the filtered "
-                            f"subset — this may significantly increase cost.",
-                            file=sys.stderr,
-                        )
+                            app_ctx_payload = None
 
-                # Persist final dataset so downstream stages see promoted
-                # entry points, per-unit signals, and the applied filter.
-                write_json(active_dataset_path, dataset, indent=2)
+                    # --limit governs the analyze stage, not how many units the
+                    # LLM reachability pass reviews — it must see the full
+                    # codebase to find missed entry points.
+                    signals = analyze_reachability(
+                        dataset=dataset,
+                        app_context=app_ctx_payload,
+                        binding=llm_reach_binding,
+                        max_code_bytes=llm_reachability_max_code_bytes,
+                    )
+                    summary = apply_signals(dataset, signals)
 
-                ctx.summary = {
-                    "units_reviewed": pre_filter_count,
-                    "signals_added": summary["signals_applied"],
-                    "entry_points_promoted": summary["entry_points_promoted"],
-                    "units_touched": summary["units_touched"],
-                    "post_filter_units": post_filter_count,
-                    "refilter_supported": refilter_supported,
-                }
-                ctx.outputs = {"signals_path": signals_path}
+                    signals_path = os.path.join(output_dir, "llm_reachability.json")
+                    write_json(signals_path, {"signals": signals_to_json(signals)}, indent=2)
 
-                print(
-                    f"  LLM reachability: {summary['signals_applied']} signals, "
-                    f"{summary['entry_points_promoted']} new entry points",
-                    file=sys.stderr,
-                )
-                if processing_level != "all" and refilter_supported:
+                    pre_filter_count = len(dataset.get("units", []))
+                    post_filter_count = pre_filter_count
+                    refilter_supported = False
+
+                    # Re-apply the structural reachability filter using
+                    # LLM-promoted entry points as additional BFS seeds.
+                    # Only possible when the parser persisted call_graph.json.
+                    # Which parsers do so is determined by PROBING THE FILESYSTEM
+                    # below, not by a hardcoded language list — an earlier comment
+                    # here claimed only Python and Zig persist it, which is wrong
+                    # (JavaScript writes a fully-formed call_graph.json too). Keep
+                    # this probe-based: parsers gain and lose the behaviour over
+                    # time, and a stale list here would silently skip re-filtering
+                    # for a language that actually supports it.
+                    if processing_level != "all":
+                        cg_dirs = resolve_call_graph_dirs(output_dir)
+                        if cg_dirs:
+                            from core.parser_adapter import apply_reachability_filter
+
+                            llm_promoted_ids = {
+                                u["id"] for u in dataset.get("units", [])
+                                if u.get("is_entry_point") and u.get("id")
+                            }
+                            partitions = partition_units_by_language(
+                                dataset.get("units", [])
+                            )
+                            kept: list[dict] = []
+                            unfilterable: dict[str, int] = {}
+                            # Per-language reachability_filter stats, aggregated back
+                            # onto the rebuilt dataset below. Without this the rebuild
+                            # at `dataset = {**dataset, "units": kept}` carried the
+                            # ORIGINAL (pre-LLM) metadata, so the reporter rendered
+                            # "reachability filtering not applied" on a scan that DID
+                            # prune via the LLM-seeded re-filter.
+                            refilter_by_language: dict[str, dict] = {}
+
+                            for lang, lang_units in partitions.items():
+                                lang_dir = cg_dirs.get(lang)
+                                if lang_dir is None and None in cg_dirs:
+                                    # Legacy flat layout: one graph covers everything.
+                                    lang_dir = cg_dirs[None]
+                                if lang_dir is None:
+                                    # This language's parser persisted no call graph,
+                                    # so its units pass through unfiltered — the
+                                    # pre-existing behaviour, now scoped per language
+                                    # instead of disabling the filter for the whole
+                                    # scan just because the primary lacked a graph.
+                                    unfilterable[lang or "unknown"] = len(lang_units)
+                                    kept.extend(lang_units)
+                                    continue
+
+                                # Deep-copy metadata: the shallow {**dataset} copy
+                                # shares the nested metadata dict across every
+                                # per-language call, so each filter's stats
+                                # overwrote the previous language's.
+                                lang_dataset = {
+                                    **dataset,
+                                    "units": lang_units,
+                                    "metadata": dict(dataset.get("metadata") or {}),
+                                }
+                                filtered = apply_reachability_filter(
+                                    lang_dataset,
+                                    lang_dir,
+                                    processing_level,
+                                    extra_entry_points=scope_entry_points_to_units(
+                                        llm_promoted_ids, lang_units
+                                    ),
+                                    library_mode=library_mode,
+                                )
+                                kept.extend(filtered.get("units", []))
+                                _rf = (filtered.get("metadata") or {}).get(
+                                    "reachability_filter"
+                                )
+                                if _rf:
+                                    refilter_by_language[lang or "unknown"] = _rf
+
+                            # Rebuild the dataset, aggregating the per-language filter
+                            # stats into metadata so the reporter reads a real record
+                            # instead of the stale pre-LLM one. Unfilterable languages
+                            # (no call graph) are folded in as pass-throughs so the
+                            # aggregate reconciles with len(kept).
+                            _new_md = dict(dataset.get("metadata") or {})
+                            # Only stamp a record when a real per-language filter ran.
+                            # If every language was unfilterable (no call graph), the
+                            # units passed through untouched, so leaving no record —
+                            # the honest "not applied" signal — is correct; a "0%
+                            # reduction" record would falsely claim filtering happened.
+                            if refilter_by_language:
+                                _per_lang = dict(refilter_by_language)
+                                _unfiltered = 0
+                                for _lang, _cnt in unfilterable.items():
+                                    _unfiltered += _cnt
+                                    _per_lang[_lang] = {
+                                        "original_units": _cnt,
+                                        "entry_points": 0,
+                                        "reachable_units": _cnt,
+                                        "filtered_out": 0,
+                                        "reduction_percentage": 0,
+                                        "unfilterable": True,
+                                    }
+                                _orig = sum(
+                                    r.get("original_units", 0) for r in _per_lang.values()
+                                )
+                                _reach = sum(
+                                    r.get("reachable_units", 0) for r in _per_lang.values()
+                                )
+                                _agg = {
+                                    "original_units": _orig,
+                                    "entry_points": sum(
+                                        r.get("entry_points", 0) for r in _per_lang.values()
+                                    ),
+                                    "reachable_units": _reach,
+                                    "filtered_out": _orig - _reach,
+                                    # Units that flowed through unfiltered (no call
+                                    # graph for their language) — folded into the
+                                    # totals above but surfaced explicitly so the
+                                    # record never silently claims they were filtered.
+                                    "unfiltered_units": _unfiltered,
+                                    "reduction_percentage": (
+                                        round((1 - _reach / _orig) * 100, 1)
+                                        if _orig
+                                        else 0
+                                    ),
+                                    "per_language": _per_lang,
+                                }
+                                # Lift any per-language advisory (e.g. an empty-seed
+                                # blackout — a language that flowed through unfiltered
+                                # because it had no real entry points) to the top
+                                # level, where the reporter reads it (reporter.py:505).
+                                # Without this the record reads "filter applied, N%
+                                # reduction" while hiding that a language blacked out —
+                                # the exact fidelity gap this record exists to close.
+                                _warnings = [
+                                    f"{_lang}: {_r['warning']}"
+                                    for _lang, _r in _per_lang.items()
+                                    if _r.get("warning")
+                                ]
+                                if _warnings:
+                                    _agg["warning"] = "; ".join(_warnings)
+                                _new_md["reachability_filter"] = _agg
+                            else:
+                                # No real filter ran (every language unfilterable):
+                                # honour the "not applied" contract by clearing any
+                                # record inherited from an upstream merge, so a stale
+                                # record can never misdescribe the passed-through units.
+                                _new_md.pop("reachability_filter", None)
+                            dataset = {**dataset, "units": kept, "metadata": _new_md}
+                            post_filter_count = len(kept)
+                            result.units_count = post_filter_count
+                            refilter_supported = True
+
+                            for lang, count in unfilterable.items():
+                                print(
+                                    f"\n  WARNING: {lang} persisted no call_graph.json; "
+                                    f"{count} unit(s) skip post-LLM re-filtering and "
+                                    f"flow to downstream stages unfiltered.",
+                                    file=sys.stderr,
+                                )
+                        else:
+                            # Parser doesn't persist call_graph.json — the full
+                            # unfiltered dataset will flow to downstream stages.
+                            # Warn loudly so the cost impact is visible.
+                            print(
+                                f"  WARNING: --llm-reachability with "
+                                f"--level {processing_level}: "
+                                f"{parse_result.language} does not yet support "
+                                f"post-LLM re-filtering (call_graph.json not found). "
+                                f"Downstream stages will process all "
+                                f"{pre_filter_count} units instead of the filtered "
+                                f"subset — this may significantly increase cost.",
+                                file=sys.stderr,
+                            )
+
+                    # Persist final dataset so downstream stages see promoted
+                    # entry points, per-unit signals, and the applied filter.
+                    write_json(active_dataset_path, dataset, indent=2)
+
+                    ctx.summary = {
+                        "units_reviewed": pre_filter_count,
+                        "signals_added": summary["signals_applied"],
+                        "entry_points_promoted": summary["entry_points_promoted"],
+                        "units_touched": summary["units_touched"],
+                        "post_filter_units": post_filter_count,
+                        "refilter_supported": refilter_supported,
+                    }
+                    ctx.outputs = {"signals_path": signals_path}
+
                     print(
-                        f"  After reachability filter: {post_filter_count} units",
+                        f"  LLM reachability: {summary['signals_applied']} signals, "
+                        f"{summary['entry_points_promoted']} new entry points",
                         file=sys.stderr,
                     )
+                    if processing_level != "all" and refilter_supported:
+                        print(
+                            f"  After reachability filter: {post_filter_count} units",
+                            file=sys.stderr,
+                        )
+            except LLMAuthError:
+                # The designed abort: bad credentials surface loudly, never
+                # degrade into a skip (a silently-skipped reachability pass
+                # reads as a clean run to a credential-less user).
+                raise
+            except Exception as exc:
+                # #268 (wave catch): the body mutates result.units_count
+                # mid-flow (post-re-filter) BEFORE the dataset persist; a
+                # failure in that window left the count describing a dataset
+                # that never reached disk. Restore the pre-stage count so the
+                # result matches what downstream actually consumes.
+                result.units_count = pre_llmreach_units_count
+                print(
+                    f"  WARNING: LLM reachability stage failed: {exc}",
+                    file=sys.stderr,
+                )
+                ctx.status = "skipped"
+                ctx.summary = {"skipped": True, "reason": str(exc)}
+                # Record the crash so the degraded reachability pass is
+                # visible in the artifacts, matching the dataset-read guard.
+                _record_skip(result, "llm-reachability", "failed")
+                dataset = None
 
         collected_step_reports.append(
             _load_step_report(output_dir, "llm-reachability")

--- a/libs/openant-core/tests/test_issue268_llmreach_stage_guard.py
+++ b/libs/openant-core/tests/test_issue268_llmreach_stage_guard.py
@@ -1,0 +1,347 @@
+"""Regression tests for issue #268 — the llm-reachability stage body must
+degrade, not abort.
+
+The stage's try/except guarded only the dataset read; everything after it
+(the app-context read, the LLM call, signal application, the post-LLM
+re-filter, the dataset re-write) ran inside ``step_context``, which
+re-raises — so a NON-LLM failure there (a corrupt/truncated
+``call_graph.json`` hit by the re-filter's unguarded ``read_json`` at
+``parser_adapter.py:472``; a failed ``write_json`` at ``scanner.py:527``/
+``:704``) aborted the whole scan instead of degrading the way ``enhance``
+and ``verify`` do.
+
+Contract locked here: ANY exception in the stage body (after the dataset
+read) records a skip (``ctx.status = "skipped"`` + ``_record_skip``) and
+the scan continues with the pre-reachability dataset — matching the
+enhance/verify pattern. Provider errors are NOT the concern:
+``analyze_reachability`` already skips failed batches and re-raises only
+``LLMAuthError`` by design (that one SHOULD abort — bad credentials).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.schemas import AnalysisMetrics  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _offline_registry(monkeypatch):
+    import utilities.llm as llm_mod
+
+    monkeypatch.setattr(
+        llm_mod, "probe_registry_or_raise", lambda *a, **k: None, raising=True)
+    orig_resolve = llm_mod.resolve_llm_config
+    monkeypatch.setattr(
+        llm_mod, "resolve_llm_config",
+        lambda cf, name: orig_resolve(cf, None), raising=True)
+
+
+def _install_pipeline(monkeypatch, tmp_path, *, llm_reach_body=None):
+    """Offline parse → llm-reachability scaffold. ``llm_reach_body`` is a
+    callable run INSIDE the stage body (after the dataset read) — raise
+    from it to simulate #268's non-LLM failures."""
+    import core.parser_adapter as parser_adapter
+    import core.analyzer as analyzer
+    import core.reporter as reporter
+    import core.tracking as tracking
+
+    class _ParseResult:
+        def __init__(self, output_dir):
+            self.dataset_path = str(Path(output_dir) / "dataset.json")
+            self.analyzer_output_path = str(Path(output_dir) / "analyzer.json")
+            self.units_count = 3
+            self.language = "python"
+            self.processing_level = "reachable"
+
+    def _fake_parse(*, output_dir, **kwargs):
+        pr = _ParseResult(output_dir)
+        Path(pr.dataset_path).write_text('{"units": [], "metadata": {}}')
+        Path(pr.analyzer_output_path).write_text("{}")
+        return pr
+
+    metrics = AnalysisMetrics(total=3, vulnerable=1, bypassable=0, inconclusive=0,
+                              protected=0, safe=2, errors=0)
+
+    class _AnalyzeResult:
+        def __init__(self, output_dir):
+            self.results_path = str(Path(output_dir) / "results.json")
+            Path(self.results_path).write_text("[]")
+            self.metrics = metrics
+
+    monkeypatch.setattr(parser_adapter, "parse_repository", _fake_parse)
+    monkeypatch.setattr(analyzer, "run_analysis",
+                        lambda *, output_dir, **kw: _AnalyzeResult(output_dir))
+    monkeypatch.setattr(
+        reporter, "build_pipeline_output",
+        lambda *, results_path, output_path, **kw:
+        (Path(output_path).write_text("{}"), output_path)[1])
+    tracking.reset_tracking()
+
+    # The scanner imports analyze_reachability from core.llm_reachability
+    # INSIDE scan_repository at call time — patch the SOURCE module.
+    import core.llm_reachability as lr
+    if llm_reach_body is not None:
+        monkeypatch.setattr(lr, "analyze_reachability", llm_reach_body)
+    monkeypatch.setattr(
+        lr, "apply_signals",
+        lambda dataset, signals: {"signals_applied": 0, "entry_points_promoted": 0,
+                                  "units_touched": 0})
+    monkeypatch.setattr(lr, "signals_to_json", lambda signals: [])
+
+
+def _scan(tmp_path, monkeypatch, **kwargs):
+    from core import scanner as scanner_mod
+    _install_pipeline(monkeypatch, tmp_path, **kwargs)
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(tmp_path / "out"),
+        generate_context=False,
+        enhance=False,
+        verify=False,
+        generate_report=False,
+        dynamic_test=False,
+        llm_reachability=True,
+        processing_level="reachable",
+    )
+    return result, tmp_path / "out"
+
+
+def test_stage_body_failure_degrades_not_aborts(tmp_path, monkeypatch):
+    """#268's core: a non-LLM exception in the stage body (e.g. the re-filter
+    hitting a corrupt call graph) records a skip and the scan COMPLETES."""
+    import json
+
+    def _body(**kwargs):
+        # Simulate the post-LLM re-filter's corrupt-call_graph failure class
+        raise json.JSONDecodeError("Expecting value", "doc", 0)
+
+    result, out = _scan(tmp_path, monkeypatch, llm_reach_body=_body)
+    assert result is not None, "the scan must COMPLETE (degrade, not abort)"
+    report = json.loads((out / "llm-reachability.report.json").read_text())
+    assert report["status"] == "skipped"
+    assert "llm-reachability" in result.skipped_steps
+
+
+def test_write_failure_degrades_not_aborts(tmp_path, monkeypatch, capsys):
+    """The write_json path (:527/:704) failing (disk full / permissions)."""
+    import core.scanner as scanner_mod
+
+    real_write = scanner_mod.write_json
+
+    def _failing_write(path, *a, **kw):
+        # Fail only the dataset re-write inside the reachability stage
+        if str(path).endswith("dataset.json"):
+            raise OSError(28, "No space left on device")
+        return real_write(path, *a, **kw)
+
+    monkeypatch.setattr(scanner_mod, "write_json", _failing_write)
+    import core.llm_reachability as lr
+    monkeypatch.setattr(lr, "analyze_reachability", lambda **kw: [])
+    monkeypatch.setattr(
+        lr, "apply_signals",
+        lambda dataset, signals: {"signals_applied": 0, "entry_points_promoted": 0,
+                                  "units_touched": 0})
+    monkeypatch.setattr(lr, "signals_to_json", lambda signals: [])
+    result, out = _scan(tmp_path, monkeypatch)
+    assert result is not None
+    # degraded: the stage skipped, the scan completed
+    assert "llm-reachability" in result.skipped_steps
+
+
+def test_clean_stage_still_succeeds(tmp_path, monkeypatch):
+    """No failure → the stage behaves exactly as before (no false skips)."""
+    result, out = _scan(tmp_path, monkeypatch, llm_reach_body=lambda **kw: [])
+    import json
+    report = json.loads((out / "llm-reachability.report.json").read_text())
+    assert report["status"] == "success"
+    assert "llm-reachability" not in result.skipped_steps
+
+
+def test_auth_error_still_aborts(tmp_path, monkeypatch):
+    """LLMAuthError is the DESIGNED abort (bad credentials must not be
+    silently skipped) — analyze_reachability re-raises it; the stage wrap
+    must not swallow it either."""
+    from utilities.llm.adapter import LLMAuthError
+    import core.scanner as scanner_mod
+
+    def _auth_fail(**kwargs):
+        raise LLMAuthError("bad key")
+
+    monkeypatch.setattr("core.llm_reachability.analyze_reachability", _auth_fail)
+    _install_pipeline(monkeypatch, tmp_path)
+    with pytest.raises(LLMAuthError):
+        scanner_mod.scan_repository(
+            repo_path=str(tmp_path),
+            output_dir=str(tmp_path / "out"),
+            generate_context=False, enhance=False, verify=False,
+            generate_report=False, dynamic_test=False,
+            llm_reachability=True, processing_level="reachable")
+
+
+def test_refilter_corrupt_call_graph_degrades_not_aborts(tmp_path, monkeypatch):
+    """The commit's OWN headline example (sonnet-2 BLOCKER): a corrupt
+    call_graph.json in the post-LLM re-filter — drive it through the REAL
+    stage body with a REAL parse fixture that persists a call graph."""
+    import json
+
+    # parse fixture that ALSO writes a corrupt call_graph.json so the
+    # re-filter's read_json raises
+    import core.parser_adapter as parser_adapter
+    import core.analyzer as analyzer
+    import core.reporter as reporter
+    import core.tracking as tracking
+    from core.schemas import AnalysisMetrics
+
+    class _ParseResult:
+        def __init__(self, output_dir):
+            self.dataset_path = str(Path(output_dir) / "dataset.json")
+            self.analyzer_output_path = str(Path(output_dir) / "analyzer.json")
+            self.units_count = 3
+            self.language = "python"
+            self.processing_level = "reachable"
+
+    def _fake_parse(*, output_dir, **kwargs):
+        pr = _ParseResult(output_dir)
+        Path(pr.dataset_path).write_text(
+            json.dumps({"units": [{"id": "a.py:f", "language": "python",
+                                   "unit_id": "a.py:f"}],
+                        "metadata": {}}))
+        Path(pr.analyzer_output_path).write_text("{}")
+        # the corrupt call graph: the re-filter's read_json raises here.
+        # Multi-language layout needs the call_graphs.json index too
+        # (resolve_call_graph_dirs reads it; the per-lang dir alone is not
+        # found without it).
+        cg_dir = Path(output_dir) / "python"
+        cg_dir.mkdir(exist_ok=True)
+        (cg_dir / "call_graph.json").write_text("{corrupt json")
+        (Path(output_dir) / "call_graphs.json").write_text(
+            json.dumps({"python": "python/call_graph.json"}))
+        return pr
+
+    metrics = AnalysisMetrics(total=3, vulnerable=1, bypassable=0, inconclusive=0,
+                              protected=0, safe=2, errors=0)
+
+    class _AnalyzeResult:
+        def __init__(self, output_dir):
+            self.results_path = str(Path(output_dir) / "results.json")
+            Path(self.results_path).write_text("[]")
+            self.metrics = metrics
+
+    monkeypatch.setattr(parser_adapter, "parse_repository", _fake_parse)
+    monkeypatch.setattr(analyzer, "run_analysis",
+                        lambda *, output_dir, **kw: _AnalyzeResult(output_dir))
+    monkeypatch.setattr(
+        reporter, "build_pipeline_output",
+        lambda *, results_path, output_path, **kw:
+        (Path(output_path).write_text("{}"), output_path)[1])
+    tracking.reset_tracking()
+
+    import core.llm_reachability as lr
+    monkeypatch.setattr(lr, "analyze_reachability", lambda **kw: [])
+    monkeypatch.setattr(
+        lr, "apply_signals",
+        lambda dataset, signals: {"signals_applied": 0, "entry_points_promoted": 0,
+                                  "units_touched": 0})
+    monkeypatch.setattr(lr, "signals_to_json", lambda signals: [])
+
+    from core import scanner as scanner_mod
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(tmp_path / "out"),
+        generate_context=False, enhance=False, verify=False,
+        generate_report=False, dynamic_test=False,
+        llm_reachability=True, processing_level="reachable")
+    assert result is not None, "the scan must COMPLETE (degrade, not abort)"
+    assert "llm-reachability" in result.skipped_steps
+    report = json.loads((tmp_path / "out" / "llm-reachability.report.json").read_text())
+    assert report["status"] == "skipped"
+
+
+def test_units_count_restored_on_stage_failure(tmp_path, monkeypatch):
+    """Wave MAJOR-1 (discriminating form): the re-filter MUST run (call-graph
+    fixture present) so units_count is actually mutated mid-body, THEN the
+    persist write fails — the except restores the pre-stage count. Removing
+    the restore makes this test fail (mutation-discriminating)."""
+    import json
+    import core.parser_adapter as parser_adapter
+    import core.analyzer as analyzer
+    import core.reporter as reporter
+    import core.tracking as tracking
+    import core.llm_reachability as lr
+    import core.scanner as scanner_mod
+    from core.schemas import AnalysisMetrics
+
+    class _ParseResult:
+        def __init__(self, output_dir):
+            self.dataset_path = str(Path(output_dir) / "dataset.json")
+            self.analyzer_output_path = str(Path(output_dir) / "analyzer.json")
+            self.units_count = 3
+            self.language = "python"
+            self.processing_level = "reachable"
+
+    def _fake_parse(*, output_dir, **kwargs):
+        pr = _ParseResult(output_dir)
+        Path(pr.dataset_path).write_text(
+            json.dumps({"units": [{"id": "a.py:f", "language": "python",
+                                   "unit_id": "a.py:f"}],
+                        "metadata": {}}))
+        Path(pr.analyzer_output_path).write_text("{}")
+        cg_dir = Path(output_dir) / "python"
+        cg_dir.mkdir(exist_ok=True)
+        (cg_dir / "call_graph.json").write_text(
+            json.dumps({"functions": {}, "callGraph": {}}))
+        (Path(output_dir) / "call_graphs.json").write_text(
+            json.dumps({"python": "python/call_graph.json"}))
+        return pr
+
+    metrics = AnalysisMetrics(total=3, vulnerable=1, bypassable=0, inconclusive=0,
+                              protected=0, safe=2, errors=0)
+
+    class _AnalyzeResult:
+        def __init__(self, output_dir):
+            self.results_path = str(Path(output_dir) / "results.json")
+            Path(self.results_path).write_text("[]")
+            self.metrics = metrics
+
+    monkeypatch.setattr(parser_adapter, "parse_repository", _fake_parse)
+    monkeypatch.setattr(analyzer, "run_analysis",
+                        lambda *, output_dir, **kw: _AnalyzeResult(output_dir))
+    monkeypatch.setattr(
+        reporter, "build_pipeline_output",
+        lambda *, results_path, output_path, **kw:
+        (Path(output_path).write_text("{}"), output_path)[1])
+    tracking.reset_tracking()
+    monkeypatch.setattr(lr, "analyze_reachability", lambda **kw: [])
+    monkeypatch.setattr(
+        lr, "apply_signals",
+        lambda dataset, signals: {"signals_applied": 0, "entry_points_promoted": 0,
+                                  "units_touched": 0})
+    monkeypatch.setattr(lr, "signals_to_json", lambda signals: [])
+
+    real_write = scanner_mod.write_json
+
+    def _failing_dataset_write(path, *a, **kw):
+        if str(path).endswith("dataset.json"):
+            raise OSError(28, "No space left on device")
+        return real_write(path, *a, **kw)
+
+    monkeypatch.setattr(scanner_mod, "write_json", _failing_dataset_write)
+
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(tmp_path / "out"),
+        generate_context=False, enhance=False, verify=False,
+        generate_report=False, dynamic_test=False,
+        llm_reachability=True, processing_level="reachable")
+    assert result is not None
+    assert "llm-reachability" in result.skipped_steps
+    # the PRE-stage count (3) is what flows downstream — the restore undid
+    # the mid-body mutation (the re-filter ran: call-graph fixture present)
+    assert result.units_count == 3


### PR DESCRIPTION
## Summary

The llm-reachability stage's try/except guarded **only the dataset read**; everything after it — the app-context read, the LLM call, signal application, the post-LLM re-filter, the dataset re-write — ran inside `step_context`, which re-raises. So a **non-LLM** failure there aborted the whole scan instead of degrading the way `enhance` and `verify` do (#268): a corrupt/truncated `call_graph.json` hit by the re-filter's unguarded `read_json` (`parser_adapter.py:472`, the same `JSONDecodeError`/`UnicodeDecodeError` class the dataset-read guard was added for), or a failed `write_json` (disk-full/permissions) at `scanner.py:527`/`:704`. This is the exact fix PR #257 named as its own follow-up and deferred.

- Wrap the whole stage body in the enhance/verify pattern (warn → `ctx.status="skipped"` → `_record_skip` → continue with the pre-reachability dataset).
- **`LLMAuthError` is re-raised first**: bad credentials are the designed abort (`analyze_reachability` re-raises only that, by design) and must never silently degrade into a skipped pass that reads as a clean run — test-locked.
- `result.units_count` is **restored on failure** (adversarial-review catch: the body mutates it mid-flow before the persist; a failure in that window left the count describing a dataset that never reached disk) — mutation-discriminating test with a call-graph fixture that drives the real mutation window.
- The stale comment at the dataset-read guard (which mis-described provider errors as the exposed class) is corrected: provider errors were already handled; the exposed class was non-LLM failures.

## Test plan

6 hermetic tests: body-failure degrades + scan completes; write-failure degrades; clean stage still success; `LLMAuthError` still aborts; the **re-filter corrupt-`call_graph.json` headline path** driven through the REAL stage body (call-graphs.json index + corrupt per-language graph); units_count restored on failure (mutation-discriminating).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue268_llmreach_stage_guard.py -q` | 6 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue268_llmreach_stage_guard.py` | 6 passed |
| mutation smokes | remove the `LLMAuthError` re-raise → auth test fails; remove the units_count restore → restore test fails (both restored → green) | kill confirmed |
| full suite | `pytest tests/ -q` | 3001 passed, 2 failed (pre-existing zig local-env, stash-replay verified; CI green with them), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Adversarial loop: 4-seat wave → units_count window MAJOR (fixed with a discriminating test) + the re-filter-path test gap (BLOCKER — the commit's own headline example was never driven; fixed with the call-graph fixture) + a smuggled non-whitespace line in the re-indent reverted + dead imports removed. glm-5.3 verified the 233-line re-indent is otherwise lossless.

</details>

Fixes #268
