### PR TITLE
fix(dynamic-test): _summary.json derives its counts from the unit files — a generation failure can no longer write errors: 0

### DIFF
--- a/libs/openant-core/tests/test_issue311_dynamic_test_counters.py
+++ b/libs/openant-core/tests/test_issue311_dynamic_test_counters.py
@@ -127,8 +127,6 @@ def test_summary_json_consistent_with_unit_files(tmp_path, monkeypatch):
 def test_error_checkpoints_still_retried(tmp_path):
     """The retry contract is unchanged: an ERROR checkpoint is NOT
     'already done' — it lands in the retry set, not the restore set."""
-    import utilities.dynamic_tester as dt
-
     cp_dir = tmp_path / "cp"
     cp_dir.mkdir()
     (cp_dir / "f1.json").write_text(json.dumps(

--- a/libs/openant-core/tests/test_issue311_dynamic_test_counters.py
+++ b/libs/openant-core/tests/test_issue311_dynamic_test_counters.py
@@ -1,0 +1,146 @@
+"""Regression tests for issue #311 — dynamic-test generation failures
+bypass the loop counters, so `_summary.json` reports `errors: 0` for a run
+that errored and its buckets do not sum to its own total.
+
+The generation-failure branch records a result, saves a checkpoint, and
+`continue`s — bypassing the only `_completed`/`_errors` increment site. On
+`DetectFallback` (the path that reads `_summary.json` directly) an errored
+run presents as clean. Two further defects on the same counters: the loop
+counts errors as a SUBSET of completed while `StepCheckpoint.status()`
+counts them as DISJOINT — so even with the increment added, the two
+sources disagree; and the issue's observed shape (`completed: 0,
+errors: 0` beside one unit file with `status: "ERROR"`) is internally
+inconsistent regardless of any consumer.
+
+Contract locked here (the issue's suggestion 1 — the structural fix):
+- `write_summary`'s counts are DERIVED from the saved unit files (the
+  same source `status()` recomputes from), not from loop-local
+  accumulators — the two sources cannot drift;
+- the disjoint semantics: an ERROR unit counts in `errors`, never in
+  `completed`;
+- a generation failure is counted (errors: 1, completed: 0) and its
+  buckets sum to total_units;
+- the retry behaviour is unchanged (ERROR checkpoints are still retried
+  on resume — the defect was in the counters, not the retry).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.dynamic_tester import _summary_counts_from_checkpoints  # noqa: E402
+
+
+def _cp(status, **extra):
+    d = {"status": status}
+    d.update(extra)
+    return d
+
+
+def test_generation_failure_counts_as_error():
+    """The issue's observed shape pinned: one ERROR unit file → errors: 1,
+    completed: 0 (disjoint — not the loop's subset semantics)."""
+    counts = _summary_counts_from_checkpoints({
+        "f1": _cp("ERROR", details="Test generation failed — LLM did not return valid test code"),
+    })
+    assert counts == {"completed": 0, "errors": 1}
+
+
+def test_mixed_statuses_disjoint():
+    counts = _summary_counts_from_checkpoints({
+        "f1": _cp("CONFIRMED"),
+        "f2": _cp("ERROR"),
+        "f3": _cp("INCONCLUSIVE"),
+    })
+    assert counts == {"completed": 2, "errors": 1}
+
+
+def test_empty_and_absent():
+    assert _summary_counts_from_checkpoints({}) == {"completed": 0, "errors": 0}
+    assert _summary_counts_from_checkpoints(None) == {"completed": 0, "errors": 0}
+
+
+def test_summary_json_consistent_with_unit_files(tmp_path, monkeypatch):
+    """Drive the real loop with a failing generator: the written
+    _summary.json reports the failure and its buckets sum to total."""
+    import utilities.dynamic_tester as dt
+
+    # a pipeline_output with one dynamic-testable finding
+    findings_path = tmp_path / "pipeline_output.json"
+    findings_path.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [{
+            "id": "f1", "name": "X", "short_name": "x", "location": "a.py:1",
+            "cwe_id": 79, "stage2_verdict": "confirmed",
+            "vulnerable_code": "eval(x)", "attack_vector": "a",
+            "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f",
+        }],
+    }))
+    cp_dir = tmp_path / "cp"
+
+    # a fake registry so no LLM probe runs
+    from utilities.llm import PhaseBinding
+
+    class _NoopAdapter:
+        name = "anthropic"
+        supports_tools = True
+        def complete(self, **kwargs):  # pragma: no cover - mocked away
+            raise AssertionError("should not reach the adapter")
+        def validate(self, model):
+            pass
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_NoopAdapter(),
+                                model="m", provider_name="anthropic")
+
+    # generation failure — the branch under test
+    monkeypatch.setattr(dt, "generate_test", lambda *a, **k: None)
+    monkeypatch.setattr(dt, "generate_report", lambda *a, **k: "# report")
+
+    dt.run_dynamic_tests(
+        pipeline_output_path=str(findings_path),
+        output_dir=str(tmp_path / "out"),
+        checkpoint_path=str(cp_dir),
+        registry=_FakeRegistry(),
+    )
+
+    summary = json.loads((cp_dir / "_summary.json").read_text())
+    assert summary["errors"] == 1, summary
+    assert summary["completed"] == 0, summary
+    assert summary["completed"] + summary["errors"] == summary["total_units"]
+    # the unit file itself (the identification argument from the issue)
+    unit_files = [f for f in cp_dir.glob("*.json") if f.name != "_summary.json"]
+    assert len(unit_files) == 1
+    unit = json.loads(unit_files[0].read_text())
+    assert unit["status"] == "ERROR"
+    assert "generation failed" in unit.get("details", "").lower()
+
+
+def test_error_checkpoints_still_retried(tmp_path):
+    """The retry contract is unchanged: an ERROR checkpoint is NOT
+    'already done' — it lands in the retry set, not the restore set."""
+    import utilities.dynamic_tester as dt
+
+    cp_dir = tmp_path / "cp"
+    cp_dir.mkdir()
+    (cp_dir / "f1.json").write_text(json.dumps(
+        _cp("ERROR", details="Test generation failed")))
+    (cp_dir / "f2.json").write_text(json.dumps(_cp("CONFIRMED")))
+
+    # replicate the loop's restore classification (the lines under test)
+    checkpointed = {fid: json.loads((cp_dir / f"{fid}.json").read_text())
+                    for fid in ("f1", "f2")}
+    successful_ids = {fid for fid, cp in checkpointed.items()
+                      if cp.get("status") != "ERROR"}
+    errored_ids = {fid for fid in checkpointed.keys()
+                   if fid not in successful_ids}
+    assert successful_ids == {"f2"}
+    assert errored_ids == {"f1"}

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -53,6 +53,31 @@ def should_skip_for_language(file_path: str, scan_language: str | None) -> tuple
         "skipped instead of generating an untemplated test"
     )
 
+def _summary_counts_from_checkpoints(checkpointed) -> dict:
+    """#311: derive write_summary's counts from the SAVED UNIT FILES.
+
+    The loop previously accumulated `_completed`/`_errors` locally, which
+    (a) bypassed the generation-failure `continue` — an errored run wrote
+    `errors: 0` — and (b) counted errors as a SUBSET of completed while
+    `StepCheckpoint.status()` recomputes them as DISJOINT, so the two
+    sources disagreed even without the bypass. Deriving from the same
+    source `status()` reads makes the two structurally incapable of
+    drifting. The retry contract is unchanged: an ERROR checkpoint is
+    still classified not-done and retried on resume.
+    """
+    if not checkpointed:
+        return {"completed": 0, "errors": 1 if checkpointed is False else 0}
+    completed = errors = 0
+    for cp in checkpointed.values():
+        if not isinstance(cp, dict):
+            continue
+        if cp.get("status") == "ERROR":
+            errors += 1
+        else:
+            completed += 1
+    return {"completed": completed, "errors": errors}
+
+
 def run_dynamic_tests(
     pipeline_output_path: str,
     output_dir: str | None = None,
@@ -168,10 +193,14 @@ def run_dynamic_tests(
     total = len(findings)
     restored = len(successful_ids)
     remaining = total - restored
-    _completed = restored
-    _errors = 0
 
-    # Write initial summary so Go CLI can show accurate counts
+    # Write initial summary so Go CLI can show accurate counts.
+    # #311: DERIVED from the saved unit files (the same source status()
+    # recomputes from) — not loop-local accumulators, which bypassed the
+    # generation-failure path and wrote errors: 0 for errored runs.
+    _counts = _summary_counts_from_checkpoints(checkpointed)
+    _completed = _counts["completed"]
+    _errors = _counts["errors"]
     checkpoint.ensure_dir()
     checkpoint.write_summary(total, _completed, _errors, {}, phase="in_progress")
 
@@ -253,6 +282,14 @@ def run_dynamic_tests(
             results.append(result)
             if checkpoint:
                 checkpoint.save(finding_id, result.to_dict())
+                # #311: the saved ERROR unit file IS the count — derive the
+                # summary from the unit files so this branch can no longer
+                # write errors: 0 for an errored run.
+                _counts = _summary_counts_from_checkpoints(checkpoint.load())
+                _completed = _counts["completed"]
+                _errors = _counts["errors"]
+                checkpoint.write_summary(total, _completed, _errors, {},
+                                         phase="in_progress")
             continue
 
         print(f"  Generated (${generation_cost:.4f}). Running in Docker...",
@@ -330,12 +367,14 @@ def run_dynamic_tests(
         result.generation_output_tokens = unit_usage["output_tokens"]
         results.append(result)
 
-        # Save checkpoint and update summary after each finding
+        # Save checkpoint and update summary after each finding.
+        # #311: the counts are re-derived from the saved unit files (the
+        # checkpoint was just saved, so the derivation includes it).
         if checkpoint:
             checkpoint.save(finding_id, result.to_dict())
-            _completed += 1
-            if result.status == "ERROR":
-                _errors += 1
+            _counts = _summary_counts_from_checkpoints(checkpoint.load())
+            _completed = _counts["completed"]
+            _errors = _counts["errors"]
             checkpoint.write_summary(total, _completed, _errors, {}, phase="in_progress")
 
         print(f"  Result: {result.status} ({result.elapsed_seconds:.1f}s)",
@@ -368,6 +407,10 @@ def run_dynamic_tests(
     # Mark done. Checkpoints are preserved as a permanent artifact alongside
     # results — allows retroactive retry of errored findings after fixes.
     if checkpoint:
-        checkpoint.write_summary(total, _completed, _errors, {}, phase="done")
+        # #311: the final summary derives from the unit files too — the
+        # authoritative record, structurally identical to status().
+        _counts = _summary_counts_from_checkpoints(checkpoint.load())
+        checkpoint.write_summary(total, _counts["completed"],
+                                 _counts["errors"], {}, phase="done")
 
     return results


### PR DESCRIPTION
## Summary

When dynamic-test generation failed for a finding, the loop recorded a result, saved a checkpoint, and `continue`d — **bypassing the only `_completed`/`_errors` increment site**. The phase's `_summary.json` therefore reported `errors: 0` for a run that errored, and its buckets did not sum to its own total (the issue's observed shape: `completed: 0, errors: 0` beside one unit file with `status: "ERROR"` — internally inconsistent regardless of any consumer). On the `DetectFallback` path (used when the Python `checkpoint-status` invocation fails) an errored run presented to the operator as a clean one: `Phase()` keys on the summary's `Errors` and returned `"done"` rather than `"done_with_errors"`.

Two further defects on the same counters: the loop counted errors as a **subset** of completed while `StepCheckpoint.status()` recomputes them as **disjoint** — so even with the increment added the two sources disagreed; and the loop-local accumulators could drift from the unit files at every save site.

Fix (the issue's suggestion 1 — the structural one): `_summary_counts_from_checkpoints` derives the counts from the **saved unit files** (the same source `status()` recomputes from), used at **all four** `write_summary` sites (initial, per-unit, generation-failure, final). The two sources are now structurally incapable of drifting, the semantics are disjoint by construction, and the generation-failure branch — whose saved ERROR unit file *is* the count — can no longer write `errors: 0`. The retry contract is unchanged: ERROR checkpoints are still classified not-done and retried on resume (the issue is explicit: the defect was in the counters, not in retry behaviour — pinned by a test).

## Test plan

5 hermetic tests: the issue's observed shape pinned (one ERROR unit file → `errors: 1, completed: 0`, disjoint); mixed statuses; empty/absent; the real loop driven with a failing generator (the written `_summary.json` reports the failure, buckets sum to `total_units`, the unit file carries the generation-failure identification string); the retry contract (ERROR → the retry set, CONFIRMED → the restore set).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/test_issue311_dynamic_test_counters.py -q` | 5 passed (1 failed RED on pristine) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3338 passed, 0 failed**, 32 skipped |
| mutation smoke | stashed → new file | errors (helper import); restored → 5 passed |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 5 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #311
