### PR TITLE
fix(c-parser): function-pointer dispatch through static containers records call-graph edges

### DIFF
--- a/libs/openant-core/parsers/c/PARSER_PIPELINE.md
+++ b/libs/openant-core/parsers/c/PARSER_PIPELINE.md
@@ -117,7 +117,16 @@ Generates `dataset.json` and `analyzer_output.json` with identical schema to Pyt
 
 ### Limitations
 
-- Cannot resolve function pointer dispatch (LLM compensates)
+- Function-pointer dispatch through STATIC containers resolves as of #298 (a
+  braced initialiser of function references — ops struct designated
+  initialisers, function-pointer arrays, struct-array command tables — plus a
+  subscript or member call through the container name records edges to every
+  function the initialisers reference; over-seed is the safe direction).
+  REMAINING unmitigated on a default scan: dispatch through pointers assigned
+  at RUNTIME (indirect calls via variables holding function addresses with no
+  static initialiser table), which the opt-in `--llm-reachability` stage
+  (off by default; reads the first 1,500 bytes per unit) only partially
+  compensates for.
 - Cannot resolve complex macro expansions (tree-sitter sees the macro call, not the expansion)
 - Does not track struct field access patterns
 - C++ template instantiation is not tracked

--- a/libs/openant-core/parsers/c/call_graph_builder.py
+++ b/libs/openant-core/parsers/c/call_graph_builder.py
@@ -32,6 +32,7 @@ Output (JSON):
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -212,12 +213,31 @@ class CallGraphBuilder:
         # method on the receiver's known type.
         local_var_types = self._extract_local_var_types(tree.root_node, code_bytes)
 
+        # #298: function-pointer dispatch containers. A name initialised
+        # with a braced list of function references (an ops struct with
+        # designated initialisers, an array of function pointers, a
+        # struct-array command table) plus a subscript or member call
+        # through that name (tbl[i]() / o.read(x) / cmds[i].fn()) is C's
+        # polymorphism idiom; previously it produced NO edge, so the
+        # dispatcher kept zero out-edges and every target was orphaned.
+        # File-scope containers are visible to every function in the file
+        # (parsed from the file itself, cached); local containers override.
+        containers = dict(self._file_containers(file_path))
+        containers.update(self._collect_container_map(tree.root_node, code_bytes, caller_file))
+
         stack = [tree.root_node]
         while stack:
             node = stack.pop()
             if node.type == 'call_expression':
                 func_node = node.child_by_field_name('function')
                 if func_node:
+                    # #298: dispatch through a known container — the
+                    # over-seed direction (a superset of the true targets
+                    # is kept; nothing is invented: only names the
+                    # container's initialisers actually referenced).
+                    for target in self._container_dispatch_targets(
+                            func_node, code_bytes, containers):
+                        calls.add(target)
                     call_name, receiver = self._extract_call_name_and_receiver(
                         func_node, code_bytes
                     )
@@ -234,8 +254,140 @@ class CallGraphBuilder:
                 # name a known function; non-function identifiers (variables) do not
                 # resolve and so do not create edges.
                 calls.update(self._extract_callback_args(node, code_bytes, caller_file))
+            elif node.type == 'initializer_list':
+                # #298: a function referenced in an initialiser is a
+                # reachability edge from the enclosing unit (the same
+                # family as _extract_callback_args' call-argument refs).
+                for target in self._initializer_targets(node, code_bytes, caller_file):
+                    calls.add(target)
             stack.extend(reversed(node.children))
         return calls
+
+    # ------------------------------------------------------------------
+    # #298: function-pointer dispatch containers
+    # ------------------------------------------------------------------
+    def _initializer_targets(self, init_node, source: bytes, caller_file: str) -> Set[str]:
+        """Resolve the function references inside an initializer_list.
+
+        Covers direct identifier elements ({ h_a, h_b }), designated
+        initialiser values ({ .read = my_read }), address-of operands
+        ({ &h_a }), and nested initializer_lists (struct-array tables:
+        { {"a", cmd_a}, {"b", cmd_b} }). Non-function identifiers (data
+        values) do not resolve and create no edges.
+        """
+        targets: Set[str] = set()
+        stack = [init_node]
+        while stack:
+            node = stack.pop()
+            name: Optional[str] = None
+            if node.type == 'identifier':
+                name = source[node.start_byte:node.end_byte] \
+                    .decode('utf-8', errors='replace')
+            elif node.type in ('pointer_expression', 'unary_expression'):
+                operand = node.child_by_field_name('argument')
+                if operand is not None and operand.type == 'identifier':
+                    name = source[operand.start_byte:operand.end_byte] \
+                        .decode('utf-8', errors='replace')
+            if name and not self._is_stdlib(name):
+                resolved = self._resolve_call(name, caller_file)
+                if resolved:
+                    targets.add(resolved)
+            if node.type == 'initializer_list' or node.type == 'initializer_pair':
+                stack.extend(reversed(node.children))
+        return targets
+
+    def _collect_container_map(self, root, source: bytes,
+                               caller_file: str) -> Dict[str, Set[str]]:
+        """#298: map container names -> the functions their initialisers
+        reference, within this tree. SINGLE-DECLARATION GUARD: a name
+        declared twice is ambiguous for a per-name map and dropped —
+        dispatch through it records nothing rather than guessing."""
+        containers: Dict[str, Set[str]] = {}
+        dropped: Set[str] = set()
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == 'declaration':
+                for child in node.children:
+                    if child.type != 'init_declarator':
+                        continue
+                    name = self._declared_var_name(child, source)
+                    if not name or name in dropped:
+                        continue
+                    init = child.child_by_field_name('value')
+                    if init is None or init.type != 'initializer_list':
+                        continue
+                    targets = self._initializer_targets(init, source, caller_file)
+                    if name in containers:
+                        dropped.add(name)
+                        containers.pop(name, None)
+                        continue
+                    containers[name] = targets
+            stack.extend(reversed(node.children))
+        return containers
+
+    def _file_containers(self, file_path: str) -> Dict[str, Set[str]]:
+        """#298: container map for a file's TOP-LEVEL declarations (cached).
+
+        File-scope tables (`static struct ops o = {...}` at file scope) are
+        the common placement and must be visible to every function in the
+        file. The builder works per-function, so parse the file itself.
+        """
+        cached = getattr(self, "_file_container_cache", None)
+        if cached is None:
+            cached = {}
+            self._file_container_cache = cached
+        if file_path in cached:
+            return cached[file_path]
+        result: Dict[str, Set[str]] = {}
+        try:
+            # file_path is the repo-relative caller-file key ("src/d.c");
+            # resolve it against the repository root the extractor recorded.
+            full = file_path if os.path.isabs(file_path) \
+                else os.path.join(self.repo_path, file_path)
+            with open(full, 'rb') as f:
+                source = f.read()
+            parser = self._get_parser_for_file(file_path)
+            tree = parser.parse(source)
+            result = self._collect_container_map(tree.root_node, source, file_path)
+        except OSError:
+            result = {}
+        cached[file_path] = result
+        return result
+
+    def _container_dispatch_targets(self, func_node, source: bytes,
+                                    containers: Dict[str, Set[str]]) -> Set[str]:
+        """#298: the callee is a subscript/member expression over a known
+        container — dispatch to every function that container references.
+
+        Handles tbl[i]() (subscript), o.read(x) (member over identifier),
+        and cmds[i].fn() (member over subscript). Returns empty for
+        anything else, including subscripts over unknown names.
+        """
+        if not containers:
+            return set()
+        base = self._dispatch_base_identifier(func_node)
+        if base is None:
+            return set()
+        return set(containers.get(base, ()))
+
+    def _dispatch_base_identifier(self, node) -> Optional[str]:
+        """Find the base identifier a subscript/member call dispatches over."""
+        current = node
+        for _ in range(4):  # bounded descent: cmds[i].fn() nests two levels
+            if current is None:
+                return None
+            if current.type == 'identifier':
+                return current.text.decode('utf-8', errors='replace') \
+                    if current.text else None
+            if current.type == 'subscript_expression':
+                current = current.children[0] if current.children else None
+                continue
+            if current.type == 'field_expression':
+                current = current.children[0] if current.children else None
+                continue
+            return None
+        return None
 
     def _extract_callback_args(self, call_node, source: bytes, caller_file: str) -> Set[str]:
         """Resolve function-name arguments passed to a call (higher-order/callback)."""
@@ -322,7 +474,12 @@ class CallGraphBuilder:
         """
         if node.type == 'identifier':
             return source[node.start_byte:node.end_byte].decode('utf-8', errors='replace')
-        if node.type in ('pointer_declarator', 'init_declarator', 'reference_declarator'):
+        if node.type in ('pointer_declarator', 'init_declarator',
+                         'reference_declarator', 'function_declarator',
+                         'array_declarator', 'parenthesized_declarator'):
+            # #298: function/array/parenthesized declarators cover the
+            # function-pointer TABLE shape `void (*tbl[])(void) = {...}` —
+            # the declared name sits under the nested declarators.
             inner = node.child_by_field_name('declarator')
             if inner is not None:
                 return self._declared_var_name(inner, source)

--- a/libs/openant-core/tests/parsers/c/test_issue298_fnptr_dispatch.py
+++ b/libs/openant-core/tests/parsers/c/test_issue298_fnptr_dispatch.py
@@ -1,0 +1,156 @@
+"""Regression tests for issue #298 — C indirect dispatch records no edges.
+
+The three canonical C indirect-dispatch idioms — an ops struct with
+designated initialisers, an array of function pointers, and a
+struct-array command table dispatched by index — produced NO edge at all,
+so the dispatching function had zero out-edges and every target was
+orphaned. In C, function-pointer dispatch is the language's polymorphism
+mechanism (kernel file_operations, driver op tables, syscall tables,
+plugin vtables), so these are exactly the edges that carry
+attacker-reachable control flow into a handler — and the dispatcher is
+retained while its targets are pruned (#295's shape, in C).
+
+The machinery for "a function referenced without being called" already
+existed in this file (_extract_callback_args covers register_handler(cb));
+initialisers and subscript/member dispatch are the missing members of that
+family.
+
+Contract locked here (the issue's fixture + controls):
+- every table target gets a caller, and every dispatcher gets outgoing
+  edges to its table's targets (over-seed is the safe direction);
+- a direct-call CONTROL keeps its edge (null-result meaningfulness);
+- unknown subscript bases and non-function initialiser values still
+  record nothing (no invented edges).
+"""
+
+from __future__ import annotations
+
+import sys
+import textwrap
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from parsers.c.call_graph_builder import CallGraphBuilder  # noqa: E402
+from parsers.c.function_extractor import FunctionExtractor  # noqa: E402
+
+
+def _build(tmp_path: Path, source: str) -> CallGraphBuilder:
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    (src_dir / "d.c").write_text(textwrap.dedent(source))
+    ex = FunctionExtractor(str(tmp_path))
+    units = ex.extract_all()
+    cg = CallGraphBuilder(units)
+    cg.build_call_graph()
+    return cg
+
+
+_FIXTURE = """
+    static void h_a(void) {}
+    static void h_b(void) {}
+    static void my_read(int x) {}
+    static void direct_target(void) {}
+
+    struct ops { void (*read)(int); };
+    static struct ops o = { .read = my_read };
+    static void (*tbl[])(void) = { h_a, h_b };
+
+    void use_ops(int x)      { o.read(x); }
+    void use_tbl(int i)      { tbl[i](); }
+    void direct_caller(void) { direct_target(); }
+"""
+
+
+def test_control_direct_call_edge_exists(tmp_path):
+    cg = _build(tmp_path, _FIXTURE)
+    assert "src/d.c:direct_target" in cg.call_graph.get("src/d.c:direct_caller", [])
+
+
+def test_ops_struct_dispatch_edges(tmp_path):
+    """o.read(x) through a struct initialised with designated
+    initialisers: use_ops edges to my_read; my_read gets a caller."""
+    cg = _build(tmp_path, _FIXTURE)
+    assert "src/d.c:my_read" in cg.call_graph.get("src/d.c:use_ops", [])
+    assert "src/d.c:use_ops" in cg.reverse_call_graph.get("src/d.c:my_read", [])
+
+
+def test_function_pointer_table_dispatch_edges(tmp_path):
+    """tbl[i]() through an array of function pointers: use_tbl edges to
+    both table targets."""
+    cg = _build(tmp_path, _FIXTURE)
+    edges = cg.call_graph.get("src/d.c:use_tbl", [])
+    assert "src/d.c:h_a" in edges and "src/d.c:h_b" in edges, edges
+
+
+def test_no_target_orphaned(tmp_path):
+    """The issue's headline consequence: no dispatch target ends up with an
+    empty caller set while its dispatcher is kept."""
+    cg = _build(tmp_path, _FIXTURE)
+    for fn in ("h_a", "h_b", "my_read"):
+        callers = cg.reverse_call_graph.get(f"src/d.c:{fn}", [])
+        assert callers, f"{fn} must have at least one caller (issue #298)"
+
+
+def test_struct_array_command_table_dispatch(tmp_path):
+    """cmds[i].fn() — a struct-array command table: the field call over a
+    subscripted known container dispatches to every function the table's
+    initialisers reference."""
+    cg = _build(tmp_path, """
+        struct cmd { const char *name; void (*fn)(void); };
+        static struct cmd cmds[] = {
+            {"a", cmd_a},
+            {"b", cmd_b},
+        };
+        static void cmd_a(void) {}
+        static void cmd_b(void) {}
+
+        void run_cmd(int i) { cmds[i].fn(); }
+    """)
+    edges = cg.call_graph.get("src/d.c:run_cmd", [])
+    assert "src/d.c:cmd_a" in edges and "src/d.c:cmd_b" in edges, edges
+
+
+def test_local_table_in_function(tmp_path):
+    """A table built INSIDE a function body: same dispatch through the
+    local name."""
+    cg = _build(tmp_path, """
+        static void h1(void) {}
+        static void h2(void) {}
+
+        void dispatch(int i) {
+            static void (*t[])(void) = { h1, h2 };
+            t[i]();
+        }
+    """)
+    edges = cg.call_graph.get("src/d.c:dispatch", [])
+    assert "src/d.c:h1" in edges and "src/d.c:h2" in edges, edges
+
+
+def test_unknown_subscript_base_records_nothing(tmp_path):
+    """Negative control: a subscript call over a name with no known
+    function-referencing initialiser records nothing — edges are only
+    added, never invented."""
+    cg = _build(tmp_path, """
+        static void sink(void) {}
+
+        void f(int i) {
+            int data[3] = {1, 2, 3};
+            data[i] = i + 1;      /* not a call at all */
+            g(i);                 /* unknown callee */
+        }
+    """)
+    assert cg.call_graph.get("src/d.c:f", []) == []
+
+
+def test_non_function_initializer_values_ignored(tmp_path):
+    """An initialiser of non-function values creates no container edges."""
+    cg = _build(tmp_path, """
+        void f(void) {
+            int nums[] = {1, 2, 3};
+            (void)nums[0];
+        }
+    """)
+    assert cg.call_graph.get("src/d.c:f", []) == []


### PR DESCRIPTION
## Summary

The three canonical C indirect-dispatch idioms — an ops struct with designated initialisers, an array of function pointers, and a struct-array command table — produced **no edge at all**: `_extract_call_name` resolved identifier/field/qualified/template callees, a `subscript_expression` callee fell through the `isidentifier()` catch-all to `None`, and the member path never fired for struct/array *literal* receivers. The dispatcher kept zero out-edges and every target was orphaned — #295's shape, in C, where function-pointer dispatch is the language's **polymorphism mechanism** (kernel `file_operations`, driver op tables, syscall tables, plugin vtables).

The machinery for "a function referenced without being called" already existed in this file (`_extract_callback_args` covers `register_handler(cb)`); initialisers and container dispatch are the missing members of that family.

Fix (issue suggestions 1+2+3; 4 = the tests):
- **initializer_list reference edges**: a bare identifier (or `&id`) as an initialiser element, a designated-initialiser value, or a nested struct-array element resolves to an edge from the enclosing unit;
- **container dispatch**: a name initialised with a braced list of function references (file-scope, parsed from the file and cached, or function-local) plus a subscript call (`tbl[i]()`), member call over an identifier (`o.read(x)`), or member-over-subscript (`cmds[i].fn()`) records edges to **every** function the initialisers reference — over-seed, the safe direction; nothing invented (unknown bases record nothing, tested);
- single-declaration guard: a name declared twice is dropped rather than guessed;
- **`PARSER_PIPELINE.md`'s compensation line corrected** (suggestion 3): static containers now resolve; runtime-assigned pointer dispatch remains unmitigated on a default scan — the opt-in `--llm-reachability` stage (off by default, 1,500-byte unit window) only partially compensates.

**T3 real-corpus differential** (redis `src/t_hash.c` + `src/rdb.c` and linenoise — 264 units): base 445 edges → fix 447 edges, **LOST: 0** (monotone). The +2 gained are **real dispatch edges in redis code**: `hashTypeDbActiveExpire → hashTypeActiveExpire` and `hashTypeExpire → onFieldExpire` (the field-expiry dispatch).

Sibling: Python is #295 (PR #388); the other seven parsers are #299.

## Test plan

8 hermetic tests in the canonical parser-test location (`tests/parsers/c/`): the issue's fixture with a direct-call control (ops-struct dispatch, function-pointer table, no target orphaned) + the struct-array command table + a function-local table + unknown-subscript and non-function-initialiser negative controls.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `pytest tests/parsers/c/test_issue298_fnptr_dispatch.py -q` | 8 passed (5 failed RED on pristine) |
| full C parser suite | `pytest tests/parsers/c/ -q` | 107 passed (symmetry included) |
| mutation smoke | builder stashed → new file | 5 failed, 3 passed (negative controls by design); restored → 8 passed |
| T3 real-corpus differential | redis t_hash.c/rdb.c + linenoise, base vs fix | 264 units; 445 → 447 edges; **LOST 0**; +2 real redis dispatch edges |
| full suite | `pytest tests/ -q` | 3170 passed, 2 failed (pre-existing zig local-env, stash-verified), 32 skipped |
| hermeticity oracle | `env -i HOME=/tmp/fakehome-noconfig python -m pytest <file>` | 8 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #298
