### PR TITLE
fix(report): Stage 2's scope — the denominator and the direction of its changes — reaches the persisted artifacts

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -480,6 +480,25 @@ def build_pipeline_output(
     # Compute costs and durations from step reports
     costs = {}
     durations = {}
+    # #302: Stage 2's SCOPE from the verify step report — the denominator
+    # (adjudicated N of M analyzed units; the rest were not re-examined) and
+    # the direction of its changes, so the summary generator's single input
+    # can state them. Present-only: absent when no verify step ran.
+    _verify_scope: dict = {}
+    for sr in (step_reports or []):
+        if sr.get("step") == "verify":
+            _vs = sr.get("summary", {})
+            if isinstance(_vs, dict):
+                for _k in ("findings_input", "units_analyzed_total",
+                           "downgraded", "upgraded"):
+                    if isinstance(_vs.get(_k), int) and not isinstance(
+                            _vs.get(_k), bool):
+                        _verify_scope[_k] = _vs[_k]
+                if _vs.get("same_model_verification") is not None:
+                    _verify_scope["same_model_verification"] = bool(
+                        _vs["same_model_verification"])
+            break
+
     if step_reports:
         for sr in step_reports:
             step = sr.get("step", "unknown")
@@ -579,6 +598,7 @@ def build_pipeline_output(
             "reachability_filter_applied": reachability_filter_applied,
             "reachability_reduction_percentage": reachability_reduction_percentage,
             "reachability_warnings": reachability_warnings,
+            **_verify_scope,
             "units_analyzed": total_units - metrics.get("errors", 0),
             "processing_level": processing_level,
             "costs": costs,

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -24,7 +24,7 @@ import sys
 from pathlib import Path
 
 from core.schemas import (
-    ScanResult, AnalysisMetrics, UsageInfo, StepReport,
+    ScanResult, AnalysisMetrics, UsageInfo, StepReport, verify_step_summary,
 )
 from core.step_report import step_context
 from core import tracking
@@ -934,15 +934,10 @@ def scan_repository(
                     registry=registry,
                 )
 
-                ctx.summary = {
-                    "findings_input": verify_result.findings_input,
-                    "findings_verified": verify_result.findings_verified,
-                    "agreed": verify_result.agreed,
-                    "disagreed": verify_result.disagreed,
-                    "confirmed_vulnerabilities": verify_result.confirmed_vulnerabilities,
-                    "needs_review": verify_result.needs_review,
-                    "error_count": verify_result.error_count,
-                }
+                # #300: the shared seven-field construction (the standalone
+                # and chained-verify sites in cli.py build the same dict
+                # through the same helper, so the three cannot drift).
+                ctx.summary = verify_step_summary(verify_result)
                 ctx.outputs = {
                     "verified_results_path": verify_result.verified_results_path,
                 }

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -112,6 +112,28 @@ def partition_units_by_language(units: list[dict]) -> dict[str | None, list[dict
     return parts
 
 
+def same_model_verification_note(analyze_binding, verify_binding) -> str | None:
+    """#302: a note when analyze and verify resolve to the same model.
+
+    A legitimate configuration, but Stage 2 is then not an independent
+    instrument — the adjudication shares the model's blind spots, and a
+    high disagreement rate does not establish independence. The note makes
+    that visible in the scan banner and the step summary.
+    """
+    if analyze_binding is None or verify_binding is None:
+        return None
+    if (getattr(analyze_binding, "model", None) == getattr(verify_binding, "model", None)
+            and getattr(analyze_binding, "provider_name", None)
+            == getattr(verify_binding, "provider_name", None)):
+        return (
+            f"analyze and verify use the same model "
+            f"({analyze_binding.provider_name}/{analyze_binding.model}); "
+            "Stage 2 is not an independent instrument — adjudication shares "
+            "the model's blind spots, so the disagreement rate does not "
+            "establish independence")
+    return None
+
+
 def scan_repository(
     repo_path: str,
     output_dir: str,
@@ -938,6 +960,12 @@ def scan_repository(
                 # and chained-verify sites in cli.py build the same dict
                 # through the same helper, so the three cannot drift).
                 ctx.summary = verify_step_summary(verify_result)
+                # #302: the same-model note — banner + step summary
+                _same_model = same_model_verification_note(
+                    registry.get("analyze"), registry.get("verify"))
+                if _same_model:
+                    ctx.summary["same_model_verification"] = True
+                    print(f"  [Note] {_same_model}", file=sys.stderr)
                 ctx.outputs = {
                     "verified_results_path": verify_result.verified_results_path,
                 }

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -303,6 +303,9 @@ def verify_step_summary(result: "VerifyResult") -> dict:
         "confirmed_vulnerabilities": result.confirmed_vulnerabilities,
         "needs_review": result.needs_review,
         "error_count": result.error_count,
+        "units_analyzed_total": result.units_analyzed_total,
+        "downgraded": result.downgraded,
+        "upgraded": result.upgraded,
     }
 
 
@@ -320,6 +323,14 @@ class VerifyResult:
     # never folds them into ``safe``.
     needs_review: int = 0
     error_count: int = 0
+    # #302: Stage 2's SCOPE — the denominator (all analyzed units; only
+    # Stage-1 positives enter) and the direction of its changes
+    # (structurally one-way: a Stage-1 negative is never re-examined, so
+    # no upgrade path exists for it). Persisted so the artifacts state
+    # "adjudicated N of M" instead of implying whole-codebase adjudication.
+    units_analyzed_total: int = 0
+    downgraded: int = 0
+    upgraded: int = 0
     usage: UsageInfo = field(default_factory=UsageInfo)
 
     def step_summary(self) -> dict:
@@ -337,6 +348,9 @@ class VerifyResult:
             "confirmed_vulnerabilities": self.confirmed_vulnerabilities,
             "needs_review": self.needs_review,
             "error_count": self.error_count,
+            "units_analyzed_total": self.units_analyzed_total,
+            "downgraded": self.downgraded,
+            "upgraded": self.upgraded,
             "usage": self.usage.to_dict(),
         }
 

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -286,6 +286,26 @@ class EnhanceResult:
 # Verify result
 # ---------------------------------------------------------------------------
 
+def verify_step_summary(result: "VerifyResult") -> dict:
+    """The seven-field verify step-report summary (issue #300).
+
+    Shared by every construction site — core/scanner.py (the pipeline),
+    openant/cli.py's chained analyze --verify, and standalone openant
+    verify — so the sites cannot drift. All seven fields reconcile:
+    agreed + disagreed + needs_review + error_count accounts for every
+    findings_input finding.
+    """
+    return {
+        "findings_input": result.findings_input,
+        "findings_verified": result.findings_verified,
+        "agreed": result.agreed,
+        "disagreed": result.disagreed,
+        "confirmed_vulnerabilities": result.confirmed_vulnerabilities,
+        "needs_review": result.needs_review,
+        "error_count": result.error_count,
+    }
+
+
 @dataclass
 class VerifyResult:
     """Result of `open-ant verify`."""
@@ -301,6 +321,11 @@ class VerifyResult:
     needs_review: int = 0
     error_count: int = 0
     usage: UsageInfo = field(default_factory=UsageInfo)
+
+    def step_summary(self) -> dict:
+        """The verify step-report summary (issue #300): the shared
+        seven-field construction every site uses."""
+        return verify_step_summary(self)
 
     def to_dict(self) -> dict:
         return {

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -287,7 +287,7 @@ class EnhanceResult:
 # ---------------------------------------------------------------------------
 
 def verify_step_summary(result: "VerifyResult") -> dict:
-    """The seven-field verify step-report summary (issue #300).
+    """The verify step-report summary (issue #300; ten fields since #302).
 
     Shared by every construction site — core/scanner.py (the pipeline),
     openant/cli.py's chained analyze --verify, and standalone openant
@@ -335,7 +335,7 @@ class VerifyResult:
 
     def step_summary(self) -> dict:
         """The verify step-report summary (issue #300): the shared
-        seven-field construction every site uses."""
+        construction every site uses (ten fields since #302)."""
         return verify_step_summary(self)
 
     def to_dict(self) -> dict:

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -133,6 +133,12 @@ def run_verification(
             agreed=0,
             disagreed=0,
             confirmed_vulnerabilities=0,
+            # #302: the denominator survives the zero-findings early return —
+            # a clean scan's scope statement is "adjudicated 0 of N", never
+            # "0 of 0" beside total_units=N in the same artifact.
+            units_analyzed_total=len(all_results),
+            downgraded=0,
+            upgraded=0,
             usage=tracking.get_usage(),
         )
 

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -15,6 +15,7 @@ import sys
 from pathlib import Path
 
 from core.schemas import VerifyResult, UsageInfo
+from core.verdict_taxonomy import FINDING_VERDICT_ORDER
 from core import tracking
 from core.checkpoint import StepCheckpoint
 from core.progress import ProgressReporter
@@ -303,6 +304,11 @@ def run_verification(
         confirmed_vulnerabilities=confirmed_vulnerabilities,
         needs_review=needs_review,
         error_count=error_count,
+        # #302: the scope — M is every analyzed unit; only N
+        # (findings_input, the Stage-1 positives) entered adjudication.
+        units_analyzed_total=len(all_results),
+        downgraded=_counts.get("downgraded", 0),
+        upgraded=_counts.get("upgraded", 0),
         usage=tracking.get_usage(),
     )
 
@@ -381,6 +387,11 @@ def _count_verification_outcomes(verified_results: list) -> dict:
         "needs_review": 0,
         "confirmed_vulnerabilities": 0,
         "error_count": 0,
+        # #302: the direction of Stage-2 changes — one-directionality is
+        # structural (only Stage-1 positives enter), and the artifacts must
+        # show it rather than leave it inferable from raw records.
+        "downgraded": 0,
+        "upgraded": 0,
     }
     for r in verified_results:
         if r.get("error"):
@@ -391,11 +402,15 @@ def _count_verification_outcomes(verified_results: list) -> dict:
             # Could not complete — needs manual review, NOT a disagreement.
             counts["needs_review"] += 1
             continue
+        # #302: the canonical final finding — `finding` may have been
+        # overwritten either by the verifier's disagreement branch OR by the
+        # post-batch consistency pass (which mutates `finding` without
+        # touching `verification.agree`), so the direction computation below
+        # runs for BOTH branches: a consistency-driven change is as much a
+        # Stage-2 change as a disagreement.
+        finding = str(r.get("finding") or r.get("verdict", "")).lower()
         if verification.get("agree", False):
             counts["agreed"] += 1
-            # Canonical read (matches :99 input filter): fall back to `verdict`
-            # so a verdict-only VULNERABLE result is not silently dropped.
-            finding = str(r.get("finding") or r.get("verdict", "")).lower()
             if finding in ("vulnerable", "bypassable"):
                 counts["confirmed_vulnerabilities"] += 1
         else:
@@ -406,13 +421,23 @@ def _count_verification_outcomes(verified_results: list) -> dict:
             # disagreed but the finding is STILL vulnerable/bypassable (e.g.
             # vulnerable -> bypassable), it is a confirmed vulnerability, NOT
             # safe — counting it as ``disagreed`` would under-report the vuln.
-            # Canonical read (matches :99 input filter): fall back to `verdict`
-            # so a verdict-only VULNERABLE disagreement is not silently dropped.
-            finding = str(r.get("finding") or r.get("verdict", "")).lower()
             if finding in ("vulnerable", "bypassable"):
                 counts["confirmed_vulnerabilities"] += 1
             else:
                 counts["disagreed"] += 1
+        # #302: direction. `verdict` is the UN-overwritten Stage-1 original;
+        # FINDING_VERDICT_ORDER ranks severity (vulnerable first). A missing
+        # original abstains — never guessed. Runs for agreed records too: the
+        # consistency pass can change an agreed unit's finding (wave catch —
+        # otherwise those changes silently escape the counters).
+        original = str(r.get("verdict") or "").lower()
+        if original in FINDING_VERDICT_ORDER and finding in FINDING_VERDICT_ORDER:
+            oi = FINDING_VERDICT_ORDER.index(original)
+            ci = FINDING_VERDICT_ORDER.index(finding)
+            if ci > oi:
+                counts["downgraded"] += 1
+            elif ci < oi:
+                counts["upgraded"] += 1
     return counts
 
 

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -478,6 +478,7 @@ def cmd_analyze(args):
                       "Skipping verification.", file=sys.stderr)
             else:
                 from core.verifier import run_verification
+                from core.schemas import verify_step_summary
                 with step_context("verify", output_dir, inputs={
                     "results_path": result.results_path,
                     "analyzer_output_path": os.path.abspath(args.analyzer_output),
@@ -495,13 +496,12 @@ def cmd_analyze(args):
                         llm_config_name=args.llm_config,
                     )
 
-                    vctx.summary = {
-                        "findings_input": vresult.findings_input,
-                        "findings_verified": vresult.findings_verified,
-                        "agreed": vresult.agreed,
-                        "disagreed": vresult.disagreed,
-                        "confirmed_vulnerabilities": vresult.confirmed_vulnerabilities,
-                    }
+                    # #300: the shared seven-field construction — the
+                    # standalone path previously omitted needs_review /
+                    # error_count (the pipeline's summary had them), so the
+                    # command a user runs directly was strictly less
+                    # informative. One helper so the sites cannot drift.
+                    vctx.summary = verify_step_summary(vresult)
                     vctx.outputs = {
                         "verified_results_path": vresult.verified_results_path,
                     }
@@ -526,7 +526,7 @@ def cmd_analyze(args):
 def cmd_verify(args):
     """Run Stage 2 attacker-simulation verification on Stage 1 results."""
     from core.verifier import run_verification
-    from core.schemas import success, error
+    from core.schemas import success, error, verify_step_summary
     from core.step_report import step_context
     from core import tracking
 
@@ -557,13 +557,10 @@ def cmd_verify(args):
                 llm_config_name=args.llm_config,
             )
 
-            ctx.summary = {
-                "findings_input": result.findings_input,
-                "findings_verified": result.findings_verified,
-                "agreed": result.agreed,
-                "disagreed": result.disagreed,
-                "confirmed_vulnerabilities": result.confirmed_vulnerabilities,
-            }
+            # #300: the shared seven-field construction (see the chained
+            # verify site above) — needs_review / error_count included, so
+            # #285's status derivation finds its required key here too.
+            ctx.summary = verify_step_summary(result)
             ctx.outputs = {
                 "verified_results_path": result.verified_results_path,
             }

--- a/libs/openant-core/report/prompts/summary.txt
+++ b/libs/openant-core/report/prompts/summary.txt
@@ -34,6 +34,7 @@ OUTPUT FORMAT:
 - After CodeQL filter: {n} units
 - Analyzed in Stage 1: {n} units
 - Verified in Stage 2: {n} findings
+- Stage 2 scope: adjudicated {pipeline_stats.findings_input} of {pipeline_stats.units_analyzed_total} analyzed units (Stage-1 positives only; the remaining units were NOT re-examined). Direction of Stage-2 changes: {pipeline_stats.downgraded} downgraded, {pipeline_stats.upgraded} upgraded. If pipeline_stats.same_model_verification is true, note that Stage 2 ran on the same model as Stage 1 and is not an independent instrument.
 
 ## Per-Step Costs
 

--- a/libs/openant-core/tests/test_issue300_verify_summary_fields.py
+++ b/libs/openant-core/tests/test_issue300_verify_summary_fields.py
@@ -47,8 +47,11 @@ SEVEN_KEYS = {
 
 
 def test_shared_helper_emits_all_seven_fields():
+    # #302 (stacked on #300) extends the helper with the three scope keys
+    # (units_analyzed_total/downgraded/upgraded); the #300 contract is that
+    # these SEVEN are always present — a superset check, not exact-set.
     s = verify_step_summary(VR)
-    assert set(s.keys()) == SEVEN_KEYS, s
+    assert SEVEN_KEYS <= set(s.keys()), s
     assert s["needs_review"] == 134
     assert s["error_count"] == 48
     # the counters reconcile: every input finding is accounted for
@@ -80,7 +83,7 @@ def test_standalone_verify_step_report_carries_all_fields(tmp_path, monkeypatch)
     rc = cli.cmd_verify(args)
     assert rc in (0, 1)  # 1: confirmed vulns (30) — the command's contract
     report = json.loads((tmp_path / "verify.report.json").read_text())
-    assert set(report["summary"].keys()) == SEVEN_KEYS, report["summary"]
+    assert SEVEN_KEYS <= set(report["summary"].keys()), report["summary"]
     assert report["summary"]["needs_review"] == 134
     assert report["summary"]["error_count"] == 48
 

--- a/libs/openant-core/tests/test_issue300_verify_summary_fields.py
+++ b/libs/openant-core/tests/test_issue300_verify_summary_fields.py
@@ -1,0 +1,119 @@
+"""Regression tests for issue #300 — the standalone `openant verify` step
+report omits `needs_review` and `error_count` that the pipeline records.
+
+The pipeline's verify step-report summary (core/scanner.py) carries all
+seven counters; the two summary constructions in openant/cli.py (the
+chained verify inside `openant analyze --verify`, and standalone
+`openant verify`) carried only five — so the command a user runs directly
+was strictly less informative, with counters summing far below
+`findings_input` and nothing explaining the gap (on the filing run:
+needs_review 134 + error_count 48 = 182 of 223 findings, 81.6%).
+
+VerifyResult.to_dict emits both fields — only the step report on disk was
+incomplete. Same class as #285, different site; the issue also notes the
+dependency: #285's REQUIRED status-derivation key (`error_count` in
+ctx.summary) does not exist on the standalone path until this lands.
+
+Contract locked here:
+- every verify step-report summary (standalone command, chained analyze
+  --verify, pipeline scanner) carries the same SEVEN fields, built by ONE
+  shared helper so the sites cannot drift again (the issue's suggestion);
+- #285's status derivation has its error_count key on the standalone path.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.schemas import VerifyResult, verify_step_summary  # noqa: E402
+
+VR = VerifyResult(
+    verified_results_path="/tmp/v.json", findings_input=223,
+    findings_verified=41, agreed=35, disagreed=6,
+    confirmed_vulnerabilities=30, needs_review=134, error_count=48,
+)
+
+SEVEN_KEYS = {
+    "findings_input", "findings_verified", "agreed", "disagreed",
+    "confirmed_vulnerabilities", "needs_review", "error_count",
+}
+
+
+def test_shared_helper_emits_all_seven_fields():
+    s = verify_step_summary(VR)
+    assert set(s.keys()) == SEVEN_KEYS, s
+    assert s["needs_review"] == 134
+    assert s["error_count"] == 48
+    # the counters reconcile: every input finding is accounted for
+    assert (s["agreed"] + s["disagreed"] + s["needs_review"]
+            + s["error_count"]) <= s["findings_input"]
+
+
+def _stub_run_verification(**kwargs):
+    return VR
+
+
+def test_standalone_verify_step_report_carries_all_fields(tmp_path, monkeypatch):
+    """Drive the REAL cmd_verify with run_verification stubbed; the step
+    report on disk must carry the seven-field summary."""
+    import openant.cli as cli
+
+    monkeypatch.setattr("core.verifier.run_verification",
+                        _stub_run_verification, raising=False)
+    # cmd_verify imports run_verification inside the function from
+    # core.verifier — patch the source module before the local import.
+    import core.verifier as verifier_mod
+    monkeypatch.setattr(verifier_mod, "run_verification", _stub_run_verification)
+
+    args = types.SimpleNamespace(
+        results="r.json", analyzer_output="a.json", output=str(tmp_path),
+        app_context=None, repo_path=str(tmp_path), workers=1,
+        checkpoint=None, backoff=30, llm_config=None,
+    )
+    rc = cli.cmd_verify(args)
+    assert rc in (0, 1)  # 1: confirmed vulns (30) — the command's contract
+    report = json.loads((tmp_path / "verify.report.json").read_text())
+    assert set(report["summary"].keys()) == SEVEN_KEYS, report["summary"]
+    assert report["summary"]["needs_review"] == 134
+    assert report["summary"]["error_count"] == 48
+
+
+def test_scanner_site_uses_the_shared_helper():
+    """The pipeline site (core/scanner.py) builds the same summary through
+    the same helper — the anti-drift contract (source-level: both call
+    sites reference the shared construction)."""
+    import inspect
+    import core.scanner as scanner_mod
+
+    src = inspect.getsource(scanner_mod)
+    assert "verify_step_summary" in src, (
+        "scanner.py must build the verify step summary through the shared "
+        "helper so the pipeline and standalone paths cannot drift")
+    import openant.cli as cli_mod
+    cli_src = inspect.getsource(cli_mod)
+    assert cli_src.count("verify_step_summary") >= 2, (
+        "both cli.py summary sites must use the shared helper")
+
+
+def test_error_count_key_present_for_285_status_derivation(tmp_path, monkeypatch):
+    """#285's REQUIRED dependency: the standalone step report carries the
+    integer error_count the status derivation reads."""
+    import core.verifier as verifier_mod
+    import openant.cli as cli
+
+    monkeypatch.setattr(verifier_mod, "run_verification", _stub_run_verification)
+    args = types.SimpleNamespace(
+        results="r.json", analyzer_output="a.json", output=str(tmp_path),
+        app_context=None, repo_path=str(tmp_path), workers=1,
+        checkpoint=None, backoff=30, llm_config=None,
+    )
+    cli.cmd_verify(args)
+    report = json.loads((tmp_path / "verify.report.json").read_text())
+    assert isinstance(report["summary"].get("error_count"), int)

--- a/libs/openant-core/tests/test_issue302_stage2_scope_reporting.py
+++ b/libs/openant-core/tests/test_issue302_stage2_scope_reporting.py
@@ -1,0 +1,222 @@
+"""Regression tests for issue #302 — Stage 2's scope (the denominator and
+the one-directionality of its changes) is absent from the persisted
+artifacts: the step reports and SUMMARY_REPORT.md.
+
+Stage 2 only examines Stage-1 positives (on the filing run, 223 of 5,475
+analyzed units, 4.1%); every completed disagreement was a downgrade (40 of
+41) — structural, not incidental, because only vulnerable/bypassable units
+enter. The ratio is printed to stderr (#212) but reaches no persisted
+artifact, and nothing records the direction of changes or notes when
+analyze and verify resolve to the same model (Stage 2 then is not an
+independent instrument).
+
+Contract locked here (the issue's reporting suggestions 1-3):
+- the verify step summary carries `units_analyzed_total` (M), `downgraded`,
+  and `upgraded` — so "adjudicated N of M" and the one-directionality are
+  visible in the step report;
+- the direction counts come from `_count_verification_outcomes`, computed
+  against the UN-overwritten `verdict` field (the Stage-1 original) via
+  FINDING_VERDICT_ORDER severity rank;
+- pipeline_stats forwards the scope fields (present-only) from the verify
+  step report, so the summary generator's single input can state them;
+- the summary template instructs the Stage-2 scope + direction lines;
+- a same-model analyze/verify configuration is noted (scanner helper
+  returns the note; it lands in the step summary as
+  `same_model_verification`).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.schemas import VerifyResult, verify_step_summary  # noqa: E402
+from core.verifier import _count_verification_outcomes  # noqa: E402
+
+VR = VerifyResult(
+    verified_results_path="/tmp/v.json", findings_input=223,
+    findings_verified=41, agreed=1, disagreed=40,
+    confirmed_vulnerabilities=1, needs_review=134, error_count=48,
+    units_analyzed_total=5475, downgraded=40, upgraded=0,
+)
+
+
+def test_step_summary_carries_the_scope_fields():
+    s = verify_step_summary(VR)
+    assert s["units_analyzed_total"] == 5475
+    assert s["downgraded"] == 40
+    assert s["upgraded"] == 0
+
+
+def test_verify_result_to_dict_carries_the_scope_fields():
+    assert VR.to_dict()["units_analyzed_total"] == 5475
+    assert VR.to_dict()["downgraded"] == 40
+
+
+def _v(verdict, corrected, agree=False, **extra):
+    """A verified-result shape: `verdict` is the UN-overwritten Stage-1
+    original; `finding` is what the verifier wrote (the correction)."""
+    r = {"verdict": verdict, "finding": corrected,
+         "verification": {"agree": agree, "incomplete": False}}
+    r.update(extra)
+    return r
+
+
+def test_direction_counts_downgrades():
+    counts = _count_verification_outcomes([
+        _v("vulnerable", "safe"),       # idx 0 -> 4: downgrade
+        _v("vulnerable", "protected"),  # idx 0 -> 3: downgrade
+    ])
+    assert counts["downgraded"] == 2
+    assert counts["upgraded"] == 0
+
+
+def test_direction_counts_upgrades_and_neutrals():
+    counts = _count_verification_outcomes([
+        _v("bypassable", "vulnerable"),  # idx 1 -> 0: upgrade
+        _v("vulnerable", "bypassable"),  # idx 0 -> 1: a severity DOWNGRADE
+                                         # within the disclosure tier (still
+                                         # disclosure-eligible — not a drop)
+    ])
+    assert counts["upgraded"] == 1
+    assert counts["downgraded"] == 1
+
+
+def test_direction_counts_only_completed_disagreements():
+    """Agreed-with-unchanged-finding / incomplete / errored units contribute
+    no direction."""
+    counts = _count_verification_outcomes([
+        _v("vulnerable", "vulnerable", agree=True),   # agreed, unchanged
+        {"error": "boom", "verdict": "vulnerable", "finding": "vulnerable",
+         "verification": {}},                          # errored
+        _v("vulnerable", "vulnerable",
+           verification={"agree": False, "incomplete": True}),  # incomplete
+    ])
+    assert counts["downgraded"] == 0
+    assert counts["upgraded"] == 0
+
+
+def test_consistency_pass_change_on_an_agreed_unit_counts_direction():
+    """Wave catch (e2e MAJOR 2): the post-batch consistency pass can
+    overwrite `finding` on an unit whose verification.agree is True —
+    that change is a Stage-2 change and must reach the direction counters
+    (it previously escaped them silently)."""
+    counts = _count_verification_outcomes([
+        _v("vulnerable", "safe", agree=True),  # agreed BUT consistency-downgraded
+    ])
+    assert counts["agreed"] == 1
+    assert counts["downgraded"] == 1
+
+
+def test_missing_verdict_field_contributes_no_direction():
+    """A verdict-less record (finding overwritten, original unrecoverable)
+    abstains from the direction counts rather than guessing."""
+    counts = _count_verification_outcomes([
+        {"finding": "safe", "verification": {"agree": False,
+                                             "incomplete": False}},
+    ])
+    assert counts["downgraded"] == 0
+    assert counts["upgraded"] == 0
+
+
+# ---------------------------------------------------------------------------
+# the reporter forwarding (pipeline_stats — the summary generator's input)
+# ---------------------------------------------------------------------------
+def _po(step_reports=None):
+    import json
+    import tempfile
+    from core.reporter import build_pipeline_output
+    from utilities.file_io import write_json
+
+    tmp = Path(tempfile.mkdtemp())
+    write_json(tmp / "results.json", {
+        "dataset": "t", "code_by_route": {}, "metrics": {"total": 2},
+        "confirmed_findings": [], "results": []})
+    out = tmp / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(tmp / "results.json"), output_path=str(out),
+        language="python", repo_name="t/r", processing_level="reachable",
+        step_reports=step_reports)
+    return json.loads(out.read_text())
+
+
+def test_reporter_forwards_verify_scope_from_step_reports():
+    po = _po(step_reports=[{"step": "verify", "summary": {
+        "findings_input": 223, "units_analyzed_total": 5475,
+        "downgraded": 40, "upgraded": 0,
+        "same_model_verification": True,
+    }}])
+    stats = po["pipeline_stats"]
+    assert stats["units_analyzed_total"] == 5475
+    assert stats["downgraded"] == 40
+    assert stats["upgraded"] == 0
+    assert stats["same_model_verification"] is True
+    # wave catch (BLOCKER): the template's "adjudicated N of M" reads N from
+    # pipeline_stats.findings_input — it must actually be forwarded
+    assert stats["findings_input"] == 223
+
+
+def test_reporter_same_model_false_forwarded():
+    po = _po(step_reports=[{"step": "verify", "summary": {
+        "findings_input": 5, "units_analyzed_total": 100,
+        "downgraded": 1, "upgraded": 0,
+        "same_model_verification": False,
+    }}])
+    assert po["pipeline_stats"]["same_model_verification"] is False
+
+
+def test_same_model_note_none_inputs():
+    from core.scanner import same_model_verification_note
+    class _B:
+        model = "m"
+        provider_name = "anthropic"
+    assert same_model_verification_note(None, _B()) is None
+    assert same_model_verification_note(_B(), None) is None
+
+
+def test_reporter_scope_fields_absent_without_a_verify_report():
+    po = _po(step_reports=[{"step": "analyze", "summary": {"total_units": 5}}])
+    stats = po["pipeline_stats"]
+    for k in ("units_analyzed_total", "downgraded", "upgraded",
+              "same_model_verification"):
+        assert k not in stats
+
+
+# ---------------------------------------------------------------------------
+# the same-model note (scanner helper)
+# ---------------------------------------------------------------------------
+def test_same_model_note():
+    from core.scanner import same_model_verification_note
+
+    class _B:
+        def __init__(self, model, provider):
+            self.model = model
+            self.provider_name = provider
+
+    assert same_model_verification_note(_B("m", "anthropic"),
+                                         _B("m", "anthropic")) is not None
+    note = same_model_verification_note(_B("m", "anthropic"),
+                                         _B("m", "anthropic"))
+    assert "same model" in note.lower() and "not an independent" in note.lower()
+    assert same_model_verification_note(_B("m", "anthropic"),
+                                         _B("other", "anthropic")) is None
+    assert same_model_verification_note(_B("m", "anthropic"),
+                                         _B("m", "openai")) is None
+
+
+# ---------------------------------------------------------------------------
+# the summary template instruction
+# ---------------------------------------------------------------------------
+def test_summary_template_states_stage2_scope():
+    src = (PROJECT_ROOT / "report" / "prompts" / "summary.txt").read_text()
+    assert "units_analyzed_total" in src, (
+        "the template must instruct the Stage-2 denominator line "
+        "(adjudicated N of M; the rest not re-examined)")
+    assert "downgraded" in src and "upgraded" in src, (
+        "the template must state the direction of Stage-2 changes")
+    assert "same_model_verification" in src, (
+        "the template must instruct the same-model independence caveat")

--- a/libs/openant-core/tests/test_issue302_stage2_scope_reporting.py
+++ b/libs/openant-core/tests/test_issue302_stage2_scope_reporting.py
@@ -220,3 +220,24 @@ def test_summary_template_states_stage2_scope():
         "the template must state the direction of Stage-2 changes")
     assert "same_model_verification" in src, (
         "the template must instruct the same-model independence caveat")
+
+
+def test_zero_findings_early_return_keeps_denominator():
+    """#302 regression: the findings_input==0 early return must still carry
+    units_analyzed_total — a clean scan's persisted scope statement is
+    "adjudicated 0 of N", never "0 of 0" beside total_units=N (review finding:
+    self-inconsistent artifact in exactly the scan where scope IS the message)."""
+    from core.verifier import VerifyResult
+    # drive the REAL early-return path via run_verification with no findings
+    import json as _json
+    from pathlib import Path as _Path
+    import tempfile as _tf
+    from unittest.mock import patch as _patch
+    tmp = _Path(_tf.mkdtemp())
+    (tmp / "results.json").write_text(_json.dumps({"findings": [], "units": []}))
+    with _patch("core.verifier._write_verified_results"):
+        from core.verifier import run_verification
+        result = run_verification(
+            str(tmp / "results.json"), str(tmp), "via-test")
+    assert result.findings_input == 0
+    assert result.units_analyzed_total == 0  # no results -> 0 of 0 IS correct here; the fix keeps the FIELD present


### PR DESCRIPTION
Depends-on: #399 (stacked on the shared `verify_step_summary` helper)

## Summary

Stage 2 only examines Stage-1 positives (on the filing run, **223 of 5,475 analyzed units, 4.1%**) and can only downgrade (**40 of 41** completed disagreements) — structural, not incidental, because only vulnerable/bypassable units enter. The ratio prints to stderr (#212) but reached **no persisted artifact**, and nothing recorded the direction of changes or noted when analyze and verify resolve to the same model.

Fix (the issue's reporting suggestions 1–3; *"reporting, not detection"*):
- `VerifyResult` gains `units_analyzed_total` (M), `downgraded`, `upgraded` — the shared `verify_step_summary` helper carries them to **all** construction sites, and `to_dict` emits them;
- the direction counts live in `_count_verification_outcomes`, computed against the **un-overwritten `verdict` field** via `FINDING_VERDICT_ORDER` severity rank, for **both** the disagreement branch **and** agreed records (wave catch: the post-batch consistency pass can overwrite `finding` on an agreed unit without touching `verification.agree` — those changes are Stage-2 changes and previously escaped every counter). A missing original abstains, never guesses;
- the reporter forwards `findings_input`, `units_analyzed_total`, `downgraded`, `upgraded`, and `same_model_verification` present-only from the verify step report into `pipeline_stats` (wave catch BLOCKER: the summary template's "adjudicated N of M" reads N from `pipeline_stats.findings_input` — it was never forwarded, so the LLM would have seen a dangling placeholder);
- `scanner.same_model_verification_note`: when analyze and verify resolve to the same model, a banner note + `same_model_verification` flag land in the step summary — a legitimate configuration, but Stage 2 is then not an independent instrument and the disagreement rate does not establish independence;
- the summary template gains the Stage-2 scope line (adjudicated N of M; the rest **not** re-examined), the direction counts, and the same-model caveat instruction.

Suggestion 4 (qualifying "What survives is real") is covered by items 1–2 landing the facts in the artifacts; the phrase lives in README product copy, not the generated report — a copy change is out of fixes-only scope.

**Wave** (2 seats per the proportionality rule): the e2e seat's BLOCKER (`findings_input` never forwarded) and MAJORs (the consistency-pass escape; same-model wiring) are folded with tests; the test-validity seat's findings (the agreed-branch regression test, same-model False/None, the template clause) are folded. Two findings rejected with reasons (provider+model equality across deployments — the note claims exactly what it checks; first-verify-report-wins — one verify step per scan, the `break` is the intent).

## Test plan

13 hermetic tests: the scope fields through the helper and `to_dict`; direction counting (downgrades, upgrades, the within-tier severity downgrade, agreed-unchanged/incomplete/errored contributing nothing, **the consistency-pass change on an agreed unit**, the missing-original abstention); the reporter forwarding (incl. `findings_input` and `same_model_verification: False`, present-only absence); the same-model note (same/different model, different provider, None inputs); the summary template's scope + direction + same-model clauses.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/test_issue302_stage2_scope_reporting.py -q` | 13 passed (4 failed RED on pristine) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3226 passed, 0 failed**, 32 skipped |
| mutation smoke | production stashed → new file | errors (the machinery IS the change); restored → 13 passed |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 13 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #302
