### PR TITLE
fix(rate-limiter): honour the empty-completion retry on the dict shape; parse status codes instead of substring scan

### DIFF
--- a/libs/openant-core/tests/test_retry_empty_completion.py
+++ b/libs/openant-core/tests/test_retry_empty_completion.py
@@ -71,3 +71,80 @@ def test_unrelated_response_error_not_retryable():
     # A serialization/other LLMResponseError (different message) is not falsely
     # caught by the "empty completion" term.
     assert is_retryable_error("AnthropicAdapter: cannot serialise block of type Foo") is False
+
+
+# ---------------------------------------------------------------------------
+# #292 — the DICT shape: enhance passes a structured dict built by
+# context_enhancer._build_error_info; before this fix the empty-completion
+# case was classified api_status with no status_code (the raise carries none),
+# so is_retryable_error returned False on the one path whose docstring
+# documented the retry. All 48 errored verify/enhance records on the run that
+# filed the issue carried exactly this exception.
+# ---------------------------------------------------------------------------
+from utilities.context_enhancer import _build_error_info  # noqa: E402
+from utilities.llm.adapter import LLMResponseError  # noqa: E402
+
+
+def _info(msg: str) -> dict:
+    """The dict enhance builds from a bare LLMResponseError raise (no `from`,
+    so no __cause__ / status_code — exactly as anthropic.py raises it)."""
+    return _build_error_info(LLMResponseError(msg))
+
+
+def test_empty_completion_dict_is_retryable():
+    # the branch asymmetry: same exception, dict shape — was False
+    assert is_retryable_error(_info(_EMPTY_ANTHROPIC)) is True
+    assert is_retryable_error(_info(_EMPTY_GEMINI)) is True
+    assert is_retryable_error(_info(_EMPTY_OPENAI_RESPONSES)) is True
+    assert is_retryable_error(_info(_EMPTY_OPENAI_CHAT_NOCHOICES)) is True
+    assert is_retryable_error(_info(_EMPTY_OPENAI_CHAT_NOBLOCKS)) is True
+
+
+def test_build_error_info_classifies_empty_completion():
+    info = _info(_EMPTY_ANTHROPIC)
+    assert info["type"] == "empty_completion"
+
+
+def test_refusal_dict_is_not_retryable():
+    assert is_retryable_error(_info(_REFUSAL)) is False
+
+
+def test_old_shape_dict_backstop():
+    """Dicts built BEFORE the empty_completion classification (e.g. stored
+    agent_context adopted on resume) carry type api_status with the
+    empty-completion message — the message backstop must honour them."""
+    old = {"type": "api_status", "exception_class": "LLMResponseError",
+           "message": _EMPTY_ANTHROPIC}
+    assert is_retryable_error(old) is True
+
+
+def test_api_status_dict_unchanged():
+    # a REAL server error still retries; a client error still does not
+    assert is_retryable_error({"type": "api_status", "status_code": 529}) is True
+    assert is_retryable_error({"type": "api_status", "status_code": 400}) is False
+
+
+# ---------------------------------------------------------------------------
+# #292 secondary — the string branch matched status codes as substrings over
+# the whole message. Now they are PARSED bounded numbers tested against the
+# SAME explicit allowlist (500,502,503,504,520,522,523,524,529 — 501 is a
+# deterministic "not implemented", deliberately excluded; NOT a 5xx range).
+# ---------------------------------------------------------------------------
+def test_status_codes_parsed_not_substring():
+    # substring-inside-longer-number false positives are gone
+    assert is_retryable_error("byte offset 5000") is False
+    assert is_retryable_error("read 15002 bytes") is False
+    # real provider status formats still retry
+    assert is_retryable_error(
+        "Error code: 529 - {'type': 'overloaded_error'}") is True
+    assert is_retryable_error("Error code: 500 - internal server error") is True
+    # 501 is deliberately excluded (deterministic not-implemented)
+    assert is_retryable_error("Error code: 501 - not implemented") is False
+
+
+def test_status_code_residual_documented():
+    """RESIDUAL (accepted by #292's corrected suggestion 3): a standalone
+    '500' in non-status context ('token count 500', 'model gpt-500') still
+    parses as the code 500 and retries — bounded to one extra attempt, and
+    distinguishing it would need format-specific parsing the issue declined."""
+    assert is_retryable_error("token count 500 exceeded") is True

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -108,6 +108,15 @@ def _build_error_info(exc: Exception) -> dict:
         info["type"] = "not_found"
     elif isinstance(exc, LLMResponseError):
         info["type"] = "api_status"
+        # #292: the transient empty-completion raise is its OWN type, so the
+        # retry decision does not depend on a status_code the exception
+        # cannot carry (the raise is bare — no `from`, no __cause__). Same
+        # substrings + refusal guard as is_retryable_error's string branch;
+        # LLMRefusalError subclasses LLMResponseError, so the guard matters.
+        msg = str(exc).lower()
+        if "refused the request" not in msg and (
+                "no usable content" in msg or "empty completion" in msg):
+            info["type"] = "empty_completion"
 
     # Best-effort diagnostics. The unified LLMError taxonomy is
     # provider-neutral and does not itself carry status_code/request_id,

--- a/libs/openant-core/utilities/rate_limiter.py
+++ b/libs/openant-core/utilities/rate_limiter.py
@@ -23,6 +23,7 @@ Usage:
 """
 
 import random
+import re
 import sys
 import threading
 import time
@@ -235,21 +236,39 @@ def is_retryable_error(error_info: dict | str | None) -> bool:
     """
     if not error_info:
         return False
-    
+
     if isinstance(error_info, dict):
         error_type = error_info.get("type", "")
-        
+
         # Always retry these transient error types. "parse_error" is a malformed
         # LLM response (unparseable JSON): re-generating the completion often
         # yields well-formed output, so it is treated as transient here.
         if error_type in ("rate_limit", "connection", "timeout", "parse_error"):
             return True
-        
+
+        # #292: the transient empty-completion raise is honoured on the DICT
+        # shape too. New dicts carry type "empty_completion"
+        # (context_enhancer._build_error_info); the message backstop below
+        # also catches dicts built before that classification existed (stored
+        # agent_context adopted on resume). Before this, the dict branch
+        # classified the same exception as api_status and looked for a
+        # status_code the raise never carries — enhance never retried the one
+        # error class that actually occurred.
+        if error_type == "empty_completion":
+            return True
+
         # Retry server errors (5xx), but not client errors (4xx)
         if error_type == "api_status":
+            # #292 message backstop: an old-shape dict (type api_status, no
+            # status_code) built from an empty-completion raise. Same
+            # substrings + refusal guard as the string branch below.
+            msg = str(error_info.get("message", "")).lower()
+            if "refused the request" not in msg and (
+                    "no usable content" in msg or "empty completion" in msg):
+                return True
             status_code = error_info.get("status_code", 0)
             return status_code >= 500
-        
+
         return False
     
     # String-based error checking.
@@ -269,14 +288,23 @@ def is_retryable_error(error_info: dict | str | None) -> bool:
     # marker wins over the substring scan.
     if "refused the request" in error_str:
         return False
-    return any(term in error_str for term in (
+    # #292: status codes are PARSED bounded numbers tested against the SAME
+    # explicit allowlist as before — not a 5xx range (501 is a deterministic
+    # "not implemented", deliberately excluded; 505/506 likewise), and not an
+    # unanchored substring scan, which matched "byte offset 5000" /
+    # "read 15002 bytes". Residual, accepted: a standalone "500" in
+    # non-status context ("token count 500") still parses as the code.
+    # Transient Anthropic/Cloudflare-edge 5xx. 529 ("overloaded") is the
+    # Anthropic overload signal; 520/522/523/524 are Cloudflare edge failures
+    # (unknown error / connection timed out / origin unreachable / timeout)
+    # that are equally transient.
+    _RETRYABLE_STATUS_CODES = frozenset(
+        ("500", "502", "503", "504", "520", "522", "523", "524", "529"))
+    status_hit = any(
+        code in _RETRYABLE_STATUS_CODES
+        for code in re.findall(r"\b5\d{2}\b", error_str))
+    return status_hit or any(term in error_str for term in (
         "rate_limit", "connection", "timeout",
-        # Transient Anthropic/Cloudflare-edge 5xx. 529 ("overloaded") is the
-        # Anthropic overload signal; 520/522/523/524 are Cloudflare edge
-        # failures (unknown error / connection timed out / origin unreachable /
-        # timeout) that are equally transient. 501 is a deterministic
-        # "not implemented" and is deliberately excluded.
-        "500", "502", "503", "504", "520", "522", "523", "524", "529",
         "overloaded",
         # A provider adapter raises LLMResponseError on an empty completion (no
         # text/tool block) — typically a thinking-block truncation or a


### PR DESCRIPTION
## Summary

`is_retryable_error` documented the empty-completion `LLMResponseError` ("... returned no usable content ...") as retryable, and the **string** branch implemented that — but the **dict** branch classified the same exception as `api_status`, looked for a `status_code` the bare raise never carries, and fell through to `False`. `analyze` passes a string and retries it; `enhance` passes a dict and does not. On the run that filed #292 this was the **only** error class that occurred (all 48 errored records carry the byte-identical string), so the retry the docstring described never fired for `enhance`.

Fix (issue suggestions 1+2):
- `context_enhancer._build_error_info` classifies the empty-completion raise as its own type (`empty_completion`) instead of `api_status` — same substrings + refusal guard as the string branch (`LLMRefusalError` subclasses `LLMResponseError`, so the guard is load-bearing);
- `is_retryable_error`'s dict branch honours the new type **and** carries a message backstop inside `api_status` (old-shape dicts from stored `agent_context` adopted on resume — the resume-staleness class #285-#287 closed for other surfaces).

Secondary (suggestion 3, as corrected 2026-08-21): the string branch's status codes are now **parsed bounded numbers** (`\b5\d{2}\b`) tested against the **same explicit allowlist** (500, 502, 503, 504, 520, 522, 523, 524, 529) — not a 5xx range (501 deliberately excluded; a blanket `5\d{2}` would silently undo that decision) and not the old unanchored substring scan, which matched "byte offset 5000" / "read 15002 bytes". Residual, accepted and test-documented: a standalone "500" in non-status context ("token count 500") still parses as the code — bounded to one extra attempt.

The private-run figures (48 errored records) quoted from the issue are provenance-labeled there; the code defect and the fix contract are fully checkable and test-covered.

## Test plan

7 new tests on top of the 4 existing (11 total): the dict shape for all five adapter empty-completion messages; the `empty_completion` classification; refusal dicts stay non-retryable; the old-shape resume backstop; real 5xx/client status dicts unchanged; parsed-vs-substring status behavior; the accepted residual documented.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new + existing tests | `pytest tests/test_retry_empty_completion.py -q` | 11 passed |
| RED proof | same file on pristine base | 4 failed (all target tests) |
| mutation smoke | fix reverted → same file | 4 failed; re-applied → 11 passed |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest <file>` | 11 passed |
| full suite | `pytest tests/ -q` | 3168 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #292
