### PR TITLE
fix(registry): close the languages.json wrong-trust paths (exec guard + wheel-layout resolve + CWD-leg visibility)

### DIFF
--- a/libs/openant-core/core/language_registry.py
+++ b/libs/openant-core/core/language_registry.py
@@ -80,7 +80,21 @@ def find_languages_config() -> Path | None:
     found = _search_upward(Path(__file__).parent)
     if found is not None:
         return found
-    return _search_upward(Path.cwd())
+    found = _search_upward(Path.cwd())
+    if found is not None:
+        # #273 visibility: the CWD leg can find a config in the working
+        # directory — including a scanned repo's own config when run from
+        # inside it. skip_dirs/extensions from it are data-only (parser
+        # scripts are hard-guarded in parser_script_path); this note makes
+        # the source loud instead of silent.
+        print(
+            f"[languages] note: config/languages.json located via the "
+            f"working directory ({found}); if this is the scanned "
+            f"repository, its settings are being trusted for "
+            f"skip_dirs/extensions",
+            file=sys.stderr,
+        )
+    return found
 
 # Root of openant-core, used to resolve parser script paths.
 _CORE_ROOT = Path(__file__).parent.parent
@@ -283,8 +297,29 @@ def docker_template_for(language: str) -> str | None:
 
 
 def parser_script_path(language: str) -> Path | None:
-    """Absolute path to a language's subprocess parser entry point."""
+    """Absolute path to a language's subprocess parser entry point.
+
+    #273 hard guard: the config file may come from an untrusted source
+    (the resolver's CWD-upward leg can find a scanned repo's own
+    config/languages.json), and ``Path('/root') / '/abs'`` is ``'/abs'``
+    in pathlib — an absolute ``parser.script`` value previously resolved
+    to ITSELF and was executed via ``sys.executable``. Resolve and require
+    the result to stay under ``_CORE_ROOT`` (rejects absolute values,
+    ``..`` escapes, and symlink escapes alike); anything else returns None
+    (the caller degrades to a typed error, never executes).
+    """
     spec = load_registry().get(language)
     if spec is None or not spec.parser_script:
         return None
-    return _CORE_ROOT / spec.parser_script
+    root = _CORE_ROOT.resolve()
+    try:
+        candidate = (root / spec.parser_script).resolve()
+    except (OSError, ValueError):
+        # Hostile script values (e.g. embedded NULs, absurd length) can
+        # make resolve itself raise — total guard, never executes.
+        return None
+    if not candidate.is_relative_to(root) or candidate == root:
+        # == root: "." and friends resolve to the root DIRECTORY — not a
+        # script; reject alongside out-of-root escapes.
+        return None
+    return candidate

--- a/libs/openant-core/core/model_registry.py
+++ b/libs/openant-core/core/model_registry.py
@@ -74,7 +74,17 @@ def find_models_config() -> Path | None:
     found = _search_upward(Path(__file__).parent)
     if found is not None:
         return found
-    return _search_upward(Path.cwd())
+    found = _search_upward(Path.cwd())
+    if found is not None:
+        # #273 sibling: same CWD-leg visibility as language_registry — the
+        # working directory (possibly the scanned repo) supplied the config.
+        print(
+            f"[models] note: config/models.json located via the working "
+            f"directory ({found}); if this is the scanned repository, "
+            f"its pricing records are being trusted",
+            file=sys.stderr,
+        )
+    return found
 
 
 @lru_cache(maxsize=1)

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -808,6 +808,19 @@ def _parse_via_subprocess(
     print(f"[Parser] Running {language} parser...", file=sys.stderr)
 
     parser_script = parser_script_path(language)
+    if parser_script is None:
+        # #273: the guard rejected the config's parser.script (absolute
+        # path, .. escape, or symlink escape out of the engine root) or the
+        # language has no script. Say THAT — a bare str(None) spawn would
+        # fail with a misleading generic RuntimeError exactly in the
+        # hostile-config scenario this guard exists for.
+        raise RuntimeError(
+            f"No runnable parser script for language {language!r}: the "
+            "registry entry has no parser.script, or its value was "
+            "rejected by the engine-root containment guard "
+            "(config/languages.json may come from an untrusted source — "
+            "see parser_script_path)"
+        )
 
     cmd = [
         sys.executable, str(parser_script),

--- a/libs/openant-core/tests/test_issue273_config_trust.py
+++ b/libs/openant-core/tests/test_issue273_config_trust.py
@@ -1,0 +1,174 @@
+"""Regression tests for issue #273 — two wrong-trust paths in locating
+config/languages.json.
+
+(1) The context corrector's fixed four-``.parent`` walk matched only the
+checkout depth; in a wheel install the config sits two parents up, so the
+walk missed and ``except Exception: pass`` silently fell back to the frozen
+``_FALLBACK_SKIP_DIRS`` — installed layouts never saw config updates to
+skip_dirs. Fix: route through the registry's own resolver.
+
+(2) The resolver's CWD-upward fallback trusts the scanned repo: a
+``config/languages.json`` planted in the working directory could supply
+``parser.script`` — and ``_CORE_ROOT / script`` does NOT constrain an
+absolute path (``Path('/a') / '/b' == Path('/b')``), so the planted script
+was executed via ``sys.executable``. Fix: ``parser_script_path`` resolves
+and requires the result to stay under ``_CORE_ROOT`` (absolute values and
+``..``/symlink escapes rejected), closing the exec vector for EVERY config
+source; the CWD leg gains stderr visibility (the residual data-only trust
+becomes loud).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.language_registry import (  # noqa: E402
+    _CORE_ROOT, LanguageSpec, parser_script_path,
+)
+
+
+def _spec_with_script(script):
+    return LanguageSpec(
+        name="testlang", extensions=(".t",),
+        parser_mode="subprocess", parser_script=script,
+        bootstrap=None, fence="test", docker_template=None, enabled=True,
+    )
+
+
+def test_absolute_script_value_rejected(monkeypatch):
+    """A planted absolute parser.script must NOT resolve to itself
+    (Path('/root') / '/abs' == '/abs' — the exec vector #273 names)."""
+    import core.language_registry as lr
+
+    monkeypatch.setattr(
+        lr, "load_registry",
+        lambda: {"testlang": _spec_with_script("/tmp/evil.py")})
+    assert parser_script_path("testlang") is None
+
+
+def test_dotdot_escape_rejected(monkeypatch):
+    import core.language_registry as lr
+
+    monkeypatch.setattr(
+        lr, "load_registry",
+        lambda: {"testlang": _spec_with_script("../../etc/passwd")})
+    assert parser_script_path("testlang") is None
+
+
+def test_legitimate_relative_script_resolves(monkeypatch):
+    import core.language_registry as lr
+
+    real = (Path(__file__).parent.parent / "parsers" / "python"
+            / "parse_repository.py").relative_to(_CORE_ROOT)
+    monkeypatch.setattr(
+        lr, "load_registry",
+        lambda: {"testlang": _spec_with_script(str(real))})
+    p = parser_script_path("testlang")
+    assert p is not None
+    assert p.is_relative_to(_CORE_ROOT.resolve())
+
+
+def test_corrector_uses_registry_resolver(monkeypatch):
+    """(1): the corrector routes through find_languages_config — no more
+    fixed-depth walk (which missed wheel layouts and silently degraded)."""
+    import utilities.context_corrector as cc
+
+    calls = {"n": 0}
+
+    def _fake_find():
+        calls["n"] += 1
+        return Path("/nonexistent/does/not/matter")
+
+    monkeypatch.setattr(
+        "core.language_registry.find_languages_config", _fake_find)
+    # call the real function; it should consult the resolver (even though
+    # the returned path does not exist — the CALL is the contract)
+    cc._canonical_skip_dirs()
+    assert calls["n"] >= 1, (
+        "context_corrector must resolve config via find_languages_config, "
+        "not a fixed-depth .parent walk"
+    )
+
+
+def test_cwd_leg_visibility(capsys, monkeypatch, tmp_path):
+    """(2) residual made loud — driving the REAL fallback order: the file
+    leg must miss, the CWD leg must hit via the REAL _search_upward walk
+    from Path.cwd()."""
+    import core.language_registry as lr
+
+    # Make the FILE leg miss: the repo tree has no config above core/
+    # (it does in the checkout — so point _search_upward's file-leg start
+    # at an empty temp dir via patching find's first call only). Simplest
+    # honest drive: chdir into tmp_path WITH a config, and make the
+    # __file__ leg miss by patching _search_upward to distinguish legs.
+    real_search = lr._search_upward
+
+    def _leg_aware_search(start):
+        # file leg starts under libs/openant-core/core; cwd leg at cwd
+        if "openant-core" in str(start):
+            return None  # the file leg misses
+        return real_search(start)  # the CWD leg uses the REAL walk
+
+    monkeypatch.setattr(lr, "_search_upward", _leg_aware_search)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config").mkdir(exist_ok=True)
+    (tmp_path / "config" / "languages.json").write_text('{"languages": {}}')
+    found = lr.find_languages_config()
+    assert found is not None
+    assert found == (tmp_path / "config" / "languages.json").resolve()
+    err = capsys.readouterr().err
+    assert "working directory" in err, (
+        f"the CWD-leg config source must be visible on stderr (got {err!r})"
+    )
+
+
+def test_caller_rejects_guarded_script_clearly(monkeypatch, tmp_path):
+    """Wave catch (3-seat convergence): the SOLE caller of
+    parser_script_path must handle None with a clear, typed message —
+    not spawn sys.executable 'None' and fail misleadingly."""
+    import pytest as _pytest
+    import core.language_registry as lr
+    import core.parser_adapter as pa
+
+    bad = {"testlang": _spec_with_script("/tmp/evil.py")}
+    monkeypatch.setattr(lr, "load_registry", lambda: bad)
+    monkeypatch.setattr(pa, "load_registry", lambda: bad)
+    with _pytest.raises(RuntimeError, match="containment guard"):
+        pa._parse_via_subprocess(
+            language="testlang", repo_path=str(tmp_path),
+            output_dir=str(tmp_path / "out"),
+            processing_level="all",
+        )
+
+
+def test_model_registry_cwd_leg_visibility(capsys, monkeypatch, tmp_path):
+    """The model_registry sibling gains the same CWD-leg note (wave catch:
+    the identical wrong-trust shape shipped unpatched there)."""
+    import core.model_registry as mr
+
+    real_search = mr._search_upward
+
+    def _leg_aware_search(start):
+        # file leg starts under libs/openant-core/core; cwd leg at cwd
+        if "openant-core" in str(start):
+            return None
+        return real_search(start)
+
+    monkeypatch.setattr(mr, "_search_upward", _leg_aware_search)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "config").mkdir(exist_ok=True)
+    (tmp_path / "config" / "models.json").write_text('{"models": []}')
+    found = mr.find_models_config()
+    assert found is not None, (
+        f"CWD leg should find {tmp_path}/config/models.json — "
+        f"check _search_upward leg detection"
+    )
+    err = capsys.readouterr().err
+    assert "working directory" in err

--- a/libs/openant-core/utilities/context_corrector.py
+++ b/libs/openant-core/utilities/context_corrector.py
@@ -61,10 +61,16 @@ def _canonical_skip_dirs() -> set[str]:
     """
     skip = set(_FALLBACK_SKIP_DIRS)
     try:
-        # utilities/context_corrector.py -> utilities -> openant-core -> libs -> repo root
-        cfg = Path(__file__).resolve().parent.parent.parent.parent / "config" / "languages.json"
-        with open(cfg, 'r', encoding='utf-8') as fh:
-            skip |= set(json.load(fh).get("skip_dirs", ()))
+        # #273: resolve through the registry's own locator. The previous
+        # fixed four-.parent walk matched only the CHECKOUT depth — in a
+        # wheel install the config sits two parents up, the walk missed,
+        # and every pip install silently degraded to this frozen fallback.
+        from core.language_registry import find_languages_config
+
+        cfg = find_languages_config()
+        if cfg is not None:
+            with open(cfg, 'r', encoding='utf-8') as fh:
+                skip |= set(json.load(fh).get("skip_dirs", ()))
     except Exception:
         pass
     return skip


### PR DESCRIPTION
## Summary

Two wrong-trust paths in locating `config/languages.json` (#273):

**(1) Silent degrade in every pip install.** `context_corrector.py`'s fixed four-`.parent` walk matched only the checkout depth; in the wheel the config sits two parents up, so the walk missed and `except Exception: pass` fell back to the frozen `_FALLBACK_SKIP_DIRS` — installed layouts never saw config updates to `skip_dirs`. Now routed through the registry's own `find_languages_config` (handles override + upward search in every layout).

**(2) The CWD-upward fallback trusted the scanned repo.** `find_languages_config`'s CWD leg can find a scanned repo's **own** `config/languages.json` when run with CWD inside it — and `parser.script` from that config was executed via `sys.executable`, because `Path('/root') / '/abs'` **is** `'/abs'` in pathlib (an absolute script value resolved to itself). `parser_script_path` now resolves and requires the result to stay under `_CORE_ROOT` — a **total** guard (resolve failures on hostile values caught; the root directory itself rejected; absolute/`..`/symlink escapes all return `None`). The sole caller raises a clear `RuntimeError` naming the containment guard (a bare `str(None)` spawn previously failed with a misleading generic error exactly in the hostile-config scenario — adversarial catch, 3-seat convergence). Both the languages and the models registry CWD legs gain a stderr note when they (not the file leg) supply the config — the residual data-only trust (skip_dirs/extensions/pricing) is loud instead of silent.

Deferred on the issue: refusing a config located under the scan target — the resolver runs during argparse construction, before the scan target exists; it needs the target plumbed through the API (a signature change), out of scope for a fixes-only pass.

## Test plan

7 hermetic tests: absolute script value rejected; `..` escape rejected; legitimate relative script resolves under `_CORE_ROOT`; the corrector consults the resolver; the CWD-leg note via the REAL upward walk; the caller's clear containment-guard `RuntimeError`; the model_registry sibling's note.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue273_config_trust.py -q` | 7 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue273_config_trust.py` | 7 passed |
| mutation smoke | remove the parser_script guard | tests fail (restored → green) |
| full suite | `pytest tests/ -q` | 3002 passed, 2 failed (pre-existing zig local-env, stash-replay verified; CI green with them), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Adversarial loop: 4-seat wave → the caller-never-handles-None catch (3-seat convergence) + the model_registry sibling (same wrong-trust shape, unpatched) + the guard's non-totality — all fixed pre-ship.

</details>

Fixes #273
