### PR TITLE
fix(php-parser): string-name dispatch containers resolve on subscript calls (#299, 4 of 7)

### DIFF
--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -776,8 +776,10 @@ class CallGraphBuilder:
         return None
 
     def _container_string_names(self, array_node, source: bytes) -> Set[str]:
-        """The string-literal elements of an array literal (both the
-        `'k' => 'fn'` value form and the bare `'fn'` list form)."""
+        """The string-literal elements of an array literal: the VALUE after
+        an `=>` arrow (`'k' => 'fn'` — the key is NEVER a target: a key like
+        'init'/'get' colliding with a real function would fabricate an
+        edge), or a bare list-form string element (`['fn', ...]`)."""
         names: Set[str] = set()
         for element in array_node.children:
             if element.type == 'string':
@@ -785,19 +787,31 @@ class CallGraphBuilder:
                 if value:
                     names.add(value)
             elif element.type == 'array_element_initializer':
-                # `'k' => 'fn'` (value after the arrow) or the bare list
-                # form `'fn'` (the initializer's own string child, no arrow)
-                seen_arrow = False
-                taken = False
+                # `'k' => 'fn'` — only the POST-ARROW value is a target; the
+                # key before the arrow is a dictionary label, not a callee.
+                # Bare `'fn'` (no arrow anywhere in this element) is the list
+                # form and IS a target.
+                arrow_seen = False
+                value_taken = False
                 for c in element.children:
                     if c.type == '=>':
-                        seen_arrow = True
-                        taken = False
-                    elif c.type in ('string', 'encapsed_string') and not taken:
-                        value = self._string_literal_value(c, source)
-                        if value:
-                            names.add(value)
-                        taken = True
+                        arrow_seen = True
+                        value_taken = False
+                    elif c.type in ('string', 'encapsed_string'):
+                        if arrow_seen and not value_taken:
+                            value = self._string_literal_value(c, source)
+                            if value:
+                                names.add(value)
+                            value_taken = True
+                        # pre-arrow string = the KEY: skipped deliberately
+                        # (a key is a label; resolving it fabricates edges)
+                if not arrow_seen:
+                    # bare list form: the element's string child is the target
+                    for c in element.children:
+                        if c.type in ('string', 'encapsed_string'):
+                            value = self._string_literal_value(c, source)
+                            if value:
+                                names.add(value)
         return names
 
     def _known_function_names(self, names: Set[str]) -> Set[str]:

--- a/libs/openant-core/parsers/php/call_graph_builder.py
+++ b/libs/openant-core/parsers/php/call_graph_builder.py
@@ -32,6 +32,7 @@ Output (JSON):
 """
 
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -213,11 +214,36 @@ class CallGraphBuilder:
             return self._extract_calls_regex(code, caller_id)
 
         root = tree.root_node
+
+        # #299 (4 of 7): PHP's dispatch-table idiom holds function names as
+        # STRINGS ($handlers = ['a' => 'handlerA']; $handlers[$k]();) — the
+        # array form of the _resolve_variable_function single-binding idiom.
+        # Collect the caller's local containers, then layer the file-scope
+        # containers (the common placement) on top; local bindings override.
+        containers = dict(self._file_containers(caller_file))
+        containers.update(self._collect_local_containers(root, code_bytes))
+        container_vars = set(containers.keys())
+
         stack = [root]
         while stack:
             node = stack.pop()
             if node.type in ('function_call_expression', 'member_call_expression',
                              'scoped_call_expression', 'object_creation_expression'):
+                # #299 (4 of 7): a subscript callee $handlers[$k]() over a KNOWN
+                # container dispatches to every function the container's strings
+                # reference (over-seed, the safe direction; unknown bases
+                # abstain — the base is a $variable, never a function name, so
+                # no false edge to a same-named function is possible).
+                base = (self._subscript_call_base(node, code_bytes)
+                        if node.type == 'function_call_expression' else None)
+                if base is not None and base in container_vars:
+                    for name in containers[base]:
+                        rid = self._resolve_simple_call(name, caller_file, None,
+                                                        caller_namespace)
+                        if rid:
+                            calls.add(rid)
+                    stack.extend(reversed(node.children))
+                    continue
                 resolved = self._resolve_call_node(node, code_bytes, caller_file,
                                                    caller_class, caller_namespace, root)
                 if resolved:
@@ -733,6 +759,124 @@ class CallGraphBuilder:
         if '\\' in name:
             return name.rsplit('\\', 1)[-1]
         return name
+
+    # ------------------------------------------------------------------
+    # #299 (4 of 7): string-name dispatch containers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _subscript_call_base(node, source: bytes):
+        """The base variable text of a $var[$k]() call's callee, or None."""
+        children = [c for c in node.children if c.type != 'arguments']
+        if len(children) < 1 or children[0].type != 'subscript_expression':
+            return None
+        for c in children[0].children:
+            if c.type == 'variable_name':
+                return source[c.start_byte:c.end_byte].decode('utf-8',
+                                                               errors='replace')
+        return None
+
+    def _container_string_names(self, array_node, source: bytes) -> Set[str]:
+        """The string-literal elements of an array literal (both the
+        `'k' => 'fn'` value form and the bare `'fn'` list form)."""
+        names: Set[str] = set()
+        for element in array_node.children:
+            if element.type == 'string':
+                value = self._string_literal_value(element, source)
+                if value:
+                    names.add(value)
+            elif element.type == 'array_element_initializer':
+                # `'k' => 'fn'` (value after the arrow) or the bare list
+                # form `'fn'` (the initializer's own string child, no arrow)
+                seen_arrow = False
+                taken = False
+                for c in element.children:
+                    if c.type == '=>':
+                        seen_arrow = True
+                        taken = False
+                    elif c.type in ('string', 'encapsed_string') and not taken:
+                        value = self._string_literal_value(c, source)
+                        if value:
+                            names.add(value)
+                        taken = True
+        return names
+
+    def _known_function_names(self, names: Set[str]) -> Set[str]:
+        """Filter container strings down to names a user function has."""
+        return {n for n in names if n in self.functions_by_name}
+
+    def _collect_local_containers(self, root, source: bytes) -> Dict[str, Set[str]]:
+        """$var = array literal of known-function strings -> container map
+        (within this caller's own body)."""
+        containers: Dict[str, Set[str]] = {}
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == 'assignment_expression':
+                children = [c for c in node.children if c.type not in ('=',)]
+                if (len(children) >= 2 and children[0].type == 'variable_name'
+                        and children[1].type == 'array_creation_expression'):
+                    var = source[children[0].start_byte:children[0].end_byte] \
+                        .decode('utf-8', errors='replace')
+                    targets = self._known_function_names(
+                        self._container_string_names(children[1], source))
+                    if var in containers:
+                        # rebound -> ambiguous, drop rather than guess
+                        containers.pop(var, None)
+                        continue
+                    if targets:
+                        containers[var] = targets
+            stack.extend(reversed(node.children))
+        return containers
+
+    def _file_containers(self, caller_file: str) -> Dict[str, Set[str]]:
+        """File-scope $var = [...] containers (the common placement), parsed
+        once per file and cached. Functions see them via `global $var;`."""
+        cached = getattr(self, '_file_container_cache', None)
+        if cached is None:
+            cached = {}
+            self._file_container_cache = cached
+        if caller_file in cached:
+            return cached[caller_file]
+        result: Dict[str, Set[str]] = {}
+        try:
+            full = (caller_file if os.path.isabs(caller_file)
+                    else os.path.join(self.repo_path, caller_file))
+            with open(full, 'rb') as fh:
+                source = fh.read()
+            tree = self.php_parser.parse(source)
+            top = tree.root_node
+            # top-level statements only: an assignment inside a function is
+            # that function's own container (per-function semantics)
+            scratch = set()
+            stack = []
+            for child in top.children:
+                if child.type == 'expression_statement':
+                    stack.append(child)
+            while stack:
+                node = stack.pop()
+                if node.type == 'assignment_expression':
+                    children = [c for c in node.children if c.type not in ('=',)]
+                    if (len(children) >= 2 and children[0].type == 'variable_name'
+                            and children[1].type == 'array_creation_expression'):
+                        var = source[children[0].start_byte:children[0].end_byte] \
+                            .decode('utf-8', errors='replace')
+                        targets = self._known_function_names(
+                            self._container_string_names(children[1], source))
+                        if var in result:
+                            result.pop(var, None)
+                        elif targets:
+                            result[var] = targets
+                        scratch.discard(var)
+                # do not descend into function/method bodies
+                for c in node.children:
+                    if c.type not in ('function_declaration', 'method_declaration',
+                                      'anonymous_function', 'arrow_function',
+                                      'class_declaration'):
+                        stack.append(c)
+        except OSError:
+            result = {}
+        cached[caller_file] = result
+        return result
 
     def _extract_calls_regex(self, code: str, caller_id: str) -> Set[str]:
         """Fallback regex-based call extraction for unparseable code."""

--- a/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
@@ -1,0 +1,128 @@
+"""Regression tests for issue #299 (PHP member — 4 of 7): container-literal
+dispatch loses call edges.
+
+PHP's dispatch-table idiom holds function NAMES AS STRINGS —
+``$handlers = ['a' => 'handlerA', 'b' => 'handlerB']; $handlers[$k]();`` —
+and `_resolve_function_call` had no subscript case: the callee is a
+`subscript_expression`, so nothing resolved and the dispatcher's targets
+were orphaned (pruned with their dispatcher kept — #295's shape). The
+in-repo template is `_resolve_variable_function` (a single string-literal
+binding `$f = 'helper'; $f()` already resolves): the container is the
+array form of that binding.
+
+Contract locked here:
+- an array literal of function-name strings plus a subscript call records
+  edges to every referenced function — the caller set contains the
+  DISPATCHER specifically (the umbrella's fixture rule);
+- a direct-call CONTROL keeps its edge;
+- a function-local container works the same as a file-scope one (with the
+  common `global` import shape);
+- an unknown subscript base abstains — no invented edges (the data-array
+  negative).
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from core.parser_adapter import parse_repository  # noqa: E402
+
+
+def _cg(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+    out = tempfile.mkdtemp()
+    parse_repository(repo, out, language="php", processing_level="all",
+                     skip_tests=True, name="r")
+    return json.load(open(os.path.join(out, "call_graph.json")))
+
+
+def _edges(cg, caller_suffix):
+    keys = [k for k in cg["call_graph"] if k.endswith(caller_suffix)]
+    return [e for k in keys for e in cg["call_graph"][k]]
+
+
+_FIXTURE = {
+    "main.php":
+        "<?php\n"
+        "function handlerA() { return 1; }\n"
+        "function handlerB() { return 2; }\n"
+        "function directTarget() { return 3; }\n"
+        # file-scope container (the common placement)
+        "$handlers = ['a' => 'handlerA', 'b' => 'handlerB'];\n"
+        "function dispatch($k) {\n"
+        "    global $handlers;\n"
+        "    directTarget();\n"          # CONTROL
+        "    $handlers[$k]();\n"
+        "    return 0;\n"
+        "}\n",
+}
+
+
+def test_file_scope_container_dispatch_edges():
+    cg = _cg(_FIXTURE)
+    edges = _edges(cg, ":dispatch")
+    assert any("handlerA" in e for e in edges), edges
+    assert any("handlerB" in e for e in edges), edges
+
+
+def test_direct_call_control_passes():
+    cg = _cg(_FIXTURE)
+    assert any("directTarget" in e for e in _edges(cg, ":dispatch"))
+
+
+def test_local_container_dispatch():
+    """A container built INSIDE the function (no `global` needed): same
+    dispatch through the local name."""
+    cg = _cg({
+        "main.php":
+            "<?php\n"
+            "function h1() { return 1; }\n"
+            "function h2() { return 2; }\n"
+            "function dispatch($k) {\n"
+            "    $t = ['x' => 'h1', 'y' => 'h2'];\n"
+            "    $t[$k]();\n"
+            "    return 0;\n"
+            "}\n",
+    })
+    edges = _edges(cg, ":dispatch")
+    assert any("h1" in e for e in edges), edges
+    assert any("h2" in e for e in edges), edges
+
+
+def test_list_form_container():
+    """The list form (bare string elements, no =>) behaves the same."""
+    cg = _cg({
+        "main.php":
+            "<?php\n"
+            "function h1() { return 1; }\n"
+            "function dispatch($i) {\n"
+            "    $t = ['h1'];\n"
+            "    $t[$i]();\n"
+            "    return 0;\n"
+            "}\n",
+    })
+    assert any("h1" in e for e in _edges(cg, ":dispatch"))
+
+
+def test_unknown_subscript_abstains():
+    """A subscript over a container with no known-function strings records
+    nothing — no invented edges."""
+    cg = _cg({
+        "main.php":
+            "<?php\n"
+            "function data() { return 1; }\n"
+            "function use_($i) {\n"
+            "    $data = ['x', 'y'];\n"
+            "    $data[$i]();\n"
+            "    return 0;\n"
+            "}\n",
+    })
+    assert _edges(cg, ":use_") == []

--- a/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
@@ -41,7 +41,8 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="php", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    with open(os.path.join(out, "call_graph.json")) as fh:
+        return json.load(fh)
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
@@ -127,3 +127,20 @@ def test_unknown_subscript_abstains():
             "}\n",
     })
     assert _edges(cg, ":use_") == []
+
+
+def test_dict_key_never_fabricates_edge():
+    """Regression (panel finding): the KEY of `'k' => 'fn'` is a label, not a
+    callee — a key colliding with a real function must not fabricate an edge."""
+    files = {
+        "handlers.php": """<?php
+function init() { return 1; }
+function handlerA() { return 2; }
+$TBL = ['init' => 'handlerA'];
+function dispatch($mode) { global $TBL; $TBL[$mode](); }
+""",
+    }
+    cg = _cg(files)
+    dispatch_edges = _edges(cg, ":dispatch")
+    assert any("handlerA" in e for e in dispatch_edges), "value dispatch still works"
+    assert not any("init" in e for e in dispatch_edges), "the KEY 'init' must NOT fabricate an edge to function init()"


### PR DESCRIPTION
## Summary

PHP's dispatch-table idiom holds function names as **strings** — `$handlers = ['a' => 'handlerA', 'b' => 'handlerB']; $handlers[$k]();` — and `_resolve_function_call` had **no subscript case**: the callee is a `subscript_expression`, so nothing resolved and the dispatcher's targets were orphaned (pruned with their dispatcher kept — #295's shape). Issue #299's PHP member (4 of 7). The in-repo template is `_resolve_variable_function` (the single string-literal binding `$f = 'helper'; $f()` already resolves): **the container is the array form of that binding**.

Fix:
- **container collection**: `$var = array-literal-of-known-function-strings` (both the `'k' => 'fn'` value form and the bare list form) binds `$var` to every referenced function name — locally in the caller's body, plus a file-scope pass (top-level statements only, cached per file — the common placement, reached via `global $var;`), with local bindings overriding;
- **subscript dispatch**: a `function_call_expression` whose callee is a `subscript_expression` over a **known** container resolves to every function the container's strings reference (over-seed, the safe direction); unknown bases abstain — the base is a `$variable`, never a function name, so no false edge to a same-named function is possible (tested).

**T3 differential** (real corpora: **flysystem 3.x** 55 files + **psr/log** 8 files; 112 edges): base vs fix, **LOST 0 / GAINED 0** — strict monotonicity.

## Test plan

5 hermetic tests through the real pipeline: file-scope container dispatch (with the `global` import shape; the caller set contains the dispatcher specifically); a direct-call control; a function-local container; the bare list form; the data-array abstention negative.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/parsers/php/test_issue299_php_container_dispatch.py -q` | 5 passed (3 failed RED on pristine) |
| PHP suite | `PYTHONPATH=<core> pytest tests/parsers/php/ -q` | 97 passed |
| mutation smoke | builder stashed → new file | 3 failed; restored → 5 passed |
| T3 differential | flysystem + psr/log, base vs fix | 112 edges / 112 edges; **LOST 0**; GAINED 0 (strict monotone) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3213 passed, 0 failed**, 32 skipped |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 5 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Refs #299 (4 of 7)
