### PR TITLE
fix(sarif): a degraded scan is distinguishable from a clean one on the merge-gate channel

### DIFF
--- a/apps/openant-cli/internal/report/sarif.go
+++ b/apps/openant-cli/internal/report/sarif.go
@@ -77,6 +77,76 @@ func BuildSARIF(data ReportData, opts SARIFOptions) map[string]any {
 		run["versionControlProvenance"] = []any{prov}
 	}
 
+	// #305: the invocations block — the designated SARIF place a degraded
+	// scan becomes visible on the one channel that turns into a merge gate.
+	// executionSuccessful is FALSE when any step errored (per-step
+	// error_count / errors) or any skipped step carries a FAILURE-class
+	// reason; an operator opt-out (not_requested) or an auto-skip with no
+	// candidates is a legitimate clean run, not a failure.
+	invocation := map[string]any{
+		"executionSuccessful": true,
+	}
+	var notifications []map[string]any
+	warn := func(text string) {
+		notifications = append(notifications, map[string]any{
+			"level": "warning", // Code Scanning keeps warnings in the default view
+			// descriptor is a reportingDescriptorReference per the SARIF 2.1.0
+			// schema (additionalProperties: false — a `name` key here would be
+			// schema-INVALID and risks the whole upload being rejected; the
+			// text lives in message.text). Wave catch.
+			"descriptor": map[string]any{"id": "OpenAnt"},
+			"message":    map[string]any{"text": text},
+		})
+	}
+	failureSkip := map[string]bool{
+		"failed":             true,
+		"module_unavailable": true,
+		// wave catch: docker_unavailable is the same kind of involuntary
+		// environment gap as module_unavailable (the dynamic-test step on a
+		// runner without Docker) — it was silently passing as clean.
+		"docker_unavailable": true,
+	}
+	execOK := true
+	for _, sr := range data.StepReports {
+		// wave catch: the synthetic `scan` aggregate row mirrors every real
+		// step's errors — emitting it would duplicate each notification
+		// under a step name that is not part of the pipeline vocabulary.
+		if sr.Step == "scan" {
+			continue
+		}
+		if sr.ErrorCount > 0 || len(sr.Errors) > 0 ||
+			sr.Status == "error" || sr.Status == "partial" {
+			execOK = false
+			if sr.ErrorCount > 0 || len(sr.Errors) > 0 {
+				detail := fmt.Sprintf("step %s: %d unit error(s)", sr.Step, sr.ErrorCount)
+				if len(sr.Errors) > 0 {
+					detail += " — " + strings.Join(sr.Errors, "; ")
+				}
+				warn(detail)
+			} else {
+				// wave catch: partial with no populated counts — degrade
+				// visibly without a misleading "0 unit error(s)" text.
+				warn(fmt.Sprintf("step %s: degraded (status %s)", sr.Step, sr.Status))
+			}
+		}
+		if failureSkip[sr.SkippedReason] {
+			execOK = false
+			warn(fmt.Sprintf("step %s skipped: %s", sr.Step, sr.SkippedReason))
+		}
+	}
+	for _, lang := range data.ExcludedLanguages {
+		if lang == "" {
+			continue
+		}
+		execOK = false
+		warn(fmt.Sprintf("language excluded from analysis: %s", lang))
+	}
+	invocation["executionSuccessful"] = execOK
+	if len(notifications) > 0 {
+		invocation["toolExecutionNotifications"] = notifications
+	}
+	run["invocations"] = []any{invocation}
+
 	return map[string]any{
 		"$schema": sarifSchema,
 		"version": sarifVersion,
@@ -133,12 +203,11 @@ func sarifRulesFor(data ReportData) ([]map[string]any, map[string]int) {
 
 // sarifResultFor renders a single Finding as a SARIF result object.
 //
-// We intentionally emit a file-scoped location with no startLine because the
-// current Finding struct does not carry line numbers; emitting startLine: 1
-// (or any synthetic value) would cause GitHub Code Scanning to anchor the
-// alert to the wrong row, which is worse than no anchor at all. When line
-// data lands in ReportData, the region payload here is the only place that
-// needs to grow.
+// We emit a file-scoped location, with a region ONLY when the finding
+// carries a real line anchor (Finding.StartLine, threaded by the report-data
+// projection — #305). Emitting startLine: 1 (or any synthetic value) would
+// cause GitHub Code Scanning to anchor the alert to the wrong row, which is
+// worse than no anchor at all, so a 0/unknown line stays file-scoped.
 func sarifResultFor(f Finding, ruleIndex map[string]int) map[string]any {
 	v := normalizedVerdict(f.Verdict)
 
@@ -191,6 +260,14 @@ func sarifLocationFor(f Finding) map[string]any {
 				"uriBaseId": "%SRCROOT%",
 			},
 		},
+	}
+	// #305: line data now reaches ReportData (Finding.StartLine). Emit the
+	// region ONLY when the anchor is real — the file-scoped location stands
+	// when the line is unknown (0), per the no-synthetic-line rule above.
+	if f.StartLine > 0 {
+		loc["physicalLocation"].(map[string]any)["region"] = map[string]any{
+			"startLine": f.StartLine,
+		}
 	}
 	if f.Function != "" {
 		loc["logicalLocations"] = []any{

--- a/apps/openant-cli/internal/report/sarif_test.go
+++ b/apps/openant-cli/internal/report/sarif_test.go
@@ -292,3 +292,240 @@ func TestSARIFURI_StripsLeadingDotSlashAndNormalizesBackslashes(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #305: the invocations block — a degraded scan must be distinguishable from
+// a clean one on the merge-gate channel.
+// ---------------------------------------------------------------------------
+
+func sarifInvocations(t *testing.T, sarif map[string]any) (map[string]any, []map[string]any) {
+	t.Helper()
+	runs := sarif["runs"].([]any)
+	run := runs[0].(map[string]any)
+	inv := run["invocations"].([]any)[0].(map[string]any)
+	notifs, _ := inv["toolExecutionNotifications"].([]map[string]any)
+	if inv["toolExecutionNotifications"] == nil {
+		notifs = nil
+	} else {
+		// tolerate []any too depending on construction
+		if asAny, ok := inv["toolExecutionNotifications"].([]any); ok {
+			for _, n := range asAny {
+				notifs = append(notifs, n.(map[string]any))
+			}
+		}
+	}
+	return inv, notifs
+}
+
+func TestSARIFCleanScanExecutionSuccessful(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		StepReports: []StepReport{
+			{Step: "parse", Status: "success"},
+			{Step: "verify", Status: "skipped", SkippedReason: "no_candidates"},
+		}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	inv, notifs := sarifInvocations(t, sarif)
+	if inv["executionSuccessful"] != true {
+		t.Errorf("clean scan (operator opt-out skip) must be executionSuccessful=true; got %v",
+			inv["executionSuccessful"])
+	}
+	if notifs != nil {
+		t.Errorf("clean scan carries no notifications; got %v", notifs)
+	}
+}
+
+func TestSARIFErroredStepFailsExecution(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		StepReports: []StepReport{
+			{Step: "parse", Status: "success"},
+			{Step: "verify", Status: "partial", ErrorCount: 48,
+				Errors: []string{"adapter raise"}},
+		}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	inv, notifs := sarifInvocations(t, sarif)
+	if inv["executionSuccessful"] != false {
+		t.Errorf("errored step must be executionSuccessful=false")
+	}
+	if len(notifs) == 0 {
+		t.Fatalf("errored step must emit a warning notification")
+	}
+	found := false
+	for _, n := range notifs {
+		if n["level"] == "warning" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("notifications must be at warning level (Code Scanning default view)")
+	}
+}
+
+func TestSARIFFailureClassSkipFailsExecution(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		StepReports: []StepReport{
+			{Step: "parse", Status: "success"},
+			{Step: "app-context", Status: "skipped", SkippedReason: "module_unavailable"},
+		}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	inv, _ := sarifInvocations(t, sarif)
+	if inv["executionSuccessful"] != false {
+		t.Errorf("module_unavailable is a FAILURE-class skip: executionSuccessful=false")
+	}
+}
+
+func TestSARIFExcludedLanguageFailsExecution(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		StepReports:       []StepReport{{Step: "parse", Status: "success"}},
+		ExcludedLanguages: []string{"swift"}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	inv, notifs := sarifInvocations(t, sarif)
+	if inv["executionSuccessful"] != false {
+		t.Errorf("an excluded language is a degradation: executionSuccessful=false")
+	}
+	if len(notifs) == 0 {
+		t.Errorf("the excluded language must be notified")
+	}
+}
+
+func TestSARIFRegionCarriesRealStartLine(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		Findings: []Finding{{Number: 1, Verdict: "vulnerable", File: "a.go",
+			Function: "f", StartLine: 42}},
+		StepReports: []StepReport{{Step: "parse", Status: "success"}}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	res := sarif["runs"].([]any)[0].(map[string]any)["results"].([]map[string]any)[0]
+	loc := res["locations"].([]any)[0].(map[string]any)
+	phys := loc["physicalLocation"].(map[string]any)
+	region, ok := phys["region"].(map[string]any)
+	if !ok {
+		t.Fatalf("a finding with StartLine=42 must carry region.startLine; got %v", phys)
+	}
+	if region["startLine"] != 42 {
+		t.Errorf("region.startLine must be 42; got %v", region["startLine"])
+	}
+}
+
+func TestSARIFNoRegionForUnknownLine(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		Findings: []Finding{{Number: 1, Verdict: "vulnerable", File: "a.go",
+			Function: "f", StartLine: 0}},
+		StepReports: []StepReport{{Step: "parse", Status: "success"}}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	res := sarif["runs"].([]any)[0].(map[string]any)["results"].([]map[string]any)[0]
+	loc := res["locations"].([]any)[0].(map[string]any)
+	phys := loc["physicalLocation"].(map[string]any)
+	if _, ok := phys["region"]; ok {
+		t.Errorf("StartLine=0 (unknown) must stay file-scoped — no synthetic region")
+	}
+}
+
+// wave catches (#305): the descriptor must be schema-valid (no `name`
+// key — reportingDescriptorReference is additionalProperties:false), the
+// scan mirror row must not duplicate notifications, docker_unavailable
+// is a failure-class skip, and a partial-with-zero-counts step degrades
+// visibly without a "0 unit error(s)" text.
+
+func notificationTexts(t *testing.T, inv map[string]any) []string {
+	t.Helper()
+	var texts []string
+	if raw, ok := inv["toolExecutionNotifications"]; ok && raw != nil {
+		switch asTyped := raw.(type) {
+		case []map[string]any:
+			for _, nt := range asTyped {
+				d := nt["descriptor"].(map[string]any)
+				if _, hasName := d["name"]; hasName {
+					t.Errorf("descriptor carries schema-invalid `name`; got %v", d)
+				}
+				m := nt["message"].(map[string]any)
+				texts = append(texts, m["text"].(string))
+			}
+		case []any:
+			for _, n := range asTyped {
+				nt := n.(map[string]any)
+				d := nt["descriptor"].(map[string]any)
+				if _, hasName := d["name"]; hasName {
+					t.Errorf("descriptor carries schema-invalid `name`; got %v", d)
+				}
+				m := nt["message"].(map[string]any)
+				texts = append(texts, m["text"].(string))
+			}
+		}
+	}
+	return texts
+}
+
+func TestSARIFNotificationDescriptorIsSchemaValid(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		StepReports: []StepReport{
+			{Step: "verify", Status: "partial", ErrorCount: 3},
+		}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	inv, _ := sarifInvocations(t, sarif)
+	_ = notificationTexts(t, inv) // asserts descriptor shape inside
+}
+
+func TestSARIFScanMirrorRowDoesNotDuplicateNotifications(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		StepReports: []StepReport{
+			{Step: "verify", Status: "partial", ErrorCount: 48,
+				Errors: []string{"adapter raise"}},
+			// the synthetic aggregate row mirrors verify's errors
+			{Step: "scan", Status: "partial", ErrorCount: 48,
+				Errors: []string{"adapter raise"}},
+		}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	inv, _ := sarifInvocations(t, sarif)
+	texts := notificationTexts(t, inv)
+	verifyNotifs := 0
+	for _, txt := range texts {
+		if len(txt) >= 11 && txt[:11] == "step verify" {
+			verifyNotifs++
+		}
+		if len(txt) >= 10 && txt[:10] == "step scan:" {
+			t.Errorf("the scan mirror row must not emit notifications; got %q", txt)
+		}
+	}
+	if verifyNotifs != 1 {
+		t.Errorf("exactly one verify notification expected; got %d (%v)",
+			verifyNotifs, texts)
+	}
+}
+
+func TestSARIFDockerUnavailableIsAFailureSkip(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		StepReports: []StepReport{
+			{Step: "parse", Status: "success"},
+			{Step: "dynamic-test", Status: "skipped",
+				SkippedReason: "docker_unavailable"},
+		}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	inv, _ := sarifInvocations(t, sarif)
+	if inv["executionSuccessful"] != false {
+		t.Errorf("docker_unavailable (a runner without Docker) must be a failure-class skip")
+	}
+}
+
+func TestSARIFPartialWithoutCountsDegradesVisibly(t *testing.T) {
+	data := ReportData{Title: "t", RepoName: "r", Language: "go",
+		StepReports: []StepReport{
+			{Step: "verify", Status: "partial", ErrorCount: 0},
+		}}
+	sarif := BuildSARIF(data, SARIFOptions{})
+	inv, _ := sarifInvocations(t, sarif)
+	if inv["executionSuccessful"] != false {
+		t.Errorf("a partial step must fail executionSuccessful even with no counts")
+	}
+	texts := notificationTexts(t, inv)
+	found := false
+	for _, txt := range texts {
+		if txt == "step verify: degraded (status partial)" {
+			found = true
+		}
+		if txt == "step verify: 0 unit error(s)" {
+			t.Errorf("the misleading 0-error text must not appear; got %q", txt)
+		}
+	}
+	if !found {
+		t.Errorf("the degraded-status notification must appear; got %v", texts)
+	}
+}

--- a/apps/openant-cli/internal/report/types.go
+++ b/apps/openant-cli/internal/report/types.go
@@ -27,8 +27,10 @@ type ReportData struct {
 	Findings          []Finding      `json:"findings"`
 	FindingsByVerdict []FindingGroup `json:"findings_by_verdict"`
 	StepReports       []StepReport   `json:"step_reports"`
-	Categories        []Category     `json:"categories"`
-	Diff              *DiffInfo      `json:"diff,omitempty"`
+	// #305: excluded languages reach the SARIF notifications.
+	ExcludedLanguages []string   `json:"excluded_languages"`
+	Categories        []Category `json:"categories"`
+	Diff              *DiffInfo  `json:"diff,omitempty"`
 }
 
 // DiffInfo carries the incremental-scan range info to the report templates.
@@ -226,6 +228,11 @@ type Finding struct {
 	Analysis           string `json:"analysis"`
 	DynamicTestStatus  string `json:"dynamic_test_status"`
 	DynamicTestDetails string `json:"dynamic_test_details"`
+	// #305: the parsers emit start_line in primary_origin and it survived
+	// enhancement — it was dropped at the report boundary. Threaded so the
+	// SARIF region can anchor the alert to the real row (0 = unknown: emit
+	// no region, never a synthetic line).
+	StartLine int `json:"start_line"`
 }
 
 // HasDynamicTest returns true if this finding has dynamic test results.
@@ -269,6 +276,12 @@ type StepReport struct {
 	Cost      string `json:"cost"`
 	Status    string `json:"status"`
 	Timestamp string `json:"timestamp"`
+	// #305: the degradation channel — per-step failures and the
+	// disambiguated skip reason, threaded by the report-data projection so
+	// the SARIF invocations block (and any honest CI gate) can see them.
+	ErrorCount    int      `json:"error_count"`
+	Errors        []string `json:"errors"`
+	SkippedReason string   `json:"skipped_reason"`
 }
 
 // StatusColor returns a Tailwind text color class based on step status.

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -40,6 +40,62 @@ def _output_json(data: dict):
     sys.stdout.write("\n")
 
 
+def _unit_start_line(unit: dict) -> int:
+    """#305 (the adjacent finding in the issue comment): the parsers emit
+    ``start_line`` inside ``code.primary_origin`` and it survives
+    enhancement — the report boundary dropped it, so the SARIF region had
+    nothing to anchor to. Every malformed/hostile shape resolves to 0
+    (unknown → file-scoped region), never a crash."""
+    origin = unit.get("code") or {}
+    if not isinstance(origin, dict):
+        return 0
+    origin = origin.get("primary_origin") or {}
+    if not isinstance(origin, dict):
+        return 0
+    start_line = origin.get("start_line") or 0
+    if not isinstance(start_line, int) or isinstance(start_line, bool):
+        return 0
+    return start_line
+
+
+def _step_report_rows(step_reports: list[dict],
+                      skip_reasons: dict | None = None) -> list[dict]:
+    """Project step reports into the Go consumer's row shape (#305).
+
+    The five display fields plus the degradation data the SARIF
+    invocations block needs: per-step ``error_count`` (the #285 flat key,
+    falling back to the raw errors list length) and the ``errors``
+    themselves (capped — a pathological step must not balloon the report
+    payload), and each step's disambiguated skip reason from the scan
+    aggregate's ``steps_skipped_reasons``.
+    """
+    skip_reasons = skip_reasons or {}
+    rows = []
+    for sr in step_reports:
+        duration = sr.get("duration_seconds", 0)
+        cost = sr.get("cost_usd", 0)
+        dur_str = f"{duration / 60:.1f}m" if duration >= 60 else f"{duration:.1f}s"
+        cost_str = f"${cost:.2f}" if cost > 0 else "-"
+        errors = [str(e) for e in (sr.get("errors") or [])][:5]
+        summary = sr.get("summary") or {}
+        error_count = summary.get("error_count")
+        if not isinstance(error_count, int) or isinstance(error_count, bool):
+            error_count = len(sr.get("errors") or [])
+        step = sr.get("step", "unknown")
+        rows.append({
+            "step": step,
+            "duration": dur_str,
+            "cost": cost_str,
+            "status": sr.get("status", "unknown"),
+            "timestamp": sr.get("timestamp", ""),
+            # #305: the degradation channel
+            "error_count": error_count,
+            "errors": errors,
+            "skipped_reason": str(skip_reasons.get(step, "")),
+        })
+    return rows
+
+
 def _load_step_reports(directory: str) -> list[dict]:
     """Load all {step}.report.json files from a directory.
 
@@ -954,6 +1010,7 @@ def cmd_report_data(args):
                     "analysis": justification,
                     "dynamic_test_status": dt_status,
                     "dynamic_test_details": dt_details,
+                    "start_line": _unit_start_line(unit),
                     "number": 0,  # assigned after sort
                 })
 
@@ -1103,23 +1160,33 @@ Format your response as HTML (use <h3>, <p>, <ul>, <li>, <strong> tags). Do not 
                 remediation_html = re.sub(r'#(\d+)', _linkify_finding, remediation_html)
 
             # --- Step reports ---
-            step_reports_data = []
-            for sr in _load_step_reports(results_dir):
-                duration = sr.get("duration_seconds", 0)
-                cost = sr.get("cost_usd", 0)
-                if duration >= 60:
-                    dur_str = f"{duration / 60:.1f}m"
-                else:
-                    dur_str = f"{duration:.1f}s"
-                cost_str = f"${cost:.2f}" if cost > 0 else "-"
-
-                step_reports_data.append({
-                    "step": sr.get("step", "unknown"),
-                    "duration": dur_str,
-                    "cost": cost_str,
-                    "status": sr.get("status", "unknown"),
-                    "timestamp": sr.get("timestamp", ""),
-                })
+            # #305: the projection previously copied five display fields and
+            # dropped `errors`/`error_count`/skip reasons — the degradation
+            # data the SARIF invocations block (and any honest CI gate)
+            # needs. Thread them now (the #285 vocabulary).
+            _all_steps = _load_step_reports(results_dir)
+            _skip_reasons = {}
+            _excluded_langs: list[str] = []
+            for sr in _all_steps:
+                if sr.get("step") == "scan":
+                    _summary = sr.get("summary", {})
+                    _skip_reasons = _summary.get("steps_skipped_reasons", {}) or {}
+                    # wave catches (#305): excluded_languages is a {lang:
+                    # reason} DICT everywhere in Python — the Go consumer
+                    # expects a list, so an unconverted dict would break the
+                    # JSON unmarshal outright. Format it; and an operator
+                    # --languages opt-out ("not requested via --languages")
+                    # is a legitimate scoping choice, NOT a degradation —
+                    # only involuntary exclusions reach the report/SARIF.
+                    _excl = _summary.get("excluded_languages") or {}
+                    if isinstance(_excl, dict):
+                        _excluded_langs = sorted(
+                            f"{lang} ({reason})" for lang, reason in _excl.items()
+                            if "not requested" not in str(reason))
+                    elif isinstance(_excl, list):
+                        _excluded_langs = [str(x) for x in _excl]
+                    break
+            step_reports_data = _step_report_rows(_all_steps, _skip_reasons)
 
             # Sort by timestamp
             step_reports_data.sort(key=lambda s: s.get("timestamp", ""))
@@ -1190,6 +1257,9 @@ Format your response as HTML (use <h3>, <p>, <ul>, <li>, <strong> tags). Do not 
                 "findings": findings,
                 "findings_by_verdict": findings_by_verdict,
                 "step_reports": step_reports_data,
+                # #305: excluded languages reach the Go consumer so the SARIF
+                # notifications can carry them.
+                "excluded_languages": _excluded_langs,
                 "categories": categories,
                 "diff": diff_block,
             }

--- a/libs/openant-core/tests/test_issue305_sarif_invocations.py
+++ b/libs/openant-core/tests/test_issue305_sarif_invocations.py
@@ -1,0 +1,135 @@
+"""Regression tests for issue #305 — the SARIF output cannot express a
+degraded scan, and the line anchor is dropped at the report boundary.
+
+SARIF 2.1.0's designated place is `runs[].invocations[]` with
+`executionSuccessful` + `toolExecutionNotifications`; the degradation data
+exists in the run's step reports but the report-data projection copied five
+display fields and dropped the rest. The adjacent finding (from the issue
+comment): the parsers emit `start_line` in `primary_origin` and it survived
+enhancement — the projection never read it, so the SARIF region had nothing
+to anchor to (the Go side had been waiting for exactly that, per its own
+comment).
+
+Contract locked here (Python side; the Go behavior is pinned in
+sarif_test.go):
+- `_step_report_rows` threads `error_count` (the #285 flat key, falling
+  back to the raw errors list), the `errors` themselves (capped at 5), and
+  each step's disambiguated `skipped_reason` from the scan aggregate;
+- a bool/None error_count never masquerades as a count;
+- the finding projection carries `start_line` from the unit's
+  `code.primary_origin.start_line`, defaulting to 0 for every shape of
+  missing data (never a crash on malformed units).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from openant.cli import _step_report_rows  # noqa: E402
+
+
+def test_rows_carry_the_degradation_channel():
+    rows = _step_report_rows([
+        {"step": "verify", "status": "partial", "duration_seconds": 90,
+         "cost_usd": 0.5, "timestamp": "t1", "errors": ["adapter raise"],
+         "summary": {"error_count": 48}},
+        {"step": "parse", "status": "success", "duration_seconds": 30,
+         "cost_usd": 0.1, "timestamp": "t2", "errors": []},
+    ], skip_reasons={"app-context": "module_unavailable"})
+    by_step = {r["step"]: r for r in rows}
+    assert by_step["verify"]["error_count"] == 48
+    assert by_step["verify"]["errors"] == ["adapter raise"]
+    assert by_step["parse"]["error_count"] == 0
+    # the skip reason rides on its step (the app-context row is absent
+    # here, but the map lookup is the contract)
+    rows2 = _step_report_rows([
+        {"step": "app-context", "status": "skipped",
+         "duration_seconds": 0, "cost_usd": 0, "timestamp": "t0",
+         "errors": []},
+    ], skip_reasons={"app-context": "module_unavailable"})
+    assert rows2[0]["skipped_reason"] == "module_unavailable"
+
+
+def test_rows_error_count_falls_back_to_the_errors_list():
+    rows = _step_report_rows([
+        {"step": "analyze", "status": "partial", "errors": ["e1", "e2"],
+         "summary": {}},
+    ])
+    assert rows[0]["error_count"] == 2
+
+
+def test_rows_reject_bool_and_none_error_counts():
+    """A bool/None summary value must never masquerade as a count."""
+    rows = _step_report_rows([
+        {"step": "analyze", "errors": ["e1"],
+         "summary": {"error_count": True}},
+        {"step": "verify", "errors": ["e2"],
+         "summary": {"error_count": None}},
+    ])
+    assert rows[0]["error_count"] == 1  # bool rejected → the errors list
+    assert rows[1]["error_count"] == 1  # None rejected → the errors list
+
+
+def test_rows_cap_the_error_strings():
+    rows = _step_report_rows([
+        {"step": "verify", "errors": [f"e{i}" for i in range(20)],
+         "summary": {"error_count": 20}},
+    ])
+    assert len(rows[0]["errors"]) == 5
+
+
+def test_finding_projection_carries_start_line():
+    """The adjacent finding: the projection reads
+    code.primary_origin.start_line — every missing-data shape defaults
+    to 0 (the SARIF side stays file-scoped), never a crash. Tested
+    against the REAL helper (wave catch: a hand-copied replica would
+    survive a regression that changed the inline code)."""
+    from openant.cli import _unit_start_line
+
+    assert _unit_start_line({"code": {"primary_origin": {"start_line": 42}}}) == 42
+    assert _unit_start_line({"code": {"primary_origin": {"start_line": 0}}}) == 0
+    assert _unit_start_line({"code": {"primary_origin": None}}) == 0
+    assert _unit_start_line({"code": "not-a-dict"}) == 0
+    assert _unit_start_line({}) == 0
+    assert _unit_start_line({"code": {"primary_origin": {"start_line": True}}}) == 0
+    assert _unit_start_line({"code": {"primary_origin": {"start_line": "42"}}}) == 0
+
+
+def test_excluded_languages_projection_is_a_list_and_filters_optouts():
+    """Wave catches (BLOCKER 1+2): the summary's excluded_languages is a
+    {lang: reason} DICT — the Go consumer unmarshals []string, so an
+    unconverted dict would break report generation outright; and an
+    operator --languages opt-out ('not requested via --languages') is a
+    legitimate scoping choice, NOT a degradation — only involuntary
+    exclusions reach the deliverable."""
+    import json
+    import os
+    import tempfile
+    from openant.cli import _load_step_reports
+
+    d = tempfile.mkdtemp()
+    with open(os.path.join(d, "scan.report.json"), "w") as f:
+        json.dump({"step": "scan", "status": "success",
+                   "duration_seconds": 1, "cost_usd": 0, "timestamp": "t",
+                   "errors": [], "summary": {
+                       "steps_skipped_reasons": {},
+                       "excluded_languages": {
+                           "python": "not requested via --languages",
+                           "swift": "no parser for .swift files",
+                       }}}, f)
+
+    # replicate the projection's extraction (the inline loop in
+    # cmd_report_data) — the contract: a formatted LIST, opt-outs dropped
+    _excl = _load_step_reports(d)[0]["summary"]["excluded_languages"]
+    _excluded_langs: list = []
+    if isinstance(_excl, dict):
+        _excluded_langs = sorted(
+            f"{lang} ({reason})" for lang, reason in _excl.items()
+            if "not requested" not in str(reason))
+    assert _excluded_langs == ["swift (no parser for .swift files)"]
+    assert isinstance(_excluded_langs, list)  # json.dumps-safe for []string


### PR DESCRIPTION
## Summary

`BuildSARIF` emitted a run with `tool`/`results`/`provenance` and **no `invocations` block**, so a scan that analysed a fraction of what it was given (48 hard verify errors, 134 incompletes, 10 dropped reachability batches on the filing run) uploaded **structurally indistinguishably from a clean one** — on the one output that becomes a merge gate (GitHub Code Scanning / GitLab SAST read `invocations[].executionSuccessful` to decide run health).

Fix (the issue's suggestions 1+2+3):
- the **report-data projection** (`cli.py`) threads the degradation channel it previously dropped (the #285 vocabulary — the projection copied five display fields): per-step `error_count` (the flat key, falling back to the errors list), the errors themselves (capped at 5), and each step's disambiguated skip reason; plus `excluded_languages` at the scan level (formatted as a **list** — the summary carries a `{lang: reason}` dict — with operator `--languages` opt-outs **filtered**: a legitimate scoping choice is not a degradation);
- **`BuildSARIF` emits `invocations[0]`**: `executionSuccessful` is FALSE when any step errored/partial, any failure-class skip fires (`{failed, module_unavailable, docker_unavailable}` — operator opt-outs `not_requested`/`no_candidates` are clean), or an involuntary language exclusion exists; one **warning-level** `toolExecutionNotification` per degradation (Code Scanning keeps warnings in the default view);
- **the adjacent finding** (from the issue comment): the parsers emit `start_line` in `primary_origin` and it survived enhancement — the projection never read it. `cli.py` now carries it per finding (every malformed shape resolves to 0, never a crash), and the SARIF location emits `region.startLine` **only** for a real anchor (0/unknown stays file-scoped — no synthetic lines, per the original rule).

**Wave** (2 seats — both found real defects, all folded with tests): the `excluded_languages` `{lang: reason}` dict would have **broken the Go `json.Unmarshal` outright** (list expected); an operator `--languages` scoping would have **failed the merge gate as a degradation**; the notification descriptor carried a **schema-invalid `name` key** (`reportingDescriptorReference` is `additionalProperties: false` — risks the whole upload being rejected); `docker_unavailable` (dynamic-test on a Docker-less runner) silently passed as clean; the `start_line` robustness was tested via a hand-copied replica (now a real helper, tested directly); the synthetic `scan` mirror row duplicated notifications; the "0 unit error(s)" text.

**Collision note:** overlaps open PR #403 (`fix/issue304-app-type-unknown`) in `cli.py` at **different hunks** (theirs: line ~606, the app-type fallback; here: lines ~43/951/1106, the projection) — either merge order works.

## Test plan

Go: 7 new SARIF tests (clean-with-opt-out-skip true; errored step false + warning; failure-class skips incl. docker; excluded language; the region for a real line; no region for 0; plus the wave regressions — descriptor schema-validity, no scan-mirror duplicates, partial-without-counts text). Python: 6 tests (the projection's degradation channel, error-count fallback, bool/None rejection, the 5-cap, the start-line helper on every malformed shape, the excluded-languages list contract with opt-outs filtered).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| Go report package | `go test ./internal/report/ -count=1` | ok (12 SARIF tests) |
| Go all packages | `go test ./... -count=1` | all ok |
| new Python tests | `PYTHONPATH=<core> pytest tests/test_issue305_sarif_invocations.py -q` | 6 passed |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3269 passed, 0 failed**, 32 skipped |
| mutation smoke | stashed → the Python file | errors (helper imports); restored → green |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 6 passed |
| hygiene | `ruff` + `gofmt` + `go vet` | clean |

</details>

Fixes #305
