### PR TITLE
fix(counters): the third per-unit state (incomplete) is counted everywhere, not as completed

### DIFF
--- a/apps/openant-cli/internal/checkpoint/checkpoint.go
+++ b/apps/openant-cli/internal/checkpoint/checkpoint.go
@@ -42,16 +42,18 @@ type Summary struct {
 	Timestamp      string         `json:"timestamp"`
 	TotalUnits     int            `json:"total_units"`
 	Completed      int            `json:"completed"`
+	Incomplete     int            `json:"incomplete"` // #293: units that ended without a verdict
 	Errors         int            `json:"errors"`
 	ErrorBreakdown map[string]int `json:"error_breakdown"`
 }
 
 // Info describes an existing checkpoint directory.
 type Info struct {
-	Dir       string   // full path to the checkpoint dir
-	Count     int      // number of successfully completed units
-	Errors    int      // number of errored units
-	Summary   *Summary // parsed _summary.json (may have counts overridden by Python)
+	Dir        string   // full path to the checkpoint dir
+	Count      int      // number of successfully completed units
+	Incomplete int      // number of units that ended without a verdict (#293)
+	Errors     int      // number of errored units
+	Summary    *Summary // parsed _summary.json (may have counts overridden by Python)
 }
 
 // Phase returns the detected phase state as a human-readable string.
@@ -92,6 +94,7 @@ func DetectViaPython(pythonPath, scanDir, stepName string) *Info {
 	var status struct {
 		Step           string         `json:"step"`
 		Completed      int            `json:"completed"`
+		Incomplete     int            `json:"incomplete"`
 		Errors         int            `json:"errors"`
 		TotalFiles     int            `json:"total_files"`
 		TotalUnits     int            `json:"total_units"`
@@ -114,14 +117,16 @@ func DetectViaPython(pythonPath, scanDir, stepName string) *Info {
 	}
 
 	info := &Info{
-		Dir:    dir,
-		Count:  status.Completed,
-		Errors: status.Errors,
+		Dir:        dir,
+		Count:      status.Completed,
+		Incomplete: status.Incomplete,
+		Errors:     status.Errors,
 		Summary: &Summary{
 			Step:           status.Step,
 			Phase:          status.Phase,
 			TotalUnits:     status.TotalUnits,
 			Completed:      status.Completed,
+			Incomplete:     status.Incomplete,
 			Errors:         status.Errors,
 			ErrorBreakdown: status.ErrorBreakdown,
 		},
@@ -191,10 +196,17 @@ func PromptResume(info *Info, stepName string, quiet bool) bool {
 		// Interrupted run — show progress out of total
 		yellow.Fprintf(os.Stderr, "Previous %s run interrupted", stepName)
 		s := info.Summary
-		if info.Errors > 0 {
+		switch {
+		case info.Errors > 0 && info.Incomplete > 0:
+			fmt.Fprintf(os.Stderr, " (%d/%d completed, %d incomplete, %d errors)\n",
+				info.Count, s.TotalUnits, info.Incomplete, info.Errors)
+		case info.Errors > 0:
 			fmt.Fprintf(os.Stderr, " (%d/%d completed, %d errors)\n",
 				info.Count, s.TotalUnits, info.Errors)
-		} else {
+		case info.Incomplete > 0:
+			fmt.Fprintf(os.Stderr, " (%d/%d completed, %d incomplete)\n",
+				info.Count, s.TotalUnits, info.Incomplete)
+		default:
 			fmt.Fprintf(os.Stderr, " (%d/%d completed)\n",
 				info.Count, s.TotalUnits)
 		}

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -569,6 +569,12 @@ def run_analysis(
     _summary_output_tokens = 0
     _summary_cost_usd = 0.0
     _summary_unpriced: set[str] = set()
+    # #293 adjudication: analyze has NO third state — "inconclusive" is a
+    # first-class COMPLETED verdict (verdict_taxonomy FINDING_VERDICT_ORDER;
+    # the Stage-1 prompt's own enum), not a degenerate no-verdict marker like
+    # verify's verification.incomplete or enhance's INCOMPLETE_CLASSIFICATION.
+    # The third bucket stays 0 here but is still emitted for shape consistency.
+    _summary_incomplete = 0
     for _uid, _cp in _existing.items():
         _r = _cp.get("result", {})
         if _r.get("verdict") == "ERROR" or _r.get("finding") == "error":
@@ -612,16 +618,19 @@ def run_analysis(
     # Write initial summary
     checkpoint.write_summary(total, _summary_completed, _summary_errors,
                              _summary_error_breakdown, phase="in_progress",
-                             usage=_usage_dict())
+                             usage=_usage_dict(), incomplete=_summary_incomplete)
 
     def _summary_callback(finding, usage=None):
         """Update summary counters after each unit. Called from main thread."""
-        nonlocal _summary_completed, _summary_errors, _summary_error_breakdown
+        nonlocal _summary_completed, _summary_incomplete, _summary_errors
+        nonlocal _summary_error_breakdown
         nonlocal _summary_input_tokens, _summary_output_tokens, _summary_cost_usd
         if finding == "error":
             _summary_errors += 1
             _summary_error_breakdown["api"] = _summary_error_breakdown.get("api", 0) + 1
         else:
+            # #293 adjudication: "inconclusive"/"insufficient_context" are
+            # completed verdicts (taxonomy), not incomplete — no third state.
             _summary_completed += 1
         if usage:
             _summary_input_tokens += usage.get("input_tokens", 0)
@@ -629,7 +638,7 @@ def run_analysis(
             _summary_cost_usd += usage.get("cost_usd", 0.0)
         checkpoint.write_summary(total, _summary_completed, _summary_errors,
                                  _summary_error_breakdown, phase="in_progress",
-                                 usage=_usage_dict())
+                                 usage=_usage_dict(), incomplete=_summary_incomplete)
 
     # --- Stage 1: Detection ---
     results, code_by_route = _run_detection(
@@ -660,7 +669,9 @@ def run_analysis(
             results[i] = out["result"]
             code_by_route[out["route_key"]] = out["code_for_route"]
 
-            # Update summary: retry succeeded → flip error to completed
+            # Update summary: retry produced a verdict → flip error to
+            # completed (#293 adjudication: inconclusive is a completed
+            # verdict; analyze has no third state)
             if out["finding"] != "error":
                 _summary_errors = max(0, _summary_errors - 1)
                 _summary_completed += 1
@@ -670,7 +681,7 @@ def run_analysis(
             _summary_cost_usd += retry_usage.get("cost_usd", 0.0)
             checkpoint.write_summary(total, _summary_completed, _summary_errors,
                                      _summary_error_breakdown, phase="in_progress",
-                                     usage=_usage_dict())
+                                     usage=_usage_dict(), incomplete=_summary_incomplete)
 
             # Update checkpoint
             if checkpoint is not None:
@@ -690,7 +701,7 @@ def run_analysis(
     # Write final summary with phase="done"
     checkpoint.write_summary(total, _summary_completed, _summary_errors,
                              _summary_error_breakdown, phase="done",
-                             usage=_usage_dict())
+                             usage=_usage_dict(), incomplete=_summary_incomplete)
 
     tracking.log_usage("Stage 1", _phase_baseline)
 

--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -251,6 +251,7 @@ class StepCheckpoint:
         error_breakdown: dict,
         phase: str = "in_progress",
         usage: dict | None = None,
+        incomplete: int = 0,
     ):
         """Write/overwrite _summary.json in checkpoint dir.
 
@@ -264,6 +265,11 @@ class StepCheckpoint:
             phase: ``"in_progress"`` or ``"done"``.
             usage: Optional dict with ``input_tokens``, ``output_tokens``,
                 ``cost_usd`` accumulated so far for this step.
+            incomplete: #293 — units that ended WITHOUT a verdict (the loop
+                ran out / gave up): neither completed nor errored. All three
+                buckets are always emitted so ``completed + incomplete +
+                errors == total_units`` is visible and checkable; callers
+                that predate the third bucket default it to 0.
         """
         self.ensure_dir()
         filepath = os.path.join(self.dir, SUMMARY_FILE)
@@ -273,6 +279,7 @@ class StepCheckpoint:
             "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "total_units": total_units,
             "completed": completed,
+            "incomplete": incomplete,
             "errors": errors,
             "error_breakdown": error_breakdown,
         }
@@ -311,8 +318,8 @@ class StepCheckpoint:
         doing its own file scanning.
 
         Returns:
-            Dict with keys: step, checkpoint_dir, completed, errors,
-            total_files, total_units, phase, error_breakdown.
+            Dict with keys: step, checkpoint_dir, completed, incomplete,
+            errors, total_files, total_units, phase, error_breakdown.
         """
         # Derive step name from directory name (e.g. "enhance_checkpoints" → "enhance")
         dir_name = os.path.basename(checkpoint_dir.rstrip("/"))
@@ -322,6 +329,7 @@ class StepCheckpoint:
             "step": step,
             "checkpoint_dir": checkpoint_dir,
             "completed": 0,
+            "incomplete": 0,
             "errors": 0,
             "total_files": 0,
             "total_units": 0,
@@ -340,6 +348,7 @@ class StepCheckpoint:
 
         # Read all checkpoint files and classify each
         completed = 0
+        incomplete = 0
         errors = 0
         error_breakdown = {}
 
@@ -365,7 +374,9 @@ class StepCheckpoint:
             #   - analyze: result.verdict == "ERROR" or result.finding == "error"
             #   - verify: verification is empty or verification.correct_finding == "error"
             #   - dynamic-test: top-level status == "ERROR"
+            #   - verify adapter-raise (#286): top-level "error" key
             is_error = False
+            is_incomplete = False
             err_type = None
 
             # Enhance-style: error under the context named by ``context_key``
@@ -385,28 +396,49 @@ class StepCheckpoint:
                     is_error = True
                     err_type = "analysis_error"
 
-            # Verify-style: verification empty or correct_finding == "error"
+            # Verify-style: verification empty or correct_finding == "error";
+            # #293: a non-empty verification carrying incomplete=True (verdict
+            # present, loop never finished) is the third state
             elif "verification" in data:
                 v = data.get("verification", {})
                 if not v or v.get("correct_finding") == "error":
                     is_error = True
                     err_type = "verification_error"
+                elif v.get("incomplete"):
+                    is_incomplete = True
 
             # Dynamic-test-style: top-level status == "ERROR"
             elif data.get("status") == "ERROR":
                 is_error = True
                 err_type = "test_error"
 
+            # #286/#293: a top-level "error" key (the verify adapter-raise
+            # marker) beats every other classification — an errored verify
+            # checkpoint carries BOTH "error" and verification.incomplete.
+            if not is_error and data.get("error"):
+                is_error = True
+                is_incomplete = False
+                err_type = "error_key"
+
+            # #293: enhance-style incomplete — the agent's degenerate exit
+            # (security_classification == "incomplete") is not a completion
+            if not is_error and not is_incomplete and isinstance(enhance_ctx, dict):
+                if enhance_ctx.get("security_classification") == "incomplete":
+                    is_incomplete = True
+
             if is_error:
                 errors += 1
                 if err_type:
                     error_breakdown[err_type] = error_breakdown.get(err_type, 0) + 1
+            elif is_incomplete:
+                incomplete += 1
             else:
                 completed += 1
 
         result["completed"] = completed
+        result["incomplete"] = incomplete
         result["errors"] = errors
-        result["total_files"] = completed + errors
+        result["total_files"] = completed + incomplete + errors
         result["error_breakdown"] = error_breakdown
 
         return result

--- a/libs/openant-core/core/enhancer.py
+++ b/libs/openant-core/core/enhancer.py
@@ -173,6 +173,7 @@ def enhance_dataset(
     error_summary = {}
     context_key = "agent_context" if mode == "agentic" else "llm_context"
 
+    incomplete_count = 0
     for unit in enhanced.get("units", []):
         ctx = unit.get(context_key, {})
         if ctx.get("error"):
@@ -186,6 +187,9 @@ def enhance_dataset(
             continue
         cls = ctx.get("security_classification", "unknown")
         classifications[cls] = classifications.get(cls, 0) + 1
+        # #293: the agent's degenerate exit is not a successful enhance
+        if cls == "incomplete":
+            incomplete_count += 1
 
     # Checkpoints are preserved as a permanent artifact alongside results.
     # Final summary (phase="done") is written by context_enhancer.
@@ -204,7 +208,7 @@ def enhance_dataset(
 
     return EnhanceResult(
         enhanced_dataset_path=output_path,
-        units_enhanced=len(units) - error_count,
+        units_enhanced=len(units) - error_count - incomplete_count,
         error_count=error_count,
         error_summary=error_summary,
         classifications=classifications,

--- a/libs/openant-core/experiment.py
+++ b/libs/openant-core/experiment.py
@@ -546,6 +546,7 @@ def run_experiment(
             metrics["verifications_total"] = 0
             metrics["verifications_agreed"] = 0
             metrics["verifications_disagreed"] = 0
+            metrics["verifications_incomplete"] = 0
             metrics["consistency_updates"] = 0
 
             # Include ALL results for verification (including inconclusive and those with missing finding)
@@ -587,7 +588,14 @@ def run_experiment(
                     result["verification"] = verification.to_dict()
                     metrics["verifications_total"] += 1
 
-                    if verification.agree:
+                    # #293: three states, not two — an incomplete
+                    # verification is un-adjudicated (neither agreed nor
+                    # disagreed; the false "Changed from X to X" note is the
+                    # same bug fixed in finding_verifier._verify_one).
+                    if verification.incomplete:
+                        metrics["verifications_incomplete"] += 1
+                        print(f"    ○ INCOMPLETE: {stage1_finding} (no verdict)")
+                    elif verification.agree:
                         metrics["verifications_agreed"] += 1
                         print(f"    ✓ AGREED: {verification.correct_finding}")
                     else:
@@ -773,6 +781,7 @@ def print_summary(experiment: dict):
         print(f"  Total verified:      {metrics['verifications_total']}")
         print(f"  Agreed:              {metrics['verifications_agreed']}")
         print(f"  Disagreed:           {metrics['verifications_disagreed']}")
+        print(f"  Incomplete:          {metrics.get('verifications_incomplete', 0)}")
         if metrics.get('consistency_updates', 0) > 0:
             print(f"  Consistency updates: {metrics['consistency_updates']}")
     print()

--- a/libs/openant-core/tests/test_issue293_three_state_counters.py
+++ b/libs/openant-core/tests/test_issue293_three_state_counters.py
@@ -1,0 +1,629 @@
+"""Regression tests for issue #293 — two-branch error/else counters count
+incomplete work as completed (5 sites).
+
+The pipeline has THREE per-unit outcomes: completed (verdict reached),
+incomplete (the loop ran out / the model produced no verdict), and errored.
+Five counter sites branched on `error` vs everything-else, so the incomplete
+case fell into the `else` and was counted as completed. Runtime proof from
+the issue: a verify checkpoint summary reported 175 completed where only 41
+verifications actually produced a verdict — a 4.3x over-report; 175 + 48
+errors looked internally consistent (== 223 total) while being wrong about
+the number that matters.
+
+Contract locked here (the issue's suggested test 4):
+- `write_summary` ALWAYS emits completed / incomplete / errors, so
+  `completed + incomplete + errors == total_units` is visible and checkable;
+- an incomplete unit does NOT increment `completed` — verified end-to-end
+  through the REAL verify_batch and enhance_dataset_agentic flows (stubbed
+  model calls, real StepCheckpoint summaries on disk);
+- an incomplete verification no longer stamps the false "Changed from X to
+  X" note (Stage-1 verdict preserved == X);
+- the analyzer callback buckets `inconclusive` / `insufficient_context`
+  (stable enum findings) as incomplete, not completed — driven through the
+  REAL run_analysis closure (stubbed _run_detection) for both fresh and
+  resumed (restore-seeded) runs, and enhance's restore seeding likewise.
+
+Deliberately NOT covered here: experiment.py's harness metric
+(verifications_incomplete) — harness-only code the issue itself lists "for
+completeness, not as a product defect"; driving run_experiment's verify
+stage is disproportionate to a 3-line print-metric change.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.checkpoint import StepCheckpoint  # noqa: E402
+from utilities.agentic_enhancer.agent import INCOMPLETE_CLASSIFICATION  # noqa: E402
+from utilities.finding_verifier import FindingVerifier, VerificationResult  # noqa: E402
+from utilities.llm_client import reset_warning_state  # noqa: E402
+
+
+def _read_summary(checkpoint_dir: Path) -> dict:
+    return json.loads((Path(checkpoint_dir) / "_summary.json").read_text())
+
+
+# ---------------------------------------------------------------------------
+# write_summary — the shared emission (all five sites route through this)
+# ---------------------------------------------------------------------------
+def test_write_summary_emits_all_three_buckets(tmp_path):
+    cp = StepCheckpoint("Verify", str(tmp_path))
+    cp.write_summary(10, 4, 2, {"api": 2}, phase="done", incomplete=4)
+    s = _read_summary(cp.dir)
+    assert s["completed"] == 4
+    assert s["incomplete"] == 4
+    assert s["errors"] == 2
+    assert s["completed"] + s["incomplete"] + s["errors"] == s["total_units"]
+
+
+def test_write_summary_third_bucket_defaults_visible(tmp_path):
+    """Pre-#293 callers (dynamic_tester) omit the kwarg — the bucket still
+    appears (0), so every _summary.json has the same shape."""
+    cp = StepCheckpoint("Analyze", str(tmp_path))
+    cp.write_summary(3, 3, 0, {}, phase="done")
+    s = _read_summary(cp.dir)
+    assert s["incomplete"] == 0
+    assert s["completed"] + s["incomplete"] + s["errors"] == s["total_units"]
+
+
+# ---------------------------------------------------------------------------
+# verify_batch — the runtime-proven site, end-to-end with a real checkpoint
+# ---------------------------------------------------------------------------
+class _ScriptedVerifier(FindingVerifier):
+    """verify_result is scripted per route_key: complete / incomplete / raise."""
+
+    SCRIPT = {}
+
+    def verify_result(self, code, finding, attack_vector, reasoning,
+                      files_included=None):
+        route = getattr(self, "_current_route", "r:complete")
+        behavior = self.SCRIPT[route]
+        if behavior == "raise":
+            raise RuntimeError("api exploded")
+        if behavior == "incomplete":
+            return VerificationResult(
+                agree=False, correct_finding=finding, explanation="Max iterations reached",
+                iterations=20, total_tokens=10, incomplete=True)
+        return VerificationResult(
+            agree=True, correct_finding=finding, explanation="ok",
+            iterations=3, total_tokens=10)
+
+
+def _verify_binding(tmp_path):
+    from utilities.agentic_enhancer.repository_index import RepositoryIndex
+    from utilities.llm import PhaseBinding
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    binding = PhaseBinding(phase="verify", adapter=_Adapter(), model="m",
+                           provider_name="anthropic")
+    return binding, RepositoryIndex({}, repo_path=None)
+
+
+def test_verify_batch_three_bucket_summary(tmp_path, monkeypatch):
+    reset_warning_state()
+    _ScriptedVerifier.SCRIPT = {
+        "r:complete": "complete",
+        "r:incomplete": "incomplete",
+        "r:error": "raise",
+    }
+    # _verify_one looks the route up in code_by_route; stamp the current
+    # route onto the instance via a wrapper around verify_result is not
+    # possible (single method) — key the script off the code argument, which
+    # verify_batch passes from code_by_route per unit.
+    orig = _ScriptedVerifier.verify_result
+
+    def keyed(self, code, finding, attack_vector, reasoning, files_included=None):
+        self._current_route = code
+        return orig(self, code, finding, attack_vector, reasoning, files_included)
+
+    monkeypatch.setattr(_ScriptedVerifier, "verify_result", keyed)
+
+    results = [
+        {"route_key": "r:complete", "finding": "vulnerable",
+         "attack_vector": "a", "reasoning": "r"},
+        {"route_key": "r:incomplete", "finding": "vulnerable",
+         "attack_vector": "a", "reasoning": "r"},
+        {"route_key": "r:error", "finding": "vulnerable",
+         "attack_vector": "a", "reasoning": "r"},
+    ]
+    code_by_route = {r["route_key"]: r["route_key"] for r in results}
+    binding, index = _verify_binding(tmp_path)
+    verifier = _ScriptedVerifier(index=index, binding=binding)
+
+    cp_dir = tmp_path / "verify_checkpoints"
+    cp = StepCheckpoint("Verify", str(tmp_path))
+    cp.dir = str(cp_dir)
+    verifier.verify_batch(results, code_by_route, workers=1, checkpoint=cp)
+    reset_warning_state()
+
+    s = _read_summary(cp_dir)
+    assert s["phase"] == "done"
+    assert s["total_units"] == 3
+    assert s["completed"] == 1, "incomplete must not count as completed"
+    assert s["incomplete"] == 1
+    assert s["errors"] == 1
+    assert s["completed"] + s["incomplete"] + s["errors"] == s["total_units"]
+
+    # the incomplete unit keeps its Stage-1 verdict and a truthful note
+    inc = results[1]
+    assert inc["finding"] == "vulnerable"
+    assert "incomplete" in inc.get("verification_note", "").lower()
+    assert "Changed from" not in inc.get("verification_note", "")
+
+
+def test_verify_restore_counts_incomplete_not_completed(tmp_path, monkeypatch):
+    """A resumed run restores an INCOMPLETE checkpoint (verdict present) —
+    the seeded summary must put it in the third bucket, not completed."""
+    reset_warning_state()
+    cp_dir = tmp_path / "verify_checkpoints"
+    cp_dir.mkdir()
+    # pre-existing checkpoint: incomplete verification WITH a verdict
+    (cp_dir / "u1.json").write_text(json.dumps({
+        "id": "u1",
+        "verification": {"incomplete": True, "correct_finding": "vulnerable"},
+        "finding": "vulnerable",
+    }))
+    # and a completed one
+    (cp_dir / "u2.json").write_text(json.dumps({
+        "id": "u2",
+        "verification": {"agree": True, "correct_finding": "safe"},
+        "finding": "safe",
+    }))
+
+    results = [
+        {"route_key": "u1", "finding": "vulnerable", "attack_vector": "a",
+         "reasoning": "r"},
+        {"route_key": "u2", "finding": "safe", "attack_vector": "a",
+         "reasoning": "r"},
+    ]
+    binding, index = _verify_binding(tmp_path)
+    verifier = FindingVerifier(index=index, binding=binding)
+
+    def _no_new_work(self, code, finding, attack_vector, reasoning,
+                     files_included=None):
+        raise AssertionError("restored units must not be re-verified")
+
+    monkeypatch.setattr(FindingVerifier, "verify_result", _no_new_work)
+    cp = StepCheckpoint("Verify", str(tmp_path))
+    cp.dir = str(cp_dir)
+    verifier.verify_batch(results, {"u1": "c", "u2": "c"}, workers=1,
+                          checkpoint=cp)
+    reset_warning_state()
+
+    s = _read_summary(cp_dir)
+    assert s["total_units"] == 2
+    assert s["completed"] == 1
+    assert s["incomplete"] == 1
+    assert s["errors"] == 0
+
+
+# ---------------------------------------------------------------------------
+# enhance — end-to-end with the real _update_summary closure
+# ---------------------------------------------------------------------------
+def test_enhance_three_bucket_summary(tmp_path, monkeypatch):
+    reset_warning_state()
+    import utilities.context_enhancer as ce
+
+    def fake_enhance(unit, index, binding, tracker, verbose):
+        cls = unit["_scripted"]
+        if cls == "error":
+            raise RuntimeError("enhance exploded")
+        unit["agent_context"] = {
+            "security_classification": cls,
+            "agent_metadata": {"input_tokens": 1, "output_tokens": 1,
+                               "cost_usd": 0.0},
+        }
+
+    monkeypatch.setattr(ce, "enhance_unit_with_agent", fake_enhance)
+
+    from utilities.llm import PhaseBinding
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    binding = PhaseBinding(phase="enhance", adapter=_Adapter(), model="m",
+                           provider_name="anthropic")
+    enhancer = ce.ContextEnhancer(binding=binding)
+
+    analyzer_out = tmp_path / "a.json"
+    analyzer_out.write_text(json.dumps({"results": []}))
+    dataset = {"units": [
+        {"id": "u1", "code": "x=1", "_scripted": "safe"},
+        {"id": "u2", "code": "x=1", "_scripted": INCOMPLETE_CLASSIFICATION},
+        {"id": "u3", "code": "x=1", "_scripted": "error"},
+    ]}
+    cp_dir = tmp_path / "enhance_checkpoints"
+    enhancer.enhance_dataset_agentic(
+        dataset, analyzer_output_path=str(analyzer_out),
+        repo_path=None, workers=1, checkpoint_path=str(cp_dir))
+    reset_warning_state()
+
+    s = _read_summary(cp_dir)
+    assert s["total_units"] == 3
+    assert s["completed"] == 1, "INCOMPLETE_CLASSIFICATION is not a completion"
+    assert s["incomplete"] == 1
+    assert s["errors"] == 1
+    assert s["completed"] + s["incomplete"] + s["errors"] == s["total_units"]
+
+
+# ---------------------------------------------------------------------------
+# analyzer — the REAL run_analysis callback + restore loop, driven with a
+# stubbed _run_detection that emits the three states through the callback
+# run_analysis itself constructs (the closure under test).
+# ---------------------------------------------------------------------------
+def test_analyzer_run_analysis_three_bucket_summary(tmp_path, monkeypatch):
+    reset_warning_state()
+    import core.analyzer as analyzer_mod
+
+    dataset_path = tmp_path / "dataset.json"
+    dataset_path.write_text(json.dumps({"units": [
+        {"id": "a1", "code": "x=1"},
+        {"id": "a2", "code": "x=1"},
+        {"id": "a3", "code": "x=1"},
+    ]}))
+    output_dir = tmp_path / "out"
+
+    # #293 adjudication: "inconclusive" is a first-class COMPLETED verdict
+    # (verdict_taxonomy FINDING_VERDICT_ORDER; the Stage-1 prompt's enum) —
+    # the analyzer has no third state.
+    findings_sequence = ["vulnerable", "inconclusive", "error"]
+
+    def fake_run_detection(units, binding, json_corrector, app_context,
+                            workers, checkpoint=None, summary_callback=None):
+        # emit the three per-unit states through the REAL closure
+        for f in findings_sequence:
+            summary_callback(f, usage={"input_tokens": 1,
+                                       "output_tokens": 1, "cost_usd": 0.0})
+        results = [
+            {"unit_id": u["id"], "finding": f, "verdict": f.upper(),
+             "confidence": 90, "vulnerabilities": [], "reasoning": "r"}
+            for u, f in zip(units, findings_sequence)
+        ]
+        return results, {r["unit_id"]: "code" for r in results}
+
+    monkeypatch.setattr(analyzer_mod, "_run_detection", fake_run_detection)
+    monkeypatch.setattr(analyzer_mod, "_analyze_fingerprint",
+                        lambda binding: {"key_digest": "sha256:test"})
+
+    from utilities.llm import PhaseBinding
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_Adapter(), model="m",
+                                provider_name="anthropic")
+
+    analyzer_mod.run_analysis(
+        str(dataset_path), str(output_dir),
+        registry=_FakeRegistry(), workers=1)
+    reset_warning_state()
+
+    s = _read_summary(output_dir / "analyze_checkpoints")
+    assert s["phase"] == "done"
+    assert s["total_units"] == 3
+    assert s["completed"] == 2, "inconclusive IS a completed verdict (taxonomy)"
+    assert s["incomplete"] == 0
+    assert s["errors"] == 1
+    assert s["completed"] + s["incomplete"] + s["errors"] == s["total_units"]
+
+
+def test_analyzer_restore_counts_inconclusive_completed(tmp_path, monkeypatch):
+    """A resumed analyze run seeds its counters from existing checkpoints —
+    a restored inconclusive result seeds COMPLETED (taxonomy adjudication:
+    inconclusive is a verdict, not a degenerate no-verdict state)."""
+    reset_warning_state()
+    import core.analyzer as analyzer_mod
+
+    dataset_path = tmp_path / "dataset.json"
+    dataset_path.write_text(json.dumps({"units": [
+        {"id": "r1", "code": "x=1"},
+        {"id": "r2", "code": "x=1"},
+    ]}))
+    output_dir = tmp_path / "out"
+    cp_dir = output_dir / "analyze_checkpoints"
+    cp_dir.mkdir(parents=True)
+    # pre-existing checkpoints: one completed, one inconclusive
+    (cp_dir / "r1.json").write_text(json.dumps({
+        "id": "r1", "result": {"finding": "safe", "verdict": "SAFE"},
+        "usage": {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0},
+    }))
+    (cp_dir / "r2.json").write_text(json.dumps({
+        "id": "r2", "result": {"finding": "inconclusive",
+                               "verdict": "INCONCLUSIVE"},
+        "usage": {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0},
+    }))
+
+    def fake_run_detection(units, binding, json_corrector, app_context,
+                            workers, checkpoint=None, summary_callback=None):
+        # both units restored — the callback must NOT fire for them
+        return [{"unit_id": u["id"], "finding": "safe", "verdict": "SAFE",
+                 "confidence": 90, "vulnerabilities": [], "reasoning": "r"}
+                for u in units], {}
+
+    monkeypatch.setattr(analyzer_mod, "_run_detection", fake_run_detection)
+    monkeypatch.setattr(analyzer_mod, "_analyze_fingerprint",
+                        lambda binding: {"key_digest": "sha256:test"})
+
+    from utilities.llm import PhaseBinding
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_Adapter(), model="m",
+                                provider_name="anthropic")
+
+    analyzer_mod.run_analysis(
+        str(dataset_path), str(output_dir),
+        registry=_FakeRegistry(), workers=1)
+    reset_warning_state()
+
+    s = _read_summary(cp_dir)
+    assert s["total_units"] == 2
+    assert s["completed"] == 2, "restored inconclusive counts completed"
+    assert s["incomplete"] == 0
+    assert s["errors"] == 0
+
+
+def test_enhance_restore_buckets_incomplete(tmp_path, monkeypatch):
+    """A resumed enhance run seeds its counters from restored agent_context
+    — a restored INCOMPLETE_CLASSIFICATION unit seeds bucket 3."""
+    reset_warning_state()
+    import utilities.context_enhancer as ce
+
+    def _no_new_work(unit, index, binding, tracker, verbose):
+        raise AssertionError("restored units must not be re-enhanced")
+
+    monkeypatch.setattr(ce, "enhance_unit_with_agent", _no_new_work)
+
+    from utilities.llm import PhaseBinding
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    binding = PhaseBinding(phase="enhance", adapter=_Adapter(), model="m",
+                           provider_name="anthropic")
+    enhancer = ce.ContextEnhancer(binding=binding)
+
+    dataset = {"units": [
+        {"id": "e1", "code": "x=1"},
+        {"id": "e2", "code": "x=1"},
+    ]}
+    cp_dir = tmp_path / "enhance_checkpoints"
+    cp_dir.mkdir()
+    # checkpoint files keyed by id; _load_completed_units counts them
+    # completed when agent_context present with no error
+    (cp_dir / "e1.json").write_text(json.dumps({
+        "id": "e1",
+        "agent_context": {"security_classification": "safe"},
+    }))
+    (cp_dir / "e2.json").write_text(json.dumps({
+        "id": "e2",
+        "agent_context": {"security_classification":
+                          INCOMPLETE_CLASSIFICATION},
+    }))
+
+    analyzer_out = tmp_path / "a.json"
+    analyzer_out.write_text(json.dumps({"results": []}))
+    enhancer.enhance_dataset_agentic(
+        dataset, analyzer_output_path=str(analyzer_out),
+        repo_path=None, workers=1, checkpoint_path=str(cp_dir))
+    reset_warning_state()
+
+    s = _read_summary(cp_dir)
+    assert s["total_units"] == 2
+    assert s["completed"] == 1
+    assert s["incomplete"] == 1, "restored INCOMPLETE seeds bucket 3"
+    assert s["errors"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Wave catches (adjudicated): the severity-upgrade fail-safe, status(), the
+# enhance retry flip, and units_enhanced.
+# ---------------------------------------------------------------------------
+def test_incomplete_preserves_severity_upgrade_fail_safe(tmp_path, monkeypatch):
+    """FAM-REPORT-2: the self-contradictory-finish path returns
+    incomplete=True with correct_finding = the MORE-SEVERE verdict. The
+    incomplete branch must propagate it — not propagating silently drops
+    the upgraded vuln at the reporter's disclosure filter."""
+    reset_warning_state()
+
+    class _UpgradeVerifier(FindingVerifier):
+        def verify_result(self, code, finding, attack_vector, reasoning,
+                          files_included=None):
+            return VerificationResult(
+                agree=False, correct_finding="vulnerable",
+                explanation="self-contradictory finish",
+                iterations=5, total_tokens=10, incomplete=True)
+
+    from utilities.agentic_enhancer.repository_index import RepositoryIndex
+    from utilities.llm import PhaseBinding
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    binding = PhaseBinding(phase="verify", adapter=_Adapter(), model="m",
+                           provider_name="anthropic")
+    verifier = _UpgradeVerifier(index=RepositoryIndex({}, repo_path=None),
+                                binding=binding)
+    result = {"route_key": "r:up", "finding": "safe", "attack_vector": "a",
+              "reasoning": "r"}
+    out = verifier._verify_one(result, {"r:up": "code"})
+    reset_warning_state()
+    assert out[1].startswith("incomplete:")
+    assert result["finding"] == "vulnerable", (
+        "the upgraded (more severe) verdict must propagate on incomplete")
+    assert "Changed from" not in result.get("verification_note", "")
+
+
+def test_status_classifies_three_states(tmp_path):
+    """StepCheckpoint.status() — the Go CLI resume path's single source of
+    truth — must classify incomplete checkpoints into the third bucket, not
+    completed (the issue's 175-of-223 headline number surfaces exactly
+    here, in the resume prompt)."""
+    from core.checkpoint import StepCheckpoint as SC
+
+    d = tmp_path / "verify_checkpoints"
+    d.mkdir()
+    (d / "c1.json").write_text(json.dumps({
+        "id": "c1",
+        "verification": {"agree": True, "correct_finding": "vulnerable"},
+        "finding": "vulnerable"}))
+    (d / "i1.json").write_text(json.dumps({
+        "id": "i1",
+        "verification": {"incomplete": True, "correct_finding": "vulnerable"},
+        "finding": "vulnerable"}))
+    (d / "e1.json").write_text(json.dumps({
+        "id": "e1",
+        "verification": {"incomplete": True},
+        "error": "RuntimeError: api exploded"}))
+    st = SC.status(str(d))
+    assert st["completed"] == 1
+    assert st["incomplete"] == 1
+    assert st["errors"] == 1
+    assert st["total_files"] == 3
+
+
+def test_status_enhance_style_incomplete(tmp_path):
+    from core.checkpoint import StepCheckpoint as SC
+
+    d = tmp_path / "enhance_checkpoints"
+    d.mkdir()
+    (d / "h1.json").write_text(json.dumps({
+        "id": "h1", "agent_context": {"security_classification": "safe"}}))
+    (d / "h2.json").write_text(json.dumps({
+        "id": "h2", "agent_context": {"security_classification": "incomplete"}}))
+    st = SC.status(str(d))
+    assert st["completed"] == 1
+    assert st["incomplete"] == 1
+    assert st["errors"] == 0
+
+
+def test_enhance_retry_landing_incomplete_counts_incomplete(tmp_path, monkeypatch):
+    """The auto-retry loop: a retried unit that lands on the agent's
+    degenerate exit flips its error into the incomplete bucket, not
+    completed (wave catch #4)."""
+    reset_warning_state()
+    import utilities.context_enhancer as ce
+    from utilities.llm import LLMRateLimitError
+
+    calls = {"n": 0}
+
+    def flaky_then_incomplete(unit, index, binding, tracker, verbose):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # rate_limit is retryable on BOTH is_retryable_error branches
+            # (this test pins the retry-loop BUCKETING, not #292's
+            # empty-completion dict classification)
+            raise LLMRateLimitError("rate limited", retry_after=0)
+        unit["agent_context"] = {
+            "security_classification": INCOMPLETE_CLASSIFICATION,
+            "agent_metadata": {"input_tokens": 1, "output_tokens": 1,
+                               "cost_usd": 0.0},
+        }
+
+    monkeypatch.setattr(ce, "enhance_unit_with_agent", flaky_then_incomplete)
+
+    from utilities.llm import PhaseBinding
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    binding = PhaseBinding(phase="enhance", adapter=_Adapter(), model="m",
+                           provider_name="anthropic")
+    enhancer = ce.ContextEnhancer(binding=binding)
+
+    analyzer_out = tmp_path / "a.json"
+    analyzer_out.write_text(json.dumps({"results": []}))
+    dataset = {"units": [{"id": "f1", "code": "x=1"}]}
+    cp_dir = tmp_path / "enhance_checkpoints"
+    enhancer.enhance_dataset_agentic(
+        dataset, analyzer_output_path=str(analyzer_out),
+        repo_path=None, workers=1, checkpoint_path=str(cp_dir))
+    reset_warning_state()
+
+    s = _read_summary(cp_dir)
+    assert s["total_units"] == 1
+    assert s["completed"] == 0, "retry landing on incomplete is not completed"
+    assert s["incomplete"] == 1
+    assert s["errors"] == 0, "the error flipped out on successful retry"
+    assert calls["n"] == 2, "the retryable error must have been retried"
+
+
+def test_units_enhanced_excludes_incomplete(tmp_path, monkeypatch):
+    """core/enhancer's EnhanceResult.units_enhanced must not count the
+    agent's degenerate exits as enhanced (wave catch #5) — driven through
+    the REAL enhance_dataset tail with the agentic loop stubbed."""
+    import core.enhancer as enh_mod
+
+    def fake_agentic(self, dataset, analyzer_output_path, repo_path=None,
+                     batch_size=5, verbose=False, checkpoint_path=None,
+                     progress_callback=None, restored_callback=None,
+                     workers=10, phase_baseline=None):
+        dataset["units"] = [
+            {"id": "u1", "agent_context": {"security_classification": "safe"}},
+            {"id": "u2", "agent_context": {"security_classification":
+                                           INCOMPLETE_CLASSIFICATION}},
+            {"id": "u3", "agent_context": {"security_classification": "safe",
+                                           "error": {"type": "api"}}},
+        ]
+        return dataset
+
+    monkeypatch.setattr(
+        "utilities.context_enhancer.ContextEnhancer.enhance_dataset_agentic",
+        fake_agentic)
+
+    from utilities.llm import PhaseBinding
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_Adapter(), model="m",
+                                provider_name="anthropic")
+
+    dataset_path = tmp_path / "dataset.json"
+    dataset_path.write_text(json.dumps({"units": [
+        {"id": "u1", "code": "x"}, {"id": "u2", "code": "x"},
+        {"id": "u3", "code": "x"},
+    ]}))
+    analyzer_out = tmp_path / "a.json"
+    analyzer_out.write_text(json.dumps({"results": []}))
+    output_path = tmp_path / "enhanced.json"
+
+    result = enh_mod.enhance_dataset(
+        str(dataset_path), str(output_path),
+        analyzer_output_path=str(analyzer_out), repo_path=str(tmp_path),
+        mode="agentic", workers=1, registry=_FakeRegistry())
+    assert result.units_enhanced == 1, (
+        "1 of 3 units was genuinely enhanced (1 error, 1 incomplete)")
+    assert result.error_count == 1
+    assert result.classifications.get(INCOMPLETE_CLASSIFICATION) == 1

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -634,7 +634,15 @@ class ContextEnhancer:
         # Initialize summary tracking for _summary.json
         # Counts are updated in the main thread (as_completed loop) — no lock needed.
         _summary_cp = None
-        _summary_completed = len(processed_ids)
+        # #293: restored INCOMPLETE units (agent degenerate exit) are restored
+        # work but not completions — seed the third bucket, not completed.
+        _restored_incomplete = sum(
+            1 for u in units
+            if u.get("id") in processed_ids
+            and (u.get("agent_context", {}) or {}).get("security_classification")
+                == INCOMPLETE_CLASSIFICATION)
+        _summary_completed = len(processed_ids) - _restored_incomplete
+        _summary_incomplete = _restored_incomplete
         _summary_errors = 0
         _summary_error_breakdown = {}
         _summary_input_tokens = 0
@@ -674,6 +682,7 @@ class ContextEnhancer:
 
             _summary_cp.write_summary(total, _summary_completed, _summary_errors,
                                       _summary_error_breakdown, phase="in_progress",
+                                      incomplete=_summary_incomplete,
                                       usage={"input_tokens": _summary_input_tokens,
                                              "output_tokens": _summary_output_tokens,
                                              "cost_usd": round(_summary_cost_usd, 6)})
@@ -753,7 +762,8 @@ class ContextEnhancer:
 
         def _update_summary(classification, unit):
             """Update summary counters after a unit completes. Called from main thread."""
-            nonlocal _summary_completed, _summary_errors, _summary_error_breakdown
+            nonlocal _summary_completed, _summary_incomplete, _summary_errors
+            nonlocal _summary_error_breakdown
             nonlocal _summary_input_tokens, _summary_output_tokens, _summary_cost_usd
             if _summary_cp is None:
                 return
@@ -762,6 +772,10 @@ class ContextEnhancer:
                 err = unit.get("agent_context", {}).get("error", {})
                 err_type = err.get("type", "unknown") if isinstance(err, dict) else "unknown"
                 _summary_error_breakdown[err_type] = _summary_error_breakdown.get(err_type, 0) + 1
+            elif classification == INCOMPLETE_CLASSIFICATION:
+                # #293: the agent's degenerate exit (no completed finish call)
+                # is the third state — not a completion, not an error.
+                _summary_incomplete += 1
             else:
                 _summary_completed += 1
             # Accumulate per-unit usage
@@ -778,7 +792,7 @@ class ContextEnhancer:
                 _usage["unpriced_models"] = sorted(_summary_unpriced)
             _summary_cp.write_summary(total, _summary_completed, _summary_errors,
                                       _summary_error_breakdown, phase="in_progress",
-                                      usage=_usage)
+                                      usage=_usage, incomplete=_summary_incomplete)
 
         if workers <= 1:
             # Sequential mode
@@ -844,8 +858,14 @@ class ContextEnhancer:
                 unit["agent_context"] = {}
                 uid, classification, elapsed, _ = _enhance_one(unit)
 
-                # Update summary: retry succeeded → flip error to completed
-                if classification != "error":
+                # Update summary: retry produced an outcome → flip the error
+                # to completed OR incomplete (#293: a retried unit can land
+                # on the agent's degenerate exit, which is not a completion)
+                if classification == INCOMPLETE_CLASSIFICATION:
+                    round_recovered += 1
+                    _summary_errors = max(0, _summary_errors - 1)
+                    _summary_incomplete += 1
+                elif classification != "error":
                     round_recovered += 1
                     _summary_errors = max(0, _summary_errors - 1)
                     _summary_completed += 1
@@ -859,6 +879,7 @@ class ContextEnhancer:
                 if _summary_cp is not None:
                     _summary_cp.write_summary(total, _summary_completed, _summary_errors,
                                               _summary_error_breakdown, phase="in_progress",
+                                              incomplete=_summary_incomplete,
                                               usage={"input_tokens": _summary_input_tokens,
                                                      "output_tokens": _summary_output_tokens,
                                                      "cost_usd": round(_summary_cost_usd, 6)})
@@ -879,6 +900,7 @@ class ContextEnhancer:
         if _summary_cp is not None:
             _summary_cp.write_summary(total, _summary_completed, _summary_errors,
                                       _summary_error_breakdown, phase="done",
+                                      incomplete=_summary_incomplete,
                                       usage={"input_tokens": _summary_input_tokens,
                                              "output_tokens": _summary_output_tokens,
                                              "cost_usd": round(_summary_cost_usd, 6)})

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -663,6 +663,7 @@ class FindingVerifier:
         # Separate already-done (successful) from to-do (new + errored)
         results_to_verify = []
         _restored_ok = 0
+        _restored_incomplete = 0
         for r in results:
             key = r.get("unit_id") or r.get("route_key", "unknown")
             cp_data = checkpointed.get(key)
@@ -674,23 +675,31 @@ class FindingVerifier:
                     r["finding"] = cp_data["finding"]
                 if "verification_note" in cp_data:
                     r["verification_note"] = cp_data["verification_note"]
-                _restored_ok += 1
+                # #293: a restored INCOMPLETE checkpoint (verdict present but
+                # incomplete) is restored work, but not a completion — seed
+                # the third bucket so the summary never counts it completed.
+                _ver = cp_data.get("verification", {})
+                if isinstance(_ver, dict) and _ver.get("incomplete"):
+                    _restored_incomplete += 1
+                else:
+                    _restored_ok += 1
             else:
                 # Either no checkpoint, or an errored one — re-verify
                 results_to_verify.append(r)
 
-        if _restored_ok:
-            print(f"[Verify] Restored {_restored_ok} findings from checkpoints",
-                  file=sys.stderr, flush=True)
+        if _restored_ok or _restored_incomplete:
+            print(f"[Verify] Restored {_restored_ok + _restored_incomplete} findings "
+                  f"from checkpoints", file=sys.stderr, flush=True)
             if restored_callback:
-                restored_callback(_restored_ok)
-        errored_retries = len(checkpointed) - _restored_ok
+                restored_callback(_restored_ok + _restored_incomplete)
+        errored_retries = len(checkpointed) - _restored_ok - _restored_incomplete
         if errored_retries:
             print(f"[Verify] Retrying {errored_retries} previously errored findings",
                   file=sys.stderr, flush=True)
 
         # Initialize summary tracking for _summary.json
         _summary_completed = _restored_ok
+        _summary_incomplete = _restored_incomplete
         _summary_errors = 0
         _summary_error_breakdown = {}
         _summary_input_tokens = 0
@@ -732,15 +741,21 @@ class FindingVerifier:
         if checkpoint is not None:
             checkpoint.write_summary(total, _summary_completed, _summary_errors,
                                      _summary_error_breakdown, phase="in_progress",
-                                     usage=_usage_dict())
+                                     usage=_usage_dict(), incomplete=_summary_incomplete)
 
         def _summary_callback(detail, usage=None):
             """Update summary counters after each unit. Called from main thread."""
-            nonlocal _summary_completed, _summary_errors, _summary_error_breakdown
+            nonlocal _summary_completed, _summary_incomplete, _summary_errors
+            nonlocal _summary_error_breakdown
             nonlocal _summary_input_tokens, _summary_output_tokens, _summary_cost_usd
             if detail == "error":
                 _summary_errors += 1
                 _summary_error_breakdown["api"] = _summary_error_breakdown.get("api", 0) + 1
+            elif detail.startswith("incomplete"):
+                # #293: the third state — the loop never reached a verdict.
+                # _verify_one tags incomplete units "incomplete:<finding>"
+                # (our own deterministic prefix, not model text).
+                _summary_incomplete += 1
             else:
                 _summary_completed += 1
             if usage:
@@ -750,7 +765,7 @@ class FindingVerifier:
             if checkpoint is not None:
                 checkpoint.write_summary(total, _summary_completed, _summary_errors,
                                          _summary_error_breakdown, phase="in_progress",
-                                         usage=_usage_dict())
+                                         usage=_usage_dict(), incomplete=_summary_incomplete)
 
         remaining = len(results_to_verify)
         mode = "sequential" if workers <= 1 else f"parallel ({workers} workers)"
@@ -770,7 +785,7 @@ class FindingVerifier:
         if checkpoint is not None:
             checkpoint.write_summary(total, _summary_completed, _summary_errors,
                                      _summary_error_breakdown, phase="done",
-                                     usage=_usage_dict())
+                                     usage=_usage_dict(), incomplete=_summary_incomplete)
 
         # Step 2: Consistency cross-check (barrier — needs all results)
         results = self._check_consistency(results, code_by_route)
@@ -801,7 +816,28 @@ class FindingVerifier:
 
             result["verification"] = verification.to_dict()
 
-            if verification.agree:
+            # #293: an INCOMPLETE verification (the loop never reached a
+            # verdict) is neither a completion nor a disagreement — it is
+            # un-adjudicated. Before this branch it fell into the disagreed
+            # else: counted as a completion by the summary callback AND
+            # stamped with the false "Changed from X to X" note (Stage-1
+            # verdict is preserved in incomplete results, so X == X).
+            if verification.incomplete:
+                # FAM-REPORT-2 (wave catch): the self-contradictory-finish
+                # path returns incomplete=True with correct_finding set to
+                # the MORE-SEVERE verdict — propagate it or the upgraded
+                # vuln is silently dropped at the reporter's disclosure
+                # filter. For the ordinary incomplete paths correct_finding
+                # IS the Stage-1 verdict, so this is a no-op there.
+                result["finding"] = verification.correct_finding
+                detail = f"incomplete:{verification.correct_finding}"
+                result["verification_note"] = (
+                    f"Verification incomplete: {verification.explanation}"
+                    if verification.explanation else "Verification incomplete")
+                self._log("info", f"Verification incomplete: {stage1_finding}",
+                          unit_id=route_key, total_tokens=verification.total_tokens,
+                          iterations=verification.iterations)
+            elif verification.agree:
                 detail = f"agreed:{verification.correct_finding}"
                 self._log("info", f"Verification agreed: {verification.correct_finding}",
                           unit_id=route_key, total_tokens=verification.total_tokens,


### PR DESCRIPTION
## Summary

Five counter sites branced on `error` vs everything-else, so INCOMPLETE work counted as COMPLETED: a verify checkpoint summary reported **175 completed where 41 verifications produced a verdict** (134 incomplete folded in; `175+48=223` looked internally consistent while the number that matters was 4.3x over-reported).

The pipeline has three per-unit states: completed (verdict reached), incomplete (the loop ran out / degenerate exit), errored. Fixed sites:
- **finding_verifier**: `_verify_one` branches three-way on `verification.incomplete` (truthful note; no false "Changed from X to X"); the summary callback has a third bucket; restored-incomplete checkpoints seed it (resume arithmetic unchanged); **the FAM-REPORT-2 severity-upgrade fail-safe PROPAGATES `correct_finding` on the incomplete path** (wave catch: not propagating silently dropped an upgraded vuln at the disclosure filter).
- **context_enhancer**: `_update_summary` buckets `INCOMPLETE_CLASSIFICATION`; restored-incomplete units seed it; the auto-retry loop flips an error into the incomplete bucket when a retry lands on the degenerate exit (wave catch).
- **`StepCheckpoint.write_summary`** ALWAYS emits `completed` / `incomplete` / `errors` — `completed + incomplete + errors == total_units`, all three visible.
- **`StepCheckpoint.status()`** — the Go CLI resume path's source of truth — classifies verify/enhance incomplete checkpoints into the third bucket and honors the #286 top-level `error` key (which it previously missed, counting errored verify checkpoints completed); Go `Summary`/`Info` structs pair the schema and the resume prompt shows the third bucket when nonzero (wave catch).
- **core/enhancer**: `units_enhanced` excludes incomplete.
- **experiment.py** harness: `verifications_incomplete` metric (the issue lists this site "for completeness, not as a product defect").

**Adjudicated deviation (wave BLOCKER, accepted after re-derivation):** `inconclusive` is **NOT** bucketed as incomplete. It is a first-class COMPLETED verdict — `verdict_taxonomy.FINDING_VERDICT_ORDER`, the Stage-1 prompt's own enum (`safe|protected|vulnerable|inconclusive`), the #289/PR #381 results partition, and experiment.py's ground-truth metrics all treat it so. The issue's analyzer row conflated a deliberate "I analyzed it and am unsure" answer with the degenerate no-verdict state; analyze has no third state. (Deviation documented for override if you disagree.)

**Wave:** a 4-seat proportionate wave ran (per campaign rule 16 — this diff exceeds the small-diff skip criterion); findings: 3 BLOCKER + 2 MAJOR + 2 MINOR, all adjudicated in-code before acceptance (one resolved by reverting my first implementation — the analyzer classification above).

The private-run figures (175/41/134/48) quoted from the issue are provenance-labeled there; the code defects and the fix contract are fully checkable and test-covered.

## Test plan

13 hermetic tests: `write_summary` always emits all three buckets (unit); verify e2e 3-bucket + truthful note + Stage-1 preservation + severity-upgrade propagation; verify restore seeds the third bucket; enhance e2e + restore + retry-landing-incomplete; `status()` three-state classification (verify + enhance styles, including the #286 error-key precedence); `units_enhanced` exclusion (real `enhance_dataset` tail); analyzer two-state contract (inconclusive counts completed, fresh + restore).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue293_three_state_counters.py -q` | 13 passed |
| mutation smoke | production stashed → same file | 13 failed; restored → 13 passed |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest <file>` | 13 passed |
| full suite | `pytest tests/ -q` | 3175 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |
| Go | `go build ./...` + `go vet ./internal/checkpoint/` + `gofmt` (touched file) | clean |

</details>

Fixes #293
