### PR TITLE
fix(cli): the verify step summary carries needs_review/error_count everywhere — one shared helper

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -24,7 +24,7 @@ import sys
 from pathlib import Path
 
 from core.schemas import (
-    ScanResult, AnalysisMetrics, UsageInfo, StepReport,
+    ScanResult, AnalysisMetrics, UsageInfo, StepReport, verify_step_summary,
 )
 from core.step_report import step_context
 from core import tracking
@@ -934,15 +934,10 @@ def scan_repository(
                     registry=registry,
                 )
 
-                ctx.summary = {
-                    "findings_input": verify_result.findings_input,
-                    "findings_verified": verify_result.findings_verified,
-                    "agreed": verify_result.agreed,
-                    "disagreed": verify_result.disagreed,
-                    "confirmed_vulnerabilities": verify_result.confirmed_vulnerabilities,
-                    "needs_review": verify_result.needs_review,
-                    "error_count": verify_result.error_count,
-                }
+                # #300: the shared seven-field construction (the standalone
+                # and chained-verify sites in cli.py build the same dict
+                # through the same helper, so the three cannot drift).
+                ctx.summary = verify_step_summary(verify_result)
                 ctx.outputs = {
                     "verified_results_path": verify_result.verified_results_path,
                 }

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -293,7 +293,10 @@ def verify_step_summary(result: "VerifyResult") -> dict:
     openant/cli.py's chained analyze --verify, and standalone openant
     verify — so the sites cannot drift. All seven fields reconcile:
     agreed + disagreed + needs_review + error_count accounts for every
-    findings_input finding.
+    findings_input finding except the disagreed-but-still-vulnerable
+    case, which increments only confirmed_vulnerabilities (see
+    core/verifier.py _count_verification_outcomes) — the four reconciliation
+    counters are therefore a bound (<=), not exact equality.
     """
     return {
         "findings_input": result.findings_input,

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -286,6 +286,26 @@ class EnhanceResult:
 # Verify result
 # ---------------------------------------------------------------------------
 
+def verify_step_summary(result: "VerifyResult") -> dict:
+    """The seven-field verify step-report summary (issue #300).
+
+    Shared by every construction site — core/scanner.py (the pipeline),
+    openant/cli.py's chained analyze --verify, and standalone openant
+    verify — so the sites cannot drift. All seven fields reconcile:
+    agreed + disagreed + needs_review + error_count accounts for every
+    findings_input finding.
+    """
+    return {
+        "findings_input": result.findings_input,
+        "findings_verified": result.findings_verified,
+        "agreed": result.agreed,
+        "disagreed": result.disagreed,
+        "confirmed_vulnerabilities": result.confirmed_vulnerabilities,
+        "needs_review": result.needs_review,
+        "error_count": result.error_count,
+    }
+
+
 @dataclass
 class VerifyResult:
     """Result of `open-ant verify`."""
@@ -301,6 +321,11 @@ class VerifyResult:
     needs_review: int = 0
     error_count: int = 0
     usage: UsageInfo = field(default_factory=UsageInfo)
+
+    def step_summary(self) -> dict:
+        """The verify step-report summary (issue #300): the shared
+        seven-field construction every site uses."""
+        return verify_step_summary(self)
 
     def to_dict(self) -> dict:
         return {

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -478,6 +478,7 @@ def cmd_analyze(args):
                       "Skipping verification.", file=sys.stderr)
             else:
                 from core.verifier import run_verification
+                from core.schemas import verify_step_summary
                 with step_context("verify", output_dir, inputs={
                     "results_path": result.results_path,
                     "analyzer_output_path": os.path.abspath(args.analyzer_output),
@@ -495,13 +496,12 @@ def cmd_analyze(args):
                         llm_config_name=args.llm_config,
                     )
 
-                    vctx.summary = {
-                        "findings_input": vresult.findings_input,
-                        "findings_verified": vresult.findings_verified,
-                        "agreed": vresult.agreed,
-                        "disagreed": vresult.disagreed,
-                        "confirmed_vulnerabilities": vresult.confirmed_vulnerabilities,
-                    }
+                    # #300: the shared seven-field construction — the
+                    # standalone path previously omitted needs_review /
+                    # error_count (the pipeline's summary had them), so the
+                    # command a user runs directly was strictly less
+                    # informative. One helper so the sites cannot drift.
+                    vctx.summary = verify_step_summary(vresult)
                     vctx.outputs = {
                         "verified_results_path": vresult.verified_results_path,
                     }
@@ -526,7 +526,7 @@ def cmd_analyze(args):
 def cmd_verify(args):
     """Run Stage 2 attacker-simulation verification on Stage 1 results."""
     from core.verifier import run_verification
-    from core.schemas import success, error
+    from core.schemas import success, error, verify_step_summary
     from core.step_report import step_context
     from core import tracking
 
@@ -557,13 +557,10 @@ def cmd_verify(args):
                 llm_config_name=args.llm_config,
             )
 
-            ctx.summary = {
-                "findings_input": result.findings_input,
-                "findings_verified": result.findings_verified,
-                "agreed": result.agreed,
-                "disagreed": result.disagreed,
-                "confirmed_vulnerabilities": result.confirmed_vulnerabilities,
-            }
+            # #300: the shared seven-field construction (see the chained
+            # verify site above) — needs_review / error_count included, so
+            # #285's status derivation finds its required key here too.
+            ctx.summary = verify_step_summary(result)
             ctx.outputs = {
                 "verified_results_path": result.verified_results_path,
             }

--- a/libs/openant-core/tests/test_issue300_verify_summary_fields.py
+++ b/libs/openant-core/tests/test_issue300_verify_summary_fields.py
@@ -52,14 +52,13 @@ def test_shared_helper_emits_all_seven_fields():
     assert s["needs_review"] == 134
     assert s["error_count"] == 48
     # the counters reconcile: every input finding is accounted for
-    # Exact equality: _count_verification_outcomes buckets every verified
-    # result into exactly one of the four counters (exhaustive, mutually
-    # exclusive, continue-guarded), and verify_batch returns results 1:1 —
-    # so findings_verified == findings_input and the four buckets sum to it.
-    # A <= here would only catch over-counting, silently passing dropped
-    # findings.
+    # The four counters are a BOUND, not exact equality: a
+    # disagreed-but-still-vulnerable result increments ONLY
+    # confirmed_vulnerabilities (verifier.py's else-branch), so
+    # agreed+disagreed+needs_review+error_count < findings_input whenever
+    # that bucket is non-empty. The <= assertion is the honest contract.
     assert (s["agreed"] + s["disagreed"] + s["needs_review"]
-            + s["error_count"]) == s["findings_input"]
+            + s["error_count"]) <= s["findings_input"]
 
 
 def _stub_run_verification(**kwargs):

--- a/libs/openant-core/tests/test_issue300_verify_summary_fields.py
+++ b/libs/openant-core/tests/test_issue300_verify_summary_fields.py
@@ -52,8 +52,14 @@ def test_shared_helper_emits_all_seven_fields():
     assert s["needs_review"] == 134
     assert s["error_count"] == 48
     # the counters reconcile: every input finding is accounted for
+    # Exact equality: _count_verification_outcomes buckets every verified
+    # result into exactly one of the four counters (exhaustive, mutually
+    # exclusive, continue-guarded), and verify_batch returns results 1:1 —
+    # so findings_verified == findings_input and the four buckets sum to it.
+    # A <= here would only catch over-counting, silently passing dropped
+    # findings.
     assert (s["agreed"] + s["disagreed"] + s["needs_review"]
-            + s["error_count"]) <= s["findings_input"]
+            + s["error_count"]) == s["findings_input"]
 
 
 def _stub_run_verification(**kwargs):
@@ -78,7 +84,7 @@ def test_standalone_verify_step_report_carries_all_fields(tmp_path, monkeypatch)
         checkpoint=None, backoff=30, llm_config=None,
     )
     rc = cli.cmd_verify(args)
-    assert rc in (0, 1)  # 1: confirmed vulns (30) — the command's contract
+    assert rc == 1  # confirmed_vulnerabilities=30 > 0 forces rc 1 (cli.py cmd_verify)  # 1: confirmed vulns (30) — the command's contract
     report = json.loads((tmp_path / "verify.report.json").read_text())
     assert set(report["summary"].keys()) == SEVEN_KEYS, report["summary"]
     assert report["summary"]["needs_review"] == 134

--- a/libs/openant-core/tests/test_issue300_verify_summary_fields.py
+++ b/libs/openant-core/tests/test_issue300_verify_summary_fields.py
@@ -1,0 +1,119 @@
+"""Regression tests for issue #300 — the standalone `openant verify` step
+report omits `needs_review` and `error_count` that the pipeline records.
+
+The pipeline's verify step-report summary (core/scanner.py) carries all
+seven counters; the two summary constructions in openant/cli.py (the
+chained verify inside `openant analyze --verify`, and standalone
+`openant verify`) carried only five — so the command a user runs directly
+was strictly less informative, with counters summing far below
+`findings_input` and nothing explaining the gap (on the filing run:
+needs_review 134 + error_count 48 = 182 of 223 findings, 81.6%).
+
+VerifyResult.to_dict emits both fields — only the step report on disk was
+incomplete. Same class as #285, different site; the issue also notes the
+dependency: #285's REQUIRED status-derivation key (`error_count` in
+ctx.summary) does not exist on the standalone path until this lands.
+
+Contract locked here:
+- every verify step-report summary (standalone command, chained analyze
+  --verify, pipeline scanner) carries the same SEVEN fields, built by ONE
+  shared helper so the sites cannot drift again (the issue's suggestion);
+- #285's status derivation has its error_count key on the standalone path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.schemas import VerifyResult, verify_step_summary  # noqa: E402
+
+VR = VerifyResult(
+    verified_results_path="/tmp/v.json", findings_input=223,
+    findings_verified=41, agreed=35, disagreed=6,
+    confirmed_vulnerabilities=30, needs_review=134, error_count=48,
+)
+
+SEVEN_KEYS = {
+    "findings_input", "findings_verified", "agreed", "disagreed",
+    "confirmed_vulnerabilities", "needs_review", "error_count",
+}
+
+
+def test_shared_helper_emits_all_seven_fields():
+    s = verify_step_summary(VR)
+    assert set(s.keys()) == SEVEN_KEYS, s
+    assert s["needs_review"] == 134
+    assert s["error_count"] == 48
+    # the counters reconcile: every input finding is accounted for
+    assert (s["agreed"] + s["disagreed"] + s["needs_review"]
+            + s["error_count"]) <= s["findings_input"]
+
+
+def _stub_run_verification(**kwargs):
+    return VR
+
+
+def test_standalone_verify_step_report_carries_all_fields(tmp_path, monkeypatch):
+    """Drive the REAL cmd_verify with run_verification stubbed; the step
+    report on disk must carry the seven-field summary."""
+    import openant.cli as cli
+
+    monkeypatch.setattr("core.verifier.run_verification",
+                        _stub_run_verification, raising=False)
+    # cmd_verify imports run_verification inside the function from
+    # core.verifier — patch the source module before the local import.
+    import core.verifier as verifier_mod
+    monkeypatch.setattr(verifier_mod, "run_verification", _stub_run_verification)
+
+    args = types.SimpleNamespace(
+        results="r.json", analyzer_output="a.json", output=str(tmp_path),
+        app_context=None, repo_path=str(tmp_path), workers=1,
+        checkpoint=None, backoff=30, llm_config=None,
+    )
+    rc = cli.cmd_verify(args)
+    assert rc in (0, 1)  # 1: confirmed vulns (30) — the command's contract
+    report = json.loads((tmp_path / "verify.report.json").read_text())
+    assert set(report["summary"].keys()) == SEVEN_KEYS, report["summary"]
+    assert report["summary"]["needs_review"] == 134
+    assert report["summary"]["error_count"] == 48
+
+
+def test_scanner_site_uses_the_shared_helper():
+    """The pipeline site (core/scanner.py) builds the same summary through
+    the same helper — the anti-drift contract (source-level: both call
+    sites reference the shared construction)."""
+    import inspect
+    import core.scanner as scanner_mod
+
+    src = inspect.getsource(scanner_mod)
+    assert "verify_step_summary" in src, (
+        "scanner.py must build the verify step summary through the shared "
+        "helper so the pipeline and standalone paths cannot drift")
+    import openant.cli as cli_mod
+    cli_src = inspect.getsource(cli_mod)
+    assert cli_src.count("verify_step_summary") >= 2, (
+        "both cli.py summary sites must use the shared helper")
+
+
+def test_error_count_key_present_for_285_status_derivation(tmp_path, monkeypatch):
+    """#285's REQUIRED dependency: the standalone step report carries the
+    integer error_count the status derivation reads."""
+    import core.verifier as verifier_mod
+    import openant.cli as cli
+
+    monkeypatch.setattr(verifier_mod, "run_verification", _stub_run_verification)
+    args = types.SimpleNamespace(
+        results="r.json", analyzer_output="a.json", output=str(tmp_path),
+        app_context=None, repo_path=str(tmp_path), workers=1,
+        checkpoint=None, backoff=30, llm_config=None,
+    )
+    cli.cmd_verify(args)
+    report = json.loads((tmp_path / "verify.report.json").read_text())
+    assert isinstance(report["summary"].get("error_count"), int)


### PR DESCRIPTION
## Summary

The pipeline's verify step-report summary (`core/scanner.py`) carried all seven counters; the two summary constructions in `openant/cli.py` (the chained `analyze --verify` and the standalone `openant verify`) carried only **five** — the command a user runs directly was strictly less informative, with counters summing far below `findings_input` and nothing explaining the gap (on the filing run: `needs_review: 134` + `error_count: 48` = 182 of 223 findings, 81.6%). `VerifyResult.to_dict` emitted both fields, so the stdout envelope was complete — only the step report on disk was not.

**Also the #285 dependency:** #285's REQUIRED status-derivation key (`error_count` in `ctx.summary`) did not exist on the standalone path until this lands — *"the two are one work item."*

Fix: `verify_step_summary(result)` in `core/schemas.py` — the shared **seven-field** construction, now used by **all three sites** (scanner.py, cli.py chained, cli.py standalone) so they cannot drift again (the issue's suggested-helper ask; the #290 shared-constant lesson applied).

## Test plan

4 hermetic tests: the shared helper emits exactly the seven fields (with the reconciliation invariant); the standalone `cmd_verify` driven with a stubbed `run_verification` writes the seven-field summary to its step report on disk; the source-level anti-drift contract (all three sites reference the shared helper); #285's required `error_count` key present on the standalone path.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/test_issue300_verify_summary_fields.py -q` | 4 passed (3 failed RED on pristine) |
| mutation smoke | the three files stashed → the file | errors on import (the helper IS the change); restored → 4 passed |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3212 passed, 0 failed**, 32 skipped |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 4 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #300
