### PR TITLE
fix(llm-reach): batch-parse drops are diagnosable — shape named, batch labeled, evidence retained, loss counted

### DIFF
--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -207,6 +207,44 @@ _VALID_KINDS = {"entry_point", "external_input", "cross_process"}
 _VALID_CONFIDENCES = {"high", "medium", "low"}
 
 
+def _strip_fence(text: str) -> str:
+    """Strip a leading ```json ... ``` (or bare ``` ... ```) fence."""
+    fence = re.match(
+        r"^```(?:json)?\s*(?P<body>.*?)\s*```\s*$",
+        text,
+        re.DOTALL | re.IGNORECASE,
+    )
+    if fence:
+        return fence.group("body").strip()
+    return text
+
+
+def _classify_malformed(response_text: str) -> str:
+    """#294: name the failure SHAPE.
+
+    Six materially different failures — a bare array (the model answered,
+    wrong shape), a truncation (budget/transport), a prose refusal (policy),
+    an empty completion (adapter empty-content), fenced variants, and valid
+    JSON of a non-object type — previously produced one byte-identical log
+    line, so a completed run could not be diagnosed even in principle.
+    """
+    if not response_text or not response_text.strip():
+        return "empty response (no content)"
+    cleaned = _strip_fence(response_text.strip())
+    try:
+        value = json.loads(cleaned)
+    except json.JSONDecodeError:
+        # Heuristic with a known blind spot (wave catch): prose that merely
+        # MENTIONS a brace ("I can't return `{}` for this") lands here as
+        # "truncated" — a diagnostic label only, never behavior-affecting.
+        if "{" in cleaned or "[" in cleaned:
+            return "truncated or unbalanced JSON"
+        return "non-JSON text (prose/refusal)"
+    if isinstance(value, list):
+        return "valid JSON array, expected an object"
+    return f"valid JSON of wrong type {type(value).__name__}, expected an object"
+
+
 def _extract_json(text: str) -> Optional[Dict[str, Any]]:
     """Best-effort JSON extraction from a model response.
 
@@ -215,16 +253,7 @@ def _extract_json(text: str) -> Optional[Dict[str, Any]]:
     """
     if not text:
         return None
-    cleaned = text.strip()
-
-    # Strip ```json ... ``` or ``` ... ``` fences.
-    fence = re.match(
-        r"^```(?:json)?\s*(?P<body>.*?)\s*```\s*$",
-        cleaned,
-        re.DOTALL | re.IGNORECASE,
-    )
-    if fence:
-        cleaned = fence.group("body").strip()
+    cleaned = _strip_fence(text.strip())
 
     try:
         return json.loads(cleaned)
@@ -247,23 +276,41 @@ def parse_response(
     response_text: str,
     valid_unit_ids: Optional[set] = None,
     on_error: Optional[Callable[[str], None]] = None,
+    batch_label: Optional[str] = None,
+    on_batch_drop: Optional[Callable[[], None]] = None,
 ) -> List[ReachabilitySignal]:
     """Parse a single LLM response into validated ``ReachabilitySignal``s.
 
     Malformed entries are skipped (not raised); the optional ``on_error``
     callback receives a one-line description per skipped item, useful for
     logging.
+
+    #294: a batch-level drop names its failure SHAPE (see
+    :func:`_classify_malformed`), carries the caller-supplied
+    ``batch_label`` and a truncated raw snippet (the evidence — the raw
+    response was previously discarded entirely), and fires ``on_batch_drop``
+    once so the caller can count the loss.
     """
     log = on_error or (lambda msg: print(f"[LLMReach] {msg}", file=sys.stderr))
+    label = f" [{batch_label}]" if batch_label else ""
+    # None-safe: the docstring promises malformed entries are skipped, not
+    # raised — a None response_text must classify, not crash (wave catch).
+    snippet = f" raw[:200]={(response_text or '')[:200]!r}"
 
     data = _extract_json(response_text)
     if not isinstance(data, dict):
-        log("malformed response: not a JSON object — skipping batch")
+        shape = _classify_malformed(response_text)
+        log(f"malformed response: {shape} — skipping batch{label};{snippet}")
+        if on_batch_drop is not None:
+            on_batch_drop()
         return []
 
     raw_signals = data.get("signals")
     if not isinstance(raw_signals, list):
-        log("malformed response: 'signals' missing or not a list — skipping batch")
+        log(f"malformed response: 'signals' missing or not a list "
+            f"(got {type(raw_signals).__name__}) — skipping batch{label};{snippet}")
+        if on_batch_drop is not None:
+            on_batch_drop()
         return []
 
     out: List[ReachabilitySignal] = []
@@ -324,6 +371,7 @@ def analyze_reachability(
     max_code_bytes: int = DEFAULT_MAX_CODE_BYTES,
     max_units: Optional[int] = None,
     on_error: Optional[Callable[[str], None]] = None,
+    stats: Optional[Dict[str, int]] = None,
 ) -> List[ReachabilitySignal]:
     """Run the LLM reachability review stage over a parsed dataset.
 
@@ -384,6 +432,13 @@ def analyze_reachability(
 
     signals: List[ReachabilitySignal] = []
     batches = _chunk(units, batch_size)
+    # #294: count parse-level batch drops and the units they carried —
+    # a dropped batch is a coverage gap in the most consequential direction
+    # (this stage decides which units are analyzed at all), and previously
+    # nothing counted it: the step report said units_reviewed=N for a run
+    # in which some units were never reviewed.
+    dropped_batches = 0
+    units_not_reviewed = 0
     for i, batch in enumerate(batches):
         prompt = build_prompt(
             batch, app_context=app_context, max_code_bytes=max_code_bytes
@@ -403,10 +458,23 @@ def analyze_reachability(
                 print(f"[LLMReach] {msg}", file=sys.stderr)
             continue
 
+        def _count_drop(batch=batch):
+            nonlocal dropped_batches, units_not_reviewed
+            dropped_batches += 1
+            units_not_reviewed += len(batch)
+
+        first = batch[0].get("id", "?") if batch else "?"
+        last = batch[-1].get("id", "?") if batch else "?"
         parsed = parse_response(
-            text, valid_unit_ids=valid_ids, on_error=on_error
+            text, valid_unit_ids=valid_ids, on_error=on_error,
+            batch_label=f"batch {i + 1}/{len(batches)}, units {first}..{last}",
+            on_batch_drop=_count_drop,
         )
         signals.extend(parsed)
+
+    if stats is not None:
+        stats["batches_dropped"] = dropped_batches
+        stats["units_not_reviewed"] = units_not_reviewed
 
     return signals
 

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -19,6 +19,7 @@ On completion, a final ``scan.report.json`` aggregates all step reports.
 import json
 import os
 import shutil
+from typing import Dict
 import sys
 from pathlib import Path
 
@@ -526,11 +527,16 @@ def scan_repository(
                     # --limit governs the analyze AND enhance stages, not how many units the
                     # LLM reachability pass reviews — it must see the full
                     # codebase to find missed entry points.
+                    # #294: collect parse-level batch-drop stats so the
+                    # step report's units_reviewed stops implying full
+                    # coverage when batches were dropped.
+                    reach_stats: Dict[str, int] = {}
                     signals = analyze_reachability(
                         dataset=dataset,
                         app_context=app_ctx_payload,
                         binding=llm_reach_binding,
                         max_code_bytes=llm_reachability_max_code_bytes,
+                        stats=reach_stats,
                     )
                     summary = apply_signals(dataset, signals)
 
@@ -721,6 +727,11 @@ def scan_repository(
                         "units_touched": summary["units_touched"],
                         "post_filter_units": post_filter_count,
                         "refilter_supported": refilter_supported,
+                        # #294: the honest coverage numbers — units_reviewed
+                        # counts what was SENT for review, not what was
+                        # actually reviewed.
+                        "batches_dropped": reach_stats.get("batches_dropped", 0),
+                        "units_not_reviewed": reach_stats.get("units_not_reviewed", 0),
                     }
                     ctx.outputs = {"signals_path": signals_path}
 

--- a/libs/openant-core/tests/test_issue294_reach_batch_diagnostics.py
+++ b/libs/openant-core/tests/test_issue294_reach_batch_diagnostics.py
@@ -145,13 +145,12 @@ class _ScriptedBinding:
 
 
 def test_analyze_reachability_counts_dropped_units(tmp_path, monkeypatch):
-    import core.llm_reachability as lr
 
     dataset = _dataset(4)  # batch_size=2 → 2 batches
     responses = iter([
         # batch 1: valid
-        '{"signals": [{"unit_id": "f0.py:fn", "kind": "entry_point", '
-        '"confidence": "high", "reason": "ok"}]}',
+        ('{"signals": [{"unit_id": "f0.py:fn", "kind": "entry_point", '
+         '"confidence": "high", "reason": "ok"}]}'),
         # batch 2: malformed (prose refusal)
         "I can't help with analyzing this code for security purposes.",
     ])
@@ -162,7 +161,7 @@ def test_analyze_reachability_counts_dropped_units(tmp_path, monkeypatch):
                         lambda binding, prompt, **kw: next(responses))
 
     stats: dict = {}
-    signals = lr.analyze_reachability(
+    signals = analyze_reachability(
         dataset, binding=_ScriptedBinding(), batch_size=2,
         on_error=errs.append, stats=stats)
 
@@ -176,13 +175,12 @@ def test_analyze_reachability_counts_dropped_units(tmp_path, monkeypatch):
 
 def test_analyze_reachability_stats_absent_means_uncounted(tmp_path, monkeypatch):
     """No stats dict → no counting (backwards-compatible call shape)."""
-    import core.llm_reachability as lr
 
     dataset = _dataset(2)
     import utilities.llm as llm_mod
     monkeypatch.setattr(llm_mod, "simple_text",
                         lambda binding, prompt, **kw: "not json at all")
-    signals = lr.analyze_reachability(dataset, binding=_ScriptedBinding(),
+    signals = analyze_reachability(dataset, binding=_ScriptedBinding(),
                                       batch_size=2)
     assert signals == []
 
@@ -196,11 +194,15 @@ def test_scanner_summary_surfaces_drop_counts(tmp_path, monkeypatch):
     import core.analyzer as analyzer
     import core.reporter as reporter
     import core.tracking as tracking
+    # Module-style import is REQUIRED here (do not "consolidate" with the
+    # file's top-level from-import): this test monkeypatches attributes ON
+    # the core.llm_reachability module (analyze_reachability, apply_signals,
+    # signals_to_json) that core.scanner resolves through the module at call
+    # time — the from-imported name would bypass the patch.
     import core.llm_reachability as lr
 
     # hermetic registry: no config file, no keys, no probe calls
     import utilities.llm as llm_mod
-    from utilities.llm import PhaseBinding
 
     class _StubAdapter:
         name = "anthropic"
@@ -210,7 +212,7 @@ def test_scanner_summary_surfaces_drop_counts(tmp_path, monkeypatch):
     class _StubRegistry:
         config_name = "stub"
         def get(self, phase):
-            return PhaseBinding(phase=phase, adapter=_StubAdapter(),
+            return llm_mod.PhaseBinding(phase=phase, adapter=_StubAdapter(),
                                 model="stub-model", provider_name="anthropic")
 
     monkeypatch.setattr(llm_mod, "build_phase_registry",

--- a/libs/openant-core/tests/test_issue294_reach_batch_diagnostics.py
+++ b/libs/openant-core/tests/test_issue294_reach_batch_diagnostics.py
@@ -181,7 +181,7 @@ def test_analyze_reachability_stats_absent_means_uncounted(tmp_path, monkeypatch
     monkeypatch.setattr(llm_mod, "simple_text",
                         lambda binding, prompt, **kw: "not json at all")
     signals = analyze_reachability(dataset, binding=_ScriptedBinding(),
-                                      batch_size=2)
+                                   batch_size=2)
     assert signals == []
 
 
@@ -213,7 +213,8 @@ def test_scanner_summary_surfaces_drop_counts(tmp_path, monkeypatch):
         config_name = "stub"
         def get(self, phase):
             return llm_mod.PhaseBinding(phase=phase, adapter=_StubAdapter(),
-                                model="stub-model", provider_name="anthropic")
+                                        model="stub-model",
+                                        provider_name="anthropic")
 
     monkeypatch.setattr(llm_mod, "build_phase_registry",
                         lambda cf, cfg: _StubRegistry())

--- a/libs/openant-core/tests/test_issue294_reach_batch_diagnostics.py
+++ b/libs/openant-core/tests/test_issue294_reach_batch_diagnostics.py
@@ -1,0 +1,288 @@
+"""Regression tests for issue #294 — llm-reachability's batch-parse failure
+is undiagnosable: six materially different failures emit one byte-identical
+log line, the raw response is discarded, the batch index is absent, and
+nothing counts the drop (the step report said ``units_reviewed: 10845`` for
+a run in which ~250 units were never reviewed — 10 of 434 batches lost).
+
+Contract locked here:
+- each failure SHAPE is named in the message: empty response / non-JSON
+  prose / truncated-or-unbalanced JSON / valid-JSON-array / valid JSON of
+  another named type — six shapes, six distinct messages;
+- the batch-level drop message carries the caller's batch label and a
+  truncated raw snippet (the evidence, previously discarded);
+- ``analyze_reachability`` counts dropped batches and the units they
+  carried into an optional ``stats`` dict (exact, computed at drop time —
+  batch membership is known there);
+- the scanner surfaces ``batches_dropped`` / ``units_not_reviewed`` in the
+  step report summary alongside ``units_reviewed``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.llm_reachability import analyze_reachability, parse_response  # noqa: E402
+
+SHAPES = {
+    "bare array": (
+        '[{"unit_id":"a.py:f","signal":"entry_point"}]',
+        "valid JSON array, expected an object"),
+    "fenced bare array": (
+        '```json\n[{"unit_id":"a.py:f"}]\n```',
+        "valid JSON array, expected an object"),
+    "truncated mid-string": (
+        '{"signals": [{"unit_id": "a.py:f", "reason": "this got cut',
+        "truncated or unbalanced JSON"),
+    "truncated mid-array": (
+        '{"signals": [{"unit_id": "a.py:f"},',
+        "truncated or unbalanced JSON"),
+    "prose refusal": (
+        "I can't help with analyzing this code for security purposes.",
+        "non-JSON text (prose/refusal)"),
+    "empty completion": (
+        "",
+        "empty response (no content)"),
+}
+
+
+def test_six_shapes_six_distinct_named_messages():
+    """The six shapes from the issue produce DISTINCT messages, each naming
+    its shape (previously: one byte-identical line for all six). The
+    distinctness check is isolated from the raw-snippet suffix — the
+    snippet differs per input regardless of classification, so comparing
+    whole messages would pass even with a collapsed classifier (wave catch)."""
+    prefixes = []
+    for name, (text, expected_shape) in SHAPES.items():
+        got: list[str] = []
+        parse_response(text, valid_unit_ids={"a.py:f"}, on_error=got.append)
+        assert len(got) == 1, name
+        assert expected_shape in got[0], (name, got[0])
+        # strip the evidence suffix: compare ONLY the classified part
+        prefixes.append(got[0].split("; raw[:200]=")[0])
+    assert len(set(prefixes)) == 4, (
+        "6 shapes → 4 distinct classified messages: bare-array and "
+        "fenced-array share the array classifier, and the two truncation "
+        "variants share the truncation classifier — both by design; "
+        "empty / prose / wrong-type must be distinct from all others")
+
+
+def test_none_response_classifies_not_raises():
+    """The docstring promises malformed entries are skipped, not raised —
+    a None response_text must classify (wave catch: the snippet slice
+    previously raised TypeError before reaching the classifier)."""
+    got: list[str] = []
+    out = parse_response(None, on_error=got.append)
+    assert out == []
+    assert "empty response (no content)" in got[0]
+
+
+def test_wrong_type_json_named():
+    got: list[str] = []
+    parse_response('"just a string"', on_error=got.append)
+    assert "valid JSON of wrong type str, expected an object" in got[0]
+
+
+def test_drop_message_carries_batch_label_and_raw_snippet():
+    got: list[str] = []
+    parse_response(
+        "I can't help with this.",
+        on_error=got.append,
+        batch_label="batch 7/434, units m.py:a..m.py:z",
+    )
+    assert "batch 7/434, units m.py:a..m.py:z" in got[0]
+    assert "raw[:200]=" in got[0]
+    assert "I can" in got[0], "the raw evidence is retained in the line"
+
+
+def test_signals_missing_branch_names_type_and_counts_drop():
+    got: list[str] = []
+    drops = []
+    parse_response(
+        '{"signals": "nope"}',
+        on_error=got.append,
+        batch_label="batch 1/1",
+        on_batch_drop=lambda: drops.append(1),
+    )
+    assert "'signals' missing or not a list (got str)" in got[0]
+    assert drops == [1]
+
+
+def test_valid_response_does_not_fire_drop_callback():
+    drops = []
+    out = parse_response(
+        '{"signals": [{"unit_id": "a.py:f", "kind": "entry_point", '
+        '"confidence": "high", "reason": "r"}]}',
+        valid_unit_ids={"a.py:f"},
+        on_batch_drop=lambda: drops.append(1),
+    )
+    assert len(out) == 1
+    assert drops == []
+
+
+# ---------------------------------------------------------------------------
+# analyze_reachability — the count (exact, computed at drop time)
+# ---------------------------------------------------------------------------
+def _dataset(n_units: int) -> dict:
+    return {"units": [
+        {"id": f"f{i}.py:fn", "code": "x = 1", "is_entry_point": False}
+        for i in range(n_units)
+    ]}
+
+
+class _ScriptedBinding:
+    """simple_text is monkeypatched at module level; binding is opaque."""
+
+    def __init__(self):  # pragma: no cover - opaque to analyze_reachability
+        self.model = "m"
+        self.adapter = None
+        self.provider_name = "anthropic"
+
+
+def test_analyze_reachability_counts_dropped_units(tmp_path, monkeypatch):
+    import core.llm_reachability as lr
+
+    dataset = _dataset(4)  # batch_size=2 → 2 batches
+    responses = iter([
+        # batch 1: valid
+        '{"signals": [{"unit_id": "f0.py:fn", "kind": "entry_point", '
+        '"confidence": "high", "reason": "ok"}]}',
+        # batch 2: malformed (prose refusal)
+        "I can't help with analyzing this code for security purposes.",
+    ])
+    errs: list[str] = []
+
+    import utilities.llm as llm_mod
+    monkeypatch.setattr(llm_mod, "simple_text",
+                        lambda binding, prompt, **kw: next(responses))
+
+    stats: dict = {}
+    signals = lr.analyze_reachability(
+        dataset, binding=_ScriptedBinding(), batch_size=2,
+        on_error=errs.append, stats=stats)
+
+    # batch 1's signal survived the drop of batch 2
+    assert [s.unit_id for s in signals] == ["f0.py:fn"]
+    assert stats["batches_dropped"] == 1
+    assert stats["units_not_reviewed"] == 2, "exact: batch membership known"
+    # the drop message is attributable
+    assert any("batch 2/2" in e and "prose/refusal" in e for e in errs), errs
+
+
+def test_analyze_reachability_stats_absent_means_uncounted(tmp_path, monkeypatch):
+    """No stats dict → no counting (backwards-compatible call shape)."""
+    import core.llm_reachability as lr
+
+    dataset = _dataset(2)
+    import utilities.llm as llm_mod
+    monkeypatch.setattr(llm_mod, "simple_text",
+                        lambda binding, prompt, **kw: "not json at all")
+    signals = lr.analyze_reachability(dataset, binding=_ScriptedBinding(),
+                                      batch_size=2)
+    assert signals == []
+
+
+# ---------------------------------------------------------------------------
+# scanner — the step-report summary surface
+# ---------------------------------------------------------------------------
+def test_scanner_summary_surfaces_drop_counts(tmp_path, monkeypatch):
+    from core.schemas import AnalysisMetrics
+    import core.parser_adapter as parser_adapter
+    import core.analyzer as analyzer
+    import core.reporter as reporter
+    import core.tracking as tracking
+    import core.llm_reachability as lr
+
+    # hermetic registry: no config file, no keys, no probe calls
+    import utilities.llm as llm_mod
+    from utilities.llm import PhaseBinding
+
+    class _StubAdapter:
+        name = "anthropic"
+        supports_tools = True
+        pricing = {}
+
+    class _StubRegistry:
+        config_name = "stub"
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_StubAdapter(),
+                                model="stub-model", provider_name="anthropic")
+
+    monkeypatch.setattr(llm_mod, "build_phase_registry",
+                        lambda cf, cfg: _StubRegistry())
+    monkeypatch.setattr(llm_mod, "probe_registry_or_raise", lambda reg: None)
+
+    class _ParseResult:
+        def __init__(self, output_dir):
+            self.dataset_path = str(Path(output_dir) / "dataset.json")
+            self.analyzer_output_path = str(Path(output_dir) / "analyzer.json")
+            self.units_count = 3
+            self.language = "python"
+            self.processing_level = "reachable"
+
+    def _fake_parse(*, output_dir, **kwargs):
+        pr = _ParseResult(output_dir)
+        Path(pr.dataset_path).write_text('{"units": [], "metadata": {}}')
+        Path(pr.analyzer_output_path).write_text("{}")
+        return pr
+
+    metrics = AnalysisMetrics(total=3, vulnerable=1, bypassable=0,
+                              inconclusive=0, protected=0, safe=2, errors=0)
+
+    class _AnalyzeResult:
+        def __init__(self, output_dir):
+            self.results_path = str(Path(output_dir) / "results.json")
+            Path(self.results_path).write_text("[]")
+            self.metrics = metrics
+
+    monkeypatch.setattr(parser_adapter, "parse_repository", _fake_parse)
+    monkeypatch.setattr(analyzer, "run_analysis",
+                        lambda *, output_dir, **kw: _AnalyzeResult(output_dir))
+    monkeypatch.setattr(
+        reporter, "build_pipeline_output",
+        lambda *, results_path, output_path, **kw:
+        (Path(output_path).write_text("{}"), output_path)[1])
+    tracking.reset_tracking()
+
+    def _fake_analyze(*, dataset, app_context, binding, max_code_bytes,
+                      stats=None, **kw):
+        # mirror the real contract: fill the stats dict the scanner passed
+        assert isinstance(stats, dict), "scanner must pass a stats dict"
+        stats["batches_dropped"] = 1
+        stats["units_not_reviewed"] = 2
+        return []
+
+    monkeypatch.setattr(lr, "analyze_reachability", _fake_analyze)
+    monkeypatch.setattr(
+        lr, "apply_signals",
+        lambda dataset, signals: {"signals_applied": 0,
+                                  "entry_points_promoted": 0,
+                                  "units_touched": 0})
+    monkeypatch.setattr(lr, "signals_to_json", lambda signals: [])
+
+    from core import scanner as scanner_mod
+    result = scanner_mod.scan_repository(
+        repo_path=str(tmp_path),
+        output_dir=str(tmp_path / "out"),
+        generate_context=False,
+        enhance=False,
+        verify=False,
+        generate_report=False,
+        dynamic_test=False,
+        llm_reachability=True,
+        processing_level="reachable",
+    )
+
+    # the step report is a per-step file (scan.report.json is the aggregate)
+    report = json.loads(
+        (tmp_path / "out" / "llm-reachability.report.json").read_text())
+    summary = report.get("summary", {})
+    assert summary.get("batches_dropped") == 1
+    assert summary.get("units_not_reviewed") == 2
+    assert "units_reviewed" in summary, "the drop count sits beside it"
+    assert result is not None


### PR DESCRIPTION
## Summary

`parse_response` emitted **one byte-identical log line for six materially different failures** (bare array, fenced array, truncated mid-string, truncated mid-array, prose refusal, empty completion), discarded the raw response, carried no batch index, and counted nothing. On the run that filed #294, 10 of 434 batches were lost through this branch (~245-250 units received no reachability review — this stage decides which units are analyzed at all) and the cause was undeterminable from any artifact: the step report said `status: success, errors: [], units_reviewed: 10845`.

Fix (issue suggestions 1-4):
- `_classify_malformed` names the failure **shape** (empty / non-JSON prose / truncated-or-unbalanced / valid-JSON-array / valid JSON of wrong named type); the drop message carries the caller's **batch label** (batch i/N, unit-id range) and a **truncated raw snippet** — the evidence, previously discarded;
- `on_batch_drop` fires once per batch-level drop; `analyze_reachability` counts dropped batches and the units they carried (**exact** — batch membership is known at drop time) into an optional `stats` dict;
- the scanner surfaces `batches_dropped` / `units_not_reviewed` in the step-report summary beside `units_reviewed` (whose semantics are unchanged: units *sent* for review — the issue's literal ask; a semantics change would alter existing consumers, noted as a known residual).

**Deliberate deviation:** suggestion 5 (reuse `json_corrector` before discarding a batch) is deferred — a behavior change (recovery attempt) with unmeasured recovery, and the issue itself disclaims it ("not claiming the batches would have parsed with a corrector").

**Wave** (proportionate per rule 16): the e2e seat found no blockers; accepted and folded: None-response safety (the snippet slice previously raised TypeError before the classifier — the never-raises docstring promise is restored + tested), the brace-heuristic blind-spot comment, and a distinctness-test fix (comparing classified prefixes, not whole messages). The test-validity seat died on a permission auto-reject mid-mutation-check; the executor's own mutation smoke (7-of-8 fail on pristine) covers that ground.

The private-run figures (10/434, ~250 units) quoted from the issue are provenance-labeled there; the code defect and the fix contract are fully checkable and test-covered.

## Test plan

9 hermetic tests: the six shapes → distinct classified messages (isolated from the raw-snippet suffix); wrong-type naming; None-response classifies without raising; batch label + raw evidence in the message; the signals-missing branch names the type and counts the drop; valid responses never fire the drop callback; `analyze_reachability` counts dropped batches and exact units-not-reviewed with attributable messages; the backwards-compatible no-stats call shape; the scanner step-report surfaces both counts beside `units_reviewed` (hermetic stub registry, real scanner flow).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue294_reach_batch_diagnostics.py -q` | 9 passed |
| mutation smoke | production stashed → same file | 7 failed, 1 passed (backwards-compat shape passes on both by design); restored → 9 passed |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest <file>` | 9 passed |
| full suite | `pytest tests/ -q` | 3171 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #294
