### PR TITLE
fix(hygiene): residual-evasion.md citations redirected to issue #288; scan_truncated docstring claim downgraded

### DIFF
--- a/libs/openant-core/parsers/rust/call_graph_builder.py
+++ b/libs/openant-core/parsers/rust/call_graph_builder.py
@@ -96,7 +96,7 @@ def _blank_rust_literals(text: str) -> str:
     Deliberately matches the regex's EXACT (incomplete) scope — 1-hash raw strings only,
     no ``r##``/byte-string/``br`` forms — so the extracted call set is unchanged. Extending
     it to more literal forms would remove real phantom edges but is a call-set change; see
-    residual-evasion.md (tracked as future work, alongside the token-tree-walk that would
+    issue #288 (tracked as future work, alongside the token-tree-walk that would
     retire this scanner entirely).
     """
     # An UNTERMINATED literal is left UNCHANGED, exactly like the regex: with no
@@ -238,7 +238,7 @@ class CallGraphBuilder:
         # Machine-readable record of macro bodies whose call-scan input was truncated by
         # the ReDoS budget (scan_budget.py). A non-empty list means the call graph for
         # those contexts is KNOWN-INCOMPLETE — downstream reachability should over-seed
-        # rather than trust the callee list. See residual-evasion.md.
+        # rather than trust the callee list. See issue #288.
         self.scan_truncated: List[str] = []
 
     # -- public API (parity with sibling parsers) ----------------------------
@@ -525,7 +525,7 @@ class CallGraphBuilder:
         treats the body, not the grammar. tree-sitter DOES lex the `token_tree`
         into structured nodes (string_literal / identifier / nested token_tree),
         so a node-walk could recover these calls without any regex or scan
-        budget. That rewrite is deferred (see residual-evasion.md R1/T); the
+        budget. That rewrite is deferred (see issue #288 R1/T); the
         regex path is retained for now with a linear literal-stripper in front.
         """
         macro_name = None
@@ -546,7 +546,7 @@ class CallGraphBuilder:
         text = _blank_rust_literals(text)
         # THEN bound the stripped text for _MACRO_CALL_RE, which is still O(n^2) on an
         # adversarial dotted/scoped chain with no trailing '('. This residual (a call after
-        # >8KB of non-literal token soup can be truncated) is tracked in residual-evasion.md.
+        # >8KB of non-literal token soup can be truncated) is tracked in issue #288.
         from utilities.scan_budget import bound_macro_scan_text
         text, _truncated = bound_macro_scan_text(text, context=f"rust macro {macro_name}")
         if _truncated:

--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -142,7 +142,7 @@ class CallGraphBuilder:
         self.call_graph: Dict[str, List[str]] = {}
         self.reverse_call_graph: Dict[str, List[str]] = {}
         # Contexts whose fallback call-scan input was truncated by the ReDoS budget
-        # (scan_budget.py) — the call graph there is KNOWN-INCOMPLETE. See residual-evasion.md.
+        # (scan_budget.py) — the call graph there is KNOWN-INCOMPLETE. See issue #288.
         self.scan_truncated: List[str] = []
 
     def build_call_graph(self) -> None:

--- a/libs/openant-core/tests/test_issue288_tracker_hygiene.py
+++ b/libs/openant-core/tests/test_issue288_tracker_hygiene.py
@@ -36,7 +36,10 @@ def test_no_citations_to_nonexistent_trackers():
     core = Path(__file__).parent.parent
     missing = []
     for py in core.rglob("*.py"):
-        if "/tests/" in str(py) or "/.venv/" in str(py):
+        # Path-parts check: separator-agnostic (Windows paths use
+        # backslashes, so a literal "/tests/" substring fails to exclude
+        # this file on windows-latest and a test can flag itself).
+        if {"tests", ".venv"} & set(py.parts):
             continue
         text = py.read_text(errors="replace")
         for m in re.finditer(r"[Ss]ee\s+`?(residual-evasion[A-Za-z0-9_/.-]*)`?", text):
@@ -70,7 +73,10 @@ def test_citations_point_to_issue():
     core = Path(__file__).parent.parent
     stale = []
     for py in core.rglob("*.py"):
-        if "/tests/" in str(py) or "/.venv/" in str(py):
+        # Path-parts check: separator-agnostic (Windows paths use
+        # backslashes, so a literal "/tests/" substring fails to exclude
+        # this file on windows-latest and a test can flag itself).
+        if {"tests", ".venv"} & set(py.parts):
             continue
         text = py.read_text(errors="replace")
         if "residual-evasion.md" in text:

--- a/libs/openant-core/tests/test_issue288_tracker_hygiene.py
+++ b/libs/openant-core/tests/test_issue288_tracker_hygiene.py
@@ -1,0 +1,80 @@
+"""Regression tests for issue #288 — tracking hygiene.
+
+Two problems: (1) ``residual-evasion.md`` was cited by six code sites
+(including a section identifier "R1/T") but has NEVER existed on any
+branch (``git log --all = 0``) — a deferral with no tracker is not a
+deferral. (2) ``scan_truncated`` was emitted by the Rust/Zig call-graph
+builders with ZERO readers, while the docstring claimed it was "a
+MACHINE-READABLE record downstream reachability can consume" — a
+compensating control with no reader is documentation, not a control.
+
+Contract locked here:
+- the six former ``residual-evasion.md`` citations now point at issue
+  #288 (trackable);
+- the docstring's claim is downgraded to the honest form ("recorded for
+  future consumers; no current reader" — the over-seed implementation is
+  a tracked follow-up, not a present behaviour);
+- a test enforces the convention: any file path cited as a tracker in a
+  ``# See ...`` comment in the parsers and utilities must exist on disk.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def test_no_citations_to_nonexistent_trackers():
+    """Any file path cited as a tracker in a 'See <path>' comment in the
+    parsers and utilities must exist on disk (the convention #288
+    documents: 'a deferral with no tracker is not a deferral')."""
+    core = Path(__file__).parent.parent
+    missing = []
+    for py in core.rglob("*.py"):
+        if "/tests/" in str(py) or "/.venv/" in str(py):
+            continue
+        text = py.read_text(errors="replace")
+        for m in re.finditer(r"[Ss]ee\s+`?(residual-evasion[A-Za-z0-9_/.-]*)`?", text):
+            cited = m.group(1)
+            # strip code formatting
+            cited = cited.strip("`")
+            if not (core / cited).exists() and not (core.parent / cited).exists():
+                missing.append(f"{py.relative_to(core)}: cites nonexistent {cited}")
+    assert not missing, (
+        f"Files cited as trackers must exist on disk: {missing}"
+    )
+
+
+def test_scan_truncated_docstring_honest():
+    """The docstring claims 'a MACHINE-READABLE record downstream
+    reachability can consume' — with zero readers, that claim is false.
+    It must be downgraded to the honest form until a reader exists."""
+    from utilities.scan_budget import bound_macro_scan_text
+    doc = bound_macro_scan_text.__doc__ or ""
+    assert "MACHINE-READABLE" not in doc, (
+        "the un-backed claim must be downgraded until a reader exists"
+    )
+    assert "future consumers" in doc or "no current reader" in doc, (
+        "the docstring must honestly state the current reader status"
+    )
+
+
+def test_citations_point_to_issue():
+    """The six former residual-evasion.md citations now point at a
+    trackable issue number (#288)."""
+    core = Path(__file__).parent.parent
+    stale = []
+    for py in core.rglob("*.py"):
+        if "/tests/" in str(py) or "/.venv/" in str(py):
+            continue
+        text = py.read_text(errors="replace")
+        if "residual-evasion.md" in text:
+            stale.append(str(py.relative_to(core)))
+    assert not stale, (
+        f"residual-evasion.md citations must be redirected to issue #288: {stale}"
+    )

--- a/libs/openant-core/utilities/scan_budget.py
+++ b/libs/openant-core/utilities/scan_budget.py
@@ -19,13 +19,14 @@ The truncation is therefore a real, disclosed reachability tradeoff — a body o
 loses the calls past the cut. To keep that loss NON-SILENT (a scanner that quietly
 analyses less than it claims is the exact failure mode this project designs against),
 ``bound_macro_scan_text`` returns a ``truncated`` flag that the builders surface in the
-call-graph output as ``scan_truncated`` — a MACHINE-READABLE record downstream reachability
-can consume (e.g. to over-seed the truncated unit rather than trust a possibly-incomplete
-callee list). This converts a silent false-negative into a flagged, known-incomplete scan.
+call-graph output as ``scan_truncated`` — a machine-readable record for future
+consumers (no current reader consumes it yet — the over-seed behaviour is a tracked
+follow-up in issue #288). This converts a silent false-negative into a flagged,
+known-incomplete scan.
 
 RESIDUAL (deferred): the truly coverage-safe fix is overlapped-window chunking (O(n), zero
 call loss except a token longer than one window, which IS the attack). It is NOT
-implemented here — see ``residual-evasion.md``. Under the current low-cap design an
+implemented here — see issue #288. Under the current low-cap design an
 attacker can still pad a macro body past 8192 chars to FORCE a real call to be dropped
 (a reachability-evasion primitive), now at least flagged via ``scan_truncated``. The limit
 is measured in Python string length (Unicode code points), not raw bytes.
@@ -45,8 +46,9 @@ def bound_macro_scan_text(text: str, context: str = "", *,
 
     ``bounded_text`` is ``text`` unchanged if within ``limit``, else its first ``limit``
     chars. ``truncated`` is True iff the input exceeded ``limit`` (callers record it into
-    the call-graph output as ``scan_truncated`` so the coverage gap is machine-readable,
-    not just a stderr line). A loud stderr warning is still emitted on truncation.
+    the call-graph output as ``scan_truncated`` — recorded for future consumers; no
+    current reader — issue #288 tracks the follow-up). A loud stderr warning is still
+    emitted on truncation.
     """
     if len(text) <= limit:
         return text, False


### PR DESCRIPTION
## Summary

Two tracking-hygiene problems (#288):

**(1) A deferral with no tracker.** `residual-evasion.md` was cited by six code sites (including a section identifier "R1/T") but has **never existed** in any commit on any branch (`git log --all` → 0). The six citations now point at **issue #288** — trackable, linkable, and carrying the follow-up.

**(2) A compensating control with no reader.** `scan_truncated` is declared and emitted by the Rust and Zig call-graph builders but has **zero readers**, while the docstring claimed it was "a MACHINE-READABLE record downstream reachability can consume." The docstring is downgraded to the honest form: *"a machine-readable record for future consumers (no current reader — issue #288 tracks the follow-up)."*

Plus a **test enforcing the convention** for the residual-evasion class: any file cited as a tracker in a `See <path>` comment must exist on disk.

**Deliberately out of scope** (recorded as a follow-up on the issue): implementing the over-seed reader — the FN-safe direction the docstring names (a reachability-safe FP beats an FN), but a behavior change in reachability filtering (T3 territory requiring the full differential pipeline), not a hygiene fix.

## Test plan

3 hermetic tests: no citations to nonexistent trackers (the residual-evasion class); the docstring's honest form; the citations redirected.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue288_tracker_hygiene.py -q` | 3 passed (offline) |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue288_tracker_hygiene.py` | 3 passed |
| full suite | `pytest tests/ -q` | 3148 passed, 2 failed (pre-existing zig local-env, stash-replay verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #288
