### PR TITLE
fix(tracking): resumed runs no longer double-count prior usage in the per-phase lines

### DIFF
--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -589,6 +589,14 @@ def run_analysis(
     if _summary_input_tokens or _summary_output_tokens:
         get_global_tracker().add_prior_usage(
             _summary_input_tokens, _summary_output_tokens, _summary_cost_usd)
+        # #281: re-snapshot the phase baseline AFTER the injection — the
+        # pre-injection baseline made the "Stage 1" delta include the prior
+        # session's tokens/cost (calls exclude restored units while
+        # tokens/cost included them: an internally inconsistent line, and
+        # #214's "this phase's delta" contract broken on resumed runs).
+        # The step reports' totals still include the prior usage (the
+        # run-total contract); only the per-phase stderr line is the delta.
+        _phase_baseline = tracking.get_usage()
 
     # Write initial summary
     checkpoint.write_summary(total, _summary_completed, _summary_errors,

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -63,7 +63,10 @@ def enhance_dataset(
     """
     # #214: snapshot cumulative usage at phase start so the "Enhance" summary
     # below reports this phase's delta, not the prior phases' total.
-    _phase_baseline = tracking.get_usage()
+    # #281: MUTABLE holder — the enhance path's checkpoint-restore injects
+    # prior usage into the tracker AFTER this snapshot; the injection site
+    # refreshes the holder (see verifier's identical shape).
+    _phase_baseline = {"usage": tracking.get_usage()}
     # Configure global rate limiter
     configure_rate_limiter(backoff_seconds=float(backoff_seconds))
 
@@ -133,8 +136,13 @@ def enhance_dataset(
             progress_callback=_on_unit_done,
             restored_callback=_on_restored,
             workers=workers,
+            phase_baseline=_phase_baseline,
         )
     elif mode == "single-shot":
+        # NOTE: single-shot enhance performs NO add_prior_usage injection
+        # (no checkpoint restore on this path) — its baseline was already
+        # correct pre-#281; no holder threading needed (wave catch: threading
+        # it anyway was dead code).
         enhanced = enhancer.enhance_dataset(
             dataset,
             progress_callback=_on_unit_done,
@@ -178,7 +186,7 @@ def enhance_dataset(
     if error_count:
         print(f"[Enhance] Errors: {error_count} ({error_summary})", file=sys.stderr)
 
-    tracking.log_usage("Enhance", _phase_baseline)
+    tracking.log_usage("Enhance", _phase_baseline["usage"])
 
     usage = tracking.get_usage()
 

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -77,7 +77,12 @@ def run_verification(
     """
     # #214: snapshot cumulative usage at phase start so the "Stage 2" summary
     # below reports this phase's delta, not every prior phase's total.
-    _phase_baseline = tracking.get_usage()
+    # #281: MUTABLE holder — verify_batch's checkpoint-restore injects the
+    # prior session's usage into the tracker AFTER this snapshot; the
+    # injection site refreshes the holder so the delta below counts only
+    # the CURRENT session's calls (calls exclude restored units, so
+    # tokens/cost must too — the internally-consistent line #214 promised).
+    _phase_baseline = {"usage": tracking.get_usage()}
     os.makedirs(output_dir, exist_ok=True)
 
     # Configure global rate limiter
@@ -212,6 +217,7 @@ def run_verification(
             workers=workers,
             checkpoint=checkpoint,
             restored_callback=_on_restored,
+            phase_baseline=_phase_baseline,
         )
     except Exception as e:
         print(f"[Verify] ERROR during batch verification: {e}", file=sys.stderr)
@@ -236,7 +242,7 @@ def run_verification(
     # Checkpoints are preserved as a permanent artifact alongside results
     # (final summary with phase="done" is written inside verify_batch).
 
-    tracking.log_usage("Stage 2", _phase_baseline)
+    tracking.log_usage("Stage 2", _phase_baseline["usage"])
 
     # Merge verified results back into the full result set
     verified_ids = {r.get("unit_id") or r.get("route_key") for r in verified_results}

--- a/libs/openant-core/tests/test_issue281_resume_baseline.py
+++ b/libs/openant-core/tests/test_issue281_resume_baseline.py
@@ -1,0 +1,149 @@
+"""Regression tests for issue #281 — resumed runs double-count prior
+session usage in the first per-phase usage line.
+
+#214 added per-phase baselines (``_phase_baseline = tracking.get_usage()``
+at phase start) so a "Stage 1" line reports the phase's delta. On a
+CHECKPOINT-RESUMED run, ``add_prior_usage(...)`` injects the prior
+session's tokens/cost into the global tracker AFTER the baseline was
+snapshotted — so the printed delta included the injected prior usage:
+``Stage 1: 20 API calls, 1,250,000 tokens, $8.25`` where 20 calls account
+for ~250k tokens/$0.25 and the extra ~1M/$8 is the restored session.
+Calls exclude restored units while tokens/cost included them — internally
+inconsistent, and #214's "this phase's delta" contract broken on resume.
+
+Contract locked here: each phase's usage line counts ONLY the current
+session's own calls/tokens/cost. The step reports' totals still include
+the prior usage (the run-total contract) — only the per-phase stderr
+line is the delta. All three restoring phases fixed: analyze (re-snapshot
+after injection), verify + enhance (mutable baseline holder refreshed at
+the injection site inside verify_batch/enhance_dataset_agentic).
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import contextlib
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core import tracking  # noqa: E402
+from utilities.llm_client import TokenTracker  # noqa: E402
+
+
+def _capture_usage_line(prefix="Stage 1", baseline=None):
+    """Call log_usage with the GIVEN baseline and return the printed line."""
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        tracking.log_usage(prefix, baseline)
+    return buf.getvalue()
+
+
+def test_analyzer_resume_baseline_excludes_prior(capfd):
+    """The #281 shape at the analyzer level: baseline → injection → own
+    calls → the line's delta must count ONLY the own calls. The analyzer
+    fix re-snapshots _phase_baseline after add_prior_usage; here we verify
+    the exact sequence the fixed code performs."""
+    tracker = tracking.get_global_tracker()
+    tracker.reset()
+    baseline = tracking.get_usage()          # #214 snapshot at phase start
+    tracker.add_prior_usage(1_000_000, 500_000, 8.00)  # resume injection
+    # THE FIX: re-snapshot after the injection (analyzer.py does this now)
+    baseline = tracking.get_usage()
+    tracker.record_call(model="m", input_tokens=250_000, output_tokens=50_000,
+                        pricing={"input": 1.0, "output": 2.0})  # own work
+    line = _capture_usage_line("Stage 1", baseline)
+    # own work: 250k input + 50k output = 300k total tokens, $0.35
+    assert "300,000" in line, f"delta must be the own tokens (got {line!r})"
+    assert "1 API calls" in line
+    assert "0.3500" in line, f"own cost $0.35 (got {line!r})"
+    assert "8." not in line, (
+        f"the restored $8 must NOT appear in the phase delta (got {line!r})"
+    )
+
+
+def test_verifier_holder_refreshed_at_injection():
+    """The verify path: a mutable baseline holder passed into verify_batch
+    is refreshed at the injection site — the final log uses the refreshed
+    value, not the pre-injection snapshot."""
+    tracker = tracking.get_global_tracker()
+    tracker.reset()
+    holder = {"usage": tracking.get_usage()}     # runner's :85 snapshot
+    # simulate verify_batch's internal sequence: injection + refresh
+    tracker.add_prior_usage(400_000, 200_000, 3.00)
+    # (finding_verifier.py:684 does exactly this when phase_baseline is not None)
+    holder["usage"] = tracking.get_usage()
+    tracker.record_call(model="m", input_tokens=100_000, output_tokens=20_000,
+                        pricing={"input": 1.0, "output": 2.0})
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        tracking.log_usage("Stage 2", holder["usage"])
+    line = buf.getvalue()
+    assert "120,000" in line  # 100k input + 20k output
+    assert "3." not in line
+
+
+def test_enhancer_holder_refreshed_at_injection():
+    """The enhance path: same holder shape through
+    enhance_dataset_agentic's injection site."""
+    tracker = tracking.get_global_tracker()
+    tracker.reset()
+    holder = {"usage": tracking.get_usage()}
+    tracker.add_prior_usage(50_000, 10_000, 0.50)
+    holder["usage"] = tracking.get_usage()   # context_enhancer.py:684
+    tracker.record_call(model="m", input_tokens=30_000, output_tokens=5_000,
+                        pricing={"input": 1.0, "output": 2.0})
+    buf = io.StringIO()
+    with contextlib.redirect_stderr(buf):
+        tracking.log_usage("Enhance", holder["usage"])
+    line = buf.getvalue()
+    assert "35,000" in line  # 30k input + 5k output
+    assert "0.5" not in line
+
+
+def test_analyzer_resnapshot_is_placed_after_injection():
+    """Source-placement contract: the analyzer's baseline re-snapshot must
+    sit AFTER the add_prior_usage call (the mutation smoke's target —
+    simulation tests can't catch a placement regression)."""
+    import re
+    src = Path(__file__).parent.parent / "core" / "analyzer.py"
+    text = src.read_text()
+    # ORDER-SENSITIVE (wave catch: the old test was order-insensitive —
+    # a pre-injection re-snapshot mutation survived it).
+    inj = text.find("get_global_tracker().add_prior_usage(")
+    assert inj != -1, "injection call present"
+    inj_end = text.find("\n", text.find(")", inj))
+    resnap = text.find("_phase_baseline = tracking.get_usage()", inj_end)
+    assert resnap != -1, (
+        "the baseline re-snapshot must FOLLOW the add_prior_usage call "
+        "(#281 — without it, resumed Stage 1 lines double-count prior usage)"
+    )
+    between = text[inj_end:resnap]
+    assert "add_prior_usage" not in between, "no second injection between"
+    assert between.count("\n") < 12, (
+        "re-snapshot should be immediately after the injection, not pages later"
+    )
+    log_call = text.find('tracking.log_usage("Stage 1", _phase_baseline)', resnap)
+    assert log_call != -1, "the Stage 1 log must use the re-snapshotted baseline"
+
+
+def test_verifier_and_enhancer_holders_wired():
+    """Source-placement contract: verify + enhance thread a mutable
+    phase_baseline holder into their batch calls, and the injection sites
+    refresh it."""
+    base = Path(__file__).parent.parent
+    vsrc = (base / "core" / "verifier.py").read_text()
+    assert '_phase_baseline = {"usage": tracking.get_usage()}' in vsrc
+    assert "phase_baseline=_phase_baseline" in vsrc
+    assert 'tracking.log_usage("Stage 2", _phase_baseline["usage"])' in vsrc
+    esrc = (base / "core" / "enhancer.py").read_text()
+    assert '_phase_baseline = {"usage": tracking.get_usage()}' in esrc
+    assert "phase_baseline=_phase_baseline" in esrc  # agentic path only
+    assert 'tracking.log_usage("Enhance", _phase_baseline["usage"])' in esrc
+    fsrc = (base / "utilities" / "finding_verifier.py").read_text()
+    assert 'phase_baseline["usage"] = _tracking.get_usage()' in fsrc
+    csrc = (base / "utilities" / "context_enhancer.py").read_text()
+    assert 'phase_baseline["usage"] = _tracking.get_usage()' in csrc

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -379,6 +379,7 @@ class ContextEnhancer:
         workers: int = 10,
         checkpoint_path: str = None,
         restored_callback: Optional[Callable] = None,
+        phase_baseline: dict | None = None,
     ) -> dict:
         """
         Enhance all units in a dataset (single-shot mode).
@@ -558,6 +559,7 @@ class ContextEnhancer:
         progress_callback: Optional[Callable] = None,
         restored_callback: Optional[Callable] = None,
         workers: int = 10,
+        phase_baseline: dict | None = None,
     ) -> dict:
         """
         Enhance all units using agentic approach with tool use.
@@ -677,6 +679,11 @@ class ContextEnhancer:
             if _summary_input_tokens or _summary_output_tokens:
                 self.tracker.add_prior_usage(
                     _summary_input_tokens, _summary_output_tokens, _summary_cost_usd)
+                # #281: refresh the caller's phase baseline AFTER the
+                # injection so its "Enhance" delta excludes restored usage.
+                if phase_baseline is not None:
+                    from core import tracking as _tracking
+                    phase_baseline["usage"] = _tracking.get_usage()
 
         remaining = total - len(processed_ids)
         self._log("info", f"Enhancing {remaining} units with agentic analysis ({len(processed_ids)} already done)", units=remaining)

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -573,6 +573,7 @@ class FindingVerifier:
         workers: int = 10,
         checkpoint=None,
         restored_callback: Optional[Callable] = None,
+        phase_baseline: dict | None = None,
     ) -> list:
         """
         Verify a batch of results with consistency cross-check.
@@ -664,6 +665,11 @@ class FindingVerifier:
         if _summary_input_tokens or _summary_output_tokens:
             self.tracker.add_prior_usage(
                 _summary_input_tokens, _summary_output_tokens, _summary_cost_usd)
+            # #281: refresh the caller's phase baseline AFTER the injection
+            # so its "Stage 2" delta excludes the restored usage.
+            if phase_baseline is not None:
+                from core import tracking as _tracking
+                phase_baseline["usage"] = _tracking.get_usage()
 
         if checkpoint is not None:
             checkpoint.write_summary(total, _summary_completed, _summary_errors,


### PR DESCRIPTION
## Summary

On a checkpoint-resumed run, the first per-phase usage line overstated by the prior session's usage (#281): `add_prior_usage` injects the prior session's tokens/cost into the global tracker AFTER the #214 baseline snapshot, so e.g. `Stage 1: 20 API calls, 1,250,000 tokens, $8.25` where the 20 calls account for ~250k tokens/$0.25 — calls exclude restored units while tokens/cost include them, internally inconsistent.

All three phases that restore from checkpoints AND log per-phase usage lines are fixed:
- **analyze**: re-snapshot `_phase_baseline` immediately after the injection (both in the same function)
- **verify**: the baseline becomes a mutable holder threaded into `verify_batch`; the injection site inside `finding_verifier` refreshes it
- **enhance** (agentic): the same holder shape through `enhance_dataset_agentic`; the single-shot path has no injection — its baseline was already correct (the initially-threaded dead holder removed per review)

The step reports' totals still include the prior usage (the run-total contract) — only the per-phase stderr line is the delta.

**Adjacent surfaces found by adversarial review, recorded rather than fixed here** (different issues): the dynamic-test phase's report cost is #333's shape (whole-run cumulative as the step's own — no `log_usage` call there); and `ProgressReporter`'s per-unit cost line snapshots cumulative cost at construction, reproducing the #281 symptom on resume — a construction-ordering fix on a surface this PR doesn't touch, noted on the issue.

## Test plan

5 hermetic tests: the three phases' delta math through the real `log_usage`; an order-sensitive placement contract for the analyzer re-snapshot (the mutation target); source-placement contracts for both holder wirings.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue281_resume_baseline.py -q` | 5 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue281_resume_baseline.py` | 5 passed |
| mutation smoke | remove the analyzer re-snapshot | placement test fails (restored → green) |
| full suite | `pytest tests/ -q` | 3000 passed, 2 failed (pre-existing zig local-env, stash-replay verified; CI green with them), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Adversarial loop: 4-seat wave → the placement test made order-sensitive (a pre-injection re-snapshot mutation survived the first version), the dead single-shot holder removed, and two adjacent surfaces recorded (#333 relationship; ProgressReporter construction-ordering).

</details>

Fixes #281
