### PR TITLE
fix(report): re-derive results.vulnerable from deduped findings; emit protected as its own key

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -586,8 +586,18 @@ def build_pipeline_output(
             "skipped_steps": skipped_steps_detail,
         },
         "results": {
-            "vulnerable": metrics.get("vulnerable", 0) + metrics.get("bypassable", 0),
-            "safe": metrics.get("safe", 0) + metrics.get("protected", 0),
+            # #289: re-derive from the DEDUPED findings list, not from
+            # metrics (the pre-dedup count) — the same file must never
+            # report 183 in results.vulnerable alongside 175 entries in
+            # findings. The pre-dedup count and the dedup delta are
+            # explicit so the difference is explainable, not contradictory.
+            "vulnerable": len(findings_data),
+            "vulnerable_before_dedup": metrics.get("vulnerable", 0) + metrics.get("bypassable", 0),
+            "deduplicated": (metrics.get("vulnerable", 0) + metrics.get("bypassable", 0)) - len(findings_data),
+            # #289: protected is its OWN key — the lossy safe-fold destroyed
+            # a verdict the pipeline computes and the template has a row for.
+            "safe": metrics.get("safe", 0),
+            "protected": metrics.get("protected", 0),
             "inconclusive": metrics.get("inconclusive", 0),
             # F13: errored units are part of `total` (see units_analyzed above), so the
             # results buckets must include them or they cannot reconcile to `total`.

--- a/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
+++ b/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
@@ -7,6 +7,17 @@ vulnerable/safe/inconclusive/total, so vulnerable+safe+inconclusive == total-err
 i.e. the buckets silently under-summed `total` by the error count. The fix adds an
 `errors` bucket so the partition closes.
 
+#289 UPDATE: `vulnerable` is now re-derived from the DEDUPED findings list
+(== len(findings)), NOT from metrics — the same file must never report 183 in
+results.vulnerable alongside 175 entries in findings. Two consequences for
+this contract:
+- the unit-partition closes via the `deduplicated` delta (a deduped unit was
+  still vulnerable — it is reported once under its caller), i.e.
+  vulnerable + deduplicated + safe + protected + inconclusive + errors
+  (+ needs_review) == total;
+- `protected` is its OWN key (the lossy safe-fold is gone — the summary
+  template has a Protected row and used to print 0 where metrics said 414).
+
 SCOPE (honest): this reconciles the buckets GIVEN a well-formed `metrics` dict. It
 does NOT repair an upstream mis-partition: `analyzer._count_verdicts` drops any row
 whose verdict is unrecognized (neither a known bucket nor verdict=="ERROR") from
@@ -29,13 +40,28 @@ from core.reporter import build_pipeline_output  # noqa: E402
 from core.analyzer import _count_verdicts  # noqa: E402
 
 
-def _emit(metrics: dict) -> dict:
+def _finding(route: str) -> dict:
+    return {"route_key": route, "finding": "vulnerable",
+            "verdict": "VULNERABLE", "cwe_id": 79, "attack_vector": "v",
+            "reasoning": "r",
+            "vulnerability": {"name": "X", "short_name": "x",
+                              "description": "d", "impact": "i",
+                              "suggested_fix": "s",
+                              "steps_to_reproduce": "st"},
+            "verification": {"agree": True}}
+
+
+def _emit(metrics: dict, confirmed=None) -> dict:
     """Run the real builder on a crafted results fixture (no LLM, no scan)."""
     d = Path(tempfile.mkdtemp()).resolve()
     results_path = d / "results_verified.json"
     out_path = d / "pipeline_output.json"
+    if confirmed is None:
+        # coherent default: one listed finding per vulnerable/bypassable unit
+        n = metrics.get("vulnerable", 0) + metrics.get("bypassable", 0)
+        confirmed = [_finding(f"u{i}.py:f") for i in range(n)]
     results_path.write_text(json.dumps(
-        {"metrics": metrics, "results": [], "confirmed_findings": []}
+        {"metrics": metrics, "results": [], "confirmed_findings": confirmed}
     ))
     build_pipeline_output(str(results_path), str(out_path))
     return json.loads(out_path.read_text())["results"]
@@ -46,14 +72,20 @@ def test_results_block_reconciles_to_total_including_errors():
     r = _emit({"vulnerable": 2, "safe": 3, "inconclusive": 1,
                "errors": 4, "total": 10})
     assert r["errors"] == 4, "errors bucket must be emitted (RED on pristine base)"
-    assert r["vulnerable"] + r["safe"] + r["inconclusive"] + r["errors"] == r["total"]
+    assert r["vulnerable"] == 2, "2 listed findings → 2 vulnerable (#289)"
+    assert (r["vulnerable"] + r["deduplicated"] + r["safe"]
+            + r["protected"] + r["inconclusive"] + r["errors"]) == r["total"]
 
 
-def test_folds_bypassable_and_protected_then_still_reconciles():
+def test_protected_is_own_key_not_folded_into_safe():
+    """#289: the lossy fold is gone — protected is emitted as its own key so
+    the summary template's Protected row is fillable (it used to print 0
+    where the metric blocks said 414/408)."""
     r = _emit({"vulnerable": 1, "bypassable": 1, "safe": 2, "protected": 1,
                "inconclusive": 1, "errors": 2, "total": 8})
-    assert r["vulnerable"] == 2 and r["safe"] == 3  # folded
-    assert r["vulnerable"] + r["safe"] + r["inconclusive"] + r["errors"] == r["total"]
+    assert r["vulnerable"] == 2 and r["safe"] == 2 and r["protected"] == 1
+    assert (r["vulnerable"] + r["deduplicated"] + r["safe"]
+            + r["protected"] + r["inconclusive"] + r["errors"]) == r["total"]
 
 
 @pytest.mark.parametrize("metrics,expected_errors", [
@@ -63,7 +95,8 @@ def test_folds_bypassable_and_protected_then_still_reconciles():
 def test_graceful_when_no_errors(metrics, expected_errors):
     r = _emit(metrics)
     assert r["errors"] == expected_errors  # .get default, no crash, no double-count
-    assert r["vulnerable"] + r["safe"] + r["inconclusive"] + r["errors"] == r["total"]
+    assert (r["vulnerable"] + r["deduplicated"] + r["safe"]
+            + r["protected"] + r["inconclusive"] + r["errors"]) == r["total"]
 
 
 def test_count_verdicts_drops_unrecognized_verdict():

--- a/libs/openant-core/tests/test_issue289_results_recompute.py
+++ b/libs/openant-core/tests/test_issue289_results_recompute.py
@@ -1,0 +1,109 @@
+"""Regression tests for issue #289 — pipeline_output.json's `results`
+block contradicts its own `findings` list.
+
+Two defects:
+(1) `results.vulnerable` was computed from `metrics` (the PRE-dedup
+count), while `findings` was built from the POST-dedup list — the same
+file reported `vulnerable: 183` alongside 175 entries in `findings` and
+175 disclosure docs on disk, with no field explaining the difference.
+(2) `protected` was folded into `safe` (lossy) even though the summary
+template has a row for it.
+
+Contract locked here:
+- `results.vulnerable` == `len(findings)` (the deduped list), plus
+  `vulnerable_before_dedup` and `deduplicated` counts;
+- `protected` is its OWN key in `results`;
+- the partition still reconciles to `total` (F13).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.reporter import build_pipeline_output  # noqa: E402
+from utilities.file_io import write_json  # noqa: E402
+
+VULN = {"name": "X", "short_name": "x", "description": "d", "impact": "i",
+        "suggested_fix": "s", "steps_to_reproduce": "st"}
+
+
+def _fixture():
+    return [
+        {"route_key": "a.py:caller", "finding": "vulnerable",
+         "verdict": "VULNERABLE", "cwe_id": 79, "attack_vector": "v",
+         "reasoning": "r",
+         "vulnerability": dict(VULN, name="X"),
+         "verification": {"agree": True, "exploit_path": {"entry": "e"}}},
+        {"route_key": "a.py:callee", "finding": "vulnerable",
+         "verdict": "VULNERABLE", "cwe_id": 79, "attack_vector": "v",
+         "reasoning": "r",
+         "vulnerability": dict(VULN, name="X"),
+         "verification": {"agree": True, "exploit_path": {"entry": "e"}}},
+        {"route_key": "b.py:other", "finding": "vulnerable",
+         "verdict": "VULNERABLE", "cwe_id": 89, "attack_vector": "w",
+         "reasoning": "r",
+         "vulnerability": dict(VULN, name="Y"),
+         "verification": {"agree": True, "exploit_path": {"entry": "e2"}}},
+    ]
+
+
+def _run(tmp_path: Path, findings=None):
+    findings = findings if findings is not None else _fixture()
+    results = {
+        "dataset": "t",
+        "code_by_route": {f["route_key"]: "code" for f in findings},
+        "metrics": {"total": 5, "vulnerable": 3, "bypassable": 0,
+                    "inconclusive": 0, "protected": 2, "safe": 0,
+                    "errors": 0},
+        "confirmed_findings": findings,
+        "results": findings,
+    }
+    write_json(tmp_path / "results.json", results)
+    # The dedup reads <results_dir>/call_graph.json; a.py:callee has exactly
+    # one caller (a.py:caller) with the same CWE 79 → collapsed.
+    write_json(tmp_path / "call_graph.json",
+               {"reverse_call_graph": {"a.py:callee": ["a.py:caller"]}})
+    out = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(tmp_path / "results.json"),
+        output_path=str(out),
+        language="python", repo_name="t/r", processing_level="reachable",
+    )
+    return json.loads(out.read_text())
+
+
+def test_results_vulnerable_matches_deduped_findings(tmp_path):
+    out = _run(tmp_path)
+    assert out["results"]["vulnerable"] == len(out["findings"])
+
+
+def test_dedup_counts_explicit(tmp_path):
+    out = _run(tmp_path)
+    r = out["results"]
+    assert r["vulnerable_before_dedup"] == 3
+    assert r["deduplicated"] == 1
+    assert r["vulnerable"] == 2
+
+
+def test_protected_own_key(tmp_path):
+    out = _run(tmp_path)
+    r = out["results"]
+    assert r["protected"] == 2
+    assert r["safe"] == 0
+
+
+def test_partition_reconciles_to_total(tmp_path):
+    """F13 (extended): all buckets sum to total — counting the dedup delta
+    (a deduped unit was still vulnerable; it is reported once under its
+    caller, so `deduplicated` is what keeps the unit-partition closed)."""
+    out = _run(tmp_path)
+    r = out["results"]
+    buckets = ["vulnerable", "deduplicated", "safe", "protected",
+               "inconclusive", "errors", "needs_review"]
+    assert sum(r[k] for k in buckets) == r["total"]


### PR DESCRIPTION
## Summary

`pipeline_output.json` contradicted itself: `results.vulnerable: 183` alongside 175 entries in `findings` and 175 disclosure docs on disk — `183-175=8`, exactly the count logged by `_dedup_caller_callee`. The same `results` dict also folded `protected` into `safe` (lossy): the summary template has a Protected row and printed `Protected | 0` where the metric blocks said 414/408.

Two changes to the `results` block in `build_pipeline_output`:

1. **`vulnerable` is re-derived from the deduped findings list** (`len(findings)` — the invariant the issue asks for: `results.vulnerable == len(findings)`), plus `vulnerable_before_dedup` and a `deduplicated` delta so the difference is explicit rather than contradictory.
2. **`protected` is its own key** — the lossy `safe = safe + protected` fold is gone; the summary template's Protected row is now fillable from real data.

The unit-partition closes as `vulnerable + deduplicated + safe + protected + inconclusive + errors (+ needs_review) == total` (F13 extended — a deduped unit was still vulnerable; it is reported once under its caller). The F13 reconciliation tests are updated to this contract (they had locked in the old fold); new tests lock the invariant on a fixture where the dedup **fires**.

Note: the private-run figures (183/175/414) quoted from the issue are provenance-labeled there and not independently reproducible; the code defects and the fix contract are fully checkable and test-covered.

## Test plan

9 hermetic tests: the `vulnerable == len(findings)` invariant on a dedup-firing fixture (callee collapsed into single-caller, same CWE); explicit pre-dedup/delta counts; `protected` as own key; partition reconciliation including the delta; updated F13 suite.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new + updated tests | `pytest tests/test_issue289_results_recompute.py tests/report/test_results_bucket_reconciliation.py -q` | 9 passed |
| mutation smoke | fix reverted → same suite | 8 failed, 1 passed (RED proof); re-applied → 9 passed |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest <same suite>` | 9 passed |
| full suite | `pytest tests/ -q` | 3153 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #289
