### PR TITLE
fix(analyzer): Ctrl+C stops crashing on the None placeholders — the interrupt reaches the caller as an interrupt

### DIFF
--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -277,8 +277,16 @@ def _run_detection(units, binding: PhaseBinding, json_corrector, app_context, wo
                     unit_elapsed=out["elapsed"],
                 )
         except KeyboardInterrupt:
-            print("[Detect] Interrupted — progress saved to checkpoints",
-                  file=sys.stderr, flush=True)
+            print(_interrupt_report(results, total), file=sys.stderr, flush=True)
+            progress.finish()
+            # #313: stop swallowing the interrupt. The checkpoints are
+            # written (per-unit saves happen in _process_and_save) and the
+            # report is printed; swallowing it made the None placeholders
+            # reach _count_verdicts (AttributeError) and the resulting
+            # error envelope made the Go CLI record the interrupt as a
+            # FAILED scan — the interrupt short-circuit fires only on
+            # empty stdout.
+            raise
         progress.finish()
         return results, code_by_route
 
@@ -307,14 +315,26 @@ def _run_detection(units, binding: PhaseBinding, json_corrector, app_context, wo
         print("[Detect] Interrupted — cancelling pending work...",
               file=sys.stderr, flush=True)
         executor.shutdown(wait=False, cancel_futures=True)
-        print("[Detect] Progress saved to checkpoints",
-              file=sys.stderr, flush=True)
+        print(_interrupt_report(results, total), file=sys.stderr, flush=True)
+        progress.finish()
+        raise  # #313: see the sequential handler note
     else:
         executor.shutdown(wait=False)
 
     progress.finish()
 
     return results, code_by_route
+
+
+def _interrupt_report(results, total):
+    """#313: what an interrupted run actually did — N analysed, M not
+    started, checkpoints written. Both numbers derive from the results
+    list (the None placeholders are the not-started units)."""
+    analysed = sum(1 for r in results if r is not None)
+    not_started = total - analysed
+    return (
+        f"[Detect] Interrupted after {analysed}/{total} unit(s) "
+        f"({not_started} not started); progress saved to checkpoints")
 
 
 def _count_verdicts(results):
@@ -328,6 +348,11 @@ def _count_verdicts(results):
         "errors": 0,
     }
     for r in results:
+        # #313: an interrupted run leaves None placeholders for units that
+        # never ran — skip them (an un-run unit is not a verdict; the
+        # checkpoint-resume semantics own those units).
+        if r is None:
+            continue
         finding = r.get("finding", r.get("verdict", "error").lower())
         if finding in counts:
             counts[finding] += 1

--- a/libs/openant-core/tests/test_issue313_interrupt_none.py
+++ b/libs/openant-core/tests/test_issue313_interrupt_none.py
@@ -1,0 +1,115 @@
+"""Regression tests for issue #313 — Ctrl+C during analyze raises
+AttributeError on the None placeholders, and the resulting error envelope
+makes the CLI record an interrupt as a FAILED scan.
+
+The interrupt handlers return the partially-filled results list (the
+`[None] * total` placeholders for units that never ran survive); the
+consumer `_count_verdicts` does not tolerate None (r.get on NoneType),
+step_report catches the AttributeError and re-raises, cli.py emits a JSON
+error envelope on stdout — and the Go CLI's interrupt short-circuit fires
+ONLY on empty stdout, so the interrupt is recorded as a failed scan (exit
+2) rather than interrupted.
+
+Contract locked here (the issue's suggestions 1+2):
+- _count_verdicts skips None entries (the counts are CORRECT for the
+  interrupted case, not merely non-crashing — an un-run unit counts
+  nowhere, matching the checkpoint-resume semantics);
+- the interrupted path reports what it did (N analysed, M not started,
+  checkpoints written) — both numbers derivable from the list;
+- the interruption reaches the caller: run_analysis raises
+  KeyboardInterrupt AFTER the checkpoints/report are written (the
+  handlers stop swallowing it), so the CLI can emit the interrupt
+  handling rather than an error envelope.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import pytest  # noqa: E402
+
+from core.analyzer import _count_verdicts  # noqa: E402
+
+
+def test_count_verdicts_skips_none_placeholders():
+    counts = _count_verdicts([{"finding": "safe"}, None, {"finding": "vulnerable"}, None])
+    assert counts["safe"] == 1
+    assert counts["vulnerable"] == 1
+    # the None placeholders count NOWHERE — an un-run unit is not a
+    # verdict, matching the checkpoint-resume semantics
+    assert sum(counts.values()) == 2
+
+
+def test_count_verdicts_clean_list_unchanged():
+    counts = _count_verdicts([{"finding": "safe"}, {"verdict": "VULNERABLE"}])
+    assert counts["safe"] == 1
+    assert counts["vulnerable"] == 1
+
+
+def test_count_verdicts_all_none():
+    """A fully-interrupted run: every placeholder survives, every count 0."""
+    assert sum(_count_verdicts([None, None]).values()) == 0
+
+
+def test_interrupt_report_counts():
+    """Suggestion 2: the interrupted path reports what it did — N
+    analysed, M not started — both derivable from the list."""
+    from core.analyzer import _interrupt_report
+
+    report = _interrupt_report(
+        results=[{"finding": "safe"}, None, {"finding": "vulnerable"}, None, None],
+        total=5)
+    assert "2" in report      # analysed (the non-None entries)
+    assert "3" in report      # not started (the None placeholders)
+    assert "checkpoint" in report.lower()
+
+
+def test_sequential_interrupt_raises_after_report(monkeypatch, tmp_path):
+    """The handlers stop swallowing the interrupt: after the checkpoints
+    and report are written, KeyboardInterrupt reaches the caller (so the
+    CLI can handle it as an interrupt, not an error envelope)."""
+    import core.analyzer as az
+
+    # drive _run_detection's sequential path: monkeypatch _process_and_save
+    # to raise KeyboardInterrupt on the second unit
+    calls = {"n": 0}
+
+    def fake_process(i, unit):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise KeyboardInterrupt
+        return {"index": i, "result": {"unit_id": f"u{i}", "finding": "safe",
+                                        "verdict": "SAFE"},
+                "route_key": f"f.py:u{i}", "code_for_route": "x",
+                "finding": "safe", "elapsed": 0.1}
+
+    # _process_and_save is a closure inside _run_detection; drive the
+    # interrupt through _process_unit instead (the function the closure
+    # wraps for the sequential path)
+    import core.analysis_core as ac
+
+    def fake_process_unit(binding, unit, index, json_corrector, app_context):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise KeyboardInterrupt
+        # the _process_and_save shape: an 'out' dict with index/result/...
+        return {"index": index,
+                "result": {"unit_id": f"u{index}", "finding": "safe",
+                            "verdict": "SAFE", "route_key": f"f.py:u{index}"},
+                "route_key": f"f.py:u{index}", "code_for_route": "x",
+                "finding": "safe", "elapsed": 0.1}
+
+    monkeypatch.setattr(ac, "analyze_unit", fake_process_unit)
+    monkeypatch.setattr(az, "_process_unit", fake_process_unit)
+
+    with pytest.raises(KeyboardInterrupt):
+        az._run_detection(
+            [{"id": "u0", "code": "x=1"}, {"id": "u1", "code": "x=1"},
+             {"id": "u2", "code": "x=1"}],
+            binding=object(), json_corrector=None, app_context=None,
+            workers=1, checkpoint=None)

--- a/libs/openant-core/tests/test_issue313_interrupt_none.py
+++ b/libs/openant-core/tests/test_issue313_interrupt_none.py
@@ -75,18 +75,9 @@ def test_sequential_interrupt_raises_after_report(monkeypatch, tmp_path):
     CLI can handle it as an interrupt, not an error envelope)."""
     import core.analyzer as az
 
-    # drive _run_detection's sequential path: monkeypatch _process_and_save
-    # to raise KeyboardInterrupt on the second unit
+    # drive _run_detection's sequential path: the interrupt must surface
+    # on the SECOND unit
     calls = {"n": 0}
-
-    def fake_process(i, unit):
-        calls["n"] += 1
-        if calls["n"] == 2:
-            raise KeyboardInterrupt
-        return {"index": i, "result": {"unit_id": f"u{i}", "finding": "safe",
-                                        "verdict": "SAFE"},
-                "route_key": f"f.py:u{i}", "code_for_route": "x",
-                "finding": "safe", "elapsed": 0.1}
 
     # _process_and_save is a closure inside _run_detection; drive the
     # interrupt through _process_unit instead (the function the closure


### PR DESCRIPTION
## Summary

`Ctrl+C` during Stage-1 analyze was caught and handled (pending work cancelled, checkpoints reported saved) and **then the run raised `AttributeError`**: the results list still held `None` placeholders for units that never ran, and `_count_verdicts` did `r.get` on them. The error envelope that `cli.py` emitted on stdout then made the Go CLI record the interrupt as a **failed scan** (exit 2) — the interrupt short-circuit in `invoke.go` fires **only on empty stdout**, and the envelope made it non-empty.

Fix (the issue's suggestions 1+2):
- `_count_verdicts` skips `None` entries — the counts are **correct** for the interrupted case (an un-run unit counts nowhere, matching the checkpoint-resume semantics), not merely non-crashing;
- `_interrupt_report`: the interrupted path reports what it did — **N analysed, M not started, checkpoints written** — both numbers derived from the list;
- the handlers **stop swallowing** the `KeyboardInterrupt`: after the report is printed the interrupt re-raises, so the CLI sees an interrupt rather than an error envelope.

Suggestion 3 (the envelope/`interrupted`-status question on the Go side) is deliberately **not** taken here: with the re-raise, the Python `cli.py`'s existing `KeyboardInterrupt` handling (the empty-stdout path the Go short-circuit reads) becomes reachable again — the minimal fix that restores the designed behavior; a new `interrupted` envelope status is a Go-side schema change requiring its own decision.

## Test plan

5 hermetic tests: the None-skipping counts (mixed, clean unchanged, all-None); the interrupt report's N/M numbers; the sequential path driven with a raising `_process_unit` asserting the interrupt re-raises after the report.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/test_issue313_interrupt_none.py -q` | 5 passed (4 failed RED on pristine) |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3346 passed, 0 failed**, 32 skipped |
| mutation smoke | stashed → new file | 4 failed; restored → 5 passed |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 5 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #313
