### PR TITLE
fix(runtime): child interpreters resolve the parent's checkout explicitly; the aggregate report records which checkout produced the scan

### DIFF
--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -29,6 +29,7 @@ from core.language_registry import (
     supported_languages,
 )
 from core.schemas import ParseResult
+from utilities.child_interp import child_interpreter_env
 from utilities.file_io import open_utf8, read_json, write_json
 from utilities.prune_telemetry import compute_prune_telemetry
 
@@ -847,6 +848,10 @@ def _parse_via_subprocess(
         stderr=sys.stderr,
         cwd=str(_CORE_ROOT),
         timeout=1800,  # 30 min — large repos, tree-sitter/Node/Go toolchains
+        # #303: the child resolves THIS checkout by construction — the shared
+        # venv's editable .pth (re-pointable mid-scan by a concurrent session)
+        # cannot win over an explicit PYTHONPATH entry.
+        env=child_interpreter_env(),
     )
 
     if result.returncode != 0:

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from core.schemas import ReportResult
 from core.language_registry import fence_for_path
 from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
+from utilities.child_interp import child_interpreter_env
 from utilities.file_io import normalize_results, open_utf8, read_json, write_json
 
 # Root of openant-core
@@ -709,7 +710,12 @@ def generate_html_report(
     # No cwd=_CORE_ROOT: these are now `-m` package invocations resolved through
     # the installed distribution, not source-tree-relative scripts. Depending on
     # cwd is what made them unrunnable from an installed wheel.
-    result = subprocess.run(cmd, stdout=sys.stderr, stderr=sys.stderr)
+    # #303: the child resolves THIS checkout by construction (PYTHONPATH
+    # precedes site-packages, so the re-pointable shared-venv .pth cannot
+    # win). -P keeps the untrusted CWD off sys.path; the env keeps the
+    # venv's .pth off the resolution.
+    result = subprocess.run(cmd, stdout=sys.stderr, stderr=sys.stderr,
+                            env=child_interpreter_env())
 
     if result.returncode != 0:
         raise RuntimeError(f"HTML report generation failed (exit code {result.returncode})")
@@ -744,7 +750,9 @@ def generate_csv_report(
     # No cwd=_CORE_ROOT: these are now `-m` package invocations resolved through
     # the installed distribution, not source-tree-relative scripts. Depending on
     # cwd is what made them unrunnable from an installed wheel.
-    result = subprocess.run(cmd, stdout=sys.stderr, stderr=sys.stderr)
+    # #303: same as the HTML path above — explicit resolution for the child.
+    result = subprocess.run(cmd, stdout=sys.stderr, stderr=sys.stderr,
+                            env=child_interpreter_env())
 
     if result.returncode != 0:
         raise RuntimeError(f"CSV export failed (exit code {result.returncode})")

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -113,6 +113,14 @@ def partition_units_by_language(units: list[dict]) -> dict[str | None, list[dict
     return parts
 
 
+def _relativize_home(path_str: str) -> str:
+    """Strip the user's home prefix (~) from an absolute path (leak hygiene)."""
+    home = os.path.expanduser("~")
+    if path_str.startswith(home):
+        return "~" + path_str[len(home):]
+    return path_str
+
+
 def aggregate_reachability_telemetry(per_lang: dict) -> dict:
     """#301: sum the per-language prune telemetry into the top-level record.
 
@@ -1443,7 +1451,11 @@ def _write_scan_report(
             # re-pointable by a concurrent session mid-scan; the children
             # now resolve explicitly (utilities/child_interp.py), and this
             # record makes any residual skew detectable after the fact.
-            "openant_core_path": str(resolved_core_path()),
+            # RELATIVIZED when under the user's home: the adjacent
+            # inputs.repo_path is deliberately basename-only, and a raw
+            # absolute path here would leak the OS username into a
+            # diagnostic artifact likely to be attached to support tickets.
+            "openant_core_path": _relativize_home(str(resolved_core_path())),
             # R5: provenance of a repo-supplied threat model. sha is absent (key
             # omitted) when no threat model was loaded — never the empty hash.
             **(

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -28,6 +28,7 @@ from core.schemas import (
 )
 from core.step_report import step_context
 from core import tracking
+from utilities.child_interp import resolved_core_path
 from utilities.file_io import read_json, write_json
 from utilities.llm.adapter import LLMAuthError
 
@@ -1437,6 +1438,12 @@ def _write_scan_report(
             "excluded_languages": result.excluded_languages,
             "degraded": result.degraded,
             "context_source": result.context_source,
+            # #303: WHICH checkout produced this scan — the parent's resolved
+            # openant-core root. The shared venv's editable .pth is
+            # re-pointable by a concurrent session mid-scan; the children
+            # now resolve explicitly (utilities/child_interp.py), and this
+            # record makes any residual skew detectable after the fact.
+            "openant_core_path": str(resolved_core_path()),
             # R5: provenance of a repo-supplied threat model. sha is absent (key
             # omitted) when no threat model was loaded — never the empty hash.
             **(

--- a/libs/openant-core/tests/test_issue303_child_interpreter_resolution.py
+++ b/libs/openant-core/tests/test_issue303_child_interpreter_resolution.py
@@ -21,7 +21,6 @@ import os
 import sys
 from pathlib import Path
 
-import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:

--- a/libs/openant-core/tests/test_issue303_child_interpreter_resolution.py
+++ b/libs/openant-core/tests/test_issue303_child_interpreter_resolution.py
@@ -129,4 +129,10 @@ def test_scan_report_records_the_resolved_core_path(tmp_path):
     result.language = "python"
     _write_scan_report(str(tmp_path), result, [])
     report = json.loads((tmp_path / "scan.report.json").read_text())
-    assert report["summary"]["openant_core_path"] == str(resolved_core_path())
+    # leak hygiene: the recorded path is ~-relativized when under the
+    # user's home (CI: /home/runner/... -> ~/...), never the raw absolute
+    import os as _os
+    _raw = str(resolved_core_path())
+    _home = _os.path.expanduser("~")
+    _expected = "~" + _raw[len(_home):] if _raw.startswith(_home) else _raw
+    assert report["summary"]["openant_core_path"] == _expected

--- a/libs/openant-core/tests/test_issue303_child_interpreter_resolution.py
+++ b/libs/openant-core/tests/test_issue303_child_interpreter_resolution.py
@@ -1,0 +1,133 @@
+"""Regression tests for issue #303 — child interpreters spawned mid-scan
+resolve through the shared venv's editable `.pth` at spawn time, so a second
+session re-pointing the venv mid-scan makes the first scan's later children
+import a different checkout than their parent did, silently.
+
+Contract locked here (the issue's suggestions 1+3; 2 is subsumed by 3 — an
+explicit PYTHONPATH makes a child unable to resolve elsewhere, deterministically):
+- `child_interpreter_env()` prepends the PARENT's resolved openant-core root
+  to PYTHONPATH (before site-packages, so it wins over the `.pth` target),
+  preserves any existing PYTHONPATH, and returns a COPY of the environment
+  (no mutation of os.environ);
+- all three child-spawn sites (the per-language parser subprocess, the HTML
+  report writer, the CSV export writer) pass that env to subprocess.run;
+- `scan.report.json` records the resolved `openant_core_path` — the skew
+  becomes detectable after the fact even when prevention fails.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.child_interp import child_interpreter_env, resolved_core_path  # noqa: E402
+
+
+def test_resolved_core_path_is_this_checkout():
+    """The parent's resolved core root is THIS checkout (the module's own
+    location), not whatever the venv `.pth` names."""
+    assert resolved_core_path() == Path(__file__).resolve().parents[1]
+
+
+def test_child_env_prepends_core_root(monkeypatch):
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    env = child_interpreter_env()
+    assert env["PYTHONPATH"] == str(resolved_core_path())
+
+
+def test_child_env_preserves_existing_pythonpath(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/some/existing/path")
+    env = child_interpreter_env()
+    assert env["PYTHONPATH"].startswith(str(resolved_core_path()))
+    assert env["PYTHONPATH"].endswith("/some/existing/path")
+    assert env["PYTHONPATH"].count(str(resolved_core_path())) == 1
+
+
+def test_child_env_is_a_copy_not_mutation(monkeypatch):
+    monkeypatch.setenv("PYTHONPATH", "/original")
+    env = child_interpreter_env()
+    assert env["PYTHONPATH"] != "/original"
+    assert os.environ["PYTHONPATH"] == "/original"  # the parent env untouched
+
+
+def _spawn_capturing(monkeypatch, call):
+    """Run `call` with subprocess.run monkeypatched; return captured kwargs."""
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured.update(kwargs)
+        captured["cmd"] = cmd
+
+        class _R:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+        return _R()
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    call()
+    return captured
+
+
+def test_parser_subprocess_passes_the_env(tmp_path, monkeypatch):
+    """The per-language parser child (the site WITHOUT -P) gets the env."""
+    from types import SimpleNamespace
+    from core import parser_adapter as pa
+
+    fake_spec = SimpleNamespace(parser_mode="subprocess", bootstrap=None)
+    monkeypatch.setattr(pa, "load_registry", lambda: {"python": fake_spec})
+    monkeypatch.setattr(pa, "parser_script_path",
+                        lambda lang: "/tmp/fake_pipeline.py")
+
+    def call():
+        pa._parse_via_subprocess("python", str(tmp_path), str(tmp_path),
+                                 "all", True, False)
+
+    captured = _spawn_capturing(monkeypatch, call)
+    assert "env" in captured, "the parser subprocess must pass env="
+    assert captured["env"]["PYTHONPATH"].startswith(str(resolved_core_path()))
+
+
+def test_html_report_subprocess_passes_the_env(tmp_path, monkeypatch):
+    from core import reporter as rep
+
+    def call():
+        rep.generate_html_report(
+            str(tmp_path / "r.json"), str(tmp_path / "d.json"),
+            str(tmp_path / "out.html"))
+
+    captured = _spawn_capturing(monkeypatch, call)
+    assert captured["env"]["PYTHONPATH"].startswith(str(resolved_core_path()))
+
+
+def test_csv_export_subprocess_passes_the_env(tmp_path, monkeypatch):
+    from core import reporter as rep
+
+    def call():
+        rep.generate_csv_report(
+            str(tmp_path / "r.json"), str(tmp_path / "d.json"),
+            str(tmp_path / "out.csv"))
+
+    captured = _spawn_capturing(monkeypatch, call)
+    assert captured["env"]["PYTHONPATH"].startswith(str(resolved_core_path()))
+
+
+def test_scan_report_records_the_resolved_core_path(tmp_path):
+    """Suggestion 1: the aggregate report records which checkout produced
+    the scan — the skew is detectable after the fact."""
+    import json
+    from core.scanner import _write_scan_report, ScanResult
+
+    result = ScanResult(output_dir=str(tmp_path))
+    result.units_count = 1
+    result.language = "python"
+    _write_scan_report(str(tmp_path), result, [])
+    report = json.loads((tmp_path / "scan.report.json").read_text())
+    assert report["summary"]["openant_core_path"] == str(resolved_core_path())

--- a/libs/openant-core/utilities/child_interp.py
+++ b/libs/openant-core/utilities/child_interp.py
@@ -1,0 +1,55 @@
+"""#303: deterministic child-interpreter resolution.
+
+The managed runtime is a single shared venv whose editable-install ``.pth``
+points at exactly one ``openant-core`` checkout at a time, and a scan
+re-points it to whichever clone is running (the anti-contamination mechanism
+in ``apps/openant-cli/internal/python/runtime.go``). A scan also spawns child
+Python interpreters *while it runs* — the per-language parser and the report
+writers — and each resolves ``openant`` through that ``.pth`` at spawn time.
+If a second session re-points the venv mid-scan, the first scan's later
+children import a different checkout than their own parent did, silently.
+
+The fix (the issue's suggestion 3): every child spawn passes an explicit
+``PYTHONPATH`` holding the PARENT's resolved core root. ``PYTHONPATH`` entries
+precede site-packages in ``sys.path``, so the ``.pth`` target cannot win —
+the child resolves the parent's checkout by construction. The resolved path
+is also recorded in ``scan.report.json`` (suggestion 1) so any residual skew
+is detectable after the fact.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def resolved_core_path() -> Path:
+    """The openant-core root THIS interpreter resolved (not the ``.pth``).
+
+    ``openant.__file__`` reflects whatever resolution produced this process —
+    the editable target under the shared venv, a dev checkout under
+    PYTHONPATH, or an installed wheel. Its parent directory IS the core root
+    that produced this scan, which is exactly the provenance to hand to
+    children and to record in the aggregate report.
+    """
+    import openant  # local import: avoids cycles at module import time
+    return Path(openant.__file__).resolve().parents[1]
+
+
+def child_interpreter_env() -> dict:
+    """An env dict for child interpreters: the parent's core root prepended.
+
+    ``PYTHONPATH`` precedes site-packages in the child's ``sys.path``, so the
+    shared venv's editable ``.pth`` (which a concurrent session may re-point
+    mid-scan) cannot redirect the child to a different checkout. Existing
+    ``PYTHONPATH`` entries are preserved AFTER the core root. Returns a copy —
+    the parent's environment is never mutated.
+    """
+    env = dict(os.environ)
+    core = str(resolved_core_path())
+    existing = env.get("PYTHONPATH", "")
+    if existing:
+        env["PYTHONPATH"] = f"{core}{os.pathsep}{existing}"
+    else:
+        env["PYTHONPATH"] = core
+    return env


### PR DESCRIPTION
## Summary

The managed runtime is a single shared venv whose editable `.pth` points at exactly one `openant-core` checkout at a time, and a scan re-points it to whichever clone is running (`runtime.go`'s anti-contamination mechanism). A scan also spawns child interpreters **while it runs** — the per-language parser (`parser_adapter.py:838`, no `-P`) and the HTML/CSV report writers (`reporter.py:705/742`, `-P`) — and each resolves `openant` through that `.pth` at **spawn** time. If a second session re-points the venv mid-scan, the first scan's later children import a different checkout than their own parent did, with no error and nothing recorded in any artifact.

Fix (the issue's suggestions **1+3**; suggestion 2 is subsumed by 3 — an explicit `PYTHONPATH` makes a child unable to resolve elsewhere, deterministically; suggestion 4, per-clone venvs, is architecture):
- `utilities/child_interp.py`: `resolved_core_path()` (the parent's resolved openant-core root, from `openant.__file__` — whatever resolution produced *this* process) and `child_interpreter_env()` (a **copy** of the environment with that root prepended to `PYTHONPATH` — `PYTHONPATH` entries precede site-packages in the child's `sys.path`, so the re-pointable `.pth` cannot win; existing `PYTHONPATH` preserved after it; the parent env never mutated);
- all three child-spawn sites pass `env=child_interpreter_env()`;
- `scan.report.json` records `openant_core_path` in its summary — the skew becomes detectable after the fact even where prevention somehow fails, and the provenance is useful regardless.

## Test plan

8 hermetic tests: the helper's contract (the resolved root is *this* checkout; the core root prepended; existing `PYTHONPATH` preserved exactly once; the env is a copy, not a mutation); all three spawn sites capture `env=` with the core root first (subprocess.run monkeypatched); the aggregate report records the resolved path.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/test_issue303_child_interpreter_resolution.py -q` | 8 passed (4 failed RED on pristine) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3265 passed, 0 failed**, 32 skipped |
| mutation smoke | production stashed → new file | 4 failed; restored → 8 passed |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 8 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #303
