### PR TITLE
fix(rust-parser): container dispatch completes the seven-parser family (#299, 7 of 7)

### DIFF
--- a/libs/openant-core/parsers/rust/call_graph_builder.py
+++ b/libs/openant-core/parsers/rust/call_graph_builder.py
@@ -24,6 +24,7 @@ design notes for the actual node-type dump this was built from):
   stream of well-known formatting/assertion macros (see `_scan_macro_body`).
 """
 
+import os
 import posixpath
 import re
 from collections import defaultdict
@@ -381,6 +382,18 @@ class CallGraphBuilder:
             return sites
         source = code.encode("utf-8")
 
+        # #299 (7 of 7): dispatch containers — an array literal of bare-ident
+        # function references (`static TBL: [fn(); N] = [a, b];` or a local
+        # `let t = [a, b];`) binds its name; a subscript call over a KNOWN
+        # container resolves to every referenced function (over-seed, the
+        # safe direction). Idiomatic Rust dispatches via match / dyn Fn /
+        # bound locals (all already resolving) — this completes the family
+        # shape; the umbrella measured the idiom as rare in real code, so
+        # corpus gains are expected ≈0 (pre-registered).
+        containers = dict(self._file_containers(caller_file))
+        containers.update(self._collect_local_containers(tree.root_node, source))
+        container_names = set(containers.keys())
+
         stack = [tree.root_node]
         entered_fn = False
         while stack:
@@ -398,6 +411,19 @@ class CallGraphBuilder:
                 entered_fn = True
             if node.type == "call_expression":
                 callee = node.children[0] if node.children else None
+                # #299 (7 of 7): a subscript callee TBL[i]() over a KNOWN
+                # container — one site per referenced function. Unknown bases
+                # fall through to _describe_callee (which abstains on the
+                # index_expression shape; no bare-name false edges).
+                if (callee is not None and callee.type == "index_expression"
+                        and container_names):
+                    base = self._index_expression_base(callee, source)
+                    if base is not None and base in containers:
+                        for target in sorted(containers[base]):
+                            sites.append({"kind": "bare", "name": target,
+                                          "bare_filter_name": target})
+                        stack.extend(node.children)
+                        continue
                 site = self._describe_callee(callee, source)
                 if site is not None:
                     sites.append(site)
@@ -425,6 +451,96 @@ class CallGraphBuilder:
                     or bare in repo_names):
                 filtered.append(site)
         return filtered
+
+    # ------------------------------------------------------------------
+    # #299 (7 of 7): dispatch containers
+    # ------------------------------------------------------------------
+    def _index_expression_base(self, callee: Node, source: bytes) -> Optional[str]:
+        """The base identifier text of an index_expression callee."""
+        for child in callee.children:
+            if child.type == "identifier":
+                return self._text(child, source)
+        return None
+
+    def _array_expression_targets(self, arr, source: bytes, repo_names) -> list:
+        """The bare-ident known-function names an array literal references."""
+        targets = []
+        for child in arr.children:
+            if child.type == "identifier":
+                name = self._text(child, source)
+                if name in repo_names:
+                    targets.append(name)
+        return targets
+
+    def _collect_local_containers(self, root, source: bytes) -> Dict[str, list]:
+        """let NAME: [fn(); N] = [a, b]; -> container map (this caller's body).
+        A rebound name is dropped rather than guessed."""
+        repo_names = set(self._build_name_index()) if not self.functions else {
+            fi.get("name") for fi in self.functions.values() if fi.get("name")}
+        containers: Dict[str, list] = {}
+        stack = [root]
+        while stack:
+            node = stack.pop()
+            if node.type == "let_declaration":
+                ident = None
+                arr = None
+                for child in node.children:
+                    if child.type == "identifier" and ident is None:
+                        ident = self._text(child, source)
+                    elif child.type == "array_expression":
+                        arr = child
+                if ident is not None and arr is not None:
+                    if ident in containers:
+                        containers.pop(ident, None)
+                    else:
+                        targets = self._array_expression_targets(arr, source, repo_names)
+                        if targets:
+                            containers[ident] = targets
+            stack.extend(node.children)
+        return containers
+
+    def _file_containers(self, caller_file: str) -> Dict[str, list]:
+        """File-scope static containers (static TBL: [...] = [a, b];), parsed
+        once per file and cached. Abstains (empty) on read/parse failure."""
+        cached = getattr(self, "_file_container_cache", None)
+        if cached is None:
+            cached = {}
+            self._file_container_cache = cached
+        if caller_file in cached:
+            return cached[caller_file]
+        result: Dict[str, list] = {}
+        repo_names = {fi.get("name") for fi in self.functions.values()
+                      if fi.get("name")}
+        try:
+            full = (caller_file if os.path.isabs(caller_file)
+                    else os.path.join(self.repository, caller_file))
+            with open(full, "rb") as fh:
+                source = fh.read()
+            tree = self.parser.parse(source)
+            stack = [tree.root_node]
+            while stack:
+                node = stack.pop()
+                if node.type == "static_item":
+                    ident = None
+                    arr = None
+                    for child in node.children:
+                        if child.type == "identifier" and ident is None:
+                            ident = self._text(child, source)
+                        elif child.type == "array_expression":
+                            arr = child
+                    if ident is not None and arr is not None:
+                        if ident in result:
+                            result.pop(ident, None)
+                        else:
+                            targets = self._array_expression_targets(arr, source,
+                                                                     repo_names)
+                            if targets:
+                                result[ident] = targets
+                stack.extend(node.children)
+        except OSError:
+            result = {}
+        cached[caller_file] = result
+        return result
 
     def _describe_callee(self, callee: Optional[Node], source: bytes) -> Optional[dict]:
         if callee is None:

--- a/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
@@ -1,0 +1,101 @@
+"""Regression tests for issue #299 (Rust member — 7 of 7): container-literal
+dispatch loses call edges.
+
+Rust's ``_describe_callee`` handled generic_function / identifier /
+field_expression / scoped_identifier — an index_expression callee
+(``TBL[i]()``) returned None, so the dispatcher's targets were orphaned.
+Per the umbrella's own measurement the subscript-call idiom is RARE in
+idiomatic Rust (zero code hits across 2,432 .rs files in 10 projects —
+match, dyn Fn, and bound-local lookup all resolve); this member completes
+the seven-parser family, fixture-proven, with the pre-registered
+expectation gained≈0 on real corpora.
+
+Contract locked here:
+- a container of function references (static array literal, the common
+  synthetic shape) plus a subscript call records edges to every referenced
+  function — the caller set contains the DISPATCHER specifically;
+- a direct-call CONTROL keeps its edge;
+- an unknown subscript base abstains — no invented edges;
+- a let-bound local container works the same.
+"""
+
+import json
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from core.parser_adapter import parse_repository  # noqa: E402
+
+
+def _cg(files: dict):
+    repo = os.path.realpath(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = os.path.join(repo, rel)
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        with open(p, "w") as fh:
+            fh.write(content)
+    out = tempfile.mkdtemp()
+    parse_repository(repo, out, language="rust", processing_level="all",
+                     skip_tests=True, name="r")
+    return json.load(open(os.path.join(out, "call_graph.json")))
+
+
+def _edges(cg, caller_suffix):
+    keys = [k for k in cg["call_graph"] if k.endswith(caller_suffix)]
+    return [e for k in keys for e in cg["call_graph"][k]]
+
+
+_FIXTURE = {
+    "main.rs":
+        "fn handler_a() -> i32 { 1 }\n"
+        "fn handler_b() -> i32 { 2 }\n"
+        "fn direct_target() -> i32 { 3 }\n"
+        "\n"
+        "static TBL: [fn() -> i32; 2] = [handler_a, handler_b];\n"
+        "\n"
+        "fn dispatch(i: usize) -> i32 {\n"
+        "    direct_target();\n"          # CONTROL
+        "    TBL[i]()\n"
+        "}\n",
+}
+
+
+def test_static_container_dispatch_edges():
+    cg = _cg(_FIXTURE)
+    edges = _edges(cg, ":dispatch")
+    assert any("handler_a" in e for e in edges), edges
+    assert any("handler_b" in e for e in edges), edges
+
+
+def test_direct_call_control_passes():
+    cg = _cg(_FIXTURE)
+    assert any("direct_target" in e for e in _edges(cg, ":dispatch"))
+
+
+def test_local_let_container_dispatch():
+    cg = _cg({
+        "main.rs":
+            "fn h1() -> i32 { 1 }\n"
+            "fn h2() -> i32 { 2 }\n"
+            "fn dispatch(i: usize) -> i32 {\n"
+            "    let t: [fn() -> i32; 2] = [h1, h2];\n"
+            "    t[i]()\n"
+            "}\n",
+    })
+    edges = _edges(cg, ":dispatch")
+    assert any("h1" in e for e in edges), edges
+    assert any("h2" in e for e in edges), edges
+
+
+def test_unknown_subscript_abstains():
+    cg = _cg({
+        "main.rs":
+            "fn data() -> i32 { 1 }\n"
+            "fn use_(i: usize) -> i32 {\n"
+            "    let d = [1, 2, 3];\n"
+            "    d[i]()\n"
+            "}\n",
+    })
+    assert _edges(cg, ":use_") == []

--- a/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
@@ -39,7 +39,8 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="rust", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    with open(os.path.join(out, "call_graph.json")) as fh:
+        return json.load(fh)
 
 
 def _edges(cg, caller_suffix):


### PR DESCRIPTION
## Summary

Rust's `_describe_callee` handled generic_function / identifier / field_expression / scoped_identifier — an `index_expression` callee (`TBL[i]()`) returned None, so the dispatcher's targets were orphaned. Per the umbrella's own measurement the subscript-call idiom is **rare in idiomatic Rust** (zero code hits across 2,432 `.rs` files in 10 projects: `match`, `dyn Fn`, and bound-local lookup all resolve) — this member completes the seven-parser family, fixture-proven, with the **pre-registered** corpus expectation gained≈0. Issue #299's Rust member (7 of 7).

Fix:
- **container collection**: a static array literal of bare-ident function references (`static TBL: [fn() -> i32; 2] = [handler_a, handler_b];`) or a local `let t = [a, b];` binds its name — file-scope statics parsed once per file and cached; a rebound name is dropped rather than guessed;
- **subscript dispatch**: an `index_expression` callee over a **known** container emits one bare site per referenced function (over-seed, the safe direction). Unknown bases fall through to `_describe_callee`, which abstains on the index shape — no invented edges (tested).

**T3 differential** (real corpora: **ripgrep** 110 files + **serde** 208 files; 5804 edges): base vs fix, **LOST 0 / GAINED 0** — exactly the pre-registered no-regression/no-gain result (the umbrella's rarity measurement reproduced on independent corpora).

**Local-env note:** the rust test-directory-only batch shows a **pre-existing** collection ImportError (16 errors, identical on pristine master — a `_rust_helpers` sys.path interaction; 0 errors in the full-suite ordering, which is what CI runs). Not introduced here; noted as a follow-up.

## Test plan

4 hermetic tests through the real pipeline: static-container dispatch (the caller set contains the dispatcher specifically); a direct-call control; a `let`-bound local container; the unknown-subscript abstention negative.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/parsers/rust/test_issue299_rust_container_dispatch.py -q` | 4 passed (2 failed RED on pristine) |
| mutation smoke | builder stashed → new file | 2 failed; restored → 4 passed |
| T3 differential | ripgrep + serde, base vs fix | 5804 edges / 5804 edges; **LOST 0**; GAINED 0 (pre-registered) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3212 passed, 0 failed**, 32 skipped (this branch's suite) |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 4 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Refs #299 (7 of 7)
