### PR TITLE
fix(js-parser): container dispatch resolves; indirect_calls gains its consumer (#299, 6 of 7)

### DIFF
--- a/libs/openant-core/parsers/javascript/typescript_analyzer.js
+++ b/libs/openant-core/parsers/javascript/typescript_analyzer.js
@@ -1726,6 +1726,115 @@ class TypeScriptAnalyzer {
     return null;
   }
 
+  // ------------------------------------------------------------------
+  // #299 (6 of 7): dispatch containers (object/array literals of handlers)
+  // ------------------------------------------------------------------
+
+  /**
+   * Map variable/const names -> handler-function names referenced by an
+   * object/array literal initializer, from one node's descendants.
+   * Rebound names are dropped (ambiguous) rather than guessed.
+   */
+  _collectContainersFrom(node) {
+    const containers = {};
+    const dropped = {};
+    if (!node) return containers;
+    const ts = require("ts-morph");
+    // getDescendantsOfKind is the reliable descent (a manual getChildren()
+    // walk stops at the SyntaxList wrapper). For the FILE map this includes
+    // declarations inside function bodies — safe by design (over-seed): a
+    // container referenced by name dispatches to its handlers regardless of
+    // which scope declared it, and the name gate still requires the literal
+    // to reference known handler names.
+    for (const decl of node.getDescendantsOfKind(
+      ts.SyntaxKind.VariableDeclaration,
+    )) {
+      const nameNode = decl.getNameNode ? decl.getNameNode() : null;
+      const init = decl.getInitializer ? decl.getInitializer() : null;
+      if (!nameNode || !init) continue;
+      const name = nameNode.getText();
+      if (dropped[name]) continue;
+      const kind = init.getKindName();
+      if (
+        kind !== "ObjectLiteralExpression" &&
+        kind !== "ArrayLiteralExpression"
+      ) {
+        continue;
+      }
+      if (Object.prototype.hasOwnProperty.call(containers, name)) {
+        // second declaration of the same name -> ambiguous, drop
+        delete containers[name];
+        dropped[name] = true;
+        continue;
+      }
+      const targets = this._containerElementNames(init);
+      if (targets.length > 0) containers[name] = targets;
+    }
+    return containers;
+  }
+
+  /**
+   * The bare-identifier handler names an object/array literal references.
+   * Object literals contribute property VALUES; array literals their
+   * elements. Non-identifier elements contribute nothing (the name gate at
+   * resolution abstains).
+   */
+  _containerElementNames(literal) {
+    const names = [];
+    const kind = literal.getKindName();
+    if (kind === "ObjectLiteralExpression") {
+      for (const prop of literal.getProperties()) {
+        const init = prop.getInitializer ? prop.getInitializer() : null;
+        if (init && init.getKindName() === "Identifier") {
+          names.push(init.getText());
+        }
+      }
+    } else if (kind === "ArrayLiteralExpression") {
+      for (const el of literal.getElements()) {
+        if (el.getKindName() === "Identifier") names.push(el.getText());
+      }
+    }
+    return names;
+  }
+
+  /**
+   * Resolve an ElementAccessExpression callee over a KNOWN container to the
+   * container's handler names, or null when the base is not a known
+   * container (abstain — no invented edges). Merges the enclosing
+   * function's local containers with the file-scope map (cached per file).
+   */
+  _containerTargetsForCallee(callee, funcNode) {
+    const base = callee.getExpression();
+    if (!base || base.getKindName() !== "Identifier") return null;
+    const name = base.getText();
+    // file-scope containers, cached per relative path
+    if (!this._fileContainersCache) this._fileContainersCache = {};
+    const rel =
+      (funcNode.getSourceFile &&
+        funcNode.getSourceFile().getFilePath()) ||
+      "";
+    let fileMap = this._fileContainersCache[rel];
+    if (fileMap === undefined) {
+      try {
+        fileMap = this._collectContainersFrom(funcNode.getSourceFile());
+      } catch (e) {
+        fileMap = {};
+      }
+      this._fileContainersCache[rel] = fileMap;
+    }
+    // NOTE: the file map is collected from the SOURCE FILE root, which
+    // includes function bodies — a function-local table is ALSO visible
+    // there. That is safe for dispatch (over-seed direction), matching the
+    // sibling parsers' file-scope merge; the name gate still requires the
+    // literal to reference known handler names.
+    const localMap = this._collectContainersFrom(funcNode);
+    const targets =
+      (localMap && Object.prototype.hasOwnProperty.call(localMap, name) && localMap[name]) ||
+      (Object.prototype.hasOwnProperty.call(fileMap, name) && fileMap[name]) ||
+      null;
+    return targets || null;
+  }
+
   /**
    * Extract function calls from within a function body.
    *
@@ -1762,6 +1871,24 @@ class TypeScriptAnalyzer {
         const isMember =
           !!callee && callee.getKindName() === "PropertyAccessExpression";
         pushName(normalized, false, isMember);
+      } else if (
+        // #299 (6 of 7): a container dispatch — `handlers[k]()` /
+        // `tbl[0]()` — an ElementAccessExpression whose BASE identifier names
+        // a known container of handler references. Resolve to EVERY
+        // referenced function (over-seed, the safe direction). The container
+        // map merges this function's local const/var declarations with the
+        // file-scope ones (the common placement).
+        callee &&
+        callee.getKindName() === "ElementAccessExpression" &&
+        this._containerTargetsForCallee
+      ) {
+        const targets = this._containerTargetsForCallee(callee, funcNode);
+        if (targets !== null) {
+          for (const target of targets) pushName(target, false);
+        } else {
+          const raw = callee.getText().replace(/\s+/g, " ").trim();
+          pushName(raw, true);
+        }
       } else {
         // Dynamic / element-access callee — record the raw span trimmed to a
         // single line so node names never become multiline blobs.
@@ -1872,6 +1999,16 @@ class TypeScriptAnalyzer {
         } else if (!target) {
           // Unresolvable static name — bucket as indirect so it isn't lost.
           if (!indirect.includes(name)) indirect.push(name);
+          // #299 (6 of 7): CONSUMER — an indirect entry that resolves when
+          // the member restriction is dropped becomes a REFERENCE edge (a
+          // receiver call `x.foo()` whose same-named free function exists:
+          // over-seed, the reachability-safe direction). This is the
+          // plumbing the umbrella asks for: the detection already worked,
+          // only the graph never consumed it.
+          const ref = resolveName(name, callerFile, false);
+          if (ref && ref !== callerId && !resolvedTargets.includes(ref)) {
+            resolvedTargets.push(ref);
+          }
         }
       }
 

--- a/libs/openant-core/tests/parsers/javascript/test_issue299_jsts_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/javascript/test_issue299_jsts_container_dispatch.py
@@ -1,0 +1,124 @@
+"""Regression tests for issue #299 (JS/TS member — 6 of 7): container-literal
+dispatch loses call edges; the detected-but-discarded `indirect_calls` has no
+consumer.
+
+The analyzer normalized `handlers['a']()` (an ElementAccessExpression callee)
+to null and bucketed the raw span into `indirect_calls` — a field with no
+non-test reader — so a dispatch table's targets were orphaned while the
+dominant real-world idiom (a named handler as an argument,
+``app.get('/x', handlerC)``) already worked. Per the umbrella: "the
+detection already works, only the plumbing is missing."
+
+Contract locked here:
+- an object/array literal of named handlers plus an element-access call
+  records edges to every referenced function — the caller set contains the
+  DISPATCHER specifically;
+- a direct-call CONTROL keeps its edge; the argument-handler idiom keeps
+  working (the mild-severity note — it must not regress);
+- `indirect_calls` entries that name a known function become REFERENCE
+  edges in the graph (the consumer the umbrella asks for);
+- an element access over an unknown container abstains — no invented edges.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(PARSERS_JS_DIR / "typescript_analyzer.js"),
+           str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}")
+    return json.loads(result.stdout)
+
+
+def _write(tmp_path, name, content, filename="file.js"):
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / filename
+    fp.write_text(content)
+    return repo, fp
+
+
+_FIXTURE = """
+function handlerA() { return 1; }
+function handlerB() { return 2; }
+function directTarget() { return 3; }
+
+const handlers = { a: handlerA, b: handlerB };
+const tbl = [handlerB, handlerA];
+
+function dispatch(k) {
+  directTarget();
+  handlers[k]();
+  tbl[0]();
+  return 0;
+}
+"""
+
+
+def test_object_container_dispatch_edges(tmp_path):
+    repo, fp = _write(tmp_path, "obj", _FIXTURE)
+    out = _analyze(repo, fp)
+    edges = out["call_graph"].get("file.js:dispatch", [])
+    assert any("handlerA" in e for e in edges), edges
+    assert any("handlerB" in e for e in edges), edges
+
+
+def test_array_container_dispatch_edges(tmp_path):
+    repo, fp = _write(tmp_path, "arr", _FIXTURE)
+    out = _analyze(repo, fp)
+    edges = out["call_graph"].get("file.js:dispatch", [])
+    assert any("handlerA" in e for e in edges), edges
+    assert any("handlerB" in e for e in edges), edges
+
+
+def test_direct_call_and_control_shapes(tmp_path):
+    repo, fp = _write(tmp_path, "ctl", _FIXTURE)
+    out = _analyze(repo, fp)
+    edges = out["call_graph"].get("file.js:dispatch", [])
+    assert any("directTarget" in e for e in edges), edges
+
+
+def test_indirect_entries_consume_as_reference_edges(tmp_path):
+    """The umbrella's plumbing ask: an indirect bucket entry becomes a
+    REFERENCE edge when it resolves with the member restriction dropped —
+    a receiver call `x.process()` whose same-named free function exists
+    keeps that function reachable from the caller (over-seed, the safe
+    direction; the detection already worked, only the graph never consumed
+    it)."""
+    repo, fp = _write(tmp_path, "ind", """
+        function process(x) { return x; }
+        function run(obj) {
+          return obj.process(1);
+        }
+    """)
+    out = _analyze(repo, fp)
+    edges = out["call_graph"].get("file.js:run", [])
+    assert any(e.endswith(":process") for e in edges), edges
+
+
+def test_unknown_element_access_abstains(tmp_path):
+    repo, fp = _write(tmp_path, "unk", """
+        function data() { return 1; }
+        function use(k) {
+          const d = { x: 1, y: 2 };
+          return d[k]();
+        }
+    """)
+    out = _analyze(repo, fp)
+    edges = out["call_graph"].get("file.js:use", [])
+    assert not any(e.endswith(":data") for e in edges), edges


### PR DESCRIPTION
## Summary

The analyzer normalized an `ElementAccessExpression` callee (`handlers['a']()` / `tbl[0]()`) to null and bucketed the raw span into `indirect_calls` — **a field with no non-test reader** — so a dispatch table's targets were orphaned while the dominant real-world idiom (a named handler as an argument, `app.get('/x', handler)`) already worked. The umbrella's JS/TS severity is the mildest of the seven; the ask was *"give `indirect_calls` a consumer, or feed its entries into the reachability graph as reference edges — the detection already works, only the plumbing is missing."* Issue #299's JS/TS member (6 of 7).

Fix:
- **container dispatch**: an object/array literal of bare-identifier handlers (`const handlers = { a: handlerA }`; `const tbl = [handlerB]`) binds its name (file-scope map cached per file + the enclosing function's locals), and an element-access callee over a **known** container resolves to **every** referenced function (over-seed, the safe direction). Unknown bases keep the existing dynamic bucket — no invented edges (tested). Note: a manual `getChildren()` walk cannot descend past ts-morph's `SyntaxList` wrapper — `getDescendantsOfKind(VariableDeclaration)` is the reliable descent;
- **`indirect_calls` consumer**: an unresolvable static name bucketed as indirect becomes a **reference edge** when it resolves with the member restriction dropped (a receiver call `obj.process()` whose same-named free function exists keeps that function reachable from the caller) — the plumbing the umbrella asks for.

**T3 differential** (real corpora: **express** 181 files + **underscore** 12 files; 462 edges): base vs fix, **LOST 0 / GAINED 0** — strict monotonicity (the mild severity confirmed: no dispatch-table gains on these corpora; the mechanism is fixture-proven).

## Test plan

5 hermetic tests through the real Node analyzer: object + array container dispatch (the caller set contains the dispatcher specifically); a direct-call control; the indirect-consumer reference edge (a receiver call resolving to a same-named free function); the unknown-element-access abstention negative.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/parsers/javascript/test_issue299_jsts_container_dispatch.py -q` | 5 passed (2 failed RED on pristine) |
| JS suite | `PYTHONPATH=<core> pytest tests/parsers/javascript/ -q` | 104 passed |
| mutation smoke | analyzer stashed → new file | 2 failed; restored → 5 passed |
| T3 differential | express + underscore, base vs fix | 462 edges / 462 edges; **LOST 0**; GAINED 0 (strict monotone) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3213 passed, 0 failed**, 32 skipped |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 5 passed |
| JS hygiene | `node --check` + `ruff` | clean |

</details>

Refs #299 (6 of 7)
