### PR TITLE
fix(verify): agent-loop output budgets share the simple_text thinking-era default (4096 → 20000)

### DIFF
--- a/libs/openant-core/tests/test_issue290_output_budget.py
+++ b/libs/openant-core/tests/test_issue290_output_budget.py
@@ -1,0 +1,65 @@
+"""Regression tests for issue #290 — the verify/enhance agent loops bypass
+`simple_text` and pinned their own output budget.
+
+`finding_verifier` and `agentic_enhancer/agent` call
+`binding.adapter.complete(...)` directly (they need raw content blocks for
+the multi-turn tool conversation), so PR #242's raise of `simple_text`'s
+default 8192→20000 — whose comment names the exact failure mode (a
+thinking-era model spends the output budget on hidden reasoning and returns
+a reasoning-only completion) — never reached them: both loops kept a private
+`MAX_TOKENS_PER_RESPONSE = 4096`, HALF the pre-#242 default, on the largest
+units in the scan. A truncated finish call is deliberately downgraded to
+verification-incomplete (FN-safe), so the undersized cap silently converted
+adjudications into needs_review (31 self-declared max_tokens truncations on
+the run that filed this).
+
+Contract locked here (the issue's "so the two cannot drift again"):
+- both agent-loop constants ARE `llm.helpers.DEFAULT_MAX_TOKENS` — same
+  object by construction, not coincidentally equal numbers;
+- `simple_text`'s signature default is that same constant;
+- neither agent-loop source pins a private numeric budget anymore.
+"""
+
+from __future__ import annotations
+
+import inspect
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.agentic_enhancer import agent as enhancer_agent  # noqa: E402
+from utilities import finding_verifier  # noqa: E402
+from utilities.llm import helpers as llm_helpers  # noqa: E402
+from utilities.llm.helpers import DEFAULT_MAX_TOKENS, simple_text  # noqa: E402
+
+
+def test_agent_loops_share_the_simple_text_budget_constant():
+    """#290: both agent-loop budgets ARE the shared constant (no private
+    4096 pins) — the two budget paths cannot drift apart again."""
+    assert finding_verifier.MAX_TOKENS_PER_RESPONSE is DEFAULT_MAX_TOKENS
+    assert enhancer_agent.MAX_TOKENS_PER_RESPONSE is DEFAULT_MAX_TOKENS
+
+
+def test_simple_text_default_is_the_shared_constant():
+    sig = inspect.signature(simple_text)
+    assert sig.parameters["max_tokens"].default is DEFAULT_MAX_TOKENS
+    # and the number is the thinking-era budget PR #242 established
+    assert DEFAULT_MAX_TOKENS == 20000
+
+
+def test_no_private_numeric_budget_pins_in_agent_loops():
+    """Neither agent-loop source pins a numeric max_tokens anymore: the
+    constants must be defined by reference to the shared default, so a
+    future edit to one site that re-pins a number is visible in review."""
+    core = PROJECT_ROOT / "utilities"
+    for rel in ("finding_verifier.py", "agentic_enhancer/agent.py"):
+        src = (core / rel).read_text()
+        for line in src.splitlines():
+            if "MAX_TOKENS_PER_RESPONSE =" in line and "=" in line:
+                rhs = line.split("=", 1)[1].strip()
+                assert rhs in ("DEFAULT_MAX_TOKENS",), (
+                    f"{rel}: budget must reference DEFAULT_MAX_TOKENS, "
+                    f"got {rhs!r}")

--- a/libs/openant-core/utilities/agentic_enhancer/agent.py
+++ b/libs/openant-core/utilities/agentic_enhancer/agent.py
@@ -25,6 +25,11 @@ from ..llm import (
     ToolUseBlock,
     lookup_pricing,
 )
+# #290 sibling: same shape as finding_verifier — this loop bypasses
+# simple_text and previously pinned its own 4096, so PR #242's raised default
+# never reached enhance either. Shares the thinking-era budget; see
+# llm/helpers.py:DEFAULT_MAX_TOKENS.
+from ..llm.helpers import DEFAULT_MAX_TOKENS
 from .repository_index import RepositoryIndex
 from .tools import TOOL_DEFINITIONS, ToolExecutor
 from .prompts import SYSTEM_PROMPT, get_user_prompt
@@ -34,7 +39,7 @@ from .reachability_analyzer import ReachabilityAnalyzer
 
 # Safety limits
 MAX_ITERATIONS = 20
-MAX_TOKENS_PER_RESPONSE = 4096
+MAX_TOKENS_PER_RESPONSE = DEFAULT_MAX_TOKENS
 
 # Classification stamped on a degenerate exit (agent ended without a completed
 # `finish` tool call: bare end_turn, no tool calls, or MAX_ITERATIONS reached).

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -49,6 +49,11 @@ from .llm import (
     ToolUseBlock,
     lookup_pricing,
 )
+# #290: this loop bypasses simple_text (it needs raw content blocks for the
+# tool conversation), so it takes its output budget from the SAME constant as
+# simple_text's default — a private 4096 here is how PR #242's raise never
+# reached verify on any route.
+from .llm.helpers import DEFAULT_MAX_TOKENS
 
 # Null logger that discards all messages (used when no logger provided)
 _null_logger = logging.getLogger("null_verifier")
@@ -71,7 +76,13 @@ except ImportError:
 
 
 MAX_ITERATIONS = 20
-MAX_TOKENS_PER_RESPONSE = 4096
+# #290: was a private 4096 — half of simple_text's raised default, on the
+# largest units in the scan, by a route PR #242 could not reach. A truncated
+# finish call is deliberately downgraded to verification-incomplete (FN-safe
+# direction), so an undersized cap silently converts adjudications into
+# needs_review. Shares simple_text's thinking-era budget; see
+# llm/helpers.py:DEFAULT_MAX_TOKENS.
+MAX_TOKENS_PER_RESPONSE = DEFAULT_MAX_TOKENS
 
 
 # Expected JSON shape of a verifier `finish` response — handed to JSONCorrector

--- a/libs/openant-core/utilities/llm/helpers.py
+++ b/libs/openant-core/utilities/llm/helpers.py
@@ -20,6 +20,20 @@ from ..llm_client import TokenTracker, get_global_tracker
 from .adapter import Message, TextBlock
 from .registry import PhaseBinding
 
+# Thinking-era output budget (the simple_text default; PR #242 raised it from
+# 8192). Claude-5 / Gemini-2.5+ / OpenAI o-series spend output budget on hidden
+# reasoning; 8192 can be fully consumed by reasoning on a large unit, yielding a
+# reasoning-only (empty) completion that the adapter drops -> hard "no usable
+# content" error. 20000 is under the Anthropic non-streaming 10-min ceiling
+# (32000 is rejected with a "Streaming is required" ValueError; 20000 is
+# accepted) and is a CAP, not a floor on generation -- models still stop at
+# end_turn on small prompts, so this does not raise cost for short answers.
+# #290: the multi-turn tool-using agent loops (finding_verifier,
+# agentic_enhancer/agent) bypass simple_text and call adapter.complete
+# directly, so they import THIS constant instead of pinning their own 4096 —
+# the two budget paths cannot drift apart again.
+DEFAULT_MAX_TOKENS = 20000
+
 
 def lookup_pricing(binding: PhaseBinding) -> Optional[dict]:
     """Return the adapter's price entry for ``binding.model``, or None.
@@ -38,15 +52,8 @@ def simple_text(
     prompt: str,
     *,
     system: Optional[str] = None,
-    # Thinking-era default. Claude-5 / Gemini-2.5+ / OpenAI o-series spend
-    # output budget on hidden reasoning; 8192 can be fully consumed by
-    # reasoning on a large unit, yielding a reasoning-only (empty) completion
-    # that the adapter drops -> hard "no usable content" error. 20000 is under
-    # the Anthropic non-streaming 10-min ceiling (32000 is rejected with a
-    # "Streaming is required" ValueError; 20000 is accepted) and is a CAP, not
-    # a floor on generation -- models still stop at end_turn on small prompts,
-    # so this does not raise cost for short answers.
-    max_tokens: int = 20000,
+    # See DEFAULT_MAX_TOKENS above for why this is 20000, not 8192.
+    max_tokens: int = DEFAULT_MAX_TOKENS,
     tracker: Optional[TokenTracker] = None,
 ) -> str:
     """Send one user-prompt completion, return the concatenated text reply.


### PR DESCRIPTION
## Summary

`finding_verifier` and `agentic_enhancer/agent` call `binding.adapter.complete(...)` directly (they need raw content blocks for the multi-turn tool conversation), so PR #242's raise of `simple_text`'s default 8192→20000 never reached them: both loops kept a private `MAX_TOKENS_PER_RESPONSE = 4096` — **half the pre-#242 default** — on the largest units in the scan. On the run that filed #290, 31 of 182 incomplete verifications self-declared "finish call truncated at max_tokens". A truncated finish is deliberately downgraded to verification-incomplete (FN-safe), so the undersized cap silently converted adjudications into needs_review.

Fix: extract `llm.helpers.DEFAULT_MAX_TOKENS` (20000, the #242 rationale comment moved with it); `simple_text`'s signature default and both agent-loop constants now reference the **same constant**, so the two budget paths cannot drift apart again. Zero behavior change for `simple_text` callers; the verify/enhance per-turn cap rises 4096→20000 (a CAP, not a floor — models still stop at end_turn).

Note: this issue was sequenced behind #285/#286/#287 so a budget change is measurable (status honesty, error-vocabulary, fingerprint keying) — those landed in #376/#377/#378.

**Scope notes (deliberate deviations from the issue's suggestions, with reasons):**
- suggestion 1's "read from configuration" and suggestion 3's `PhaseBinding` property are architecture/config-surface changes, not fixes — deferred; the shared constant delivers the anti-drift property they were after.
- suggestion 4's full 16-site census guard is **not** added: the other 4096 sites (`llm_reachability`, report generator, `context_enhancer`, etc.) are single-shot `simple_text`-style calls with their own cost/shape tradeoffs this issue did not analyze; blanket-justifying them would be guessing. The drift test covers the agent loops the issue indicts.
- #291 (the input cap on appended tool results) is the sibling gap, independent, and remains open.

The private-run figures (31/182) quoted from the issue are provenance-labeled there; the code defect and the fix contract are fully checkable and test-covered.

## Test plan

3 hermetic tests: both agent-loop constants ARE the shared constant (identity, not coincidental equality); `simple_text`'s signature default is that constant; no private numeric budget pins remain in the agent-loop sources.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new + helper tests | `pytest tests/test_issue290_output_budget.py tests/test_llm_helpers.py tests/test_llm_helpers_unit.py -q` | 24 passed |
| mutation smoke | fix reverted → new test file | errors (import `DEFAULT_MAX_TOKENS` fails) — RED proof; re-applied → green |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest tests/test_issue290_output_budget.py` | 3 passed |
| full suite | `pytest tests/ -q` | 3152 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #290
