### PR TITLE
fix(verifier): adapter-raise errored verify checkpoints retry on resume

### DIFF
--- a/libs/openant-core/tests/test_issue286_errored_checkpoint_retry.py
+++ b/libs/openant-core/tests/test_issue286_errored_checkpoint_retry.py
@@ -1,0 +1,74 @@
+"""Regression tests for issue #286 — errored verify checkpoints are
+restored as completed on resume, so failed units are never retried.
+
+The resume classifier ``_cp_is_error`` returned True only when the
+checkpoint had no ``verification`` dict or when
+``verification["correct_finding"] == "error"`` — a value the normal verify
+error path never writes. The error path writes ``verification =
+{"incomplete": True}``. Every errored unit therefore looked like finished
+work on resume and was adopted, never retried — #286's measured 223/223
+adoption with 48 hard errors.
+
+Contract locked here: a checkpoint whose verification carries
+``incomplete: True`` IS an errored checkpoint (retryable) — the exact
+signal the error path writes. A genuine completed verification
+(agree + correct_finding, incomplete absent/False) is NOT errored.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.finding_verifier import FindingVerifier  # noqa: E402
+
+
+def _classifier_from_source():
+    """Extract the REAL _cp_is_error from the live source (no copy-paste
+    predicate: the assertion reads the shipped code's semantics)."""
+    import inspect
+    src = inspect.getsource(FindingVerifier)
+    m = re.search(r"def _cp_is_error\(cp_data\):\n(.*?)(?=\n        # Separate)", src, re.S)
+    assert m, "the resume classifier must exist in the live source"
+    body = m.group(0)
+    ns = {}
+    exec(body, ns)
+    return ns["_cp_is_error"]
+
+
+def test_errored_checkpoint_classifies_as_retry():
+    """The #286 core: the verify-error shape (verification carries
+    incomplete=True — exactly what finding_verifier.py:802 writes) must
+    classify as ERRORED (retryable), not completed."""
+    cp = {"verification": {"agree": False, "incomplete": True},
+          "finding": "vulnerable"}
+    assert _classifier_from_source()(cp) is True, (
+        "an incomplete-verification checkpoint IS errored — the exact "
+        "signal the verify error path writes; treating it as completed "
+        "adopts a failed unit and never retries it (#286)"
+    )
+
+
+def test_completed_checkpoint_not_errored():
+    cp = {"verification": {"agree": True, "correct_finding": "vulnerable",
+                           "incomplete": False},
+          "finding": "vulnerable"}
+    assert _classifier_from_source()(cp) is False
+
+
+def test_missing_verification_errored():
+    assert _classifier_from_source()({}) is True
+    assert _classifier_from_source()({"verification": {}}) is True
+
+
+def test_correct_finding_error_still_errored():
+    """The legacy correct_finding='error' path (written by the Stage-1
+    consistency path) still classifies as errored."""
+    cp = {"verification": {"correct_finding": "error", "incomplete": True},
+          "finding": "vulnerable"}
+    assert _classifier_from_source()(cp) is True

--- a/libs/openant-core/tests/test_issue286_errored_checkpoint_retry.py
+++ b/libs/openant-core/tests/test_issue286_errored_checkpoint_retry.py
@@ -42,15 +42,31 @@ def _classifier_from_source():
 
 
 def test_errored_checkpoint_classifies_as_retry():
-    """The #286 core: the verify-error shape (verification carries
-    incomplete=True — exactly what finding_verifier.py:802 writes) must
-    classify as ERRORED (retryable), not completed."""
+    """The #286 core: the verify-ERROR shape (the adapter-raise error
+    string, now copied into the checkpoint by the writer) must classify
+    as ERRORED (retryable), not completed."""
     cp = {"verification": {"agree": False, "incomplete": True},
-          "finding": "vulnerable"}
+          "finding": "vulnerable",
+          "error": "LLMRefusalError: refused"}
     assert _classifier_from_source()(cp) is True, (
-        "an incomplete-verification checkpoint IS errored — the exact "
-        "signal the verify error path writes; treating it as completed "
-        "adopts a failed unit and never retries it (#286)"
+        "a checkpoint carrying the adapter-raise error string IS "
+        "errored — treating it as completed adopts a failed unit and "
+        "never retries it (#286)"
+    )
+
+
+def test_deterministic_incomplete_does_not_retry():
+    """Wave catch (glm F1/F2, kimi F2): incomplete=True alone is NOT a
+    retry signal — five non-error fail-safe writers set it (max
+    iterations, truncated finish, no tool calls, degenerate finish);
+    those are deterministic outcomes, and retrying them on every resume
+    is unbounded waste (Opus 5 refusals are deterministic per #212)."""
+    cp = {"verification": {"agree": False, "incomplete": True,
+                           "explanation": "Verification incomplete"},
+          "finding": "vulnerable"}
+    assert _classifier_from_source()(cp) is False, (
+        "incomplete WITHOUT an error string is a deterministic "
+        "fail-safe outcome, not a retryable error"
     )
 
 

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -625,17 +625,20 @@ class FindingVerifier:
             checkpointed = checkpoint.load()
 
         def _cp_is_error(cp_data):
-            """A verify checkpoint is errored if verification is missing/empty,
-            correct_finding == 'error', or the verification is INCOMPLETE.
+            """A verify checkpoint is errored (retryable on resume) when:
+            verification is missing/empty, correct_finding == 'error',
+            OR the checkpoint carries the adapter-raise ``error`` string.
 
-            #286: the verify error path writes ``verification =
-            {"incomplete": True}`` (finding_verifier.py:802 — the adapter-raise
-            fail-safe) and puts the error string on the RESULT dict, which the
-            checkpoint writer does not copy. correct_finding == 'error' has no
-            writer on that path, so the old two-condition classifier read
-            errored units as finished work and adopted them on resume — never
-            retried (the reporter's 223/223 adoption with 48 hard errors).
-            ``incomplete`` is the signal the error path actually writes.
+            #286: the verify ERROR path (adapter raise — the retryable
+            class) writes the error string on the RESULT dict; the checkpoint
+            writer now copies it into ``cp_data["error"]``. That field is
+            the SURGICAL retry signal. ``verification.incomplete`` alone is
+            deliberately NOT a retry signal: five non-error fail-safe
+            writers set incomplete=True (degenerate finish, truncated
+            finish, no tool calls, max iterations, plus the error path) —
+            those are deterministic outcomes, and retrying them on every
+            resume is unbounded waste (wave catches F1/F2: Opus 5 refusals
+            are deterministic; they would retry forever).
             """
             if not cp_data:
                 return True
@@ -644,7 +647,7 @@ class FindingVerifier:
                 return True
             if v.get("correct_finding") == "error":
                 return True
-            return bool(v.get("incomplete"))
+            return bool(cp_data.get("error"))
 
         # Separate already-done (successful) from to-do (new + errored)
         results_to_verify = []
@@ -840,6 +843,15 @@ class FindingVerifier:
                         "finding": result.get("finding", ""),
                         "verification_note": result.get("verification_note", ""),
                     }
+                    # #286: the adapter-raise error string lives on the
+                    # RESULT dict — copy it into the checkpoint so the
+                    # resume classifier can distinguish a retryable ERROR
+                    # (adapter raised) from a deterministic incomplete
+                    # (max-iterations / truncated finish / no tool calls —
+                    # those are stable outcomes, retrying them forever is
+                    # unbounded waste).
+                    if result.get("error"):
+                        cp_data["error"] = result["error"]
                     if usage:
                         cp_data["usage"] = usage
                     checkpoint.save(key, cp_data)
@@ -871,6 +883,10 @@ class FindingVerifier:
                         "finding": result.get("finding", ""),
                         "verification_note": result.get("verification_note", ""),
                     }
+                    # #286: copy the adapter-raise error into the
+                    # checkpoint (see the sequential writer's note).
+                    if result.get("error"):
+                        cp_data["error"] = result["error"]
                     if usage:
                         cp_data["usage"] = usage
                     checkpoint.save(key, cp_data)

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -625,14 +625,26 @@ class FindingVerifier:
             checkpointed = checkpoint.load()
 
         def _cp_is_error(cp_data):
-            """A verify checkpoint is errored if verification is missing/empty
-            or correct_finding == 'error'."""
+            """A verify checkpoint is errored if verification is missing/empty,
+            correct_finding == 'error', or the verification is INCOMPLETE.
+
+            #286: the verify error path writes ``verification =
+            {"incomplete": True}`` (finding_verifier.py:802 — the adapter-raise
+            fail-safe) and puts the error string on the RESULT dict, which the
+            checkpoint writer does not copy. correct_finding == 'error' has no
+            writer on that path, so the old two-condition classifier read
+            errored units as finished work and adopted them on resume — never
+            retried (the reporter's 223/223 adoption with 48 hard errors).
+            ``incomplete`` is the signal the error path actually writes.
+            """
             if not cp_data:
                 return True
             v = cp_data.get("verification", {})
             if not v:
                 return True
-            return v.get("correct_finding") == "error"
+            if v.get("correct_finding") == "error":
+                return True
+            return bool(v.get("incomplete"))
 
         # Separate already-done (successful) from to-do (new + errored)
         results_to_verify = []


### PR DESCRIPTION
## Summary

The verify resume classifier `_cp_is_error` returned True only when the checkpoint had no `verification` dict or when `verification["correct_finding"] == "error"` — **a value the normal verify error path never writes**. That path (an adapter raise — the retryable class) writes the error string on the *result* dict (`finding_verifier.py:800`), which the checkpoint writer did not copy, and sets `verification["incomplete"] = True`. Every errored unit therefore looked like finished work on resume and was **adopted, never retried** (#286: the reporter's 223/223 adoption with 48 hard errors).

**The fix is surgical** (per adversarial review): the checkpoint writer — both sequential and parallel — now copies the adapter-raise error string into `cp_data["error"]`, and the classifier retries **only** checkpoints carrying it (plus the legacy `correct_finding == "error"` and the missing-verification shapes). `verification["incomplete"]` alone is deliberately **not** a retry signal: five non-error fail-safe writers set it (deterministic outcomes — max iterations, truncated finish, no tool calls, degenerate finish, no-agree finish); retrying those on every resume is unbounded waste, and #212 established that refusals are **deterministic** — an incomplete-based classifier would retry them forever.

## Test plan

5 hermetic tests: the adapter-error shape retries; deterministic incomplete does NOT; the completed shape, the missing shapes, and the legacy `correct_finding` shape unchanged. The classifier is extracted from the **live source** via `inspect` — no copy-paste predicate.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue286_errored_checkpoint_retry.py -q` | 5 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue286_errored_checkpoint_retry.py` | 5 passed |
| mutation smoke | revert the error-check | the core test fails (restored → green) |
| full suite | `pytest tests/ -q` | 3124 passed, 2 failed (pre-existing zig local-env, stash-replay verified), 32 skipped |
| lint | `ruff check .` | clean |

Adversarial loop: 4-seat wave → the over-retry catch (my first fix classified ALL incomplete as errored — the wave identified five non-error `incomplete=True` writers and the deterministic-refusal infinite-retry risk; fixed with the surgical `error`-string discriminator copied into the checkpoint by the writer).

</details>

Fixes #286
