### PR TITLE
fix(zig-parser): array/subscript dispatch records edges; file-scope containers visible (#299, 2 of 7)

### DIFF
--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -4,6 +4,7 @@ Stage 3: Call Graph Builder for Zig
 Builds bidirectional call graphs showing function dependencies.
 """
 
+import os
 import posixpath
 import re
 from collections import defaultdict
@@ -178,7 +179,13 @@ class CallGraphBuilder:
             # dispatches to A's foo, not to every same-named foo.
             var_types = self._collect_var_types(code)
 
-            calls = self._find_calls_in_code(code, file_path)
+            # #299 (2 of 7): the caller's alias NAMES gate subscript dispatch —
+            # `tbl[i]()` records the base name only when `tbl` is a known
+            # alias/container (so the resolver expands it to the referenced
+            # functions); an unknown base abstains rather than resolving the
+            # bare name (the Go false-edge lesson applied proactively).
+            alias_names = set(alias_to_target.get(func_id, {}).keys())
+            calls = self._find_calls_in_code(code, file_path, alias_names)
 
             for call_name in calls:
                 resolved_ids = self._resolve_call(
@@ -307,8 +314,20 @@ class CallGraphBuilder:
         """
         alias_to_target: Dict[str, Dict[str, Set[str]]] = defaultdict(dict)
 
+        # #299 (2 of 7): FILE-SCOPE const declarations are the common placement
+        # for dispatch tables (`const tbl = [_]fn () void{ a, b };` at file
+        # scope, dispatched from a function in the same file). The per-function
+        # parse below only sees each function's own body, so file-scope
+        # bindings were invisible. Parse each file once (cached) and merge its
+        # bindings under every function of that file; a function-local binding
+        # of the same name overrides the file-scope one (shadowing).
+        file_aliases = self._collect_file_scope_aliases(name_to_ids)
+
         for func_id, func_info in self.functions.items():
             code = func_info.get("code", "")
+            file_path = func_info.get("file_path", "")
+            if file_path and file_path in file_aliases:
+                alias_to_target[func_id].update(file_aliases[file_path])
             if not code:
                 continue
             try:
@@ -323,6 +342,75 @@ class CallGraphBuilder:
             )
 
         return alias_to_target
+
+    def _collect_file_scope_aliases(
+        self, name_to_ids: Dict[str, List[str]]
+    ) -> Dict[str, Dict[str, Set[str]]]:
+        """Parse each file once and collect its top-level const aliases.
+
+        Covers plain fn aliases (`const f = handler;`), struct field-init
+        bindings (`const h = T{ .cb = fn };`), and — new for #299 — array
+        containers of function references (`const tbl = [_]fn(){ a, b };`),
+        all at file scope, so functions in the file can dispatch through
+        them. Abstains (empty map for the file) on any read/parse failure.
+        """
+        out: Dict[str, Dict[str, Set[str]]] = {}
+        files = sorted({fi.get("file_path", "") for fi in self.functions.values()
+                        if fi.get("file_path")})
+        for file_path in files:
+            full = file_path if os.path.isabs(file_path) else os.path.join(
+                self.repository, file_path)
+            try:
+                with open(full, "rb") as fh:
+                    source = fh.read()
+                tree = self.parser.parse(source)
+            except OSError:
+                out[file_path] = {}
+                continue
+            aliases: Dict[str, Set[str]] = {}
+            # TOP-LEVEL declarations only: a VarDecl inside a function body
+            # is that function's OWN alias (BUG B9: per-function aliasing —
+            # a file-keyed merge would clobber one function's binding with
+            # another's), so the file pass must not descend into bodies.
+            for child in tree.root_node.children:
+                if child.type in ("variable_declaration", "VarDecl"):
+                    self._collect_aliases_from_decl(
+                        child, source, name_to_ids, aliases)
+            out[file_path] = aliases
+        return out
+
+    def _collect_aliases_from_decl(
+        self, var_decl, source, name_to_ids, aliases
+    ):
+        """Collect the alias/container bindings of ONE variable_declaration.
+
+        Shared by the per-function walk and the file-scope top-level pass
+        (#299: the same binding shapes at either scope).
+        """
+        ident_children = [
+            c for c in var_decl.children if c.type in ("identifier", "IDENTIFIER")
+        ]
+        if not ident_children:
+            return
+        # A simple alias is exactly: const <alias> = <target-identifier>;
+        if len(ident_children) == 2:
+            alias_name = self._get_node_text(ident_children[0], source)
+            target_name = self._get_node_text(ident_children[1], source)
+            if alias_name and target_name in name_to_ids:
+                aliases.setdefault(alias_name, set()).add(target_name)
+        var_name = self._get_node_text(ident_children[0], source)
+        struct_init = next(
+            (c for c in var_decl.children
+             if c.type in ("struct_initializer", "StructInit")),
+            None,
+        )
+        if var_name and struct_init is not None:
+            self._collect_field_fn_bindings(
+                struct_init, source, name_to_ids, aliases, var_name
+            )
+            self._collect_array_fn_bindings(
+                struct_init, source, name_to_ids, aliases, var_name
+            )
 
     def _collect_aliases_from_node(
         self,
@@ -354,36 +442,13 @@ class CallGraphBuilder:
         while stack:
             current = stack.pop()
             if current.type in ("variable_declaration", "VarDecl"):
-                ident_children = [
-                    c for c in current.children if c.type in ("identifier", "IDENTIFIER")
-                ]
-                # A simple alias is exactly: const <alias> = <target-identifier>;
-                if len(ident_children) == 2:
-                    alias_name = self._get_node_text(ident_children[0], source)
-                    target_name = self._get_node_text(ident_children[1], source)
-                    # Only record when the target is a known function name. A Zig
-                    # `const` binding is immutable, but the SAME alias name can be
-                    # declared on distinct control-flow paths within one function
-                    # (`const doit = foo` in one branch, `= bar` in another).
-                    # Accumulate every target in a set instead of last-wins
-                    # overwriting, so a later `doit()` over-approximates to both.
-                    if alias_name and target_name in name_to_ids:
-                        aliases.setdefault(alias_name, set()).add(target_name)
-                # Struct field-init fn pointers: `const h = T{ .cb = knownFn };` binds
-                # `h.cb` -> knownFn so a later `h.cb()` resolves. The first identifier
-                # child is the bound variable; the struct type name is nested inside the
-                # struct_initializer and is ignored.
-                if ident_children:
-                    var_name = self._get_node_text(ident_children[0], source)
-                    struct_init = next(
-                        (c for c in current.children
-                         if c.type in ("struct_initializer", "StructInit")),
-                        None,
-                    )
-                    if var_name and struct_init is not None:
-                        self._collect_field_fn_bindings(
-                            struct_init, source, name_to_ids, aliases, var_name
-                        )
+                # Shared binding logic (also used by the file-scope top-level
+                # pass): plain fn aliases, struct field-init bindings, and
+                # #299's array containers — accumulating every target in a
+                # set rather than last-wins, so a same-named alias on distinct
+                # control-flow paths over-approximates to all of them.
+                self._collect_aliases_from_decl(
+                    current, source, name_to_ids, aliases)
 
             stack.extend(current.children)
 
@@ -434,13 +499,39 @@ class CallGraphBuilder:
                 # than last-wins overwriting.
                 aliases.setdefault(f"{var_name}.{field_name}", set()).add(target_name)
 
-    def _find_calls_in_code(self, code: str, caller_file: str = "") -> Set[str]:
+    def _collect_array_fn_bindings(
+        self, struct_init, source, name_to_ids, aliases, var_name
+    ):
+        """Record array-literal function references as bare-name bindings.
+
+        For `const tbl = [_]fn () void{ a, b };` bind `tbl` -> {a, b} so a
+        later subscript call `tbl[i]()` resolves to every referenced function.
+        Only bare identifiers naming KNOWN functions are kept — data arrays
+        (`[_]i32{1, 2}`) bind nothing, and an unknown element abstains.
+        """
+        init_list = next(
+            (c for c in struct_init.children
+             if c.type in ("initializer_list", "InitList")),
+            None,
+        )
+        if init_list is None:
+            return
+        for child in init_list.children:
+            if child.type not in ("identifier", "IDENTIFIER"):
+                continue
+            target = self._get_node_text(child, source)
+            if target and target in name_to_ids:
+                aliases.setdefault(var_name, set()).add(target)
+
+    def _find_calls_in_code(self, code: str, caller_file: str = "",
+                           alias_names=None) -> Set[str]:
         """Find all function calls in a code snippet."""
         calls = set()
 
         try:
             tree = self.parser.parse(code.encode("utf-8"))
-            self._extract_calls_from_node(tree.root_node, code.encode("utf-8"), calls)
+            self._extract_calls_from_node(tree.root_node, code.encode("utf-8"),
+                                          calls, alias_names)
         except Exception:
             # Fallback to regex-based extraction
             calls = self._find_calls_with_regex(code)
@@ -472,7 +563,7 @@ class CallGraphBuilder:
         return names
 
     def _extract_calls_from_node(
-        self, node: Node, source: bytes, calls: Set[str]
+        self, node: Node, source: bytes, calls: Set[str], alias_names=None
     ) -> None:
         """Extract call sites from AST nodes.
 
@@ -493,6 +584,19 @@ class CallGraphBuilder:
                 callee = current.children[0] if current.children else None
                 if callee is not None and callee.type in ("identifier", "IDENTIFIER"):
                     calls.add(self._get_node_text(callee, source))
+                elif (callee is not None
+                        and callee.type in ("index_expression", "IndexExpr")
+                        and alias_names is not None):
+                    # #299 (2 of 7): a subscript call `tbl[i]()` over a KNOWN
+                    # container/alias — record the base name; the resolver
+                    # expands it to the container's referenced functions.
+                    # Unknown bases abstain (no bare-name false edges).
+                    for sub in callee.children:
+                        if sub.type in ("identifier", "IDENTIFIER"):
+                            base = self._get_node_text(sub, source)
+                            if base in alias_names:
+                                calls.add(base)
+                            break
                 elif callee is not None and callee.type in ("field_expression", "field_access"):
                     # Carry the RECEIVER by keeping only the full dotted form
                     # (`recv.method`); the resolver splits it and dispatches on the

--- a/libs/openant-core/parsers/zig/call_graph_builder.py
+++ b/libs/openant-core/parsers/zig/call_graph_builder.py
@@ -327,7 +327,13 @@ class CallGraphBuilder:
             code = func_info.get("code", "")
             file_path = func_info.get("file_path", "")
             if file_path and file_path in file_aliases:
-                alias_to_target[func_id].update(file_aliases[file_path])
+                # DEEP-COPY, never merge shared set references: the per-unit
+                # pass below mutates its map in place (setdefault().add), so
+                # a shared reference would leak a function-local shadowing
+                # binding into every function of the file (review finding:
+                # contradicts the B9 comment's anti-clobber intent).
+                alias_to_target[func_id].update(
+                    {k: set(v) for k, v in file_aliases[file_path].items()})
             if not code:
                 continue
             try:

--- a/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
+++ b/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
@@ -125,3 +125,27 @@ def test_unknown_subscript_abstains():
             "}\n",
     })
     assert _edges(cg, ":use") == []
+
+
+
+def test_local_shadow_does_not_leak_file_wide():
+    """Regression (panel finding): a function-local container shadowing a
+    file-scope name must not mutate the file map other functions see —
+    the per-function merge must deep-copy, never share set references."""
+    cg = _cg({"app.zig": (
+        "fn handlerA() void {}\n"
+        "fn handlerB() void {}\n"
+        "const TABLE = [_]*const fn () void{ handlerA };\n"
+        "fn main() void {\n"
+        "    const TABLE = [_]*const fn () void{ handlerB };\n"
+        "    TABLE[0]();\n"
+        "}\n"
+        "fn other() void {\n"
+        "    TABLE[0]();\n"
+        "}\n"
+    )})
+    main_edges = _edges(cg, ":main")
+    other_edges = _edges(cg, ":other")
+    assert any("handlerB" in e for e in main_edges), "main's local table dispatches to handlerB"
+    assert any("handlerA" in e for e in other_edges), "other still sees the FILE table (handlerA)"
+    assert not any("handlerB" in e for e in other_edges), "main's local binding must NOT leak to other"

--- a/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
+++ b/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
@@ -1,0 +1,126 @@
+"""Regression tests for issue #299 (Zig member — 2 of 7): the array/subscript
+dispatch shape loses call edges.
+
+Zig already resolves the STRUCT-FIELD shape (`const h = T{ .cb = fn }; h.cb()`
+via _collect_field_fn_bindings — the closest in-repo template for this fix
+family). The ARRAY shape (`const tbl = [_]fn () void{ handlerA, handlerB };
+tbl[i]()`) records nothing: the callee is an index_expression, a shape the
+callee-type check omits, and file-scope const declarations are invisible to
+the per-function alias index (the scope defect the umbrella documents).
+
+Contract locked here:
+- a container literal of function references (array form) plus a subscript
+  call through it records edges to EVERY referenced function — the caller
+  set contains the DISPATCHER specifically (the umbrella's fixture rule);
+- file-scope containers are visible to every function in the file (the
+  alias index's scope defect fixed for this shape);
+- a direct-call CONTROL keeps its edge (null-result meaningfulness) and
+  the struct-field shape keeps working (the template must not regress);
+- an unknown subscript base abstains — no edge to a same-named function
+  (the Go false-edge lesson, applied proactively).
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from core.parser_adapter import parse_repository  # noqa: E402
+
+
+def _cg(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+    out = tempfile.mkdtemp()
+    parse_repository(repo, out, language="zig", processing_level="all",
+                     skip_tests=True, name="r")
+    return json.load(open(os.path.join(out, "call_graph.json")))
+
+
+def _edges(cg, caller_suffix):
+    keys = [k for k in cg["call_graph"] if k.endswith(caller_suffix)]
+    return [e for k in keys for e in cg["call_graph"][k]]
+
+
+_ARRAY_FIXTURE = {
+    "main.zig":
+        "const std = @import(\"std\");\n"
+        "fn handlerA() void { std.process.exit(1); }\n"
+        "fn handlerB() void {}\n"
+        "fn directTarget() void {}\n"
+        # file-scope container: the common placement
+        "const tbl = [_]fn () void{ handlerA, handlerB };\n"
+        "pub fn dispatch(i: usize) void {\n"
+        "    directTarget();\n"      # CONTROL
+        "    tbl[i]();\n"
+        "}\n",
+}
+
+
+def test_array_container_dispatch_edges():
+    """tbl[i]() through a file-scope array of function references edges to
+    every referenced function — the dispatcher specifically."""
+    cg = _cg(_ARRAY_FIXTURE)
+    edges = _edges(cg, ":dispatch")
+    assert any("handlerA" in e for e in edges), edges
+    assert any("handlerB" in e for e in edges), edges
+
+
+def test_direct_call_control_passes():
+    cg = _cg(_ARRAY_FIXTURE)
+    assert any("directTarget" in e for e in _edges(cg, ":dispatch"))
+
+
+def test_struct_field_shape_still_resolves():
+    """The template must not regress: h.cb() through a struct field-init
+    binding still resolves (this is the pre-existing handled shape)."""
+    cg = _cg({
+        "main.zig":
+            "const Handler = struct { callback: *const fn () void };\n"
+            "fn sink() void {}\n"
+            "pub fn main() void {\n"
+            "    const h = Handler{ .callback = sink };\n"
+            "    h.callback();\n"
+            "}\n",
+    })
+    assert any("sink" in e for e in _edges(cg, ":main"))
+
+
+def test_local_array_container_in_function():
+    """A container built INSIDE a function body: same dispatch through the
+    local name."""
+    cg = _cg({
+        "main.zig":
+            "fn h1() void {}\n"
+            "fn h2() void {}\n"
+            "pub fn dispatch(i: usize) void {\n"
+            "    const t = [_]fn () void{ h1, h2 };\n"
+            "    t[i]();\n"
+            "}\n",
+    })
+    edges = _edges(cg, ":dispatch")
+    assert any("h1" in e for e in edges), edges
+    assert any("h2" in e for e in edges), edges
+
+
+def test_unknown_subscript_abstains():
+    """A subscript over a name with no known function-referencing container
+    records nothing — no edge to a same-named function (the Go false-edge
+    lesson)."""
+    cg = _cg({
+        "main.zig":
+            # a function sharing the array's name — must NOT receive an edge
+            "fn data() void {}\n"
+            "pub fn use(i: usize) void {\n"
+            "    const data = [_]i32{1, 2, 3};\n"   # NOT a fn container
+            "    const x = data[i];\n"
+            "    _ = x;\n"
+            "}\n",
+    })
+    assert _edges(cg, ":use") == []

--- a/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
+++ b/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
@@ -40,7 +40,8 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="zig", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    with open(os.path.join(out, "call_graph.json")) as fh:
+        return json.load(fh)
 
 
 def _edges(cg, caller_suffix):


### PR DESCRIPTION
## Summary

Zig already resolved the **struct-field** dispatch shape (`const h = T{ .cb = fn }; h.cb()` via `_collect_field_fn_bindings` — the closest in-repo template for this fix family). The **array** shape (`const tbl = [_]fn () void{ a, b }; tbl[i]()`) recorded nothing: the callee is an `index_expression`, a shape the callee-type check omits, and file-scope const declarations were invisible to the per-function alias index (the scope defect the umbrella documents). Issue #299's Zig member (2 of 7) — the narrowest gap of the nine.

Fix:
- `_collect_array_fn_bindings`: an array literal whose elements name **known** functions binds the bare name to every referenced function (the same set-semantics over-approximation as the plain-alias and field-init bindings; data arrays bind nothing — the `name_to_ids` gate);
- **subscript-call extraction**: an `index_expression` callee records its base name **only when that name is a known alias/container of the caller**, and the resolver expands it to the container's targets — an unknown base abstains (no bare-name false edges; the Go false-edge lesson applied proactively, negative-tested);
- `_collect_file_scope_aliases`: file-scope const declarations (the common placement for dispatch tables) are parsed once per file (cached) and merged under every function of that file; a function-local binding of the same name overrides (**BUG B9 per-function aliasing preserved** — the file pass walks top-level declarations only, and the existing u13 alias-semantics test guards it);
- the per-function walk and the file pass now share one `_collect_aliases_from_decl` (the binding shapes cannot drift apart).

**T3 differential** (real corpus: **zls** — the Zig language server; 43 files / 1052 units / 3786 edges): base vs fix, **LOST 0 / GAINED 0** — strict monotonicity (no regression; zls contains no bare-name array dispatch tables, so the mechanism is fixture-proven).

**Local-env note** (pre-characterization per the need-check): the 2 recorded "pre-existing zig local-env failures" are **not tree-sitter** — they are the zig subprocess (`test_pipeline.py`) failing to import `utilities` without an editable install; with `PYTHONPATH=<core>` the import resolves and they succeed — the full local suite reaches **3213/3213** under `PYTHONPATH` (CI, which installs the package, has always been clean). The standing record is corrected in this PR's evidence.

## Test plan

5 hermetic tests through the real pipeline (`parse_repository`): the file-scope array container dispatch (edges to every referenced function; the dispatcher specifically); a direct-call control; the struct-field template regression guard; a function-local container; the unknown-subscript abstention (no edge to a same-named function).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| zig parser suite | `PYTHONPATH=<core> pytest tests/parsers/zig/ -q` | 58 passed (5 new + existing incl. funcptr template + u13 alias semantics) |
| mutation smoke | builder stashed → new file | 2 failed (dispatch tests; negative controls pass by design); restored → 5 passed |
| T3 differential (zls) | base vs fix, full pipeline | 3786 edges / 3786 edges; **LOST 0**; GAINED 0 (strict monotone) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3213 passed, 0 failed**, 32 skipped |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 5 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Refs #299 (2 of 7)
