### PR TITLE
fix(backend-identity): verify's generation budget joins the checkpoint identity; gen-param exclusion documented

### DIFF
--- a/libs/openant-core/core/backend_identity.py
+++ b/libs/openant-core/core/backend_identity.py
@@ -29,6 +29,20 @@ Deliberate exclusions (minimal by mandate):
     non-deterministically every scan; callers MUST render templates with
     ``app_context=None`` so it never enters ``templates_sha`` (including it
     caused a VERIFIED ~17k-token spurious re-pay on a same-config resume).
+  * Generation parameters (``max_tokens``, ``temperature``, etc.) are
+    deliberately NOT global KEY members (#242: "this config-only change does
+    not invalidate prior checkpoints. Rationale is FN-safe: pre-fix empty
+    completions were recorded as ERROR, which never adopts on resume, so
+    truncation-degraded successes are the only carry-over"). #287 re-checked
+    the rationale: the FN-safety argument is CONDITIONAL on the ERROR-retry
+    working — restored by #286/#377 (the adapter-raise error string is now
+    copied into the checkpoint and retried on resume). The residual
+    carry-over is truncation-degraded SUCCESSES (stale adoption, weaker
+    than FN). The VERIFY phase opts IN its budget via ``extra_key`` (the
+    existing mechanism, verifier.py:182): a ``max_tokens`` change invalidates
+    verify checkpoints specifically, without a scheme bump. Other phases use
+    ``simple_text`` whose default lives in helpers.py (a change there is a
+    code-level behavior change, already visible in ``templates_sha``).
 
 Bump ``FINGERPRINT_SCHEME_VERSION`` when the KEY definition changes; it is part
 of the KEY, so old sidecars invalidate cleanly.

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -27,7 +27,7 @@ from utilities.llm import (
     resolve_llm_config,
 )
 from utilities.file_io import normalize_results, read_json, write_json
-from utilities.finding_verifier import FindingVerifier
+from utilities.finding_verifier import FindingVerifier, MAX_TOKENS_PER_RESPONSE
 from utilities.agentic_enhancer.repository_index import load_index_from_file
 
 # Import application context (optional)
@@ -179,7 +179,14 @@ def run_verification(
         [lambda: get_verification_system_prompt(None)])
     checkpoint.sync_identity(fingerprint_for_binding(
         verify_binding, _verify_texts,
-        extra_key={"analyze_fingerprint": experiment.get("analyze_fingerprint")}))
+        extra_key={
+            "analyze_fingerprint": experiment.get("analyze_fingerprint"),
+            # #287: the verify phase's generation budget is part of its
+            # checkpoint identity — a budget change invalidates verify
+            # checkpoints specifically (no scheme bump; the extra_key
+            # mechanism is the pre-existing plumbing).
+            "gen_params": {"max_tokens": MAX_TOKENS_PER_RESPONSE},
+        }))
 
     # Run Stage 2 verification via verify_batch
     tracker = get_global_tracker()

--- a/libs/openant-core/tests/test_issue287_fingerprint_gen_params.py
+++ b/libs/openant-core/tests/test_issue287_fingerprint_gen_params.py
@@ -1,0 +1,82 @@
+"""Regression tests for issue #287 — generation parameters are excluded
+from the backend fingerprint's KEY, so a budget change leaves
+``key_digest`` unchanged and a resumed run adopts checkpoints produced
+under the old budget.
+
+The exclusion is a DOCUMENTED DELIBERATE decision (PR #242). #287's
+narrowed ask: the rationale was CONDITIONAL on ERROR checkpoints not
+adopting (#286's bug, now fixed by PR #377). The residual carry-over is
+truncation-degraded SUCCESSES (stale adoption — weaker than FN).
+
+Contract locked here:
+- the verify phase's fingerprint KEY includes the phase's generation
+  budget (``max_tokens``) via the existing ``extra_key`` mechanism;
+- the deliberate-exclusion register in backend_identity.py documents the
+  decision with its rationale AND the #286/#377 dependency;
+- other phases' fingerprints are unchanged.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _verify_fingerprint(max_tokens):
+    """Build the verify-phase fingerprint exactly as verifier.py:182 does
+    (the extra_key mechanism), with the given max_tokens."""
+    from core.backend_identity import fingerprint_for_binding
+
+    class _Binding:
+        phase = "verify"
+        model = "claude-opus-5"
+        provider_name = "anthropic"
+        base_url = None
+
+        class adapter:
+            name = "anthropic"
+
+    class _Template(str):
+        pass
+
+    return fingerprint_for_binding(
+        _Binding(), [_Template("template")],
+        extra_key={"analyze_fingerprint": "sha256:abc",
+                   "gen_params": {"max_tokens": max_tokens}})
+
+
+def test_different_max_tokens_different_digest():
+    """The #287 core: two verify fingerprints with identical identity but
+    different max_tokens must have different key_digest values."""
+    a = _verify_fingerprint(4096)
+    b = _verify_fingerprint(20000)
+    assert a["key_digest"] != b["key_digest"], (
+        "a budget change must invalidate the verify checkpoint identity "
+        "(stale adoption of truncation-degraded successes otherwise)"
+    )
+
+
+def test_same_max_tokens_same_digest():
+    a = _verify_fingerprint(4096)
+    b = _verify_fingerprint(4096)
+    assert a["key_digest"] == b["key_digest"]
+
+
+def test_exclusion_documented_in_backend_identity():
+    """#287's ask (a): the deliberate exclusion is recorded in the file's
+    own documented-exclusions register with its rationale and the #286
+    dependency."""
+    from core import backend_identity as bi
+    import inspect
+    src = inspect.getsource(bi)
+    assert "max_tokens" in src and "generation param" in src.lower(), (
+        "the deliberate exclusion of generation parameters must be "
+        "documented in backend_identity.py's exclusions register"
+    )
+    assert "#286" in src or "377" in src, (
+        "the FN-safety rationale's #286/#377 dependency must be named"
+    )


### PR DESCRIPTION
## Summary

The backend fingerprint's KEY excluded generation parameters (`max_tokens`, temperature, etc.) — a **documented deliberate decision** (PR #242: "this config-only change does not invalidate prior checkpoints. Rationale is FN-safe: pre-fix empty completions were recorded as ERROR, which never adopts on resume, so truncation-degraded successes are the only carry-over").

#287 re-checked that rationale: the FN-safety argument was **conditional** on ERROR checkpoints not adopting on resume — which was #286's bug, now fixed (PR #377: the adapter-raise error string is copied into the checkpoint and the classifier retries it). The residual carry-over is truncation-degraded **successes** (stale adoption — weaker than a demonstrated FN, as #287 itself says). Two changes:

1. **The verify phase's generation budget joins its fingerprint** via the existing `extra_key` mechanism (`verifier.py:182` — the plumbing was already there for the analyze fingerprint): a `max_tokens` change now invalidates verify checkpoints specifically, without a scheme-version bump (no global checkpoint churn). Verify is the one phase whose budget is a hardcoded module constant invisible to `templates_sha`.

2. **The deliberate exclusion is now recorded** in `backend_identity.py`'s documented-exclusions register — with the rationale, its **#286/#377 dependency**, and the verify opt-in — so the decision is discoverable where the file's own discipline says it belongs (today it lived only in PR #242's body; the canonical register never mentioned `max_tokens`).

## Test plan

3 hermetic tests: different `max_tokens` → different `key_digest`; same → same; the exclusion documented in the register with the #286 dependency.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue287_fingerprint_gen_params.py -q` | 3 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue287_fingerprint_gen_params.py` | 3 passed |
| full suite | `pytest tests/ -q` | 3142 passed, 2 failed (pre-existing zig local-env, stash-replay verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

Scope note: this is a *preventive* fix (verify's budget is a hardcoded constant, not user-tunable) — it self-invalidates on a future code-level budget change. Not a revert of #242; the global exclusion stands for other phases (they use `simple_text` whose default lives in helpers.py — a change there is a code-level behavior change already visible in `templates_sha`).

</details>

Fixes #287
