### PR TITLE
fix(python-parser): four call-graph constructs gain their edges — __init__ definitions, import aliases, property reads, annotated receivers

### DIFF
--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -186,6 +186,11 @@ class CallGraphBuilder:
         # Local variable -> constructor-type map, so that `v = ClassName(); v.method()`
         # dispatches to the bound type's method.
         local_types = self._collect_local_types(tree)
+        # #309 (item 4): a type-annotated parameter carries its receiver
+        # type in the signature — consult it (a local Assign binding still
+        # wins, matching Python's own scoping).
+        for pname, ptype in self._collect_annotated_params(tree).items():
+            local_types.setdefault(pname, ptype)
         # Receiver names that refer to the current instance/class: self/cls plus any
         # local name single-bound to them (obj = self; obj.method()).
         self_aliases = {'self', 'cls'} | self._collect_self_aliases(tree)
@@ -212,6 +217,25 @@ class CallGraphBuilder:
         containers.update(local_map)
 
         for node in ast.walk(tree):
+            # #309 (item 3): a @property READ (an ast.Attribute in Load
+            # context — the idiomatic use) emits a reference edge when the
+            # receiver's type is known and the attribute resolves to a
+            # unit classified as a property. A property reached only by
+            # reads is otherwise indistinguishable from dead code. A CALL
+            # through the property (w.secret_prop()) is an ast.Call and
+            # resolves through the normal path above — this handles the
+            # read alone.
+            if isinstance(node, ast.Attribute):
+                value = node.value
+                if (isinstance(value, ast.Name)
+                        and isinstance(node.ctx, ast.Load)
+                        and value.id in local_types):
+                    typed = self._resolve_class_method(
+                        local_types[value.id], node.attr, caller_file)
+                    if typed:
+                        func_data = self.functions.get(typed, {})
+                        if func_data.get('unit_type') == 'property':
+                            calls.add(typed)
             if isinstance(node, ast.Call):
                 resolved = self._resolve_call_node(node, caller_file, caller_class, local_types, aliases, self_aliases)
                 if resolved:
@@ -281,6 +305,24 @@ class CallGraphBuilder:
             if isinstance(node, self._SCOPE_NODES):
                 continue                  # do not cross into a nested scope
             stack.extend(ast.iter_child_nodes(node))
+
+    def _collect_annotated_params(self, tree: ast.AST) -> Dict[str, str]:
+        """#309 (item 4): map parameter names to their CLASS annotation.
+
+        ``ast.arg.annotation`` was never read anywhere in the parser — the
+        receiver's type was written down in the signature and simply not
+        consulted. Only a bare ``ast.Name`` annotation is recorded (the
+        conservative case: ``w: Widget``); anything more complex
+        (``Optional[Widget]``, strings) abstains.
+        """
+        types: Dict[str, str] = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.arguments):
+                for arg in (*node.args, *node.kwonlyargs):
+                    ann = arg.annotation
+                    if isinstance(ann, ast.Name) and arg.arg not in ("self", "cls"):
+                        types[arg.arg] = ann.id
+        return types
 
     def _collect_local_types(self, tree: ast.AST) -> Dict[str, str]:
         """Map local variable names to the class name they are constructed from.
@@ -811,11 +853,24 @@ class CallGraphBuilder:
                         target_id = f"{potential_file}:{class_name}.{func_name}"
                         if target_id in self.functions:
                             return target_id
+                        # #309 (item 2): `from X import f as g` records
+                        # imports['g'] = 'X.f' — the TRUE name is the path
+                        # tail, not the local alias g the caller used.
+                        target_id = f"{potential_file}:{class_name}.{remaining[-1]}"
+                        if target_id in self.functions:
+                            return target_id
 
                 # Look for standalone function
                 target_id = f"{potential_file}:{target_name}"
                 if target_id in self.functions:
                     return target_id
+                # #309 (item 2): the from-import alias — the true name is
+                # the dotted path's tail (`from X import f as g` → look for
+                # f at X, not g).
+                if remaining:
+                    target_id = f"{potential_file}:{remaining[-1]}"
+                    if target_id in self.functions:
+                        return target_id
 
         # Strategy 1b: package re-export via __init__.py.
         # `from pkg import name` records import_path 'pkg.name', but `name` may not live in
@@ -878,6 +933,13 @@ class CallGraphBuilder:
             if init_file in seen:                       # re-export cycle guard
                 continue
             pkg_imports = self.imports[init_file]
+            # #309 (item 1): the name may be DEFINED in the package
+            # __init__.py (not re-exported) — probe the definition directly.
+            # `from pkg import defined_here` previously resolved only the
+            # re-export arm; the definition got no edge at all.
+            defined_id = f"{init_file}:{func_name}"
+            if defined_id in self.functions:
+                return defined_id
             if func_name not in pkg_imports:
                 continue
             seen.add(init_file)

--- a/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
+++ b/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
@@ -1,0 +1,115 @@
+"""Regression tests for issue #309 — four Python call-graph constructs
+resolve to no call edge, leaving live functions with empty caller sets
+(reachability then cannot distinguish them from dead code).
+
+The four (each reproduced with a control that DOES resolve, so a null
+result is never a broken harness):
+1. `from pkg import f` where f is DEFINED in pkg/__init__.py (a re-export
+   through the same file resolves; the definition does not);
+2. `from X import f as g` (the import alias: the extractor records
+   g→X.f, but the resolver looks for a function named g at X's path);
+3. a `@property` READ (an ast.Attribute in Load context — the builder
+   walks only ast.Call; calling the property's result DOES emit an edge);
+4. a method on a type-annotated parameter (ast.arg.annotation is never
+   read; a local `w = Widget()` receiver resolves).
+
+Contract: each construct gains its edge — the over-seed direction for
+reachability (a reference/edge that is not a call is still reachability
+signal — the #295 family). WHAT IS SCANNED does not change for any
+control case.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.parser_adapter import parse_repository  # noqa: E402
+
+
+def _cg(files: dict):
+    repo = Path(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    out = tempfile.mkdtemp()
+    parse_repository(str(repo), out, language="python",
+                   processing_level="all", skip_tests=True, name="r")
+    return json.load(open(Path(out) / "call_graph.json"))["call_graph"]
+
+
+def test_init_definition_resolves():
+    cg = _cg({
+        "pkg/impl.py": "def reexported(): return 2\n",
+        "pkg/__init__.py": ("from .impl import reexported\n"
+                            "def defined_here(): return 1\n"),
+        "main.py": ("from pkg import defined_here\n"
+                    "from pkg import reexported\n"
+                    "def caller():\n"
+                    "    defined_here()\n"
+                    "    reexported()\n"),
+    })
+    edges = cg.get("main.py:caller", [])
+    assert "pkg/impl.py:reexported" in edges, edges       # control
+    assert "pkg/__init__.py:defined_here" in edges, edges  # the defect
+
+
+def test_import_alias_resolves():
+    cg = _cg({
+        "pkg/impl.py": ("def f_a(): return 1\n"
+                        "def f_b(): return 2\n"
+                        "def f_c(): return 3\n"),
+        "main.py": ("from pkg.impl import f_a as aliased\n"
+                    "from pkg.impl import f_b\n"
+                    "import pkg.impl as mod\n"
+                    "def c_funcalias():  aliased()\n"
+                    "def c_plain():      f_b()\n"
+                    "def c_modalias():   mod.f_c()\n"),
+    })
+    assert "pkg/impl.py:f_a" in cg.get("main.py:c_funcalias", []), cg
+    assert "pkg/impl.py:f_b" in cg.get("main.py:c_plain", [])       # control
+    assert "pkg/impl.py:f_c" in cg.get("main.py:c_modalias", [])    # control
+
+
+def test_property_read_emits_reference_edge():
+    cg = _cg({
+        "app.py": ("class Widget:\n"
+                   "    @property\n"
+                   "    def secret_prop(self): return 1\n"
+                   "    def normal_method(self): return 2\n"
+                   "def reads_property():\n"
+                   "    w = Widget()\n"
+                   "    return w.secret_prop\n"
+                   "def calls_method():\n"
+                   "    w = Widget()\n"
+                   "    return w.normal_method()\n"),
+    })
+    assert "app.py:Widget.normal_method" in cg.get("app.py:calls_method", [])
+    assert "app.py:Widget.secret_prop" in cg.get("app.py:reads_property", []), (
+        "a @property READ is the idiomatic use of the property; the reference"
+        "edge is the over-seed direction (a property reached only by reads "
+        "is otherwise indistinguishable from dead code)")
+
+
+def test_annotated_parameter_receiver_resolves():
+    cg = _cg({
+        "shapes.py": ("class Widget:\n"
+                      "    def m_annotated(self): return 1\n"
+                      "    def m_local(self): return 2\n"
+                      "    def m_modlevel(self): return 3\n"
+                      "WIDGET = Widget()\n"
+                      "def via_annotated_param(w: Widget):  return w.m_annotated()\n"
+                      "def via_local_var():\n"
+                      "    w = Widget()\n"
+                      "    return w.m_local()\n"
+                      "def via_module_instance():           return WIDGET.m_modlevel()\n"),
+    })
+    assert "shapes.py:Widget.m_annotated" in cg.get("shapes.py:via_annotated_param", [])
+    assert "shapes.py:Widget.m_local" in cg.get("shapes.py:via_local_var", [])  # control

--- a/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
+++ b/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
@@ -42,7 +42,8 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(str(repo), out, language="python",
                    processing_level="all", skip_tests=True, name="r")
-    return json.load(open(Path(out) / "call_graph.json"))["call_graph"]
+    with open(Path(out) / "call_graph.json") as fh:
+        return json.load(fh)["call_graph"]
 
 
 def test_init_definition_resolves():


### PR DESCRIPTION
## Summary

Four constructs in the Python call graph produced **no call edge**, leaving live functions with empty caller sets (reachability cannot distinguish that from dead code — the FN direction). Each reproduced with a control that does resolve:

1. **`from pkg import f` where f is DEFINED in `pkg/__init__.py`**: the re-export arm resolved (Strategy 1b) but the definition did not — `_resolve_via_package_init` now probes `<prefix>/__init__.py` for a *definition* of the name before falling through to the re-export map.
2. **`from X import f as g`** (the import alias): the extractor correctly records `imports['g'] = 'X.f'`, but `_resolve_import` looked for a function named `g` at X's path — the true name is the dotted path's **tail**. Both the standalone and class-method arms now also probe `remaining[-1]`. (Module aliasing already worked; the defect is specific to `ImportFrom` carrying an `asname`.)
3. **A `@property` READ** (`ast.Attribute` in Load context — the idiomatic use; *calling* the property's result already resolved via `ast.Call`): the builder now emits a **reference edge** when the receiver's type is known and the attribute resolves to a unit classified as `property`. This is the issue's "emit a reference edge" option, chosen per the over-seed rule (a property reached only by reads is otherwise indistinguishable from dead code) and consistent with the #295 reference-edge family (a reference that is not a call is still reachability signal).
4. **A method on a type-annotated parameter**: `ast.arg.annotation` was never read anywhere in the parser — the type was written in the signature and not consulted. `_collect_annotated_params` records bare `ast.Name` annotations (the conservative case; `Optional[Widget]` and string annotations abstain), merged into `local_types` with locals winning.

The issue's severity note (measured practical yield near zero on one target: 5,475 → 5,572 kept, ~1.8%) frames this as correctness, not yield: the conservative direction for a scanner.

**Local-env note:** the test-directory-only run hits the pre-existing ordering pollution (the `parsers` package import chain; identical on pristine master; the full-suite ordering — what CI runs — is green at 3328/0).

## Test plan

4 hermetic tests through the real pipeline, each with its control (the re-export control; the plain-import and module-alias controls; the ordinary-method-call control; the local-var control). The full suite (3328/0) includes them in the CI ordering.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3328 passed, 0 failed**, 32 skipped (the 4 new tests pass in the full-suite ordering) |
| python parser dir | `PYTHONPATH=<core> pytest tests/parsers/python/ -q` | 163 passed, 1 skipped |
| mutation smoke | stashed → full suite | 4 new tests fail; restored → 3328/0 |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #309
