### PR TITLE
fix(telemetry): the orphan/dead-cluster prune classification reaches the deliverable and warns at a health-signal rate

### DIFF
--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -572,12 +572,17 @@ def apply_reachability_filter(
     # already claim the slot. call_graph/reverse_call_graph are the UN-pruned graphs.
     _rf = dataset["metadata"]["reachability_filter"]
     _pruned_ids = [u.get("id", "") for u in units if u.get("id", "") not in reachable_ids]
-    _extra, _asym_warning = compute_prune_telemetry(
+    _extra, _asym_warning, _orphan_advisory = compute_prune_telemetry(
         reachable_ids, sorted(_pruned_ids), call_graph, reverse_call_graph, output_dir)
     _rf.update(_extra)
     if _asym_warning and "warning" not in _rf:
         _rf["warning"] = _asym_warning
         print(f"  [Warning] {_asym_warning}", file=sys.stderr)
+    # #301: the orphan-rate advisory — its own key, NEVER the reserved
+    # ``warning`` slot, and it reaches the scan summary on stderr.
+    if _orphan_advisory:
+        _rf["orphan_advisory"] = _orphan_advisory
+        print(f"  [Advisory] {_orphan_advisory}", file=sys.stderr)
 
     # Warn about unimplemented higher-level filters
     if processing_level == "codeql":

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -517,6 +517,7 @@ def build_pipeline_output(
         os.path.dirname(os.path.abspath(results_path))
     )
     reachability_warnings: list[str] = []
+    _reach_telemetry: dict = {}
     reachability_filter_applied = _reach is not None
     reachable_units = total_units
     original_units = total_units
@@ -531,6 +532,21 @@ def build_pipeline_output(
         _rf_warning = _reach.get("warning")
         if isinstance(_rf_warning, str) and _rf_warning:
             reachability_warnings.append(_rf_warning)
+        # #301: the prune classification (orphan = missing-edge ROOT
+        # candidate; dead_cluster = downstream shadow) previously reached no
+        # consumer — forward it present-only so pipeline_output carries the
+        # signal that distinguishes genuinely-dead code from missing edges.
+        for _tk in ("pruned_orphan_count", "pruned_in_dead_cluster_count",
+                    "pruned_forward_called_by_reachable_count"):
+            _tv = _reach.get(_tk)
+            if isinstance(_tv, int):
+                _reach_telemetry[_tk] = _tv
+        _bf = _reach.get("pruned_by_file")
+        if isinstance(_bf, dict):
+            _reach_telemetry["pruned_by_file"] = _bf
+        _oa = _reach.get("orphan_advisory")
+        if isinstance(_oa, str) and _oa:
+            _reach_telemetry["orphan_advisory"] = _oa
     elif total_units > 0 and (processing_level or "").lower() not in ("", "all", "none"):
         reachability_warnings.append(
             f"Reachability filtering was requested (level={processing_level!r}) "
@@ -579,6 +595,7 @@ def build_pipeline_output(
             "reachability_filter_applied": reachability_filter_applied,
             "reachability_reduction_percentage": reachability_reduction_percentage,
             "reachability_warnings": reachability_warnings,
+            **_reach_telemetry,
             "units_analyzed": total_units - metrics.get("errors", 0),
             "processing_level": processing_level,
             "costs": costs,

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -112,6 +112,58 @@ def partition_units_by_language(units: list[dict]) -> dict[str | None, list[dict
     return parts
 
 
+def aggregate_reachability_telemetry(per_lang: dict) -> dict:
+    """#301: sum the per-language prune telemetry into the top-level record.
+
+    The merged-run shape keeps the orphan/dead-cluster counts per language
+    (under ``reachability_filter.per_language``) while the reporter reads only
+    the top level — so on a multi-language scan the classification the
+    reporter now forwards would otherwise exist but never reach it. Counts sum
+    exactly; ``pruned_by_file`` merges per-file and re-caps at the module's
+    top-20 (each language capped its own top-20, so a cross-language sum can
+    miss a file outside its own language's cap — an advisory pointer, noted).
+    Present-only: a record set without telemetry contributes nothing, and
+    the result is empty when no language ran the classification.
+    """
+    agg: Dict[str, int] = {}
+    by_file: Dict[str, int] = {}
+    asym = 0
+    for record in per_lang.values():
+        if not isinstance(record, dict):
+            continue
+        for key in ("pruned_orphan_count", "pruned_in_dead_cluster_count"):
+            v = record.get(key)
+            if isinstance(v, int):
+                agg[key] = agg.get(key, 0) + v
+        v = record.get("pruned_forward_called_by_reachable_count")
+        if isinstance(v, int):
+            asym += v
+        bf = record.get("pruned_by_file")
+        if isinstance(bf, dict):
+            for f, c in bf.items():
+                if isinstance(c, int):
+                    by_file[f] = by_file.get(f, 0) + c
+    out: dict = {}
+    out.update(agg)
+    if agg or asym:
+        # the hard invariant is always present when the classification ran —
+        # a measured 0 is the healthy signal, not a fabricated one
+        out["pruned_forward_called_by_reachable_count"] = asym
+    if by_file:
+        top = sorted(by_file.items(), key=lambda kv: (-kv[1], kv[0]))[:20]
+        out["pruned_by_file"] = dict(top)
+    # per-language orphan advisories lift to the top level (the same shape
+    # as the warning lift; its own key, never the reserved warning slot).
+    advisories = [
+        f"{lang}: {record['orphan_advisory']}"
+        for lang, record in sorted(per_lang.items())
+        if isinstance(record, dict) and record.get("orphan_advisory")
+    ]
+    if advisories:
+        out["orphan_advisory"] = "; ".join(advisories)
+    return out
+
+
 def scan_repository(
     repo_path: str,
     output_dir: str,
@@ -650,6 +702,7 @@ def scan_repository(
                                     r.get("reachable_units", 0) for r in _per_lang.values()
                                 )
                                 _agg = {
+                                    **aggregate_reachability_telemetry(_per_lang),
                                     "original_units": _orig,
                                     "entry_points": sum(
                                         r.get("entry_points", 0) for r in _per_lang.values()
@@ -682,6 +735,7 @@ def scan_repository(
                                 ]
                                 if _warnings:
                                     _agg["warning"] = "; ".join(_warnings)
+
                                 _new_md["reachability_filter"] = _agg
                             else:
                                 # No real filter ran (every language unfilterable):

--- a/libs/openant-core/parsers/swift/test_pipeline.py
+++ b/libs/openant-core/parsers/swift/test_pipeline.py
@@ -264,13 +264,18 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
             # `result[...]`: a pruned graph forces the asymmetry invariant to a
             # manufactured 0. Highest-risk line in this change.
             pruned_ids = sorted(set(functions) - set(filtered_functions))
-            _extra, _asym_warning = compute_prune_telemetry(
+            # #301: third return value = the orphan-rate advisory (its own
+            # key, never the reserved warning slot; core parity).
+            _extra, _asym_warning, _orphan_advisory = compute_prune_telemetry(
                 reachable, pruned_ids, call_graph, reverse_call_graph, output_dir)
             rf.update(_extra)
             if _asym_warning:
                 rf["warning"] = _asym_warning
             if _blackout:            # blackout warning takes precedence (core parity)
                 rf["warning"] = _blackout
+            if _orphan_advisory:
+                rf["orphan_advisory"] = _orphan_advisory
+                print(f"  [Advisory] {_orphan_advisory}", file=sys.stderr)
         result["_reachability_filter"] = rf
     except Exception as _e:          # telemetry is advisory; never break the scan
         print(f"  [Warning] prune telemetry skipped: {_e}", file=sys.stderr)

--- a/libs/openant-core/tests/test_issue301_prune_telemetry_deliverable.py
+++ b/libs/openant-core/tests/test_issue301_prune_telemetry_deliverable.py
@@ -1,0 +1,314 @@
+"""Regression tests for issue #301 — the orphan/dead-cluster prune
+classification is computed, written into dataset metadata, and then dropped
+before the deliverable.
+
+`compute_prune_telemetry` classifies every pruned unit as an ``orphan`` (no
+non-self caller — a missing-edge ROOT candidate) or a ``dead_cluster`` (has a
+pruned caller — a downstream shadow). On the run that filed this, 3,128 of
+5,370 pruned units (58.2%) were orphans — the exact signal that distinguishes
+"genuinely dead code" from "our call graph is missing an edge" (the #295/#298/
+#299 dispatch-table shape prunes as orphans). The counts reached
+``dataset.metadata`` and no further: the reporter copies only four reachability
+fields into ``pipeline_output.json``, no code reads the counts, and the
+multi-language aggregate never sums them.
+
+Contract locked here:
+- the four telemetry keys forward into ``pipeline_output.pipeline_stats``
+  (present-only: absent when no filter record / no telemetry ran);
+- the multi-language aggregate SUMS the per-language counts (the filing run's
+  shape: keys existed per-language under ``reachability_filter.per_language``,
+  never at the top level the reporter reads) and merges the by-file pointer;
+- an orphan rate above the threshold surfaces a scan-summary advisory
+  (stderr + its own metadata key), worded as the issue requires: orphans are
+  missing-edge CANDIDATES — genuinely dead code is also an orphan;
+- the advisory does NOT claim the reserved ``warning`` slot (the
+  forward-asymmetry / blackout class owns it).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.prune_telemetry import (  # noqa: E402
+    ORPHAN_MIN_PRUNED_FOR_ADVISORY,
+    ORPHAN_RATE_WARN_THRESHOLD,
+    compute_prune_telemetry,
+)
+from core.reporter import build_pipeline_output  # noqa: E402
+from utilities.file_io import write_json  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# the advisory (item 2)
+# ---------------------------------------------------------------------------
+def _simple_graphs(orphan_ids, cluster_root):
+    """A graph where orphan_ids have no callers (orphans) and cluster_root
+    calls everything else (which itself prunes as a dead cluster)."""
+    cg = {cluster_root: []}
+    rcg = {}
+    return cg, rcg
+
+
+def _many_orphan_fixture(n_orphan=8, n_cluster=2):
+    """n_orphan orphans + n_cluster dead-cluster units (called by a pruned
+    root, itself an orphan)."""
+    pruned = [f"a.py:o{i}" for i in range(n_orphan)] + \
+             [f"a.py:c{i}" for i in range(n_cluster)]
+    reachable = ["a.py:root"]
+    call_graph = {"a.py:root": [], "a.py:cr": [f"a.py:c{i}" for i in range(n_cluster)]}
+    rcg = {f"a.py:c{i}": ["a.py:cr"] for i in range(n_cluster)}
+    return reachable, pruned, call_graph, rcg
+
+
+def test_advisory_fires_above_threshold():
+    # 8 orphans of 10 pruned (cr is NOT pruned in this fixture) = 80%
+    reachable, pruned, call_graph, rcg = _many_orphan_fixture()
+    extra, warning, advisory = compute_prune_telemetry(
+        reachable, pruned, call_graph, rcg)
+    assert extra["pruned_orphan_count"] == 8
+    assert advisory is not None
+    assert "candidate" in advisory.lower(), (
+        "the issue's wording requirement: orphans are missing-edge "
+        "CANDIDATES, not proven missing edges")
+    assert "80.0%" in advisory  # the measured rate, rendered
+
+
+def test_advisory_silent_on_tiny_sets_below_floor():
+    """Wave catch (e2e): 2-of-3 at 66% is not the evidence 3128-of-5370 is;
+    the advisory stays silent below ORPHAN_MIN_PRUNED_FOR_ADVISORY."""
+    reachable, pruned, call_graph, rcg = _many_orphan_fixture(2, 1)
+    extra, warning, advisory = compute_prune_telemetry(
+        reachable, pruned, call_graph, rcg)
+    assert advisory is None
+
+
+def test_advisory_silent_at_exactly_threshold():
+    """Wave catch (test-validity): the boundary — exactly 50% does NOT fire
+    (strictly greater), pinning > vs >=."""
+    reachable, pruned, call_graph, rcg = _many_orphan_fixture(4, 4)
+    extra, warning, advisory = compute_prune_telemetry(
+        reachable, pruned, call_graph, rcg)
+    # 4 orphans of 8 pruned = exactly 50% -> silent (strictly-greater)
+    assert extra["pruned_orphan_count"] == 4
+    assert advisory is None
+
+
+def test_advisory_pointer_ranks_orphan_files_not_dead_clusters():
+    """Wave catch (test-validity MAJOR 2): the 'top files' pointer must rank
+    by ORPHAN-heavy files. A dead-cluster-heavy file with MORE total prunes
+    (d.py: 1 orphan root + 12 downstream shadows = 13) must NOT outrank the
+    orphan-heavy file (o.py: 12 orphans) — the combined counter would lead
+    with d.py; the orphan-only counter must lead with o.py."""
+    pruned = ([f"o.py:o{i}" for i in range(12)]
+              + [f"d.py:dr"] + [f"d.py:c{i}" for i in range(12)])
+    reachable = ["x.py:root"]
+    call_graph = {"x.py:root": [], "d.py:dr": [f"d.py:c{i}" for i in range(12)]}
+    rcg = {f"d.py:c{i}": ["d.py:dr"] for i in range(12)}
+    extra, warning, advisory = compute_prune_telemetry(
+        reachable, pruned, call_graph, rcg)
+    # 13 orphans (12 o.py + dr) of 25 = 52% > 50%, above the floor
+    assert advisory is not None
+    assert "o.py (12)" in advisory
+    assert "d.py (13)" not in advisory  # the combined-counter ranking would show 13
+    # and o.py ranks FIRST (the orphan-heavy pointer)
+    assert advisory.index("o.py") < advisory.index("d.py")
+
+
+def test_advisory_silent_below_threshold_at_scale():
+    """11 units: 1 orphan of 11 = 9% — above the floor, below the rate."""
+    reachable, pruned, call_graph, rcg = _many_orphan_fixture(1, 9)
+    extra, warning, advisory = compute_prune_telemetry(
+        reachable, pruned, call_graph, rcg)
+    assert advisory is None  # 2 orphans (o0 + cr) of 11 = 18% < threshold
+
+
+def test_advisory_silent_when_nothing_pruned():
+    extra, warning, advisory = compute_prune_telemetry(
+        ["a.py:root"], [], {"a.py:root": []}, {})
+    assert advisory is None
+    assert extra["pruned_orphan_count"] == 0
+
+
+def test_asymmetry_warning_unchanged():
+    """The hard invariant keeps its own warning channel (contract guard)."""
+    reachable = ["a.py:root"]
+    pruned = ["a.py:p1"]
+    call_graph = {"a.py:root": ["a.py:p1"]}  # reachable -> pruned: ASYMMETRY
+    rcg = {"a.py:p1": ["a.py:root"]}
+    extra, warning, advisory = compute_prune_telemetry(
+        reachable, pruned, call_graph, rcg)
+    assert extra["pruned_forward_called_by_reachable_count"] == 1
+    assert warning is not None and "ASYMMETRY" in warning
+
+
+# ---------------------------------------------------------------------------
+# the deliverable forwarding (item 1)
+# ---------------------------------------------------------------------------
+def _write_scan(tmp_path, telemetry=None):
+    results = {"dataset": "t", "code_by_route": {}, "metrics": {"total": 2},
+               "confirmed_findings": [], "results": []}
+    write_json(tmp_path / "results.json", results)
+    if telemetry is not None:
+        write_json(tmp_path / "dataset.json", {
+            "metadata": {"reachability_filter": {
+                "reachable_units": 2, "original_units": 10,
+                "reduction_percentage": 80.0, **telemetry,
+            }},
+            "units": []})
+    out = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(tmp_path / "results.json"), output_path=str(out),
+        language="python", repo_name="t/r", processing_level="reachable")
+    return json.loads(out.read_text())
+
+
+TELEMETRY = {
+    "pruned_orphan_count": 8,
+    "pruned_in_dead_cluster_count": 6,
+    "pruned_forward_called_by_reachable_count": 0,
+    "pruned_by_file": {"a.py": 8, "b.py": 6},
+    "pruned_units_path": "pruned_units.json",
+}
+
+
+def test_reporter_forwards_the_four_telemetry_keys(tmp_path):
+    po = _write_scan(tmp_path, telemetry=TELEMETRY)
+    stats = po["pipeline_stats"]
+    assert stats["pruned_orphan_count"] == 8
+    assert stats["pruned_in_dead_cluster_count"] == 6
+    assert stats["pruned_forward_called_by_reachable_count"] == 0
+    assert stats["pruned_by_file"] == {"a.py": 8, "b.py": 6}
+
+
+def test_reporter_keys_absent_when_no_record(tmp_path):
+    """Present-only: no filter record → no fabricated zeros."""
+    po = _write_scan(tmp_path, telemetry=None)
+    stats = po["pipeline_stats"]
+    assert "pruned_orphan_count" not in stats
+    assert "pruned_by_file" not in stats
+
+
+# ---------------------------------------------------------------------------
+# the multi-language aggregate (the filing run's shape)
+# ---------------------------------------------------------------------------
+def test_scanner_aggregates_per_language_telemetry():
+    """The merged-run shape: telemetry exists per-language under
+    reachability_filter.per_language; the aggregate the reporter reads must
+    SUM the counts and merge the by-file pointer."""
+    from core.scanner import aggregate_reachability_telemetry
+
+    per_lang = {
+        "python": dict(TELEMETRY),
+        "go": {"pruned_orphan_count": 2,
+               "pruned_in_dead_cluster_count": 1,
+               "pruned_forward_called_by_reachable_count": 0,
+               "pruned_by_file": {"x.go": 3}},
+    }
+    agg = aggregate_reachability_telemetry(per_lang)
+    assert agg["pruned_orphan_count"] == 10
+    assert agg["pruned_in_dead_cluster_count"] == 7
+    assert agg["pruned_forward_called_by_reachable_count"] == 0
+    assert agg["pruned_by_file"]["a.py"] == 8
+    assert agg["pruned_by_file"]["x.go"] == 3
+
+
+def test_scanner_aggregate_absent_when_no_telemetry():
+    from core.scanner import aggregate_reachability_telemetry
+
+    per_lang = {"python": {"original_units": 4, "reachable_units": 4}}
+    agg = aggregate_reachability_telemetry(per_lang)
+    assert "pruned_orphan_count" not in agg
+
+
+# ---------------------------------------------------------------------------
+# wave catches: the INTEGRATION sites (test-validity BLOCKER + MAJOR 3)
+# ---------------------------------------------------------------------------
+def test_parser_adapter_integration_stores_advisory_in_its_own_key(tmp_path, capsys):
+    """Drive the REAL apply_reachability_filter: the advisory lands in its own
+    metadata key (NEVER the reserved warning slot) and reaches stderr."""
+    import json
+    from core.parser_adapter import apply_reachability_filter
+
+    ids = ["f.py:root"] + [f"f.py:o{i}" for i in range(8)] + ["f.py:cr", "f.py:c1"]
+    (tmp_path / "call_graph.json").write_text(json.dumps({
+        "functions": {u: {} for u in ids},
+        "call_graph": {"f.py:root": [], "f.py:cr": ["f.py:c1"]},
+        "reverse_call_graph": {"f.py:c1": ["f.py:cr"]},
+    }))
+    ds = {"units": [{"id": i} for i in ids]}
+    res = apply_reachability_filter(ds, str(tmp_path), "reachable",
+                                    extra_entry_points={"f.py:root"})
+    rf = res["metadata"]["reachability_filter"]
+    assert "orphan_advisory" in rf
+    assert "ORPHANS" in rf["orphan_advisory"]
+    # the reserved slot belongs to the asymmetry/blackout class only
+    assert "warning" not in rf or "ORPHAN" not in rf.get("warning", "")
+    err = capsys.readouterr().err
+    assert "[Advisory]" in err and "ORPHANS" in err
+
+
+def test_parser_adapter_no_advisory_no_stderr_noise(tmp_path, capsys):
+    """Below the rate: no key, no stderr line."""
+    import json
+    from core.parser_adapter import apply_reachability_filter
+
+    ids = ["f.py:root", "f.py:a", "f.py:b", "f.py:c"]
+    (tmp_path / "call_graph.json").write_text(json.dumps({
+        "functions": {u: {} for u in ids},
+        "call_graph": {"f.py:root": ["f.py:a", "f.py:b", "f.py:c"],
+                       "f.py:a": [], "f.py:b": [], "f.py:c": []},
+        "reverse_call_graph": {},
+    }))
+    ds = {"units": [{"id": i} for i in ids]}
+    res = apply_reachability_filter(ds, str(tmp_path), "reachable",
+                                    extra_entry_points={"f.py:root"})
+    rf = res["metadata"]["reachability_filter"]
+    assert "orphan_advisory" not in rf
+    assert "[Advisory]" not in capsys.readouterr().err
+
+
+def test_reporter_forwards_the_advisory(tmp_path):
+    po = _write_scan(tmp_path, telemetry={
+        "pruned_orphan_count": 8, "pruned_in_dead_cluster_count": 6,
+        "pruned_forward_called_by_reachable_count": 0,
+        "pruned_by_file": {"a.py": 14},
+        "orphan_advisory": "9 of 11 pruned units (81.8%) are ORPHANS",
+    })
+    assert "ORPHANS" in po["pipeline_stats"]["orphan_advisory"]
+
+
+def test_scanner_lift_aggregates_per_language_advisories():
+    from core.scanner import aggregate_reachability_telemetry
+
+    per_lang = {
+        "python": {"pruned_orphan_count": 8, "pruned_in_dead_cluster_count": 2,
+                   "pruned_forward_called_by_reachable_count": 0,
+                   "pruned_by_file": {"a.py": 10},
+                   "orphan_advisory": "8 of 10 pruned units (80%) are ORPHANS"},
+        "go": {"pruned_orphan_count": 2, "pruned_in_dead_cluster_count": 1,
+               "pruned_forward_called_by_reachable_count": 0,
+               "pruned_by_file": {"x.go": 3}},
+    }
+    agg = aggregate_reachability_telemetry(per_lang)
+    assert agg["orphan_advisory"].startswith("python: ")
+    assert "go" not in agg["orphan_advisory"]  # go had no advisory
+
+
+def test_scanner_aggregate_recaps_by_file_at_20():
+    """Wave catch (test-validity MINOR 4): the documented top-20 re-cap."""
+    from core.scanner import aggregate_reachability_telemetry
+
+    per_lang = {"python": {
+        "pruned_orphan_count": 25,
+        "pruned_by_file": {f"f{i:02d}.py": 26 - i for i in range(25)},
+    }}
+    agg = aggregate_reachability_telemetry(per_lang)
+    assert len(agg["pruned_by_file"]) == 20
+    assert "f00.py" in agg["pruned_by_file"]      # highest count survives
+    assert "f24.py" not in agg["pruned_by_file"]  # lowest is capped away

--- a/libs/openant-core/tests/test_issue301_prune_telemetry_deliverable.py
+++ b/libs/openant-core/tests/test_issue301_prune_telemetry_deliverable.py
@@ -36,8 +36,6 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from utilities.prune_telemetry import (  # noqa: E402
-    ORPHAN_MIN_PRUNED_FOR_ADVISORY,
-    ORPHAN_RATE_WARN_THRESHOLD,
     compute_prune_telemetry,
 )
 from core.reporter import build_pipeline_output  # noqa: E402
@@ -232,7 +230,6 @@ def test_scanner_aggregate_absent_when_no_telemetry():
 def test_parser_adapter_integration_stores_advisory_in_its_own_key(tmp_path, capsys):
     """Drive the REAL apply_reachability_filter: the advisory lands in its own
     metadata key (NEVER the reserved warning slot) and reaches stderr."""
-    import json
     from core.parser_adapter import apply_reachability_filter
 
     ids = ["f.py:root"] + [f"f.py:o{i}" for i in range(8)] + ["f.py:cr", "f.py:c1"]
@@ -255,7 +252,6 @@ def test_parser_adapter_integration_stores_advisory_in_its_own_key(tmp_path, cap
 
 def test_parser_adapter_no_advisory_no_stderr_noise(tmp_path, capsys):
     """Below the rate: no key, no stderr line."""
-    import json
     from core.parser_adapter import apply_reachability_filter
 
     ids = ["f.py:root", "f.py:a", "f.py:b", "f.py:c"]

--- a/libs/openant-core/tests/test_reachability_prune_telemetry.py
+++ b/libs/openant-core/tests/test_reachability_prune_telemetry.py
@@ -50,7 +50,7 @@ def _load_helper():
 
 
 def test_compute_prune_telemetry_tolerates_null_graphs():
-    extra, warn = _load_helper()({"f:a"}, ["f:b"], None, None, None)
+    extra, warn, advisory = _load_helper()({"f:a"}, ["f:b"], None, None, None)
     assert extra == {"pruned_orphan_count": 1, "pruned_in_dead_cluster_count": 0,
                      "pruned_forward_called_by_reachable_count": 0, "pruned_by_file": {"f": 1}}
     assert warn is None

--- a/libs/openant-core/utilities/prune_telemetry.py
+++ b/libs/openant-core/utilities/prune_telemetry.py
@@ -45,7 +45,7 @@ def compute_prune_telemetry(reachable_ids, pruned_ids, call_graph, reverse_call_
       - When ``output_dir`` is given and something was pruned, writes ``pruned_units.json``
         (best-effort; a telemetry failure never propagates).
 
-    Returns ``(extra_rf_keys, asym_warning_or_None)`` — the caller merges the keys into
+    Returns ``(extra_rf_keys, asym_warning_or_None, orphan_advisory_or_None)`` — the caller merges the keys into
     its own base rf (original_units/entry_points/... stay caller-owned) and applies its
     own warning precedence (e.g. a blackout warning may override the asymmetry one).
 

--- a/libs/openant-core/utilities/prune_telemetry.py
+++ b/libs/openant-core/utilities/prune_telemetry.py
@@ -13,6 +13,19 @@ import sys
 from utilities.file_io import open_utf8
 
 
+# #301: above this share of pruned units being ORPHANS, surface a scan-summary
+# advisory. Advisory only, deliberately NOT the reserved ``warning`` slot (the
+# forward-asymmetry / blackout class owns that): an orphan is a missing-edge
+# ROOT *candidate* — genuinely dead code is also an orphan, so a high rate is a
+# call-graph HEALTH signal to check (dispatch-table targets prune as orphans:
+# #295/#298/#299), never a proven defect count.
+ORPHAN_RATE_WARN_THRESHOLD = 0.5
+
+# #301 (wave catch): the advisory stays silent on tiny prune sets — the same
+# rate on 3 units is noise where on 3,000 it is the signal the issue filed.
+ORPHAN_MIN_PRUNED_FOR_ADVISORY = 10
+
+
 def compute_prune_telemetry(reachable_ids, pruned_ids, call_graph, reverse_call_graph,
                             output_dir=None):
     """Classify every pruned unit + enforce the forward-asymmetry invariant.
@@ -45,6 +58,7 @@ def compute_prune_telemetry(reachable_ids, pruned_ids, call_graph, reverse_call_
     reverse_call_graph = reverse_call_graph or {}
     pruned_set = set(pruned_ids)
     pruned_records, by_file = [], Counter()
+    orphan_by_file = Counter()
     orphan_ct = cluster_ct = 0
     for pid in pruned_ids:
         callers = [c for c in (reverse_call_graph.get(pid) or []) if c != pid]
@@ -52,6 +66,12 @@ def compute_prune_telemetry(reachable_ids, pruned_ids, call_graph, reverse_call_
         orphan_ct += bucket == "orphan"
         cluster_ct += bucket == "dead_cluster"
         by_file[pid.split(":", 1)[0]] += 1
+        # wave catch (test-validity): the advisory's "top files" pointer must
+        # rank by ORPHAN-heavy files (the missing-edge candidates), not the
+        # combined counter — a dead-cluster-heavy file is downstream of a
+        # pruned root and would misdirect the edge-coverage check.
+        if bucket == "orphan":
+            orphan_by_file[pid.split(":", 1)[0]] += 1
         pruned_records.append({"id": pid, "file": pid.split(":", 1)[0],
                                "callers": sorted(callers), "bucket": bucket})
     asym = {callee for c in reachable_ids for callee in (call_graph.get(c) or [])
@@ -79,4 +99,25 @@ def compute_prune_telemetry(reachable_ids, pruned_ids, call_graph, reverse_call_
             f"{len(asym)} pruned unit(s) are forward-called by a REACHABLE unit "
             "(call_graph/reverse_call_graph ASYMMETRY) — genuinely-reachable units were silently "
             "pruned. Investigate graph symmetry (test_callgraph_symmetry).")
-    return extra, asym_warning
+    # #301: the orphan-rate advisory — the classification that distinguishes
+    # "genuinely dead code" from "the call graph is missing an edge" previously
+    # reached no consumer at all. Present-only (None at/below the threshold and
+    # when nothing pruned).
+    # wave catches: (a) an absolute floor — 2-of-3 at 66% is not the same
+    # evidence as 3128-of-5370 at 58%, so tiny sets stay silent; (b) absence is
+    # a three-way overload (never ran / nothing pruned / rate at-or-below) — a
+    # consumer distinguishing them checks pruned_orphan_count's presence.
+    orphan_advisory = None
+    if (len(pruned_ids) >= ORPHAN_MIN_PRUNED_FOR_ADVISORY
+            and orphan_ct / len(pruned_ids) > ORPHAN_RATE_WARN_THRESHOLD):
+        rate = round(100 * orphan_ct / len(pruned_ids), 1)
+        orphan_advisory = (
+            f"{orphan_ct} of {len(pruned_ids)} pruned units ({rate}%) are ORPHANS: "
+            "no non-self caller, so each is a missing-edge ROOT candidate (genuinely "
+            "dead code is also an orphan — a rate above "
+            f"{int(ORPHAN_RATE_WARN_THRESHOLD * 100)}% is a call-graph health "
+            "signal, not a proven defect count; dispatch-table targets prune "
+            "as orphans). Check call-graph edge coverage; top files: "
+            + ", ".join(f"{f} ({c})" for f, c in sorted(
+                orphan_by_file.items(), key=lambda kv: (-kv[1], kv[0]))[:3]))
+    return extra, asym_warning, orphan_advisory


### PR DESCRIPTION
## Summary

`compute_prune_telemetry` classifies every pruned unit as an **orphan** (no non-self caller — a missing-edge ROOT candidate) or a **dead_cluster** (has a pruned caller — a downstream shadow). On the run that filed #301, **3,128 of 5,370 pruned units (58.2%) were orphans** — the exact signal that distinguishes "genuinely dead code" from "our call graph is missing an edge" (the #295/#298/#299 dispatch-table shape prunes as orphans). The counts reached `dataset.metadata` and no further: the reporter copies only four reachability fields into `pipeline_output`, no code reads the counts, and the multi-language aggregate never sums them.

Fix (issue suggestions 1+2):
- the **reporter forwards the four telemetry keys** (+ the advisory) present-only into `pipeline_stats` — `pipeline_output` now carries the classification;
- `scanner.aggregate_reachability_telemetry` **sums the per-language counts** into the top-level record the reporter reads (the filing run's shape: keys existed per-language under `reachability_filter.per_language`, never at the top level), re-caps `pruned_by_file` at the module's top-20, and lifts per-language advisories;
- an **orphan-rate advisory** surfaces in the scan summary (stderr, its own metadata key — never the reserved `warning` slot the asymmetry/blackout class owns): above `ORPHAN_RATE_WARN_THRESHOLD=0.5` and `ORPHAN_MIN_PRUNED_FOR_ADVISORY=10`, worded as the issue requires — orphans are missing-edge *candidates*, genuinely dead code is also an orphan, and the pointer ranks by **orphan-heavy files**, not total prunes;
- both callers of `compute_prune_telemetry` updated (core `parser_adapter` + the Swift pipeline sibling — the arity change from 2 to 3 values).

**Identity differential** (base vs fix, seeded multi-orphan corpus): kept units and every pre-existing `reachability_filter` field **identical** — the fix adds the advisory only; no filter behavior change.

**Two named residuals, both pre-existing and not fixed here** (found by the review wave):
1. only the core-Python and Swift filters emit this telemetry — other parsers' per-language records carry none, so a mixed-language aggregate reflects only the instrumented languages;
2. the base multi-language merge (`dataset_merge`'s BUG-2b — keeps only the first language's metadata) is a separate defect; the aggregate here covers the single-language and post-LLM-refilter paths.

**Wave** (2 seats per the campaign's proportionality rule — the diff exceeded the small-diff criterion): the test-validity seat's BLOCKER (the advisory's four integration sites were untested — a broken integration folding into the warning slot would have passed the suite) and MAJORs (the top-files pointer ranked by the combined counter, misdirecting the edge-coverage check; the lift lived untested outside the helper) are folded with tests; the e2e seat's small-N floor and the 3-way absence-overload doc are folded.

## Test plan

16 hermetic tests: the advisory contract (fires above threshold+floor at the measured rate; silent on tiny sets, at exactly 50%, and below the rate at scale; the orphan-only pointer discrimination — a dead-cluster-heavy file with more total prunes must not outrank the orphan-heavy file; the asymmetry warning channel unchanged); the reporter forwarding (four keys + advisory present-only; absent without a record); the aggregation (sums, re-caps at 20, lifts advisories); the integration sites (parser_adapter stores the advisory in its own key + stderr via capsys; no advisory → no stderr noise).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/test_issue301_prune_telemetry_deliverable.py -q` | 16 passed |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3224 passed, 0 failed**, 32 skipped |
| mutation smoke | production stashed → new file | errors (the machinery IS the change); restored → 16 passed |
| identity differential | seeded corpus, base vs fix | kept identical; rf identical minus advisory (no filter behavior change) |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 16 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #301
