### PR TITLE
fix(verifier): name the conclusive-guard marker; pin the protective asymmetry (#296 lower-risk items)

### DIFF
--- a/libs/openant-core/parsers/c/PARSER_PIPELINE.md
+++ b/libs/openant-core/parsers/c/PARSER_PIPELINE.md
@@ -117,7 +117,16 @@ Generates `dataset.json` and `analyzer_output.json` with identical schema to Pyt
 
 ### Limitations
 
-- Cannot resolve function pointer dispatch (LLM compensates)
+- Function-pointer dispatch through STATIC containers resolves as of #298 (a
+  braced initialiser of function references — ops struct designated
+  initialisers, function-pointer arrays, struct-array command tables — plus a
+  subscript or member call through the container name records edges to every
+  function the initialisers reference; over-seed is the safe direction).
+  REMAINING unmitigated on a default scan: dispatch through pointers assigned
+  at RUNTIME (indirect calls via variables holding function addresses with no
+  static initialiser table), which the opt-in `--llm-reachability` stage
+  (off by default; reads the first 1,500 bytes per unit) only partially
+  compensates for.
 - Cannot resolve complex macro expansions (tree-sitter sees the macro call, not the expansion)
 - Does not track struct field access patterns
 - C++ template instantiation is not tracked

--- a/libs/openant-core/parsers/c/call_graph_builder.py
+++ b/libs/openant-core/parsers/c/call_graph_builder.py
@@ -349,7 +349,18 @@ class CallGraphBuilder:
                 source = f.read()
             parser = self._get_parser_for_file(file_path)
             tree = parser.parse(source)
-            result = self._collect_container_map(tree.root_node, source, file_path)
+            # TOP-LEVEL ONLY (panel finding): _collect_container_map walks the
+            # whole tree, so a container nested inside an unrelated function's
+            # body would leak file-wide (an opaque same-named parameter in
+            # another function would dispatch to THIS function's targets).
+            # Walk the root's children without descending into function_definition.
+            top_level = [c for c in tree.root_node.children
+                         if c.type != 'function_definition']
+            class _ShallowRoot:
+                type = 'translation_unit'
+                def __init__(self, children):
+                    self.children = children
+            result = self._collect_container_map(_ShallowRoot(top_level), source, file_path)
         except OSError:
             result = {}
         cached[file_path] = result
@@ -372,7 +383,12 @@ class CallGraphBuilder:
         return set(containers.get(base, ()))
 
     def _dispatch_base_identifier(self, node) -> Optional[str]:
-        """Find the base identifier a subscript/member call dispatches over."""
+        """Find the base identifier a SUBSCRIPT/MEMBER call dispatches over.
+        A bare identifier root returns None (panel finding): a direct call
+        through a name shadowing a file-scope container must not fabricate
+        edges to all of the container's targets."""
+        if node is not None and node.type == "identifier":
+            return None
         current = node
         for _ in range(4):  # bounded descent: cmds[i].fn() nests two levels
             if current is None:

--- a/libs/openant-core/parsers/c/call_graph_builder.py
+++ b/libs/openant-core/parsers/c/call_graph_builder.py
@@ -32,6 +32,7 @@ Output (JSON):
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -212,12 +213,31 @@ class CallGraphBuilder:
         # method on the receiver's known type.
         local_var_types = self._extract_local_var_types(tree.root_node, code_bytes)
 
+        # #298: function-pointer dispatch containers. A name initialised
+        # with a braced list of function references (an ops struct with
+        # designated initialisers, an array of function pointers, a
+        # struct-array command table) plus a subscript or member call
+        # through that name (tbl[i]() / o.read(x) / cmds[i].fn()) is C's
+        # polymorphism idiom; previously it produced NO edge, so the
+        # dispatcher kept zero out-edges and every target was orphaned.
+        # File-scope containers are visible to every function in the file
+        # (parsed from the file itself, cached); local containers override.
+        containers = dict(self._file_containers(file_path))
+        containers.update(self._collect_container_map(tree.root_node, code_bytes, caller_file))
+
         stack = [tree.root_node]
         while stack:
             node = stack.pop()
             if node.type == 'call_expression':
                 func_node = node.child_by_field_name('function')
                 if func_node:
+                    # #298: dispatch through a known container — the
+                    # over-seed direction (a superset of the true targets
+                    # is kept; nothing is invented: only names the
+                    # container's initialisers actually referenced).
+                    for target in self._container_dispatch_targets(
+                            func_node, code_bytes, containers):
+                        calls.add(target)
                     call_name, receiver = self._extract_call_name_and_receiver(
                         func_node, code_bytes
                     )
@@ -234,8 +254,140 @@ class CallGraphBuilder:
                 # name a known function; non-function identifiers (variables) do not
                 # resolve and so do not create edges.
                 calls.update(self._extract_callback_args(node, code_bytes, caller_file))
+            elif node.type == 'initializer_list':
+                # #298: a function referenced in an initialiser is a
+                # reachability edge from the enclosing unit (the same
+                # family as _extract_callback_args' call-argument refs).
+                for target in self._initializer_targets(node, code_bytes, caller_file):
+                    calls.add(target)
             stack.extend(reversed(node.children))
         return calls
+
+    # ------------------------------------------------------------------
+    # #298: function-pointer dispatch containers
+    # ------------------------------------------------------------------
+    def _initializer_targets(self, init_node, source: bytes, caller_file: str) -> Set[str]:
+        """Resolve the function references inside an initializer_list.
+
+        Covers direct identifier elements ({ h_a, h_b }), designated
+        initialiser values ({ .read = my_read }), address-of operands
+        ({ &h_a }), and nested initializer_lists (struct-array tables:
+        { {"a", cmd_a}, {"b", cmd_b} }). Non-function identifiers (data
+        values) do not resolve and create no edges.
+        """
+        targets: Set[str] = set()
+        stack = [init_node]
+        while stack:
+            node = stack.pop()
+            name: Optional[str] = None
+            if node.type == 'identifier':
+                name = source[node.start_byte:node.end_byte] \
+                    .decode('utf-8', errors='replace')
+            elif node.type in ('pointer_expression', 'unary_expression'):
+                operand = node.child_by_field_name('argument')
+                if operand is not None and operand.type == 'identifier':
+                    name = source[operand.start_byte:operand.end_byte] \
+                        .decode('utf-8', errors='replace')
+            if name and not self._is_stdlib(name):
+                resolved = self._resolve_call(name, caller_file)
+                if resolved:
+                    targets.add(resolved)
+            if node.type == 'initializer_list' or node.type == 'initializer_pair':
+                stack.extend(reversed(node.children))
+        return targets
+
+    def _collect_container_map(self, root, source: bytes,
+                               caller_file: str) -> Dict[str, Set[str]]:
+        """#298: map container names -> the functions their initialisers
+        reference, within this tree. SINGLE-DECLARATION GUARD: a name
+        declared twice is ambiguous for a per-name map and dropped —
+        dispatch through it records nothing rather than guessing."""
+        containers: Dict[str, Set[str]] = {}
+        dropped: Set[str] = set()
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == 'declaration':
+                for child in node.children:
+                    if child.type != 'init_declarator':
+                        continue
+                    name = self._declared_var_name(child, source)
+                    if not name or name in dropped:
+                        continue
+                    init = child.child_by_field_name('value')
+                    if init is None or init.type != 'initializer_list':
+                        continue
+                    targets = self._initializer_targets(init, source, caller_file)
+                    if name in containers:
+                        dropped.add(name)
+                        containers.pop(name, None)
+                        continue
+                    containers[name] = targets
+            stack.extend(reversed(node.children))
+        return containers
+
+    def _file_containers(self, file_path: str) -> Dict[str, Set[str]]:
+        """#298: container map for a file's TOP-LEVEL declarations (cached).
+
+        File-scope tables (`static struct ops o = {...}` at file scope) are
+        the common placement and must be visible to every function in the
+        file. The builder works per-function, so parse the file itself.
+        """
+        cached = getattr(self, "_file_container_cache", None)
+        if cached is None:
+            cached = {}
+            self._file_container_cache = cached
+        if file_path in cached:
+            return cached[file_path]
+        result: Dict[str, Set[str]] = {}
+        try:
+            # file_path is the repo-relative caller-file key ("src/d.c");
+            # resolve it against the repository root the extractor recorded.
+            full = file_path if os.path.isabs(file_path) \
+                else os.path.join(self.repo_path, file_path)
+            with open(full, 'rb') as f:
+                source = f.read()
+            parser = self._get_parser_for_file(file_path)
+            tree = parser.parse(source)
+            result = self._collect_container_map(tree.root_node, source, file_path)
+        except OSError:
+            result = {}
+        cached[file_path] = result
+        return result
+
+    def _container_dispatch_targets(self, func_node, source: bytes,
+                                    containers: Dict[str, Set[str]]) -> Set[str]:
+        """#298: the callee is a subscript/member expression over a known
+        container — dispatch to every function that container references.
+
+        Handles tbl[i]() (subscript), o.read(x) (member over identifier),
+        and cmds[i].fn() (member over subscript). Returns empty for
+        anything else, including subscripts over unknown names.
+        """
+        if not containers:
+            return set()
+        base = self._dispatch_base_identifier(func_node)
+        if base is None:
+            return set()
+        return set(containers.get(base, ()))
+
+    def _dispatch_base_identifier(self, node) -> Optional[str]:
+        """Find the base identifier a subscript/member call dispatches over."""
+        current = node
+        for _ in range(4):  # bounded descent: cmds[i].fn() nests two levels
+            if current is None:
+                return None
+            if current.type == 'identifier':
+                return current.text.decode('utf-8', errors='replace') \
+                    if current.text else None
+            if current.type == 'subscript_expression':
+                current = current.children[0] if current.children else None
+                continue
+            if current.type == 'field_expression':
+                current = current.children[0] if current.children else None
+                continue
+            return None
+        return None
 
     def _extract_callback_args(self, call_node, source: bytes, caller_file: str) -> Set[str]:
         """Resolve function-name arguments passed to a call (higher-order/callback)."""
@@ -322,7 +474,12 @@ class CallGraphBuilder:
         """
         if node.type == 'identifier':
             return source[node.start_byte:node.end_byte].decode('utf-8', errors='replace')
-        if node.type in ('pointer_declarator', 'init_declarator', 'reference_declarator'):
+        if node.type in ('pointer_declarator', 'init_declarator',
+                         'reference_declarator', 'function_declarator',
+                         'array_declarator', 'parenthesized_declarator'):
+            # #298: function/array/parenthesized declarators cover the
+            # function-pointer TABLE shape `void (*tbl[])(void) = {...}` —
+            # the declared name sits under the nested declarators.
             inner = node.child_by_field_name('declarator')
             if inner is not None:
                 return self._declared_var_name(inner, source)

--- a/libs/openant-core/tests/parsers/c/test_issue298_fnptr_dispatch.py
+++ b/libs/openant-core/tests/parsers/c/test_issue298_fnptr_dispatch.py
@@ -1,0 +1,156 @@
+"""Regression tests for issue #298 — C indirect dispatch records no edges.
+
+The three canonical C indirect-dispatch idioms — an ops struct with
+designated initialisers, an array of function pointers, and a
+struct-array command table dispatched by index — produced NO edge at all,
+so the dispatching function had zero out-edges and every target was
+orphaned. In C, function-pointer dispatch is the language's polymorphism
+mechanism (kernel file_operations, driver op tables, syscall tables,
+plugin vtables), so these are exactly the edges that carry
+attacker-reachable control flow into a handler — and the dispatcher is
+retained while its targets are pruned (#295's shape, in C).
+
+The machinery for "a function referenced without being called" already
+existed in this file (_extract_callback_args covers register_handler(cb));
+initialisers and subscript/member dispatch are the missing members of that
+family.
+
+Contract locked here (the issue's fixture + controls):
+- every table target gets a caller, and every dispatcher gets outgoing
+  edges to its table's targets (over-seed is the safe direction);
+- a direct-call CONTROL keeps its edge (null-result meaningfulness);
+- unknown subscript bases and non-function initialiser values still
+  record nothing (no invented edges).
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from parsers.c.call_graph_builder import CallGraphBuilder  # noqa: E402
+from parsers.c.function_extractor import FunctionExtractor  # noqa: E402
+
+
+def _build(tmp_path: Path, source: str) -> CallGraphBuilder:
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "d.c").write_text(textwrap.dedent(source))
+    ex = FunctionExtractor(str(tmp_path))
+    units = ex.extract_all()
+    cg = CallGraphBuilder(units)
+    cg.build_call_graph()
+    return cg
+
+
+_FIXTURE = """
+    static void h_a(void) {}
+    static void h_b(void) {}
+    static void my_read(int x) {}
+    static void direct_target(void) {}
+
+    struct ops { void (*read)(int); };
+    static struct ops o = { .read = my_read };
+    static void (*tbl[])(void) = { h_a, h_b };
+
+    void use_ops(int x)      { o.read(x); }
+    void use_tbl(int i)      { tbl[i](); }
+    void direct_caller(void) { direct_target(); }
+"""
+
+
+def test_control_direct_call_edge_exists(tmp_path):
+    cg = _build(tmp_path, _FIXTURE)
+    assert "src/d.c:direct_target" in cg.call_graph.get("src/d.c:direct_caller", [])
+
+
+def test_ops_struct_dispatch_edges(tmp_path):
+    """o.read(x) through a struct initialised with designated
+    initialisers: use_ops edges to my_read; my_read gets a caller."""
+    cg = _build(tmp_path, _FIXTURE)
+    assert "src/d.c:my_read" in cg.call_graph.get("src/d.c:use_ops", [])
+    assert "src/d.c:use_ops" in cg.reverse_call_graph.get("src/d.c:my_read", [])
+
+
+def test_function_pointer_table_dispatch_edges(tmp_path):
+    """tbl[i]() through an array of function pointers: use_tbl edges to
+    both table targets."""
+    cg = _build(tmp_path, _FIXTURE)
+    edges = cg.call_graph.get("src/d.c:use_tbl", [])
+    assert "src/d.c:h_a" in edges and "src/d.c:h_b" in edges, edges
+
+
+def test_no_target_orphaned(tmp_path):
+    """The issue's headline consequence: no dispatch target ends up with an
+    empty caller set while its dispatcher is kept."""
+    cg = _build(tmp_path, _FIXTURE)
+    for fn in ("h_a", "h_b", "my_read"):
+        callers = cg.reverse_call_graph.get(f"src/d.c:{fn}", [])
+        assert callers, f"{fn} must have at least one caller (issue #298)"
+
+
+def test_struct_array_command_table_dispatch(tmp_path):
+    """cmds[i].fn() — a struct-array command table: the field call over a
+    subscripted known container dispatches to every function the table's
+    initialisers reference."""
+    cg = _build(tmp_path, """
+        struct cmd { const char *name; void (*fn)(void); };
+        static struct cmd cmds[] = {
+            {"a", cmd_a},
+            {"b", cmd_b},
+        };
+        static void cmd_a(void) {}
+        static void cmd_b(void) {}
+
+        void run_cmd(int i) { cmds[i].fn(); }
+    """)
+    edges = cg.call_graph.get("src/d.c:run_cmd", [])
+    assert "src/d.c:cmd_a" in edges and "src/d.c:cmd_b" in edges, edges
+
+
+def test_local_table_in_function(tmp_path):
+    """A table built INSIDE a function body: same dispatch through the
+    local name."""
+    cg = _build(tmp_path, """
+        static void h1(void) {}
+        static void h2(void) {}
+
+        void dispatch(int i) {
+            static void (*t[])(void) = { h1, h2 };
+            t[i]();
+        }
+    """)
+    edges = cg.call_graph.get("src/d.c:dispatch", [])
+    assert "src/d.c:h1" in edges and "src/d.c:h2" in edges, edges
+
+
+def test_unknown_subscript_base_records_nothing(tmp_path):
+    """Negative control: a subscript call over a name with no known
+    function-referencing initialiser records nothing — edges are only
+    added, never invented."""
+    cg = _build(tmp_path, """
+        static void sink(void) {}
+
+        void f(int i) {
+            int data[3] = {1, 2, 3};
+            data[i] = i + 1;      /* not a call at all */
+            g(i);                 /* unknown callee */
+        }
+    """)
+    assert cg.call_graph.get("src/d.c:f", []) == []
+
+
+def test_non_function_initializer_values_ignored(tmp_path):
+    """An initialiser of non-function values creates no container edges."""
+    cg = _build(tmp_path, """
+        void f(void) {
+            int nums[] = {1, 2, 3};
+            (void)nums[0];
+        }
+    """)
+    assert cg.call_graph.get("src/d.c:f", []) == []

--- a/libs/openant-core/tests/parsers/c/test_issue298_fnptr_dispatch.py
+++ b/libs/openant-core/tests/parsers/c/test_issue298_fnptr_dispatch.py
@@ -154,3 +154,46 @@ def test_non_function_initializer_values_ignored(tmp_path):
         }
     """)
     assert cg.call_graph.get("src/d.c:f", []) == []
+
+
+
+def test_local_container_does_not_leak_file_wide(tmp_path):
+    """Regression (panel finding): a container initialised INSIDE a function
+    is that function's local — it must not enter the file-scope map another
+    function resolves against (a same-named opaque parameter in the other
+    function would otherwise dispatch to THIS function's targets)."""
+    src = """
+    static void h1(void) {}
+    static void h2(void) {}
+    static void real_target(void) {}
+    void funcA(int i) {
+        void (*tbl[])(void) = { h1, h2 };
+        tbl[i]();
+    }
+    void funcB(void (*tbl[])(void), int i) {
+        tbl[i]();
+    }
+    """
+    cg = _build(tmp_path, src)
+    a = cg.call_graph.get("src/d.c:funcA", [])
+    b = cg.call_graph.get("src/d.c:funcB", [])
+    assert "src/d.c:h1" in a and "src/d.c:h2" in a, "funcA's local table still dispatches"
+    assert "src/d.c:h1" not in b and "src/d.c:h2" not in b, "funcA's LOCAL must not leak into funcB"
+
+
+def test_bare_identifier_call_does_not_dispatch_container(tmp_path):
+    """Regression (panel finding): a DIRECT call through a name that merely
+    shadows a file-scope container must not fabricate edges to all of the
+    container's targets."""
+    src = """
+    static void h1(void) {}
+    static void h2(void) {}
+    static void cmds(void) { h1(); }
+    static void (*CMD_TABLE[])(void) = { h1, h2 };
+    static void runner(int i) { CMD_TABLE[i](); }
+    static void caller(void) { cmds(); }
+    """
+    cg = _build(tmp_path, src)
+    caller = cg.call_graph.get("src/d.c:caller", [])
+    assert "src/d.c:cmds" in caller, "the direct call still resolves to the function"
+    assert "src/d.c:h2" not in caller, "a bare-name call must NOT fabricate h2 (a table-only target)"

--- a/libs/openant-core/tests/test_issue296_conclusive_guards.py
+++ b/libs/openant-core/tests/test_issue296_conclusive_guards.py
@@ -1,0 +1,131 @@
+"""Regression tests for issue #296 — the conclusive-exploit-path guards
+test a free-text explanation string; the structured signal
+(``verification["incomplete"]``) sits unused on the same object.
+
+Scope of this change (the issue's lower-risk items, explicitly NOT the
+direction-aware behavior change the maintainer raised as an open question):
+
+1. The matched marker is a NAMED constant (``INCOMPLETE_VERIFICATION_MARKER``)
+   with the match set UNCHANGED — widening it is the false-negative direction
+   for BOTH guards and must wait for the direction-awareness analysis.
+2. The ASYMMETRY is pinned (the issue's suggested test 3): an INCOMPLETE
+   verification carrying an INTACT exploit path must still leave
+   ``_has_conclusive_exploitable_path`` True — the downgrade into
+   DISCLOSURE_DROPPED stays BLOCKED. Whatever future fix makes the guards
+   signal-aware, it must not let an unfinished verification become the
+   reason a finding is downgraded out of disclosure.
+3. The guards' current behavior on the marker and on the constructed
+   defect input is characterized so any change forces a conscious decision.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.finding_verifier import (  # noqa: E402
+    INCOMPLETE_VERIFICATION_MARKER,
+    FindingVerifier,
+)
+
+_INTACT = {"entry_point": "h", "sink_reached": True,
+           "attacker_control_at_sink": "full", "path_broken_at": None}
+_BROKEN = {"sink_reached": False, "attacker_control_at_sink": "none",
+           "path_broken_at": "validated at :112"}
+
+_MODEL_TEXT = ("I traced the path but could not confirm the sink guard.")
+
+
+def _exploit_path(verification):
+    return FindingVerifier._has_conclusive_exploit_path(
+        None, {"verification": verification})
+
+
+def _exploitable(verification):
+    return FindingVerifier._has_conclusive_exploitable_path(
+        None, {"verification": verification})
+
+
+def test_marker_constant_is_exactly_todays_match_set():
+    """The constant must not widen the match set: more markers => both
+    guards return False more often => the traced FN direction (Stage-1
+    verdict protection lost; downgrade block lost). Widening requires the
+    direction-aware fix first (#296)."""
+    assert INCOMPLETE_VERIFICATION_MARKER == "Max iterations reached"
+
+
+def test_marker_still_disqualifies_both_guards():
+    v = {"explanation": INCOMPLETE_VERIFICATION_MARKER,
+         "exploit_path": dict(_BROKEN)}
+    assert _exploit_path(v) is False
+    v2 = {"explanation": INCOMPLETE_VERIFICATION_MARKER,
+          "exploit_path": dict(_INTACT)}
+    assert _exploitable(v2) is False
+
+
+def test_asymmetry_incomplete_intact_path_blocks_downgrade():
+    """The issue's suggested test 3: incomplete:True + intact path +
+    model-authored explanation (the _parse_finish_result shape) — the
+    MIRROR guard must stay True so the DISCLOSURE_DROPPED downgrade is
+    blocked. This is the protective outcome PR #195/#243 established; any
+    signal-aware rework must preserve it."""
+    v = {"incomplete": True, "explanation": _MODEL_TEXT,
+         "exploit_path": dict(_INTACT)}
+    assert _exploitable(v) is True, (
+        "an incomplete verification with an intact, attacker-controlled "
+        "path must still block the downgrade — the protective direction")
+    # and the broken-path guard is not involved (an intact path is not
+    # conclusively broken)
+    assert _exploit_path(v) is False
+
+
+def test_characterization_incomplete_broken_path_is_the_open_defect():
+    """CHARACTERIZATION (the open defect, pinned so any change is a
+    conscious decision): incomplete:True + BROKEN path + model-authored
+    explanation reads as conclusive today, suppressing a consistency
+    correction. #296's traced constraint: the obvious tightening re-opens
+    the disclosure FN via the consistency update at :918 — the fix must be
+    direction-aware (skip only for non-downgrade updates). Changing this
+    assertion without that analysis is exactly what #296 warns against."""
+    v = {"incomplete": True, "explanation": _MODEL_TEXT,
+         "exploit_path": dict(_BROKEN)}
+    assert _exploit_path(v) is True, (
+        "KNOWN DEFECT (see #296): an incomplete verification's broken path "
+        "currently suppresses corrections — fix requires direction-awareness")
+
+
+def _verifier():
+    v = FindingVerifier.__new__(FindingVerifier)
+    v._use_logger = False
+    v.verbose = False
+    return v
+
+
+def test_e2e_incomplete_intact_path_downgrade_still_blocked():
+    """The asymmetry at the call site: a downgrade proposal into a
+    DISCLOSURE_DROPPED verdict is still blocked for an INCOMPLETE
+    verification with an intact exploit path (PR #243's protection,
+    surviving #296's signal-awareness question)."""
+    from utilities.finding_verifier import ConsistencyCheckResult
+
+    v = _verifier()
+    rk = "pkg/logger/console.go:runMsg.json"
+    sibling = "pkg/logger/console.go:infoMsg.json"
+    v._resolve_inconsistency = lambda group, cbr: ConsistencyCheckResult(
+        "logger json emitter", "safe",
+        [{"route_key": rk, "should_be": "safe", "reason": "looks safe"}], "x")
+    incomplete_v = {"incomplete": True, "correct_finding": "vulnerable",
+                    "explanation": _MODEL_TEXT,
+                    "exploit_path": dict(_INTACT)}
+    out = v._check_consistency([
+        {"route_key": rk, "finding": "vulnerable",
+         "verification": incomplete_v},
+        {"route_key": sibling, "finding": "safe",
+         "verification": {"correct_finding": "safe"}}], {})
+    got = next(r for r in out if r["route_key"] == rk)
+    assert got.get("finding") == "vulnerable", "the downgrade was applied!"
+    assert "consistency_downgrade_blocked" in got

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -84,6 +84,21 @@ MAX_ITERATIONS = 20
 # llm/helpers.py:DEFAULT_MAX_TOKENS.
 MAX_TOKENS_PER_RESPONSE = DEFAULT_MAX_TOKENS
 
+# #296: the ONE incomplete-verification marker the conclusive-exploit-path
+# guards exact-match today. Deliberately a single string — introducing the
+# constant must NOT change which inputs match. Widening it to the other
+# incomplete markers ("Verification incomplete (finish call truncated at
+# max_tokens)", "... (no tool calls)", the errored note, or model-authored
+# text) would make BOTH guards return False more often, and for both that
+# is the false-negative direction traced in #296: _has_conclusive_exploit_path
+# stops protecting the Stage-1 verdict, and _has_conclusive_exploitable_path
+# stops blocking the downgrade into DISCLOSURE_DROPPED — re-opening the
+# silent vulnerable->safe/inconclusive/rejected family PR #195/#243 closed.
+# Any behavior change here must be direction-aware first (see #296's
+# suggested-fix section): an unfinished verification must not become the
+# reason a finding is downgraded out of disclosure.
+INCOMPLETE_VERIFICATION_MARKER = "Max iterations reached"
+
 
 # Expected JSON shape of a verifier `finish` response — handed to JSONCorrector
 # so a malformed-but-recoverable verifier reply is repaired into THIS shape (no
@@ -1024,7 +1039,8 @@ class FindingVerifier:
         verification = result.get("verification", {})
 
         # If max iterations was reached, the analysis is not conclusive
-        if verification.get("explanation") == "Max iterations reached":
+        # (#296: the marker is a named constant; the match set is UNCHANGED)
+        if verification.get("explanation") == INCOMPLETE_VERIFICATION_MARKER:
             return False
 
         # Check for exploit path analysis. A model may emit ``exploit_path``
@@ -1055,7 +1071,12 @@ class FindingVerifier:
         shows the path IS reachable, attacker-controlled, and unbroken. Defaults
         require proof — a missing field must NOT read as exploitable."""
         verification = result.get("verification", {})
-        if verification.get("explanation") == "Max iterations reached":
+        # #296: the marker is a named constant; the match set is UNCHANGED.
+        # DO NOT widen this test without reading #296 first: this guard
+        # BLOCKS the downgrade into DISCLOSURE_DROPPED — making it False
+        # more often re-opens the silent vulnerable->safe family PR
+        # #195/#243 closed.
+        if verification.get("explanation") == INCOMPLETE_VERIFICATION_MARKER:
             return False
         exploit_path = verification.get("exploit_path")
         if not isinstance(exploit_path, dict):


### PR DESCRIPTION
## Summary

Both conclusive-exploit-path guards exact-match **one free-text string** ("Max iterations reached" — one of five distinct incomplete markers the verifier writes) while the structured signal (`verification["incomplete"]`) sits unused on the same object. The issue's corrected analysis: the two helpers guard in **opposite directions** — `_has_conclusive_exploit_path` returning True **suppresses a correction** (the defect), while `_has_conclusive_exploitable_path` returning True **blocks a downgrade** into `DISCLOSURE_DROPPED` (the PR #195/#243 protection) — and any tightening of either re-opens the silent `vulnerable → safe/inconclusive/rejected` false negative.

The direction-aware behavior change is raised in the issue **as an open question, not a proposal** — and the traced consequence of the obvious fix (test `incomplete` in the first helper) is that an incomplete+broken-path unit stops being skipped, nothing blocks the update, and a downgrade to `safe` removes the record from disclosure. This PR therefore ships **only the explicitly-safe lower-risk items**:

- **`INCOMPLETE_VERIFICATION_MARKER`** names the matched marker as a constant with the match set **unchanged**; both guards carry the do-not-widen warning with the traced consequence (the issue's item 1, phase 1);
- **the asymmetry is pinned** (item 3): an incomplete verification carrying an **intact** exploit path still blocks the `DISCLOSURE_DROPPED` downgrade — at the predicate level AND at the `_check_consistency` call site on the PR #243 fixture shape — so any future signal-aware rework cannot silently lose the protection;
- **the open defect is characterized** (incomplete + broken path reads conclusive today and suppresses corrections) with the direction-aware constraint in the test docstring — changing it forces a conscious decision, not a drift;
- **item 4 answered**: there is no Stage-1 mirror guard to keep in sync — `utilities/stage1_consistency.py` (the PR #245 path) carries no exploit-path/conclusive guard at all; the direction-aware fix, if adopted, should consider both consistency paths together.

Behavior is preserved exactly: the pre-existing guard tests (`test_verifier_consistency_no_exploitable_downgrade`, `test_exploit_path_nondict`, `test_verifier_consistency_disclosure_dropped_downgrade`) pass unchanged.

**Refs #296** — deliberately not "Fixes": the behavioral question (the direction-aware guard change) remains open as the issue itself frames it; this PR is the safety net that makes answering it safe.

## Test plan

5 new hermetic tests: the constant is exactly today's match set (widening = the traced FN direction, requires the direction-aware fix first); the marker still disqualifies both guards; the asymmetry — incomplete + intact path blocks the downgrade (predicate + e2e call site on the #243 fixture shape); the open defect characterized with its constraint.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new + existing guard tests | `pytest tests/test_issue296_conclusive_guards.py tests/test_verifier_consistency_no_exploitable_downgrade.py tests/test_exploit_path_nondict.py tests/test_verifier_consistency_disclosure_dropped_downgrade.py -q` | 17 passed (pre-existing tests unchanged) |
| mutation smoke | guard change stashed → new file | errors on import (the constant IS the change); restored → 5 passed |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest <file>` | 5 passed |
| full suite | `pytest tests/ -q` | 3167 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

</details>

Refs #296
