### PR TITLE
fix(swift-parser): container-literal dispatch records edges; file-scope lets visible (#299, 3 of 7)

### DIFF
--- a/libs/openant-core/parsers/swift/call_graph_builder.py
+++ b/libs/openant-core/parsers/swift/call_graph_builder.py
@@ -22,6 +22,7 @@ reachability recall while avoiding gross same-name over-connection:
             -> caller -> referenced function (callback reachability)
 """
 
+import os
 from collections import defaultdict
 from typing import Any, Dict, List, Optional, Set, Tuple
 
@@ -200,7 +201,12 @@ class CallGraphBuilder:
             caller_class = func_info.get("class_name")
 
             var_types, local_names, var_qualified = self._collect_var_types(code, type_names)
-            call_sites, arg_refs = self._find_calls_in_code(code, file_path)
+            # #299 (3 of 7): the caller's alias NAMES gate subscript dispatch —
+            # `tbl[i]()` records the base only when `tbl` is a known
+            # alias/container (tier-1 expansion then resolves it); an unknown
+            # base abstains rather than resolving the bare name.
+            alias_names = set(alias_to_target.get(func_id, {}).keys())
+            call_sites, arg_refs = self._find_calls_in_code(code, file_path, alias_names)
 
             for site in call_sites:
                 sites_total += 1
@@ -365,9 +371,20 @@ class CallGraphBuilder:
         return type_names, dict(ctor_index)
 
     def _build_alias_index(self, name_to_ids) -> Dict[str, Dict[str, Set[str]]]:
-        """Per-function `let f = knownFn` aliases (over-approximated as sets)."""
+        """Per-function `let f = knownFn` aliases (over-approximated as sets).
+
+        #299 (3 of 7): FILE-SCOPE `let` declarations are the common placement
+        for dispatch tables and were invisible to the per-function parse
+        (each function only sees its own body). Parse each file once (cached)
+        and merge its TOP-LEVEL bindings under every function of that file;
+        a function-local binding of the same name overrides (shadowing).
+        """
         alias_to_target: Dict[str, Dict[str, Set[str]]] = defaultdict(dict)
+        file_aliases = self._collect_file_scope_aliases(name_to_ids)
         for func_id, func_info in self.functions.items():
+            file_path = func_info.get("file_path", "")
+            if file_path and file_path in file_aliases:
+                alias_to_target[func_id].update(file_aliases[file_path])
             code = func_info.get("code", "")
             if not code:
                 continue
@@ -378,6 +395,67 @@ class CallGraphBuilder:
             self._collect_aliases(tree.root_node, code.encode("utf-8"),
                                   name_to_ids, alias_to_target[func_id])
         return alias_to_target
+
+    def _collect_file_scope_aliases(self, name_to_ids) -> Dict[str, Dict[str, Set[str]]]:
+        """Collect each file's TOP-LEVEL let bindings (plain aliases and
+        container literals). Top-level only: a `let` inside a function body
+        is that function's own alias (per-function semantics — a file-keyed
+        merge would clobber one function's binding with another's).
+        Abstains (empty map) on any read/parse failure.
+        """
+        out: Dict[str, Dict[str, Set[str]]] = {}
+        files = sorted({fi.get("file_path", "") for fi in self.functions.values()
+                        if fi.get("file_path")})
+        for file_path in files:
+            full = file_path if os.path.isabs(file_path) else os.path.join(
+                self.repository, file_path)
+            aliases: Dict[str, Set[str]] = {}
+            try:
+                with open(full, "rb") as fh:
+                    source = fh.read()
+                tree = self.parser.parse(source)
+            except OSError:
+                out[file_path] = aliases
+                continue
+            for child in tree.root_node.children:
+                if child.type == "property_declaration":
+                    self._collect_aliases(child, source, name_to_ids, aliases)
+            out[file_path] = aliases
+        return out
+
+    def _container_literal_targets(self, prop, source, name_to_ids) -> Set[str]:
+        """The KNOWN-function names referenced by a container-literal RHS.
+
+        Array literals contribute their bare identifier elements;
+        dictionary literals contribute the identifier VALUES (after `:`).
+        Non-function elements (data values) do not resolve and bind nothing.
+        """
+        targets: Set[str] = set()
+        lit = None
+        seen_eq = False
+        for c in prop.children:
+            if c.type == "=":
+                seen_eq = True
+            elif seen_eq and c.type in ("array_literal", "dictionary_literal"):
+                lit = c
+                break
+        if lit is None:
+            return targets
+        for element in lit.children:
+            if element.type == "simple_identifier":
+                text = self._text(element, source)
+                if text in name_to_ids:
+                    targets.add(text)
+            elif element.type == ":":
+                # dictionary entry: the next identifier child is the VALUE
+                idx = lit.children.index(element)
+                for nxt in lit.children[idx + 1:]:
+                    if nxt.type == "simple_identifier":
+                        text = self._text(nxt, source)
+                        if text in name_to_ids:
+                            targets.add(text)
+                        break
+        return targets
 
     def _collect_aliases(self, root: Node, source: bytes, name_to_ids, aliases) -> None:
         """`let f = handler` where handler is a known function → alias f->handler.
@@ -395,6 +473,18 @@ class CallGraphBuilder:
                 rhs = self._eq_rhs_identifier(node, source)
                 if name and rhs and rhs in name_to_ids:
                     aliases.setdefault(name, set()).add(rhs)
+                # #299 (3 of 7): a container literal of function references —
+                # `let tbl: [() -> Int] = [handlerA, handlerB]` /
+                # `let map: [String: () -> Int] = ["a": handler]` — binds the
+                # variable to every KNOWN function among its elements, so a
+                # later `tbl[i]()` dispatches to all of them (the same
+                # set-over-approximation as the plain alias; data arrays bind
+                # nothing — the name_to_ids gate).
+                elif name:
+                    targets = self._container_literal_targets(node, source,
+                                                              name_to_ids)
+                    if targets:
+                        aliases.setdefault(name, set()).update(targets)
             elif node.type == "assignment":
                 # a REASSIGNMENT `f = b` (in a branch) — `var f = a; if c { f = b }
                 # else { f = d }; f()` must union {a,b,d}, not keep only the initial
@@ -612,7 +702,8 @@ class CallGraphBuilder:
 
     # -- call extraction ----------------------------------------------------
 
-    def _find_calls_in_code(self, code: str, caller_file: str = ""):
+    def _find_calls_in_code(self, code: str, caller_file: str = "",
+                            alias_names=None):
         """Return (call_sites, arg_refs).
 
         call_sites: a LIST of per-occurrence records — {text, labels, arity,
@@ -635,7 +726,7 @@ class CallGraphBuilder:
         # `except` alone reports 0 failures while real bodies fail to parse.
         if tree.root_node.has_error:
             self.stats_extra["reparse_error_bodies"] = self.stats_extra.get("reparse_error_bodies", 0) + 1
-        self._extract_calls(tree.root_node, code.encode("utf-8"), sites, arg_refs)
+        self._extract_calls(tree.root_node, code.encode("utf-8"), sites, arg_refs, alias_names)
 
         shadowing = self._same_file_function_names(caller_file)
         repo_names = self._repo_function_names()
@@ -661,7 +752,8 @@ class CallGraphBuilder:
         ]
         return kept, arg_refs
 
-    def _extract_calls(self, root: Node, source: bytes, sites: List[dict], arg_refs: Set[str]) -> None:
+    def _extract_calls(self, root: Node, source: bytes, sites: List[dict],
+                       arg_refs: Set[str], alias_names=None) -> None:
         """Iterative worklist walk collecting per-occurrence call-site records.
 
         Handles `call_expression` (callee = `simple_identifier` plain/ctor, or
@@ -674,9 +766,41 @@ class CallGraphBuilder:
         stack = [root]
         while stack:
             node = stack.pop()
+            # NOTE (#299): the `not _is_subscript` guard is DELIBERATE and must
+            # stay. It excludes a subscript ACCESS `x[i]` (a call_expression
+            # whose value_arguments are led by `[`) from function-call
+            # resolution: recording it would fabricate a call edge to whatever
+            # `x` resolves to — a data-array access mis-read as a function
+            # call. The DISPATCH idiom (`tbl[i]()` — the outer call whose
+            # CALLEE is such a subscript node) is handled separately below via
+            # the alias-gated container path, which abstains unless the base
+            # names a known function-referencing container.
             if node.type == "call_expression" and not self._is_subscript(node):
                 callee = node.children[0] if node.children else None
                 if callee is not None:
+                    # #299 (3 of 7): a subscript-callee call `tbl[i]()` —
+                    # the callee is an INNER call_expression (the subscript
+                    # `tbl[i]`) — dispatches through a KNOWN container: the
+                    # base name is recorded only when it is a known alias of
+                    # the caller (the resolver's tier-1 expansion resolves it
+                    # to the container's referenced functions). Unknown bases
+                    # abstain — no bare-name false edges.
+                    if (callee.type == "call_expression"
+                            and self._is_subscript(callee)
+                            and alias_names is not None):
+                        inner_callee = callee.children[0] if callee.children else None
+                        if (inner_callee is not None
+                                and inner_callee.type == "simple_identifier"):
+                            base = self._text(inner_callee, source)
+                            if base in alias_names:
+                                labels, arity, trailing, unlabeled_trailing = (
+                                    self._call_labels(node, source))
+                                sites.append({"text": base,
+                                              "labels": labels, "arity": arity,
+                                              "trailing": trailing,
+                                              "unlabeled_trailing": unlabeled_trailing})
+                        stack.extend(callee.children)
+                        continue
                     if callee.type == "simple_identifier":
                         labels, arity, trailing, unlabeled_trailing = self._call_labels(node, source)
                         sites.append({"text": self._text(callee, source),

--- a/libs/openant-core/parsers/swift/call_graph_builder.py
+++ b/libs/openant-core/parsers/swift/call_graph_builder.py
@@ -384,7 +384,10 @@ class CallGraphBuilder:
         for func_id, func_info in self.functions.items():
             file_path = func_info.get("file_path", "")
             if file_path and file_path in file_aliases:
-                alias_to_target[func_id].update(file_aliases[file_path])
+                # DEEP-COPY (panel finding): shared set references leak a
+                # local shadowing binding into every function of the file.
+                alias_to_target[func_id].update(
+                    {k: set(v) for k, v in file_aliases[file_path].items()})
             code = func_info.get("code", "")
             if not code:
                 continue
@@ -799,8 +802,11 @@ class CallGraphBuilder:
                                               "labels": labels, "arity": arity,
                                               "trailing": trailing,
                                               "unlabeled_trailing": unlabeled_trailing})
+                        # DO NOT `continue` here (panel finding: a dropped-edge
+                        # regression) — the OUTER call still needs its argument
+                        # references collected and its remaining children walked
+                        # (tbl[i](makeArg()) must record makeArg's ref too).
                         stack.extend(callee.children)
-                        continue
                     if callee.type == "simple_identifier":
                         labels, arity, trailing, unlabeled_trailing = self._call_labels(node, source)
                         sites.append({"text": self._text(callee, source),

--- a/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
@@ -1,0 +1,110 @@
+"""Regression tests for issue #299 (Swift member — 3 of 7): container-literal
+dispatch loses call edges.
+
+Swift drops `tbl[i]()` because the OUTER call node's callee is an INNER
+call_expression (the subscript `tbl[i]`), a shape _extract_calls handles only
+as simple_identifier or navigation_expression; the inner subscript is skipped
+by the explicit `not _is_subscript(node)` guard. The maintainer's corrected
+guidance (the original item-4 narrowing is WITHDRAWN — it fabricates edges):
+bind container literals in _collect_aliases (array_literal /
+dictionary_literal RHS), make file-scope `let` visible (the alias index
+parses only each function's own code), and add a subscript-callee case that
+resolves through the alias set. The guard itself stays (it excludes genuine
+subscript OPERATOR calls) and gains its rationale comment.
+
+Contract locked here:
+- an array/dictionary literal of function references plus a subscript call
+  records edges to every referenced function — the caller set contains the
+  DISPATCHER specifically (the umbrella's fixture rule);
+- NO edge to a function that merely shares the container's name (the
+  Go/Swift negative the umbrella requires — the alias gate abstains);
+- a direct-call CONTROL keeps its edge; a local (in-function) container
+  works the same as a file-scope one;
+- an unknown subscript base abstains — no invented edges.
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from core.parser_adapter import parse_repository  # noqa: E402
+
+
+def _cg(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+    out = tempfile.mkdtemp()
+    parse_repository(repo, out, language="swift", processing_level="all",
+                     skip_tests=True, name="r")
+    return json.load(open(os.path.join(out, "call_graph.json")))
+
+
+def _edges(cg, caller_suffix):
+    keys = [k for k in cg["call_graph"] if k.endswith(caller_suffix)]
+    return [e for k in keys for e in cg["call_graph"][k]]
+
+
+_FIXTURE = {
+    "main.swift":
+        "func handlerA() -> Int { return 1 }\n"
+        "func handlerB() -> Int { return 2 }\n"
+        "func directTarget() -> Int { return 3 }\n"
+        "func tbl() -> Int { return 4 }\n"   # SHADOW: shares the container's name
+        "\n"
+        "let tbl: [() -> Int] = [handlerA, handlerB]\n"     # file scope
+        "let map: [String: () -> Int] = [\"a\": handlerB]\n"  # dictionary literal
+        "\n"
+        "func dispatch(_ i: Int, _ k: String) -> Int {\n"
+        "    let local: [() -> Int] = [handlerA]\n"           # function local
+        "    directTarget()\n"                               # CONTROL
+        "    return tbl[i]() + map[k]!() + local[i]()\n"
+        "}\n",
+}
+
+
+def test_array_container_dispatch_edges():
+    cg = _cg(_FIXTURE)
+    edges = _edges(cg, ":dispatch")
+    assert any("handlerA" in e for e in edges), edges
+    assert any("handlerB" in e for e in edges), edges
+
+
+def test_no_edge_to_same_named_function():
+    """The umbrella's Go/Swift negative: the function named `tbl` must NOT
+    receive an edge from the subscript dispatch."""
+    cg = _cg(_FIXTURE)
+    edges = _edges(cg, ":dispatch")
+    assert not any(e.endswith(":tbl") for e in edges), edges
+
+
+def test_direct_call_control_passes():
+    cg = _cg(_FIXTURE)
+    assert any("directTarget" in e for e in _edges(cg, ":dispatch"))
+
+
+def test_local_and_dictionary_forms():
+    """Both the function-local array and the dictionary-literal container
+    dispatch through their names (the three forms behave the same)."""
+    cg = _cg(_FIXTURE)
+    edges = _edges(cg, ":dispatch")
+    assert any("handlerA" in e for e in edges), edges  # local[i]()
+    assert any("handlerB" in e for e in edges), edges  # map[k]!()
+
+
+def test_unknown_subscript_abstains():
+    cg = _cg({
+        "main.swift":
+            "func data() -> Int { return 1 }\n"
+            "func use(_ i: Int) -> Int {\n"
+            "    let data = [1, 2, 3]\n"   # NOT a function container
+            "    return data[i]()\n"
+            "}\n",
+    })
+    assert _edges(cg, ":use") == []

--- a/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
@@ -43,7 +43,8 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="swift", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    with open(os.path.join(out, "call_graph.json")) as fh:
+        return json.load(fh)
 
 
 def _edges(cg, caller_suffix):


### PR DESCRIPTION
## Summary

Swift dropped `tbl[i]()` entirely: the outer call's callee is an **inner** `call_expression` (the subscript `tbl[i]`), a shape `_extract_calls` handled only as `simple_identifier` or `navigation_expression`, and the inner node is excluded by the explicit `not _is_subscript` guard. Issue #299's Swift member (3 of 7), per the issue's **corrected** item 4 (the original narrowing is withdrawn — it fabricates edges):

- `_collect_aliases` accepts `array_literal` / `dictionary_literal` RHS: the variable binds to every **known** function among its elements (the `name_to_ids` gate — data containers bind nothing);
- `_build_alias_index` gains a **file-scope pass**: each file's top-level `let` bindings (plain aliases and container literals) are parsed once (cached) and merged under every function of that file; a function-local binding overrides (shadowing; top-level only, so per-function bindings cannot clobber each other);
- `_extract_calls` gains the subscript-callee case: `tbl[i]()` records its base name **only when it is a known alias/container of the caller** — tier-1 alias expansion then resolves it to the container's referenced functions. Unknown bases abstain (no bare-name false edges; the Go/Swift same-named-function negative the umbrella requires is tested);
- the `not _is_subscript` guard **stays** (it excludes genuine subscript-operator accesses from function-call resolution) and gains its rationale comment — the guard's docstring said what it detects, never what it prevents, which is how the withdrawn item 4 came to recommend removing it.

**T3 differential** (real corpora: **swift-argument-parser** 55 files + **Alamofire** 43 files; 2682 edges): base vs fix, **LOST 0 / GAINED 0** — strict monotonicity.

**Local-env note:** the swift-only test-directory batch shows a **pre-existing** ordering pollution (14 failed on pristine master in that batch; 0 failed in the full-suite ordering, which is what CI runs). Individually the affected tests pass. Not introduced here; noted as a follow-up.

## Test plan

5 hermetic tests through the real pipeline: array + dictionary + function-local container dispatch (the caller set contains the dispatcher specifically); the same-named-function negative (the umbrella's Go/Swift rule); a direct-call control; the unknown-subscript abstention.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/parsers/swift/test_issue299_swift_container_dispatch.py -q` | 5 passed (2 failed RED on pristine) |
| mutation smoke | builder stashed → new file | 2 failed (dispatch tests; negatives by design); restored → 5 passed |
| T3 differential | swift-argument-parser + Alamofire, base vs fix | 2682 edges / 2682 edges; **LOST 0**; GAINED 0 (strict monotone) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3213 passed, 0 failed**, 32 skipped |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 5 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Refs #299 (3 of 7)
