### PR TITLE
fix(docs): reachability wording says what the filter computes — call-graph reachability, not exploitability

### DIFF
--- a/libs/openant-core/PIPELINE_MANUAL.md
+++ b/libs/openant-core/PIPELINE_MANUAL.md
@@ -348,9 +348,11 @@ Entry Point: handle_request()
 Intermediate: process_data()
     │
     ▼
-Target: unsafe_eval()  ← REACHABLE (exploitable)
+Target: unsafe_eval()  ← REACHABLE in the static call graph
 
-Isolated: helper_function()  ← NOT REACHABLE (not exploitable)
+Isolated: helper_function()  ← NOT REACHABLE in the static call graph (no recorded call path
+from any entry point — which is a claim about the parsed call graph, not a proof of
+unexploitability: an edge the parser did not record produces the same result as dead code)
 ```
 
 **Entry points** are functions that directly receive external input:
@@ -503,7 +505,7 @@ if reachability.is_reachable_from_entry_point(func_id):
     print(f"REACHABLE from {entry}")
     print(f"Path: {' → '.join(path)}")
 else:
-    print("NOT REACHABLE - cannot be exploited externally")
+    print("NOT REACHABLE in the static call graph - no recorded call path from any entry point")
 ```
 
 ### Statistics

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -232,8 +232,12 @@ class EntryPointDetector:
     """
     Detects entry points in a codebase where user input enters the application.
 
-    Entry points are the starting points for taint analysis - if vulnerable code
-    is not reachable from any entry point, it cannot be exploited by external users.
+    Entry points are the starting points for reachability filtering. What the
+    filter computes today is call-graph reachability: a unit with no recorded
+    call path from any entry point is dropped — a claim about the parsed
+    call graph, not a proof of unexploitability (an edge the parser did not
+    record produces the same result as dead code). "Taint analysis" is the
+    roadmap framing, not a description of the current filter.
 
     Attributes:
         functions: Dict of func_id -> func_data from extractor

--- a/libs/openant-core/utilities/agentic_enhancer/reachability_analyzer.py
+++ b/libs/openant-core/utilities/agentic_enhancer/reachability_analyzer.py
@@ -2,7 +2,10 @@
 Reachability Analyzer
 
 Determines if functions are reachable from entry points using the reverse call graph.
-This enables filtering vulnerable code based on whether user input can reach it.
+This enables filtering vulnerable code based on call-graph reachability (whether a
+recorded call path exists from any entry point) — NOT taint reachability: an edge the
+parser did not record produces the same result as dead code, and the two are
+indistinguishable in the output.
 
 A function is "reachable" if there exists a call path from any entry point to that
 function. The path is traced backwards: starting from the target function, we follow
@@ -19,7 +22,7 @@ Usage:
     analyzer = ReachabilityAnalyzer(functions, reverse_call_graph, entry_points)
 
     if analyzer.is_reachable_from_entry_point('file.py:unsafe_eval'):
-        print("Exploitable!")
+        print("Reachable in the call graph!")
         path = analyzer.get_entry_point_path('file.py:unsafe_eval')
         print(f"Path: {' -> '.join(path)}")
 """


### PR DESCRIPTION
## Summary

The pipeline manual and three code comments told the reader that reachability filtering answers **exploitability** ("not reachable = not exploitable", "cannot be exploited externally", "Exploitable!"). The filter computes **call-graph reachability** — a forward BFS closure with no taint state. A unit can be dropped for having no recorded caller and be described, in user-facing documentation, as "not exploitable", while any unrecorded call edge (#309: four such constructs in the Python parser alone) produces the same result as genuinely dead code and the two are indistinguishable in the output.

Documentation only — no behaviour change, per the issue's explicit scope (and the #241 precedent: the architecture survives; the docstring that asserted the premise does not).

- `PIPELINE_MANUAL.md`: `REACHABLE (exploitable)` → `REACHABLE in the static call graph`; `NOT REACHABLE (not exploitable)` → `NOT REACHABLE in the static call graph`, with the no-recorded-call-path framing; the manual's sample output prints the call-graph wording;
- `reachability_analyzer.py`: the module docstring says call-graph reachability and names the overstatement risk; the usage example's `Exploitable!` → `Reachable in the call graph!`;
- `entry_point_detector.py`: the taint-analysis framing kept as the **roadmap** (the issue allows this) but separated from the sentence describing what the filter does today.

## Test plan

The overstating-words grep over the three sites returns no matches (the residual `exploit` hits are the roadmap-separating sentences themselves). Full suite green (docs + comments only; the module docstrings are import-time invariant).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| overstating words | `rg "not exploitable\|cannot be exploited\|Exploitable!" <the three sites>` | no matches |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3332 passed, 0 failed**, 32 skipped |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #310
