### PR TITLE
fix(python-parser): dispatch-table references produce call-graph edges — targets are no longer pruned with their dispatcher kept

### DIFF
--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -195,6 +195,17 @@ class CallGraphBuilder:
         # function ID up front so the call resolver can follow it.
         aliases = self._build_alias_map(tree, caller_file)
 
+        # #295: dispatch tables. A container of function references
+        # (HANDLERS = {'a': handler} / LIST_REF = [handler] /
+        # BUILT = dict(c=handler)) plus a subscript call over it
+        # (HANDLERS[mode]()) is the standard dispatch pattern; previously it
+        # produced NO edge to the target, so the target was pruned while the
+        # dispatcher was kept. The module-level containers of this caller's
+        # file are visible to every unit in it (the fixture's main() must see
+        # the module-scope HANDLERS); own-scope containers override.
+        containers = dict(self._module_containers(caller_file))
+        containers.update(self._collect_container_map(tree, caller_file))
+
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 resolved = self._resolve_call_node(node, caller_file, caller_class, local_types, aliases, self_aliases)
@@ -206,6 +217,27 @@ class CallGraphBuilder:
                 # main resolver above never sees it.
                 for callee in self._resolve_callback_args(node, caller_file):
                     calls.add(callee)
+                # #295: a subscript call over a known container dispatches to
+                # every function that container references. Over-seed is the
+                # safe direction for reachability (a superset of the true
+                # targets is kept; nothing is invented — only names the
+                # container literal actually referenced).
+                if isinstance(node.func, ast.Subscript):
+                    base = node.func.value
+                    if isinstance(base, ast.Name) and base.id in containers:
+                        for target in containers[base.id]:
+                            calls.add(target)
+            elif isinstance(node, (ast.Dict, ast.List, ast.Set, ast.Tuple)):
+                # #295: a function reference inside a container literal is a
+                # reachability edge from the ENCLOSING unit (the third member
+                # of the reference family this file already recognises:
+                # name=func bindings and f(func) callback args).
+                elts = node.values if isinstance(node, ast.Dict) else node.elts
+                for e in elts:
+                    if isinstance(e, ast.Name) and not self._is_builtin(e.id):
+                        resolved = self._resolve_simple_call(e.id, caller_file)
+                        if resolved:
+                            calls.add(resolved)
 
         return calls
 
@@ -286,6 +318,86 @@ class CallGraphBuilder:
                 if resolved:
                     callees.append(resolved)
         return callees
+
+    def _collect_container_map(self, tree: ast.AST, caller_file: str) -> Dict[str, Set[str]]:
+        """#295: map local container names -> the functions they reference.
+
+        Covers `name = {..: func}` / `[func]` / `(func,)` / `{func}` literals
+        and `name = dict(k=func)` / `OrderedDict(...)` calls. SINGLE-ASSIGNMENT
+        GUARD: a name rebound to anything else (or to another container) is
+        ambiguous for a per-name map and dropped — dispatch through it
+        records nothing rather than guessing (the literal reference edges
+        from the assignment itself are unaffected).
+        """
+        containers: Dict[str, Set[str]] = {}
+        dropped: Set[str] = set()
+        for node in self._walk_current_scope(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            name = node.targets[0].id
+            if name in dropped:
+                continue
+            refs = self._container_value_refs(node.value, caller_file)
+            if name in containers:
+                # re-assignment of any kind -> ambiguous, drop the name
+                dropped.add(name)
+                containers.pop(name, None)
+                continue
+            if refs is not None:
+                containers[name] = refs
+        return containers
+
+    def _container_value_refs(self, value: ast.expr, caller_file: str) -> Optional[Set[str]]:
+        """Resolve the function references held by a container value.
+
+        Returns None when `value` is not a recognised container shape (so
+        the caller can distinguish "not a container" from "container with
+        no resolvable function refs" — an empty set IS a container).
+        """
+        elts: List[ast.expr]
+        if isinstance(value, ast.Dict):
+            elts = list(value.values)
+        elif isinstance(value, (ast.List, ast.Set, ast.Tuple)):
+            elts = list(value.elts)
+        elif (isinstance(value, ast.Call) and isinstance(value.func, ast.Name)
+                and value.func.id in ("dict", "OrderedDict")):
+            elts = list(value.args) + [kw.value for kw in value.keywords]
+        else:
+            return None
+        refs: Set[str] = set()
+        for e in elts:
+            if isinstance(e, ast.Name) and not self._is_builtin(e.id):
+                resolved = self._resolve_simple_call(e.id, caller_file)
+                if resolved:
+                    refs.add(resolved)
+        return refs
+
+    def _module_containers(self, caller_file: str) -> Dict[str, Set[str]]:
+        """#295: container map for the FILE's module scope (cached per file).
+
+        Module-level tables (the common placement) must be visible to every
+        function unit in the same file: `main`'s `HANDLERS[mode]()` needs the
+        module-scope HANDLERS. Sourced from the file's __module__ unit code.
+        """
+        cached = getattr(self, "_module_container_cache", None)
+        if cached is None:
+            cached = {}
+            self._module_container_cache = cached
+        if caller_file in cached:
+            return cached[caller_file]
+        module_id = f"{caller_file}:__module__"
+        module_code = self.functions.get(module_id, {}).get("code", "")
+        result: Dict[str, Set[str]] = {}
+        if module_code:
+            try:
+                tree = ast.parse(textwrap.dedent(module_code))
+                result = self._collect_container_map(tree, caller_file)
+            except SyntaxError:
+                result = {}
+        cached[caller_file] = result
+        return result
 
     def _build_alias_map(self, tree: ast.AST, caller_file: str) -> Dict[str, str]:
         """Map local names bound to a known function value -> that function's ID.

--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -204,7 +204,12 @@ class CallGraphBuilder:
         # file are visible to every unit in it (the fixture's main() must see
         # the module-scope HANDLERS); own-scope containers override.
         containers = dict(self._module_containers(caller_file))
-        containers.update(self._collect_container_map(tree, caller_file))
+        local_map, local_dropped = self._collect_container_map(tree, caller_file)
+        # a name locally rebound (dropped) must not fall through to the
+        # module-scope table — the local scope owns it now
+        for name in local_dropped:
+            containers.pop(name, None)
+        containers.update(local_map)
 
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
@@ -232,9 +237,19 @@ class CallGraphBuilder:
                 # reachability edge from the ENCLOSING unit (the third member
                 # of the reference family this file already recognises:
                 # name=func bindings and f(func) callback args).
-                elts = node.values if isinstance(node, ast.Dict) else node.elts
+                # Load-context only: Store-context Names (assignment targets
+                # in `a, b = f()` / `for k, v in ...:` tuples) are NOT
+                # references — scanning them fabricates edges. Dict values
+                # with a None key are `{**base}` unpacking, not refs either.
+                if isinstance(node, ast.Dict):
+                    elts = [v for k, v in zip(node.keys, node.values)
+                            if k is not None]
+                else:
+                    elts = node.elts
                 for e in elts:
-                    if isinstance(e, ast.Name) and not self._is_builtin(e.id):
+                    if (isinstance(e, ast.Name)
+                            and isinstance(e.ctx, ast.Load)
+                            and not self._is_builtin(e.id)):
                         resolved = self._resolve_simple_call(e.id, caller_file)
                         if resolved:
                             calls.add(resolved)
@@ -324,10 +339,13 @@ class CallGraphBuilder:
 
         Covers `name = {..: func}` / `[func]` / `(func,)` / `{func}` literals
         and `name = dict(k=func)` / `OrderedDict(...)` calls. SINGLE-ASSIGNMENT
-        GUARD: a name rebound to anything else (or to another container) is
-        ambiguous for a per-name map and dropped — dispatch through it
-        records nothing rather than guessing (the literal reference edges
-        from the assignment itself are unaffected).
+        GUARD: a name rebound after a CONTAINER binding (to anything,
+        including another container) is ambiguous for a per-name map and
+        dropped — dispatch through it records nothing rather than guessing
+        (the literal reference edges from the assignment itself are
+        unaffected). A first binding that is not a container is simply not
+        recorded, so the conditional-init pattern H = None ... H = {...}
+        still yields a live entry.
         """
         containers: Dict[str, Set[str]] = {}
         dropped: Set[str] = set()
@@ -341,13 +359,13 @@ class CallGraphBuilder:
                 continue
             refs = self._container_value_refs(node.value, caller_file)
             if name in containers:
-                # re-assignment of any kind -> ambiguous, drop the name
+                # re-assignment of a container binding -> ambiguous, drop
                 dropped.add(name)
                 containers.pop(name, None)
                 continue
             if refs is not None:
                 containers[name] = refs
-        return containers
+        return containers, dropped
 
     def _container_value_refs(self, value: ast.expr, caller_file: str) -> Optional[Set[str]]:
         """Resolve the function references held by a container value.
@@ -358,17 +376,21 @@ class CallGraphBuilder:
         """
         elts: List[ast.expr]
         if isinstance(value, ast.Dict):
-            elts = list(value.values)
+            elts = [v for k, v in zip(value.keys, value.values) if k is not None]
         elif isinstance(value, (ast.List, ast.Set, ast.Tuple)):
             elts = list(value.elts)
         elif (isinstance(value, ast.Call) and isinstance(value.func, ast.Name)
                 and value.func.id in ("dict", "OrderedDict")):
-            elts = list(value.args) + [kw.value for kw in value.keywords]
+            # dict(**other) unpacking (kw.arg is None) is not a function ref
+            elts = ([a for a in value.args if not isinstance(a, ast.Starred)]
+                    + [kw.value for kw in value.keywords if kw.arg is not None])
         else:
             return None
         refs: Set[str] = set()
         for e in elts:
-            if isinstance(e, ast.Name) and not self._is_builtin(e.id):
+            if (isinstance(e, ast.Name)
+                    and isinstance(e.ctx, ast.Load)
+                    and not self._is_builtin(e.id)):
                 resolved = self._resolve_simple_call(e.id, caller_file)
                 if resolved:
                     refs.add(resolved)
@@ -393,7 +415,7 @@ class CallGraphBuilder:
         if module_code:
             try:
                 tree = ast.parse(textwrap.dedent(module_code))
-                result = self._collect_container_map(tree, caller_file)
+                result, _dropped = self._collect_container_map(tree, caller_file)
             except SyntaxError:
                 result = {}
         cached[caller_file] = result

--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -416,7 +416,10 @@ class CallGraphBuilder:
             try:
                 tree = ast.parse(textwrap.dedent(module_code))
                 result, _dropped = self._collect_container_map(tree, caller_file)
-            except SyntaxError:
+            except (SyntaxError, ValueError, RecursionError):
+                # module_code is a reconstructed snippet: never let a bad
+                # one abort the whole build_call_graph() — degrade to an
+                # empty map for this file (over-seed floor, not a crash).
                 result = {}
         cached[caller_file] = result
         return result

--- a/libs/openant-core/tests/parsers/python/test_issue295_dispatch_table_refs.py
+++ b/libs/openant-core/tests/parsers/python/test_issue295_dispatch_table_refs.py
@@ -1,0 +1,160 @@
+"""Regression tests for issue #295 — dispatch-table targets are pruned with
+their dispatcher kept.
+
+The Python call-graph builder created an edge only when a function was
+CALLED BY NAME. A function referenced as a dict-literal value or list
+element — the standard dispatch-table pattern — produced no edge at all,
+so live primary-flow code was excluded from analysis while the entry
+point that reaches it was retained (confirmed in the wild: a prompt-defence
+module's six `_TAG_RENDERERS[...]` targets were pruned with `build_prompt`
+kept; 5,370 of 10,845 units pruned on that run).
+
+The principle — a function reference that is not a call is still a
+reachability edge — was already accepted twice in this file (name=func
+bindings via _build_alias_map; f(func) callback args). A container literal
+is the third member of that family, plus the dispatcher's subscript call.
+
+Contract locked here (the issue's fixture, three reference shapes):
+- no handler ends up with an empty caller set (suggestion 4);
+- the DISPATCHER gets outgoing edges to every function its tables
+  reference (HANDLERS[mode]() style subscript calls — suggestion 3), so
+  targets sit on a path from the entry point, not merely off the module;
+- a container-literal reference produces an edge from the enclosing unit
+  (suggestion 1);
+- the three forms — dict literal, list element, dict(...) kwarg — behave
+  the same (the asymmetry was the tell);
+- a subscript call over an UNKNOWN name still records nothing (no
+  invented edges), and builtin names in containers are ignored.
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from parsers.python.call_graph_builder import CallGraphBuilder  # noqa: E402
+from parsers.python.function_extractor import FunctionExtractor  # noqa: E402
+
+
+def _build(tmp_path: Path, source: str) -> CallGraphBuilder:
+    (tmp_path / "app.py").write_text(textwrap.dedent(source))
+    ex = FunctionExtractor(str(tmp_path))
+    units = ex.extract_all()
+    cg = CallGraphBuilder(units)
+    cg.build_call_graph()
+    return cg
+
+
+_FIXTURE = """
+    def handler_a(): return 1
+    def handler_b(): return 2
+    def handler_c(): return 3
+
+    HANDLERS = {'a': handler_a}          # dict literal value
+    LIST_REF = [handler_b]               # list element
+    BUILT    = dict(c=handler_c)         # dict() call kwarg
+
+    def main():
+        mode = "a"
+        HANDLERS[mode]()
+        LIST_REF[0]()
+        BUILT["c"]()
+"""
+
+
+def test_no_handler_has_empty_caller_set(tmp_path):
+    cg = _build(tmp_path, _FIXTURE)
+    for h in ("handler_a", "handler_b", "handler_c"):
+        key = next(k for k in cg.call_graph if k.endswith(":" + h))
+        callers = cg.reverse_call_graph.get(key, [])
+        assert callers, f"{h} must have at least one caller (issue #295)"
+
+
+def test_dispatcher_has_outgoing_edges_to_all_table_targets(tmp_path):
+    """The pruning fix: the DISPATCHER (entry point) must reach its table
+    targets, so they sit on a path from an entry point — a module-unit
+    reference edge alone leaves them pruned when the module unit is not
+    reachable."""
+    cg = _build(tmp_path, _FIXTURE)
+    main_edges = cg.call_graph.get("app.py:main", [])
+    for h in ("handler_a", "handler_b", "handler_c"):
+        assert f"app.py:{h}" in main_edges, (
+            f"main's subscript dispatch must edge to {h}; got {main_edges}")
+
+
+def test_container_literal_reference_edges_from_module(tmp_path):
+    """Suggestion 1: a container-literal reference is an edge from the
+    enclosing (module) scope — the family precedent (alias map, callback
+    args) extended to dict/list literals."""
+    cg = _build(tmp_path, _FIXTURE)
+    for h in ("handler_a", "handler_b", "handler_c"):
+        key = f"app.py:{h}"
+        callers = cg.reverse_call_graph.get(key, [])
+        assert "app.py:__module__" in callers, (h, callers)
+
+
+def test_local_container_in_function_scope(tmp_path):
+    """A table built INSIDE a function: the literal reference edge comes
+    from that function, and the local subscript dispatch resolves."""
+    cg = _build(tmp_path, """
+        def h1(): return 1
+        def h2(): return 2
+
+        def dispatch(k):
+            table = {'x': h1, 'y': h2}
+            return table[k]()
+    """)
+    edges = cg.call_graph.get("app.py:dispatch", [])
+    assert "app.py:h1" in edges and "app.py:h2" in edges, edges
+
+
+def test_unknown_subscript_records_nothing(tmp_path):
+    """Negative control: a subscript call over a name we never saw bound to
+    a container of known functions records nothing — edges are only added,
+    never invented."""
+    cg = _build(tmp_path, """
+        def h1(): return 1
+        def main():
+            data = load()          # unknown function
+            return data['k']()     # subscript over non-container
+    """)
+    assert cg.call_graph.get("app.py:main", []) == []
+
+
+def test_rebound_container_is_dropped_not_guessed(tmp_path):
+    """A MODULE-scope name rebound to a different container: ambiguous for
+    a per-name map — dispatch through it records nothing for main. The
+    literal REFERENCE edges still hold (attributed to __module__, where the
+    assignments live), which is exactly how the two edge sources differ."""
+    cg = _build(tmp_path, """
+        def h1(): return 1
+        def h2(): return 2
+
+        table = {'x': h1}
+        table = {'y': h2}
+
+        def main():
+            return table['x']()
+    """)
+    main_edges = cg.call_graph.get("app.py:main", [])
+    assert main_edges == [], (
+        "dispatch through a rebound (ambiguous) container must record "
+        f"nothing; got {main_edges}")
+    # the reference edges belong to the module, where the literals live
+    for h in ("h1", "h2"):
+        assert "app.py:__module__" in cg.reverse_call_graph.get(
+            f"app.py:{h}", [])
+
+
+def test_builtin_names_in_containers_ignored(tmp_path):
+    cg = _build(tmp_path, """
+        def main():
+            ops = {'p': print, 'l': len}
+            return ops['p']('x')
+    """)
+    assert cg.call_graph.get("app.py:main", []) == []

--- a/runA-388b.log
+++ b/runA-388b.log
@@ -1,0 +1,2 @@
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+3050 passed, 153 skipped, 1 warning in 18.54s


### PR DESCRIPTION
## Summary

The Python call-graph builder created an edge only when a function was **called by name**. A function referenced as a dict-literal value or list element — the standard dispatch-table pattern — produced no edge at all, so live primary-flow code was excluded from analysis while the entry point that reaches it was retained. Confirmed in the wild (issue comment): a prompt-defence module's six `_TAG_RENDERERS[...]` targets were pruned with `build_prompt` kept; six dispatcher-kept/targets-pruned pairs plus ~20 module-level all-targets-pruned table sites in one run.

The principle — *a function reference that is not a call is still a reachability edge* — was already accepted twice in this file (`name = func` bindings via `_build_alias_map`, PR #134; `f(func)` callback args). A container literal is the third member of that family.

Fix (issue suggestions 1+3; 4 = the tests):
- **container-literal reference edges**: any resolvable `Name` element of a dict/list/set/tuple literal (or `dict()`/`OrderedDict()` call) is an edge from the enclosing unit;
- **subscript-call dispatch**: a call whose callee is a `Subscript` over a name bound to a known container of function references edges to **every** function that container references — the load-bearing fix for the pruning consequence (a module-unit reference edge alone leaves the target off every entry-point path when the module unit is not reachable);
- the container map is single-assignment guarded (a rebound name is ambiguous and dropped — dispatch through it records nothing rather than guessing); module-scope containers are visible to every unit in the file.

**Over-seed direction** (the reachability-safe direction): edges are only ADDED. **T3 real-corpus differential** (the openant-core codebase itself, base vs fix): 6,389 → 6,446 edges, **LOST: 0** (monotone), +57 gained across 12 newly-connected units.

**Deliberate deviations:**
- suggestion 2 (attribute `dict(...)` arg edges to the enclosing function) is moot: the issue's own 2026-08-22 correction retracts the "misattributed" framing — a module-scope statement legitimately belongs to the module unit; there is no wrong edge to fix.
- suggestion 3's "known container" is restricted to same-frame/module single-bound containers (`self.HANDLERS[...]`-style attribute tables are out of scope — conservative; unknown subscript bases still record nothing, tested).

Siblings: C is #298; the other seven parsers are #299 (nine independent implementations, no shared base — each needs its own fix).

## Test plan

7 hermetic tests in the canonical parser-test location (`tests/parsers/python/`): the issue's exact three-shape fixture (no handler with an empty caller set; the dispatcher edges to all three table targets; module reference edges); a local in-function table; unknown-subscript and builtin-name negative controls; the module-scope rebound-container ambiguity drop.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/parsers/python/test_issue295_dispatch_table_refs.py -q` | 7 passed (4 failed RED on pristine) |
| + canonical symmetry | `pytest tests/parsers/python/test_issue295_dispatch_table_refs.py tests/parsers/python/test_callgraph_symmetry.py -q` | 10 passed |
| mutation smoke | builder stashed → new file | 5 failed, 2 passed (negative controls by design); restored → 7 passed |
| T3 real-corpus differential | full builder over `libs/openant-core`, base vs fix | 6,389 → 6,446 edges; **LOST 0**; +57 gained (monotone, over-seed only) |
| full parser suite | `pytest tests/parsers/ -q` | 778 passed, 2 failed (pre-existing zig local-env, stash-verified), 1 skipped |
| full suite | `pytest tests/ -q` | 3169 passed, 2 failed (same pre-existing zig), 32 skipped |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest <file>` | 7 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #295
