### PR TITLE
fix(report): scan.report.json derives its status and errors from the step reports it aggregates

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -868,6 +868,11 @@ def scan_repository(
         ctx.summary = {
             "total_units": analyze_result.metrics.total,
             "analyzed": analyze_result.metrics.total - analyze_result.metrics.errors,
+            # #285 (wave catch): the flat error_count the step-status
+            # derivation reads — analyze counts per-unit failures here, not
+            # in ctx.errors, so without this key every-unit-errors stayed
+            # status="success" (the same false-green shape verify had).
+            "error_count": analyze_result.metrics.errors,
             "verdicts": {
                 "vulnerable": analyze_result.metrics.vulnerable,
                 "bypassable": analyze_result.metrics.bypassable,
@@ -1302,6 +1307,15 @@ def _write_scan_report(
     """Write ``scan.report.json`` — the aggregate report for the full pipeline."""
     total_cost = sum(sr.get("cost_usd", 0) for sr in step_reports)
     total_duration = sum(sr.get("duration_seconds", 0) for sr in step_reports)
+    # #285: aggregate the per-step status and errors — the scan report must
+    # be at least as informative as the per-step files it summarises.
+    _STATUS_RANK = {"success": 0, "skipped": 1, "partial": 2, "error": 3}
+    _worst_status = "success"
+    for sr in step_reports:
+        _st = str(sr.get("status", "success") or "success").lower()
+        if _STATUS_RANK.get(_st, 0) > _STATUS_RANK.get(_worst_status, 0):
+            _worst_status = _st
+    _all_errors = [e for sr in step_reports for e in sr.get("errors", [])]
     total_input = sum(
         sr.get("token_usage", {}).get("input_tokens", 0) for sr in step_reports
     )
@@ -1309,8 +1323,14 @@ def _write_scan_report(
         sr.get("token_usage", {}).get("output_tokens", 0) for sr in step_reports
     )
 
+    # #285: carry the derived status/errors onto the ScanResult so the
+    # envelope and downstream consumers see the degraded scan.
+    result.scan_status = _worst_status
+    result.scan_errors = _all_errors
     scan_report = StepReport(
         step="scan",
+        status=_worst_status,
+        errors=_all_errors,
         summary={
             "units_count": result.units_count,
             "language": result.language,

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -161,6 +161,11 @@ class ScanResult:
     output_dir: str
     dataset_path: str | None = None
     enhanced_dataset_path: str | None = None
+    # #285: the scan-level status (worst per-step: error > partial > skipped
+    # > success) and the aggregate errors — carried so the envelope / webui /
+    # CLI consumers see a degraded scan without re-reading scan.report.json.
+    scan_status: str = "success"
+    scan_errors: list = field(default_factory=list)
     analyzer_output_path: str | None = None
     app_context_path: str | None = None
     results_path: str | None = None
@@ -219,6 +224,8 @@ class ScanResult:
     def to_dict(self) -> dict:
         return {
             "output_dir": self.output_dir,
+            "scan_status": self.scan_status,
+            "scan_errors": self.scan_errors,
             "dataset_path": self.dataset_path,
             "enhanced_dataset_path": self.enhanced_dataset_path,
             "analyzer_output_path": self.analyzer_output_path,

--- a/libs/openant-core/core/step_report.py
+++ b/libs/openant-core/core/step_report.py
@@ -60,18 +60,21 @@ def step_context(step: str, output_dir: str, inputs: dict | None = None):
         traceback.print_exc(file=sys.stderr)
         raise
     finally:
-        # Issue #209: a step that records errors via ``ctx.errors.append(...)``
-        # (exception caught BY DESIGN — e.g. the report phase's summary and
-        # disclosure handlers in ``core/scanner.py``) must not report success.
-        # Derive the status from the errors list at exit: non-empty errors
-        # means "error", idempotently with the propagating-exception path
-        # above. Errors also WIN over an explicitly-set ``"skipped"`` (a
-        # skipped step that recorded errors is more error than skipped — no
-        # current call site produces that combination; locked by test). The
-        # scanner's degrade idiom (status="skipped" with the reason in
-        # ``summary``, no errors) is unaffected.
-        if report.errors and report.status != "error":
-            report.status = "error"
+        # Issue #209/#285: a step that records errors via
+        # ``ctx.errors.append(...)`` or that counts per-item failures in
+        # ``summary["error_count"]`` (exception caught BY DESIGN) must not
+        # report success. Derive the status from evidence at exit:
+        # non-empty ``errors`` OR a positive integer ``error_count`` in
+        # ``summary`` ⇒ ``"partial"`` — deliberately NOT ``"error"`` (which
+        # stays reserved for the propagating-exception path). The scanner's
+        # degrade idiom (status="skipped", reason in summary, no errors) is
+        # unaffected.
+        if report.status != "error":
+            _summary = report.summary if isinstance(report.summary, dict) else {}
+            _counted = _summary.get("error_count")
+            _error_count = _counted if isinstance(_counted, int) and _counted > 0 else 0
+            if report.errors or _error_count:
+                report.status = "partial"
 
         report.duration_seconds = round(time.monotonic() - start, 2)
 

--- a/libs/openant-core/tests/test_issue209_step_report_status.py
+++ b/libs/openant-core/tests/test_issue209_step_report_status.py
@@ -1,6 +1,6 @@
 """Regression tests for issue #209 (per-step status half).
 
-``step_context`` only set ``status="error"`` when an exception PROPAGATED out
+``step_context`` only set ``status="partial"`` when an exception PROPAGATED out
 of the ``with`` block. A step that catches its own exception by design and
 records it via ``ctx.errors.append(...)`` — exactly what the scan's report
 phase does for summary/disclosure generation (``core/scanner.py`` handlers,
@@ -46,7 +46,7 @@ def test_errors_recorded_without_exception_yield_error_status(tmp_path: Path):
 
     report = _read_report(tmp_path, "report")
     assert report["errors"], "errors list must be recorded"
-    assert report["status"] == "error", (
+    assert report["status"] == "partial", (
         f"a step with recorded errors must not claim success (got {report['status']!r})"
     )
 
@@ -62,6 +62,8 @@ def test_propagated_exception_still_error(tmp_path: Path):
         with step_context("analyze", str(tmp_path)):
             raise RuntimeError("boom")
     report = _read_report(tmp_path, "analyze")
+    # The escaping exception keeps the RESERVED "error" status (#285: only
+    # caught-by-design errors/downgrades are "partial").
     assert report["status"] == "error"
     assert any("boom" in e for e in report["errors"])
 
@@ -87,7 +89,7 @@ def test_errors_recorded_override_explicit_skipped(tmp_path: Path):
     with step_context("weird", str(tmp_path)) as ctx:
         ctx.status = "skipped"
         ctx.errors.append("boom")
-    assert _read_report(tmp_path, "weird")["status"] == "error"
+    assert _read_report(tmp_path, "weird")["status"] == "partial"
 
 
 # ---------------------------------------------------------------------------
@@ -212,24 +214,24 @@ def test_scan_report_step_error_status_when_summary_fails(
 ):
     """The #209 end-to-end shape: summary raises (#279's guard), handler
     catches by design, scan continues — and report.report.json must say
-    status="error" with the recorded error, not success."""
+    status="partial" with the recorded error, not success."""
     result, report = _scan_with_report_failures(
         monkeypatch, tmp_path, summary_fails=True, disclosures_fail=False
     )
     assert result is not None, "scan must COMPLETE (report failure must not abort)"
-    assert report["status"] == "error"
+    assert report["status"] == "partial"
     assert len(report["errors"]) == 1
     assert "Summary report" in report["errors"][0]
 
 
 def test_scan_report_step_error_status_when_both_fail(monkeypatch, tmp_path):
-    """Both deliverables fail: two recorded errors, still status="error",
+    """Both deliverables fail: two recorded errors, still status="partial",
     scan still completes (multiple-errors shape)."""
     result, report = _scan_with_report_failures(
         monkeypatch, tmp_path, summary_fails=True, disclosures_fail=True
     )
     assert result is not None
-    assert report["status"] == "error"
+    assert report["status"] == "partial"
     assert len(report["errors"]) == 2
 
 
@@ -243,7 +245,7 @@ def test_scan_report_step_error_status_when_only_disclosures_fail(
         monkeypatch, tmp_path, summary_fails=False, disclosures_fail=True
     )
     assert result is not None
-    assert report["status"] == "error"
+    assert report["status"] == "partial"
     assert len(report["errors"]) == 1
     assert "Disclosure docs" in report["errors"][0]
 

--- a/libs/openant-core/tests/test_issue285_scan_report_status.py
+++ b/libs/openant-core/tests/test_issue285_scan_report_status.py
@@ -1,0 +1,171 @@
+"""Regression tests for issue #285 — the scan aggregate report is
+unconditionally green.
+
+``_write_scan_report`` built the aggregate ``StepReport(step="scan", ...)``
+with no ``status=`` and no ``errors=``, and read only cost/duration/tokens/
+step from the per-step reports it aggregates. ``StepReport.status`` defaults
+to ``"success"`` — so a scan whose verify step recorded ``error_count: 48``
+in its own summary, or whose report step appended to ``ctx.errors``, still
+wrote ``scan.report.json: status=success, errors: []``. A partially-degraded
+scan and a clean one were indistinguishable at the top level.
+
+Contract locked here:
+- ``step_context``: a body that records errors without raising ⇒ the step's
+  status is ``"partial"`` (NOT "error" — nothing that branches on "error"
+  changes behaviour), and the errors list is written;
+- a body that completes clean with no errors ⇒ still ``"success"``;
+- steps that count per-item failures in ``summary["error_count"]`` fire
+  "partial" too (the REQUIRED step 3 — without it the derivation is inert
+  for the most common degradation shape: verify with 48 errors);
+- ``_write_scan_report`` aggregates: the scan status is the WORST per-step
+  status (error > partial > skipped > success), and the aggregate errors
+  list carries every per-step error.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.step_report import step_context  # noqa: E402
+
+
+def _read(tmp_path: Path, step: str) -> dict:
+    return json.loads((tmp_path / f"{step}.report.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# step-level: partial status derivation
+# ---------------------------------------------------------------------------
+
+def test_errors_without_raise_yields_partial(tmp_path: Path):
+    """A step that records errors without raising gets status="partial"
+    (not "success", not "error")."""
+    with step_context("report", str(tmp_path)) as ctx:
+        ctx.errors.append("Summary report: boom")
+        ctx.summary = {"formats_generated": []}
+    report = _read(tmp_path, "report")
+    assert report["status"] == "partial", (
+        f"recorded errors must not read as success (got {report['status']!r})"
+    )
+    assert report["errors"] == ["Summary report: boom"]
+
+
+def test_clean_step_still_success(tmp_path: Path):
+    with step_context("parse", str(tmp_path)) as ctx:
+        ctx.summary = {"ok": True}
+    assert _read(tmp_path, "parse")["status"] == "success"
+
+
+def test_summary_error_count_fires_partial(tmp_path: Path):
+    """The REQUIRED step-3: verify counts failures in summary["error_count"]
+    without touching ctx.errors — the derivation must see them (the issue's
+    own correction: without this, the fix is inert for the reporter's run
+    shape: verify with 48 errors, all ten step reports success)."""
+    with step_context("verify", str(tmp_path)) as ctx:
+        ctx.summary = {"error_count": 48, "needs_review": 134,
+                       "agreed": 1, "disagreed": 40}
+    report = _read(tmp_path, "verify")
+    assert report["status"] == "partial", (
+        f"error_count>0 in summary must fire partial (got {report['status']!r})"
+    )
+
+
+def test_summary_zero_error_count_stays_success(tmp_path: Path):
+    with step_context("verify", str(tmp_path)) as ctx:
+        ctx.summary = {"error_count": 0, "needs_review": 0, "agreed": 5}
+    assert _read(tmp_path, "verify")["status"] == "success"
+
+
+def test_skipped_still_skipped(tmp_path: Path):
+    """The #254 catch-and-continue degrade idiom is unaffected."""
+    with step_context("enhance", str(tmp_path)) as ctx:
+        ctx.status = "skipped"
+        ctx.summary = {"skipped": True, "reason": "api down"}
+    assert _read(tmp_path, "enhance")["status"] == "skipped" or \
+        _read(tmp_path, "enhance")["status"] == "partial"
+    # skipped + no errors → skipped (no false partial)
+    if _read(tmp_path, "enhance")["status"] == "partial":
+        assert _read(tmp_path, "enhance").get("errors"), "partial fired without errors"
+
+
+# ---------------------------------------------------------------------------
+# aggregate: _write_scan_report derives the worst status + collects errors
+# ---------------------------------------------------------------------------
+
+def _write_scan(tmp_path: Path, step_reports: list[dict]):
+    from core.scanner import _write_scan_report
+    from core.schemas import ScanResult, AnalysisMetrics
+    metrics = AnalysisMetrics(total=0, vulnerable=0, bypassable=0, inconclusive=0,
+                              protected=0, safe=0, errors=0)
+    result = ScanResult(output_dir=str(tmp_path), units_count=0,
+                        language="python", metrics=metrics)
+    return _write_scan_report(str(tmp_path), result, step_reports)
+
+
+def test_aggregate_status_worst_wins(tmp_path: Path):
+    """The scan status = the worst per-step status; the aggregate errors
+    carry every per-step error."""
+    step_reports = [
+        {"step": "parse", "status": "success", "errors": [],
+         "cost_usd": 0.0, "duration_seconds": 1.0,
+         "token_usage": {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10}},
+        {"step": "verify", "status": "partial", "errors": ["boom-1", "boom-2"],
+         "cost_usd": 0.0, "duration_seconds": 1.0,
+         "token_usage": {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10}},
+    ]
+    path = _write_scan(tmp_path, step_reports)
+    agg = json.loads(Path(path).read_text())
+    assert agg["status"] == "partial"
+    assert sorted(agg["errors"]) == ["boom-1", "boom-2"]
+
+
+def test_aggregate_all_success(tmp_path):
+    step_reports = [
+        {"step": "parse", "status": "success", "errors": [],
+         "cost_usd": 0.1, "duration_seconds": 1.0,
+         "token_usage": {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10}},
+    ]
+    path = _write_scan(tmp_path, step_reports)
+    agg = json.loads(Path(path).read_text())
+    assert agg["status"] == "success"
+    assert agg["errors"] == []
+
+
+def test_analyze_stage_summary_error_count_fires_partial(tmp_path):
+    """kimi wave MAJOR-1: analyze counts per-unit failures in
+    metrics.errors — its summary now carries the flat error_count the
+    derivation reads, so an every-unit-errors Stage 1 is no longer
+    status='success'."""
+    with step_context("analyze", str(tmp_path)) as ctx:
+        ctx.summary = {"total_units": 3, "analyzed": 1, "error_count": 2,
+                       "verdicts": {"vulnerable": 0, "bypassable": 0,
+                                    "inconclusive": 0, "protected": 0,
+                                    "safe": 1, "errors": 2}}
+    report = _read(tmp_path, "analyze")
+    assert report["status"] == "partial"
+
+
+def test_scanresult_carries_derived_status(tmp_path):
+    """sonnet wave BLOCKER-1: the derived status/errors reach the
+    ScanResult (envelope/webui consumers), not just the on-disk report."""
+    from core.schemas import ScanResult, AnalysisMetrics
+    from core.scanner import _write_scan_report
+    metrics = AnalysisMetrics(total=0, vulnerable=0, bypassable=0, inconclusive=0,
+                              protected=0, safe=0, errors=0)
+    result = ScanResult(output_dir=str(tmp_path), units_count=0,
+                        language="python", metrics=metrics)
+    step_reports = [
+        {"step": "verify", "status": "partial", "errors": ["e1"],
+         "cost_usd": 0.0, "duration_seconds": 1.0,
+         "token_usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}},
+    ]
+    _write_scan_report(str(tmp_path), result, step_reports)
+    assert result.scan_status == "partial"
+    assert result.scan_errors == ["e1"]
+    assert result.to_dict()["scan_status"] == "partial"


### PR DESCRIPTION
## Summary

The scan aggregate report was **unconditionally green** (#285): `_write_scan_report` built the aggregate `StepReport` with no `status=` and no `errors=`, read only cost/duration/tokens/step from the per-step reports it aggregates — and `StepReport.status` defaults to `"success"` while the only non-default writer (the except block) re-raises, so a step that caught its own exception and recorded it in `ctx.errors` kept `status="success"`. On the reporter's run, all ten step reports read `success`/`errors:[]` — beside `verify.report.json`'s own `summary.error_count=48` and `needs_review=134` — and `scan.report.json` aggregated to `success`/`errors:[]`. A partially-degraded scan and a clean one were indistinguishable at the top level.

Three-part fix (per the issue's own corrected steps):
1. **`step_context` derives `"partial"` from evidence** — non-empty `ctx.errors` OR a positive integer `summary["error_count"]` ⇒ `"partial"` (deliberately NOT `"error"` — that stays reserved for the propagating exception, so nothing that branches on `"error"` changes behaviour). The REQUIRED step-3 is built in: `error_count` in the summary fires the derivation, so verify's 48-error shape — and, added from adversarial review, **analyze's every-unit-errors shape** (its summary now carries the flat `error_count` alongside the nested `verdicts.errors`) — are no longer invisible.
2. **`_write_scan_report` aggregates**: the scan status is the worst per-step status (`error > partial > skipped > success`); the aggregate `errors` carries every per-step error; both are also assigned onto `ScanResult` (`scan_status`/`scan_errors`, serialized in `to_dict`) so the envelope/webui consumers see a degraded scan without re-reading the file — the wave's BLOCKER catch.
3. The #209 tests are updated to the evolved contract (non-raising errors ⇒ `"partial"`; propagating exceptions keep the reserved `"error"`).

Prior art: PR #257 named the report-step half as its own known follow-up; PR #254 made the five catch-and-continue sites `"skipped"` — this closes the remaining gap (the report step + the aggregate + the summary-counted-failure class).

## Test plan

9 hermetic tests: caught-errors ⇒ partial (not success/error); clean ⇒ success; `summary["error_count"]>0` ⇒ partial; zero count ⇒ success; skipped unchanged; the analyze-stage shape; aggregate worst-wins + errors carried; ScanResult carries the derived status (envelope contract); aggregate all-success.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|--- |---|---|
| new tests | `pytest tests/test_issue285_scan_report_status.py -q` | 9 passed (offline) |
| evolved #209 tests | `pytest tests/test_issue209_step_report_status.py -q` | 9 passed (partial contract; propagated = error) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue285_scan_report_status.py` | 9 passed |
| mutation smoke | remove the error_count derivation | tests fail (restored → green) |
| full suite | `pytest tests/ -q` | 3128 passed, 2 failed (pre-existing zig local-env, stash-replay verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Adversarial loop: 4-seat wave → analyze's nested-count shape (MAJOR, fixed with the flat `error_count` key); ScanResult never carrying the derived status — the webui structurally blind (BLOCKER, fixed with `scan_status`/`scan_errors` on the result + `to_dict`); the Go `StatusColor` not knowing "partial" and the CLI projection dropping errors (the issue's own Go-side observation) recorded as follow-ups on the issue — Go-side changes are separate-surface work.

</details>

Fixes #285
