### PR TITLE
fix(verify): cap the tool-loop conversation input (reuse the enhance loop's PR #133 caps)

### DIFF
--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -27,7 +27,12 @@ from utilities.llm import (
     resolve_llm_config,
 )
 from utilities.file_io import normalize_results, read_json, write_json
-from utilities.finding_verifier import FindingVerifier, MAX_TOKENS_PER_RESPONSE
+from utilities.finding_verifier import (
+    FindingVerifier,
+    MAX_TOKENS_PER_RESPONSE,
+    MAX_PROMPT_CHARS,
+    MAX_TOOL_RESULT_CHARS,
+)
 from utilities.agentic_enhancer.repository_index import load_index_from_file
 
 # Import application context (optional)
@@ -186,6 +191,16 @@ def run_verification(
             # checkpoints specifically (no scheme bump; the extra_key
             # mechanism is the pre-existing plumbing).
             "gen_params": {"max_tokens": MAX_TOKENS_PER_RESPONSE},
+            # Union-diff checkpoint (20 submitted, 2026-08-29): #291's input
+            # caps are part of the verify conversation's identity exactly
+            # like the output budget — a resumed run must not adopt
+            # checkpoints produced under uncapped-input semantics (the same
+            # silent-staleness class #285/#286/#287 closed for errors and
+            # generation params).
+            "input_caps": {
+                "max_prompt_chars": MAX_PROMPT_CHARS,
+                "max_tool_result_chars": MAX_TOOL_RESULT_CHARS,
+            },
         }))
 
     # Run Stage 2 verification via verify_batch

--- a/libs/openant-core/tests/test_issue287_fingerprint_gen_params.py
+++ b/libs/openant-core/tests/test_issue287_fingerprint_gen_params.py
@@ -26,14 +26,14 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 
-def _verify_fingerprint(max_tokens):
+def _verify_fingerprint(max_tokens, input_caps=None):
     """Build the verify-phase fingerprint exactly as verifier.py:182 does
-    (the extra_key mechanism), with the given max_tokens."""
+    (the extra_key mechanism), with the given max_tokens and input caps."""
     from core.backend_identity import fingerprint_for_binding
 
     class _Binding:
         phase = "verify"
-        model = "claude-opus-5"
+        model = "claude-5-opus"
         provider_name = "anthropic"
         base_url = None
 
@@ -43,10 +43,12 @@ def _verify_fingerprint(max_tokens):
     class _Template(str):
         pass
 
+    extra_key = {"analyze_fingerprint": "sha256:abc",
+                 "gen_params": {"max_tokens": max_tokens}}
+    if input_caps is not None:
+        extra_key["input_caps"] = input_caps
     return fingerprint_for_binding(
-        _Binding(), [_Template("template")],
-        extra_key={"analyze_fingerprint": "sha256:abc",
-                   "gen_params": {"max_tokens": max_tokens}})
+        _Binding(), [_Template("template")], extra_key=extra_key)
 
 
 def test_different_max_tokens_different_digest():
@@ -79,4 +81,19 @@ def test_exclusion_documented_in_backend_identity():
     )
     assert "#286" in src or "377" in src, (
         "the FN-safety rationale's #286/#377 dependency must be named"
+    )
+
+
+def test_different_input_caps_different_digest():
+    """Union-diff checkpoint (20 submitted, 2026-08-29): #291's input caps
+    change what the model saw on every turn — they are part of the verify
+    conversation's identity exactly like max_tokens. A cap change must
+    invalidate the checkpoint identity (stale adoption of checkpoints
+    produced under uncapped-input semantics otherwise)."""
+    caps_a = {"max_prompt_chars": 60_000, "max_tool_result_chars": 24_000}
+    caps_b = {"max_prompt_chars": 30_000, "max_tool_result_chars": 24_000}
+    a = _verify_fingerprint(20000, caps_a)
+    b = _verify_fingerprint(20000, caps_b)
+    assert a["key_digest"] != b["key_digest"], (
+        "an input-cap change must invalidate the verify checkpoint identity"
     )

--- a/libs/openant-core/tests/test_issue291_input_caps.py
+++ b/libs/openant-core/tests/test_issue291_input_caps.py
@@ -1,0 +1,141 @@
+"""Regression tests for issue #291 — verify's tool loop appends raw tool
+results with no input cap, while the structurally identical enhance loop
+caps both and documents why.
+
+`agentic_enhancer/agent.py` has bounded its conversation input since PR
+#133: MAX_PROMPT_CHARS (60k) on inlined primary_code and
+cap_tool_result_content (24k) on every serialized tool result, with a
+comment naming the failure the caps prevent — "input grew unbounded until
+it overflowed the model context (400)". `finding_verifier.py` ran the same
+20-iteration tool loop with NEITHER cap: `json.dumps(outcome)` was appended
+verbatim every turn, so verify's input grew without bound (on the run that
+filed this, incomplete verifications consumed 3.2x the tokens of completed
+ones, the largest accumulating 5.8M tokens across 20 turns; the max-iteration
+group's median input/turn was 2.2x the completed group's while output/turn
+was indistinguishable — the growth is on the input side).
+
+Contract locked here:
+- every tool result appended to the verify conversation is bounded by the
+  SAME helper and limit the enhance loop uses (cap_tool_result_content /
+  MAX_TOOL_RESULT_CHARS), with the truncation marker when it fires;
+- the inlined unit code in the initial verify prompt is capped at the
+  enhance loop's MAX_PROMPT_CHARS, with the truncation marker;
+- a small tool result still round-trips as valid JSON (not gratuitously
+  truncated).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_CORE_ROOT))
+
+from utilities.agentic_enhancer.agent import MAX_PROMPT_CHARS, MAX_TOOL_RESULT_CHARS
+from utilities.agentic_enhancer.repository_index import RepositoryIndex
+from utilities.finding_verifier import FindingVerifier
+from utilities.llm import PhaseBinding, TextBlock, ToolResultBlock, ToolUseBlock
+from utilities.llm.adapter import CompletionResult
+from utilities.llm_client import reset_warning_state
+
+STAGE1_FINDING = "vulnerable"
+
+
+class _RecordingAdapter:
+    """Issues one oversized-outcome tool call, then a finish; records every
+    conversation it is handed so the test can inspect what was appended."""
+
+    name = "anthropic"
+    supports_tools = True
+    pricing = {"claude-x": {"input": 1.0, "output": 1.0}}
+
+    def __init__(self):
+        self.seen_messages = []
+
+    def complete(self, *, model, system, messages, max_tokens, tools=None):
+        self.seen_messages.append(messages)
+        if len(self.seen_messages) == 1:
+            return CompletionResult(
+                content=[ToolUseBlock(id="t1", name="read_function",
+                                      input={"function": "big"})],
+                input_tokens=1, output_tokens=1, stop_reason="tool_use",
+            )
+        return CompletionResult(
+            content=[ToolUseBlock(id="t2", name="finish",
+                                  input={"agree": True,
+                                         "correct_finding": "vulnerable"})],
+            input_tokens=1, output_tokens=1, stop_reason="tool_use",
+        )
+
+
+class _HugeOutcomeExecutor:
+    """Stands in for the real ToolExecutor: returns a 200k-char payload."""
+
+    def execute(self, tool_name, tool_input):
+        return {"content": "A" * 200_000}
+
+
+def _verify(adapter, code="x = 1", executor=None):
+    binding = PhaseBinding(phase="verify", adapter=adapter, model="claude-x",
+                           provider_name="anthropic")
+    v = FindingVerifier(index=RepositoryIndex({}, repo_path=None),
+                        binding=binding)
+    if executor is not None:
+        v.tool_executor = executor
+    return v.verify_result(code=code, finding=STAGE1_FINDING,
+                           attack_vector="a", reasoning="r")
+
+
+def _tool_result_blocks(messages):
+    blocks = []
+    for m in messages:
+        content = m.content if isinstance(m.content, (list, tuple)) else []
+        for b in content:
+            if isinstance(b, ToolResultBlock) and b.name == "read_function":
+                blocks.append(b)
+    return blocks
+
+
+def test_oversized_tool_result_is_capped(tmp_path):
+    reset_warning_state()
+    adapter = _RecordingAdapter()
+    _verify(adapter, executor=_HugeOutcomeExecutor())
+    reset_warning_state()
+    # the conversation is one growing list (the adapter sees the same
+    # object each turn); the tool result is in the last recorded state
+    results = _tool_result_blocks(adapter.seen_messages[-1])
+    assert len(results) == 1
+    content = results[0].content
+    assert len(content) <= MAX_TOOL_RESULT_CHARS
+    assert content.endswith("\n... (truncated)")
+
+
+def test_small_tool_result_round_trips_valid_json():
+    reset_warning_state()
+
+    class _SmallExecutor:
+        def execute(self, tool_name, tool_input):
+            return {"content": "small"}
+
+    adapter = _RecordingAdapter()
+    _verify(adapter, executor=_SmallExecutor())
+    reset_warning_state()
+    results = _tool_result_blocks(adapter.seen_messages[-1])
+    assert json.loads(results[0].content) == {"content": "small"}
+
+
+def test_oversized_unit_code_is_capped_in_initial_prompt():
+    reset_warning_state()
+    adapter = _RecordingAdapter()
+    tail = "END_OF_UNIT_MARKER"
+    huge = "B" * (MAX_PROMPT_CHARS + 50_000) + tail
+    _verify(adapter, code=huge)
+    reset_warning_state()
+    first_user = adapter.seen_messages[0][0]
+    text = "".join(b.text for b in first_user.content
+                   if isinstance(b, TextBlock))
+    assert len(text) < MAX_PROMPT_CHARS + 10_000
+    assert tail not in text                       # the unit was truncated
+    assert "\n... (truncated)" in text            # with the explicit marker

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -55,6 +55,15 @@ _null_logger = logging.getLogger("null_verifier")
 _null_logger.addHandler(logging.NullHandler())
 from .agentic_enhancer.repository_index import RepositoryIndex
 from .agentic_enhancer.tools import ToolExecutor
+# #291: the enhance loop has capped its conversation input since PR #133
+# (MAX_PROMPT_CHARS on inlined primary_code, cap_tool_result_content on every
+# serialized tool result) with a comment naming the failure mode — unbounded
+# input growth until context overflow (400). This loop is structurally
+# identical (20-iteration tool conversation) and applied NEITHER cap: raw
+# json.dumps(outcome) appended every turn, so verify's input grew without
+# bound. Reuse the enhance caps rather than redefining them, so the two
+# loops cannot drift apart.
+from .agentic_enhancer.agent import MAX_PROMPT_CHARS, cap_tool_result_content
 from prompts.verification_prompts import (
     VERIFICATION_SYSTEM_PROMPT,
     get_verification_prompt,
@@ -384,6 +393,13 @@ class FindingVerifier:
         Returns:
             VerificationResult with verdict, exploit path, and explanation
         """
+        # #291: cap the inlined unit code the way the enhance loop caps its
+        # primary_code (MAX_PROMPT_CHARS) — an oversized unit otherwise
+        # overflows the model context on turn 1. Explicit marker so the model
+        # knows content was elided.
+        if len(code) > MAX_PROMPT_CHARS:
+            marker = "\n... (truncated)"
+            code = code[: MAX_PROMPT_CHARS - len(marker)] + marker
         user_prompt = get_verification_prompt(
             code=code,
             finding=finding,
@@ -495,7 +511,12 @@ class FindingVerifier:
                             ToolResultBlock(
                                 tool_use_id=tool_use_id,
                                 name=tool_name,
-                                content=json.dumps(outcome),
+                                # #291: capped, not raw json.dumps — the
+                                # enhance loop's cap_tool_result_content
+                                # (PR #133) with the same 24k limit; raw
+                                # appends grew verify's input without bound
+                                # across the 20 iterations.
+                                content=cap_tool_result_content(outcome),
                             )
                         )
 

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -63,7 +63,11 @@ from .agentic_enhancer.tools import ToolExecutor
 # json.dumps(outcome) appended every turn, so verify's input grew without
 # bound. Reuse the enhance caps rather than redefining them, so the two
 # loops cannot drift apart.
-from .agentic_enhancer.agent import MAX_PROMPT_CHARS, cap_tool_result_content
+from .agentic_enhancer.agent import (
+    MAX_PROMPT_CHARS,
+    MAX_TOOL_RESULT_CHARS,
+    cap_tool_result_content,
+)
 from prompts.verification_prompts import (
     VERIFICATION_SYSTEM_PROMPT,
     get_verification_prompt,


### PR DESCRIPTION
## Summary

`finding_verifier` runs a structurally identical 20-iteration tool loop to `agentic_enhancer/agent` but applied **neither** of the input caps PR #133 landed for enhance: it appended raw `json.dumps(outcome)` on every turn, so verify's conversation grew without bound (on the run that filed #291, incomplete verifications consumed 3.2x the tokens of completed ones, largest single accumulation 5.8M tokens across 20 turns; the max-iteration group's median input/turn was 2.2x the completed group's while output/turn was indistinguishable — the growth is input-side).

Fix (the issue's suggestions 1+2 — **reuse, not reimplement**):
- tool results: `cap_tool_result_content(outcome)` at the append site — the same helper and 24k limit enhance uses;
- initial prompt: the inlined unit code is capped at enhance's `MAX_PROMPT_CHARS` (60k) with the same explicit truncation marker.

Both imported from `agentic_enhancer/agent` so the two loops cannot drift. This is the second instance of the verify-specific-gap pattern (#290 was the first: output budget; this one: input budget).

**Amendment (union-diff review of the open PRs, commit 7d6a726):** the union review caught that the verify checkpoint fingerprint (which #287 made cover the generation budget) did not cover these input caps — a resumed run would adopt stale checkpoints produced under uncapped-input semantics, the exact silent-staleness class #285/#286/#287 closed. `input_caps {max_prompt_chars, max_tool_result_chars}` now joins the fingerprint's extra_key next to `gen_params`, with the #287 fingerprint test extended and a new cap-change-invalidates-digest test.

**Deliberate deviations from the issue's suggestions, with reasons:**
- suggestion 3 (total-conversation budget on top of the per-result cap) is new design, not reuse — deferred; the per-result + prompt caps are the merged, reviewed #133 semantics.
- the `finish` ack (`json.dumps({"status": "complete"})`) is left uncapped: it is a fixed 27-byte string.
- the consistency-check single-shot path is untouched: it is not the agent loop this issue indicts.

The private-run figures quoted from the issue are provenance-labeled there; the code defect and the fix contract are fully checkable and test-covered.

## Test plan

4 hermetic tests (stub adapter + stub executor, no LLM): an oversized 200k tool outcome produces a bounded `ToolResultBlock` with the truncation marker; a small result round-trips as valid JSON (no gratuitous truncation); a 110k unit is capped in the initial prompt with the marker and its tail absent; an input-cap change invalidates the verify checkpoint fingerprint.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue291_input_caps.py -q` | 3 passed |
| fingerprint tests (incl. new input-caps digest test) | `pytest tests/test_issue287_fingerprint_gen_params.py -q` | 4 passed |
| mutation smoke | fix reverted → input-cap tests | 2 failed (both target tests; the round-trip guard passes on both, by design); re-applied → 3 passed |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest <both files>` | 7 passed |
| full suite | `pytest tests/ -q` | 3153 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #291
