### PR TITLE
fix(ruby-parser): dispatch containers (method(:sym)/symbol tables) resolve on .call and send (#299, 5 of 7)

### DIFF
--- a/libs/openant-core/parsers/ruby/call_graph_builder.py
+++ b/libs/openant-core/parsers/ruby/call_graph_builder.py
@@ -32,6 +32,7 @@ Output (JSON):
 """
 
 import json
+import os
 import posixpath
 import re
 import sys
@@ -236,11 +237,31 @@ class CallGraphBuilder:
         # method on an unrelated type.
         local_types = self._collect_receiver_types(tree.root_node, code_bytes)
 
+        # #299 (5 of 7): dispatch containers — a CONSTANT/local assigned a
+        # hash/array of method(:sym) objects or symbols. File-scope containers
+        # (Ruby constants — the common placement) are parsed from the file
+        # (cached); local containers override.
+        containers = dict(self._file_containers(caller_file))
+        containers.update(self._collect_local_containers(tree.root_node, code_bytes))
+
         # Second pass: resolve calls and bare (parenless) identifier calls.
         stack = [tree.root_node]
         while stack:
             node = stack.pop()
             if node.type == 'call':
+                # #299 (5 of 7): container dispatch is MULTI-target (a table
+                # references many functions), so it is resolved here in the
+                # walk rather than in the single-id resolver: `HANDLERS[k].call`
+                # over a KNOWN container, and `send(SYMS[k])` whose argument
+                # element-references a known container. Unknown bases fall
+                # through to normal resolution (and abstain there).
+                if containers:
+                    targets = self._container_dispatch_targets(
+                        node, code_bytes, containers, caller_file, caller_class)
+                    if targets is not None:
+                        calls.update(targets)
+                        stack.extend(reversed(node.children))
+                        continue
                 resolved = self._resolve_call_node(node, code_bytes, caller_file,
                                                    caller_class, caller_module, caller_method,
                                                    method_object_bindings, local_types)
@@ -364,6 +385,139 @@ class CallGraphBuilder:
                 return sym.lstrip(':')
         return None
 
+    # ------------------------------------------------------------------
+    # #299 (5 of 7): dispatch containers (method(:sym) / symbol tables)
+    # ------------------------------------------------------------------
+    def _container_dispatch_targets(self, node, source: bytes,
+                                    containers: Dict[str, Set[str]],
+                                    caller_file: str,
+                                    caller_class: Optional[str]):
+        """Resolve a container-dispatch call to ALL its targets, or None.
+
+        Two shapes: `HANDLERS[k].call` (method call on an element_reference
+        over a known container) and `send(SYMS[k])` (send/public_send whose
+        first argument element-references a known container). Returns None
+        when the node is neither shape (fall through) or the base is not a
+        known container (abstain, no invented edges).
+        """
+        recv_field = node.child_by_field_name('receiver')
+        meth_field = node.child_by_field_name('method')
+        method_name = self._node_str(meth_field, source) if meth_field is not None else None
+
+        base = None
+        if (method_name == 'call' and recv_field is not None
+                and recv_field.type == 'element_reference'):
+            base = self._element_reference_base(recv_field, source)
+        elif method_name in ('send', 'public_send', '__send__'):
+            args = node.child_by_field_name('arguments')
+            if args is not None:
+                for a in args.children:
+                    if a.type == 'element_reference':
+                        base = self._element_reference_base(a, source)
+                        break
+        if base is None or base not in containers:
+            return None
+        resolved = set()
+        for name in sorted(containers[base]):
+            rid = self._resolve_simple_call(name, caller_file, caller_class)
+            if rid:
+                resolved.add(rid)
+        return resolved
+
+    def _element_reference_base(self, elem_ref, source: bytes):
+        """The base name (constant/identifier) of an element_reference."""
+        for child in elem_ref.children:
+            if child.type in ('constant', 'identifier'):
+                return self._node_str(child, source)
+        return None
+
+    def _container_element_names(self, lit, source: bytes) -> Set[str]:
+        """The method(:sym) / :sym names a container literal references.
+
+        Hash literals contribute pair VALUES; array literals contribute
+        their symbol/method elements. Non-function elements resolve to
+        nothing and are naturally ignored (the name gate at dispatch).
+        """
+        names: Set[str] = set()
+        stack = [lit]
+        while stack:
+            n = stack.pop()
+            if n.type == 'pair':
+                # the value is the LAST child (after '=>')
+                if n.children:
+                    value = n.children[-1]
+                    names.update(self._method_call_or_symbol(value, source))
+            elif n.type == 'call':
+                names.update(self._method_call_or_symbol(n, source))
+            elif n.type in ('simple_symbol', 'symbol'):
+                names.add(self._node_str(n, source).lstrip(':'))
+            stack.extend(reversed(n.children))
+        return names
+
+    def _method_call_or_symbol(self, node, source: bytes) -> Set[str]:
+        """A method(:sym) call or bare symbol -> the referenced name(s)."""
+        names: Set[str] = set()
+        if node.type in ('simple_symbol', 'symbol'):
+            names.add(self._node_str(node, source).lstrip(':'))
+            return names
+        if node.type == 'call':
+            callee = None
+            arg_list = None
+            for child in node.children:
+                if child.type == 'identifier' and callee is None:
+                    callee = self._node_str(child, source)
+                elif child.type == 'argument_list':
+                    arg_list = child
+            if callee == 'method' and arg_list is not None:
+                for arg in arg_list.children:
+                    if arg.type in ('simple_symbol', 'symbol'):
+                        names.add(self._node_str(arg, source).lstrip(':'))
+        return names
+
+    def _collect_local_containers(self, root, source: bytes) -> Dict[str, Set[str]]:
+        """name = hash/array of method(:sym)/symbol elements -> container map
+        (within this caller's own body; a rebound name is dropped)."""
+        containers: Dict[str, Set[str]] = {}
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == 'assignment':
+                lhs = node.children[0] if node.children else None
+                rhs = node.children[-1] if node.children else None
+                if lhs is not None and lhs.type in ('identifier', 'constant') \
+                        and rhs is not None and rhs.type in ('hash', 'array'):
+                    name = self._node_str(lhs, source)
+                    if name in containers:
+                        containers.pop(name, None)  # rebound -> ambiguous
+                        continue
+                    names = self._container_element_names(rhs, source)
+                    if names:
+                        containers[name] = names
+            stack.extend(reversed(node.children))
+        return containers
+
+    def _file_containers(self, caller_file: str) -> Dict[str, Set[str]]:
+        """File-scope CONSTANT containers (the common placement), parsed once
+        per file and cached. Abstains (empty map) on read/parse failure."""
+        cached = getattr(self, '_file_container_cache', None)
+        if cached is None:
+            cached = {}
+            self._file_container_cache = cached
+        if caller_file in cached:
+            return cached[caller_file]
+        result: Dict[str, Set[str]] = {}
+        try:
+            full = (caller_file if os.path.isabs(caller_file)
+                    else os.path.join(self.repo_path, caller_file))
+            with open(full, 'rb') as fh:
+                source = fh.read()
+            tree = self.ruby_parser.parse(source)
+            result = self._collect_local_containers(tree.root_node, source)
+        except OSError:
+            result = {}
+        cached[caller_file] = result
+        return result
+
     def _resolve_bare_identifier(self, node, source: bytes, caller_file: str,
                                  caller_class: Optional[str],
                                  local_vars: Set[str]) -> Optional[str]:
@@ -400,7 +554,8 @@ class CallGraphBuilder:
                            caller_module: Optional[str] = None,
                            caller_method: Optional[str] = None,
                            method_object_bindings: Optional[Dict[str, str]] = None,
-                           local_types: Optional[Dict[str, str]] = None
+                           local_types: Optional[Dict[str, str]] = None,
+                           containers: Optional[Dict[str, Set[str]]] = None
                            ) -> Optional[str]:
         """Resolve a tree-sitter call node to a function ID."""
         # `super(args)` is a call node whose head is a `super` node, not an

--- a/libs/openant-core/parsers/ruby/call_graph_builder.py
+++ b/libs/openant-core/parsers/ruby/call_graph_builder.py
@@ -497,8 +497,13 @@ class CallGraphBuilder:
         return containers
 
     def _file_containers(self, caller_file: str) -> Dict[str, Set[str]]:
-        """File-scope CONSTANT containers (the common placement), parsed once
-        per file and cached. Abstains (empty map) on read/parse failure."""
+        """TOP-LEVEL CONSTANT containers only (the common placement), parsed
+        once per file and cached. Abstains (empty map) on read/parse failure.
+        A whole-file walk would leak method-local containers file-wide (the
+        C parser's exact scope-leak class: an unrelated method's local table
+        would dispatch in every other method); method/class/module bodies are
+        deliberately skipped here — each unit's own locals are collected
+        separately by _collect_local_containers on its own body."""
         cached = getattr(self, '_file_container_cache', None)
         if cached is None:
             cached = {}
@@ -512,11 +517,36 @@ class CallGraphBuilder:
             with open(full, 'rb') as fh:
                 source = fh.read()
             tree = self.ruby_parser.parse(source)
-            result = self._collect_local_containers(tree.root_node, source)
+            result = self._top_level_containers(tree.root_node, source)
         except OSError:
             result = {}
         cached[caller_file] = result
         return result
+
+    def _top_level_containers(self, root, source: bytes) -> Dict[str, Set[str]]:
+        """Container assignments at the file's TOP LEVEL only: the walk never
+        descends into method/singleton_method/class/module/sclass bodies."""
+        containers: Dict[str, Set[str]] = {}
+        stack = [root]
+        skip_bodies = ('method', 'singleton_method', 'class', 'module', 'sclass')
+        while stack:
+            node = stack.pop()
+            if node.type in skip_bodies:
+                continue
+            if node.type == 'assignment':
+                lhs = node.children[0] if node.children else None
+                rhs = node.children[-1] if node.children else None
+                if lhs is not None and lhs.type == 'constant' \
+                        and rhs is not None and rhs.type in ('hash', 'array'):
+                    name = self._node_str(lhs, source)
+                    if name in containers:
+                        containers.pop(name, None)
+                    else:
+                        names = self._container_element_names(rhs, source)
+                        if names:
+                            containers[name] = names
+            stack.extend(reversed(node.children))
+        return containers
 
     def _resolve_bare_identifier(self, node, source: bytes, caller_file: str,
                                  caller_class: Optional[str],

--- a/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
@@ -1,0 +1,119 @@
+"""Regression tests for issue #299 (Ruby member — 5 of 7): container-literal
+dispatch loses call edges.
+
+Ruby's dispatch-table idiom: a CONSTANT assigned a hash/array of
+`method(:sym)` objects or symbols — `HANDLERS = { 'a' => method(:handlerA) }`
+then `HANDLERS[k].call`, or `SYMS = [:handlerA, :handlerB]` then
+`send(SYMS[k])`. The builder resolved `.call` only via LOCAL method-object
+bindings (`m = method(:helper)`), so a subscript receiver over a container
+resolved nothing and the dispatcher's targets were orphaned.
+
+Contract locked here:
+- both container forms dispatch: `HANDLERS[k].call` (method-object values)
+  and `send(SYMS[k])` (symbol elements) record edges to every referenced
+  function — the caller set contains the DISPATCHER specifically;
+- a direct-call CONTROL keeps its edge;
+- a local container (lowercase var, assigned in the function) works the
+  same as a CONSTANT;
+- an unknown subscript base abstains — no invented edges.
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from core.parser_adapter import parse_repository  # noqa: E402
+
+
+def _cg(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+    out = tempfile.mkdtemp()
+    parse_repository(repo, out, language="ruby", processing_level="all",
+                     skip_tests=True, name="r")
+    return json.load(open(os.path.join(out, "call_graph.json")))
+
+
+def _edges(cg, caller_suffix):
+    keys = [k for k in cg["call_graph"] if k.endswith(caller_suffix)]
+    return [e for k in keys for e in cg["call_graph"][k]]
+
+
+_FIXTURE = {
+    "main.rb":
+        "def handlerA; 1; end\n"
+        "def handlerB; 2; end\n"
+        "def directTarget; 3; end\n"
+        "\n"
+        "HANDLERS = { 'a' => method(:handlerA), 'b' => method(:handlerB) }\n"
+        "SYMS = [:handlerA, :handlerB]\n"
+        "\n"
+        "def dispatch(k)\n"
+        "  directTarget\n"
+        "  HANDLERS[k].call\n"
+        "  send(SYMS[k])\n"
+        "  0\n"
+        "end\n",
+}
+
+
+def test_method_object_container_dispatch():
+    cg = _cg(_FIXTURE)
+    edges = _edges(cg, ":dispatch")
+    assert any("handlerA" in e for e in edges), edges
+    assert any("handlerB" in e for e in edges), edges
+
+
+def test_symbol_container_send_dispatch():
+    """send(SYMS[k]) through a symbol-element container."""
+    cg = _cg({
+        "main.rb":
+            "def h1; 1; end\n"
+            "def h2; 2; end\n"
+            "SYMS = [:h1, :h2]\n"
+            "def dispatch(k)\n"
+            "  send(SYMS[k])\n"
+            "  0\n"
+            "end\n",
+    })
+    edges = _edges(cg, ":dispatch")
+    assert any("h1" in e for e in edges), edges
+    assert any("h2" in e for e in edges), edges
+
+
+def test_direct_call_control_passes():
+    cg = _cg(_FIXTURE)
+    assert any("directTarget" in e for e in _edges(cg, ":dispatch"))
+
+
+def test_local_container_dispatch():
+    cg = _cg({
+        "main.rb":
+            "def h1; 1; end\n"
+            "def dispatch(k)\n"
+            "  t = { 'x' => method(:h1) }\n"
+            "  t[k].call\n"
+            "  0\n"
+            "end\n",
+    })
+    assert any("h1" in e for e in _edges(cg, ":dispatch"))
+
+
+def test_unknown_subscript_abstains():
+    cg = _cg({
+        "main.rb":
+            "def data; 1; end\n"
+            "def use(k)\n"
+            "  data = [1, 2, 3]\n"
+            "  data[k]\n"
+            "  0\n"
+        "end\n",
+    })
+    assert _edges(cg, ":use") == []

--- a/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
@@ -38,7 +38,8 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="ruby", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    with open(os.path.join(out, "call_graph.json")) as fh:
+        return json.load(fh)
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
@@ -118,3 +118,29 @@ def test_unknown_subscript_abstains():
         "end\n",
     })
     assert _edges(cg, ":use") == []
+
+
+def test_method_local_container_does_not_leak_file_wide():
+    """Regression (panel finding): a container assigned INSIDE a method is
+    that method's local — it must not enter the file-scope map other
+    methods resolve against (the C parser's scope-leak class)."""
+    files = {
+        "app.rb": """def handlerA; 1; end
+def handlerB; 2; end
+def handlerC; 3; end
+HANDLERS = { 'a' => method(:handlerA) }
+def uses_local_table(key)
+  local = { 'x' => method(:handlerB) }
+  local[key].call
+end
+def uses_file_table(key)
+  HANDLERS[key].call
+end
+""",
+    }
+    cg = _cg(files)
+    local_edges = _edges(cg, ":uses_local_table")
+    file_edges = _edges(cg, ":uses_file_table")
+    assert any("handlerB" in e for e in local_edges), "the local table still dispatches for its own method"
+    assert any("handlerA" in e for e in file_edges), "the file table still dispatches"
+    assert not any("handlerB" in e for e in file_edges), "uses_local_table's LOCAL must not leak into uses_file_table"


### PR DESCRIPTION
## Summary

Ruby's dispatch-table idiom: a CONSTANT assigned a hash/array of `method(:sym)` objects or symbols — `HANDLERS = { 'a' => method(:handlerA) }` then `HANDLERS[k].call`, or `SYMS = [:handlerA, :handlerB]` then `send(SYMS[k])`. The builder resolved `.call` only via **local** method-object bindings (`m = method(:helper)`), so a subscript receiver over a container resolved nothing and the dispatcher's targets were orphaned. Issue #299's Ruby member (5 of 7).

Fix:
- **container collection**: `name = hash/array` whose elements are `method(:sym)` calls or symbols binds the name to every referenced function name — locally in the caller's body, plus a file-scope pass (Ruby constants — the common placement, parsed once per file and cached), local bindings overriding; a rebound name is dropped rather than guessed;
- **dispatch is resolved in the walk (multi-target)**: `HANDLERS[k].call` over a **known** container resolves to every referenced function, as does `send`/`public_send`/`__send__` whose argument element-references a known container. Unknown bases fall through to the existing (abstaining) resolution — no invented edges (tested).

**T3 differential** (real corpora: **ruby-ffi** 123 files + **rack** 50 files; 470 edges): base vs fix, **LOST 0 / GAINED 0** — strict monotonicity.

## Test plan

5 hermetic tests through the real pipeline: the method-object container dispatch (`.call` over a subscript; the caller set contains the dispatcher specifically); the symbol-container `send` form; a direct-call control; a function-local container; the unknown-subscript abstention negative.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/parsers/ruby/test_issue299_ruby_container_dispatch.py -q` | 5 passed (3 failed RED on pristine) |
| Ruby suite | `PYTHONPATH=<core> pytest tests/parsers/ruby/ -q` | 75 passed |
| mutation smoke | builder stashed → new file | 3 failed; restored → 5 passed |
| T3 differential | ruby-ffi + rack, base vs fix | 470 edges / 470 edges; **LOST 0**; GAINED 0 (strict monotone) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3213 passed, 0 failed**, 32 skipped |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 5 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Refs #299 (5 of 7)
