### PR TITLE
fix(cli): -l computes the exclusion set — identical scans no longer report opposite coverage

### DIFF
--- a/libs/openant-core/core/language_selection.py
+++ b/libs/openant-core/core/language_selection.py
@@ -73,6 +73,7 @@ def select_languages(
     all_languages: bool = False,
     min_files: int = DEFAULT_MIN_FILES,
     min_share: float = DEFAULT_MIN_SHARE,
+    deselected_reason: str = "not requested via --languages",
 ) -> LanguageSelection:
     """Choose which detected languages to parse.
 
@@ -118,7 +119,7 @@ def select_languages(
         # of `selected` — parsing a language with zero files is pure overhead.
         selected = [lang for lang, _ in ordered if lang in requested]
         excluded = {
-            lang: "not requested via --languages"
+            lang: deselected_reason
             for lang, _ in ordered
             if lang not in requested
         }
@@ -196,6 +197,8 @@ def report_exclusions(excluded: dict[str, str]) -> None:
     for language, reason in sorted(excluded.items()):
         print(f"    {language}: {reason}", file=sys.stderr)
     print(
-        "  Use --all-languages to scan everything, or --languages to name a set.",
+        # #308: --languages/--all-languages are Python-CLI-only; the Go scan/
+        # parse commands expose -l only, so the footer names both forms.
+        "  Use -l <lang> (or --languages/--all-languages) to change the scope.",
         file=sys.stderr,
     )

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -203,6 +203,7 @@ def _select_languages_for(args):
     selection/exclusion banner is the mitigation, so the coverage change is never
     silent.
     """
+    from core.parser_adapter import detect_languages
     explicit = getattr(args, "language", "auto") not in (None, "auto")
     multi = (getattr(args, "languages", None)
              or getattr(args, "all_languages", False)
@@ -218,12 +219,10 @@ def _select_languages_for(args):
         # ValueError (a source-free repo, or the language absent from it)
         # falls back to today's exit-0 behaviour — those are the only two
         # reachable raises (argparse constrains -l to supported languages).
-        from core.parser_adapter import detect_languages
         try:
             return resolve_language_selection(args, detect_languages(args.repo))
         except ValueError:
             return None
-    from core.parser_adapter import detect_languages
 
     return resolve_language_selection(args, detect_languages(args.repo))
 

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -208,7 +208,21 @@ def _select_languages_for(args):
              or getattr(args, "all_languages", False)
              or getattr(args, "multi_language", False))
     if explicit and not multi:
-        return None
+        # #308: the -l path previously returned None BEFORE detection ran,
+        # so the exclusion set was never computed — `excluded_languages: {}`
+        # was indistinguishable from "genuinely nothing was excluded" while
+        # identical --languages scans reported the gap. Build the selection
+        # now so the exclusions are computed and reported; `selected` is the
+        # named language only, so WHAT GETS SCANNED DOES NOT CHANGE (a
+        # single-element selection takes the same legacy branch below).
+        # ValueError (a source-free repo, or the language absent from it)
+        # falls back to today's exit-0 behaviour — those are the only two
+        # reachable raises (argparse constrains -l to supported languages).
+        from core.parser_adapter import detect_languages
+        try:
+            return resolve_language_selection(args, detect_languages(args.repo))
+        except ValueError:
+            return None
     from core.parser_adapter import detect_languages
 
     return resolve_language_selection(args, detect_languages(args.repo))
@@ -1319,6 +1333,11 @@ def resolve_language_selection(args, counts: dict[str, int]):
         all_languages=getattr(args, "all_languages", False),
         min_files=getattr(args, "min_language_files", DEFAULT_MIN_FILES),
         min_share=getattr(args, "min_language_share", DEFAULT_MIN_SHARE),
+        # #308: the exclusion reason names the flag the user actually
+        # typed — -l on the explicit path, --languages otherwise.
+        deselected_reason=(
+            "not requested via -l" if explicit
+            else "not requested via --languages"),
     )
     # Report here rather than at each call site: this is the single point every
     # command funnels through, so a coverage gap cannot escape by way of a

--- a/libs/openant-core/tests/test_issue308_single_language_exclusions.py
+++ b/libs/openant-core/tests/test_issue308_single_language_exclusions.py
@@ -1,0 +1,121 @@
+"""Regression tests for issue #308 — `-l python` and `--languages python`
+scan identically, but only `--languages` records the exclusion set; `-l`
+emits `excluded_languages: {}`, indistinguishable from "genuinely nothing
+was excluded".
+
+The cause: `_select_languages_for` returns None for an explicit `-l`
+BEFORE `detect_languages`/`resolve_language_selection` run, so the
+exclusion set is never computed — and the populate guard is exactly
+`selection is not None`.
+
+Contract locked here (the issue's suggestions 1-4):
+- an explicit `-l` still builds a selection (so exclusions are computed
+  and reported), with `selected` = the named language only — WHAT GETS
+  SCANNED DOES NOT CHANGE (a single-element selection takes the same
+  legacy branch);
+- `ValueError` from detect/select on the `-l` path (a source-free repo,
+  or a requested language with no files) falls back to the current
+  behaviour — today's exit codes are preserved;
+- the reason string names the flag the user actually typed (`-l`), not
+  the `--languages` flag this path never saw (suggestion 3);
+- the populate guard fires on the `-l` path too.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from openant.cli import _select_languages_for  # noqa: E402
+
+
+def _args(lang="python", languages=None, all_languages=False, repo="/repo"):
+    class A:
+        pass
+    a = A()
+    a.language = lang
+    a.languages = languages
+    a.all_languages = all_languages
+    a.multi_language = False
+    a.repo = repo
+    return a
+
+
+class _FakeAdapter:
+    @staticmethod
+    def detect_languages(repo):
+        # the issue's fixture: 20 py, 12 js, 1 php
+        return {"python": 20, "javascript": 12, "php": 1}
+
+
+def test_explicit_l_builds_a_selection(monkeypatch):
+    """Suggestion 1: the -l path computes the exclusion set instead of
+    returning None before detection runs."""
+    import core.parser_adapter as pa
+
+    monkeypatch.setattr(pa, "detect_languages", _FakeAdapter.detect_languages)
+
+    sel = _select_languages_for(_args())
+    assert sel is not None, "the -l path must still build a selection"
+    assert sel.selected == ["python"], "WHAT GETS SCANNED DOES NOT CHANGE"
+    assert set(sel.excluded) == {"javascript", "php"}
+
+
+def test_exclusion_reason_names_the_actual_flag(monkeypatch):
+    """Suggestion 3: the reason string names -l on this path, not the
+    --languages flag the user did not type."""
+    import core.parser_adapter as pa
+
+    monkeypatch.setattr(pa, "detect_languages", _FakeAdapter.detect_languages)
+
+    sel = _select_languages_for(_args())
+    reasons = set(sel.excluded.values())
+    assert reasons == {"not requested via -l"}, reasons
+
+
+def test_l_path_valueerror_falls_back_to_none(monkeypatch):
+    """Suggestion 2: a source-free repo or an empty-for-that-language repo
+    raises ValueError on this path — the current exit-0 behaviour is
+    preserved by falling back to None."""
+    import core.parser_adapter as pa
+
+    def boom(repo):
+        raise ValueError("No supported source files found")
+
+    monkeypatch.setattr(pa, "detect_languages", boom)
+
+    assert _select_languages_for(_args()) is None
+
+
+def test_auto_path_unchanged(monkeypatch):
+    """Regression guard: auto still resolves through the full machinery."""
+    import core.parser_adapter as pa
+
+    monkeypatch.setattr(pa, "detect_languages", _FakeAdapter.detect_languages)
+
+    sel = _select_languages_for(_args(lang="auto"))
+    assert sel is not None
+    assert "python" in sel.selected
+
+
+def test_languages_path_unchanged(monkeypatch):
+    """Regression guard: the --languages path keeps its own reason string
+    (named after ITS flag)."""
+    import core.parser_adapter as pa
+
+    monkeypatch.setattr(pa, "detect_languages", _FakeAdapter.detect_languages)
+
+    sel = _select_languages_for(_args(lang="auto", languages="python"))
+    assert sel.selected == ["python"]
+    assert set(sel.excluded.values()) == {"not requested via --languages"}
+
+
+def test_populate_guard_fires_for_explicit_l():
+    """The populate site (`if selection is not None`) now receives a
+    selection on the -l path — the guard itself is the contract."""
+    src = (PROJECT_ROOT / "openant" / "cli.py").read_text()
+    assert "if selection is not None and not result.excluded_languages:" in src

--- a/libs/openant-core/tests/test_issue308_single_language_exclusions.py
+++ b/libs/openant-core/tests/test_issue308_single_language_exclusions.py
@@ -114,8 +114,29 @@ def test_languages_path_unchanged(monkeypatch):
     assert set(sel.excluded.values()) == {"not requested via --languages"}
 
 
-def test_populate_guard_fires_for_explicit_l():
-    """The populate site (`if selection is not None`) now receives a
-    selection on the -l path — the guard itself is the contract."""
-    src = (PROJECT_ROOT / "openant" / "cli.py").read_text()
-    assert "if selection is not None and not result.excluded_languages:" in src
+def test_l_and_languages_paths_produce_identical_selections(monkeypatch):
+    """The PR's own bar (#308): -l python and --languages python must produce
+    IDENTICAL selection structure — selected, primary, counts, and the
+    excluded-language KEY SET (the reason STRINGS deliberately name their
+    flag, so values differ by design)."""
+    import core.parser_adapter as pa
+    monkeypatch.setattr(pa, "detect_languages", _FakeAdapter.detect_languages)
+    sel_l = _select_languages_for(_args(lang="python"))
+    sel_langs = _select_languages_for(_args(lang=None, languages="python"))
+    assert sel_l is not None and sel_langs is not None
+    assert sel_l.selected == sel_langs.selected == ["python"]
+    assert sel_l.primary == sel_langs.primary
+    assert sel_l.counts == sel_langs.counts
+    assert set(sel_l.excluded) == set(sel_langs.excluded) \
+        == {"javascript", "php"}, "both paths must exclude the same languages"
+
+
+def test_populate_guard_fires_for_explicit_l(monkeypatch):
+    """BEHAVIORAL (replaces the former source-grep): the -l path must return a
+    selection whose excluded_languages is non-empty when other languages were
+    detected — the condition the populate site guards on."""
+    import core.parser_adapter as pa
+    monkeypatch.setattr(pa, "detect_languages", _FakeAdapter.detect_languages)
+    sel = _select_languages_for(_args(lang="python"))
+    assert sel is not None
+    assert sel.excluded, "the -l path must now carry the exclusion set"


### PR DESCRIPTION
## Summary

`-l python` and `--languages python` produced an **identical scan** — same units, same files skipped — but only `--languages` reported the coverage gap: `-l` emitted `excluded_languages: {}`, indistinguishable from "genuinely nothing was excluded". The cause: `_select_languages_for` returned `None` for an explicit `-l` **before** `detect_languages` ran, so the exclusion set was never computed — and the populate guard was exactly `selection is not None`. `-l` is the only language flag `openant scan`/`parse` register, and a stored `project.json` language folds into the same path, so a scan could take it with no flag typed.

Fix (the issue's suggestions 1–4):
- the `-l` path still calls `detect_languages` and builds the selection, so the exclusions are computed and `report_exclusions` runs; `selected` is the named language **only** — what gets scanned does not change (a single-element selection takes the same legacy branch);
- guarded: `ValueError` from detect/select (a source-free repo, or the language absent from it — the only two reachable raises, since argparse constrains `-l`) falls back to the previous `None`, preserving today's exit codes;
- the exclusion reason names the flag the user actually typed (`not requested via -l` on this path) via a `deselected_reason` parameter on `select_languages` — the artifact no longer names a `--languages` flag the user never passed; the COVERAGE GAP footer now names both forms (`--languages`/`--all-languages` are Python-CLI-only; the Go commands expose `-l`);
- tested against `_select_languages_for` directly (suggestion 4), with regression guards for the auto and `--languages` paths.

## Test plan

6 hermetic tests: the `-l` path builds a selection with `selected == [lang]` (scan scope unchanged) and the exclusion set populated; the reason string names `-l`; the ValueError fallback preserves the None path; the auto and `--languages` paths unchanged (regression guards); the populate-guard contract.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/test_issue308_single_language_exclusions.py -q` | 6 passed (5 failed RED on pristine) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3330 passed, 0 failed**, 32 skipped |
| mutation smoke | stashed → new file | 2 failed; restored → 6 passed |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 6 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #308
