### PR TITLE
fix(cli): when the invoke deadline fires, the error says so — not the cryptic pipe error (#161)

### DIFF
--- a/apps/openant-cli/internal/python/invoke.go
+++ b/apps/openant-cli/internal/python/invoke.go
@@ -219,7 +219,15 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 			exitCode = ee.ExitCode()
 			// #161: a deadline kill can surface here first (the race
 			// with the pipe-close path above) — the same diagnosis.
-			if ctx.Err() == context.DeadlineExceeded {
+			// Review finding: gate on the KILL ITSELF (ExitCode < 0, a
+			// signal death), not ctx.Err() alone. A child that finished
+			// legitimately with exit 1 ("vulnerabilities found") in the
+			// window just before the deadline hit must keep its envelope —
+			// the #313 principle: a fully-parsed envelope MUST win over a
+			// late/expired context. ctx.Err() == DeadlineExceeded alone
+			// misdiagnosed that natural finish as a kill and discarded a
+			// complete scan result.
+			if ctx.Err() == context.DeadlineExceeded && exitCode < 0 {
 				return nil, fmt.Errorf(
 					"openant: the invoke deadline fired after %v — the phase "+
 						"was killed mid-run. Completed units are checkpointed "+

--- a/apps/openant-cli/internal/python/invoke.go
+++ b/apps/openant-cli/internal/python/invoke.go
@@ -186,6 +186,25 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 	var stdoutBuf strings.Builder
 	if _, err := io.Copy(&stdoutBuf, stdout); err != nil {
 		_ = cmd.Wait() // reap the child even on read error so it isn't leaked
+		// #161 (jblu42): when the deadline fired, the watchdog's close of
+		// the read-ends surfaces as the cryptic "read |0: file already
+		// closed" — the exact error the reporter hit against a local
+		// Ollama model (~1 min/unit; the 30m deadline fires after ~20-40
+		// entries, killing the enhance phase and discarding its output).
+		// Name the cause and both recovery paths instead. The gate is
+		// ctx.Err() == DeadlineExceeded — never error text/type — so every
+		// surface of the kill (pipe close, ExitError, a descendant-held
+		// pipe tripping WaitDelay) converges on the same diagnosis.
+		if ctx.Err() == context.DeadlineExceeded {
+			return nil, fmt.Errorf(
+				"openant: the invoke deadline fired after %v — the phase "+
+					"was killed mid-run and its output discarded. Completed "+
+					"units are checkpointed (a re-run resumes from them); to "+
+					"finish a long run outright, raise the budget via "+
+					"OPENANT_INVOKE_TIMEOUT (e.g. OPENANT_INVOKE_TIMEOUT=2h). "+
+					"Underlying read error: %w",
+				resolveInvokeTimeout(), err)
+		}
 		return nil, fmt.Errorf("failed to read stdout: %w", err)
 	}
 
@@ -198,6 +217,16 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 	if exitErr != nil {
 		if ee, ok := exitErr.(*exec.ExitError); ok {
 			exitCode = ee.ExitCode()
+			// #161: a deadline kill can surface here first (the race
+			// with the pipe-close path above) — the same diagnosis.
+			if ctx.Err() == context.DeadlineExceeded {
+				return nil, fmt.Errorf(
+					"openant: the invoke deadline fired after %v — the phase "+
+						"was killed mid-run. Completed units are checkpointed "+
+						"(a re-run resumes from them); raise the budget via "+
+						"OPENANT_INVOKE_TIMEOUT to finish a long run outright",
+					resolveInvokeTimeout())
+			}
 		} else {
 			return nil, fmt.Errorf("failed waiting for Python process: %w", exitErr)
 		}

--- a/apps/openant-cli/internal/python/invoke_test.go
+++ b/apps/openant-cli/internal/python/invoke_test.go
@@ -1,6 +1,7 @@
 package python
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -245,5 +246,57 @@ func TestInvoke_LateInterruptDoesNotDiscardEnvelope(t *testing.T) {
 	}
 	if got.res.ExitCode != 0 {
 		t.Fatalf("expected normalized exit 0 for clean success, got %d", got.res.ExitCode)
+	}
+}
+
+func TestInvoke_TimeoutErrorNamesTheDeadline(t *testing.T) {
+	// #161 (jblu42, the extra-care protocol): the deadline kill used to
+	// surface as the cryptic "failed to read stdout: read |0: file already
+	// closed" — the exact error the reporter hit against a local Ollama
+	// model (~1 min/unit; the deadline fires after ~20-40 entries). The
+	// surfaced error must carry the DIAGNOSIS: the deadline, the env
+	// override (#237's surface — regression-tested by driving it here, not
+	// a test hook), and the checkpoint-resume path.
+	// C1 (fable need-check): assert diagnosis-PRESENCE, not the racy
+	// literal string — which error surfaces first post-kill is a race.
+	hang, _ := writeHangScript(t)
+	// C2: shrink the deadline via the PUBLIC override — no test hooks.
+	t.Setenv("OPENANT_INVOKE_TIMEOUT", "1") // 1 second
+
+	_, err := Invoke(hang, []string{"parse", "."}, "", true, "")
+	if err == nil {
+		t.Fatalf("expected the deadline to fire on a hung subprocess")
+	}
+	msg := err.Error()
+	for _, want := range []string{"invoke deadline", "OPENANT_INVOKE_TIMEOUT", "checkpoint"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("the timeout error must name %q; got: %s", want, msg)
+		}
+	}
+	// C5.6: the effective deadline (the override's 1s) must appear —
+	// confirms to an override user that their setting took effect.
+	if !strings.Contains(msg, "1s") {
+		t.Errorf("the error must show the effective deadline value; got: %s", msg)
+	}
+}
+
+func TestInvoke_NonDeadlineDeathDoesNotClaimADeadline(t *testing.T) {
+	// C4 (the negative control): a subprocess death WITHOUT the deadline
+	// expired must NOT be mis-diagnosed as a timeout — a false "you hit
+	// the deadline" is worse than no diagnosis. Also pins the #313
+	// interaction: a non-timeout death keeps its own semantics.
+	dir := t.TempDir()
+	script := filepath.Join(dir, "failer.py")
+	if err := os.WriteFile(script, []byte("import sys; sys.exit(3)\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENANT_INVOKE_TIMEOUT", "600") // far beyond this test's run
+
+	_, err := Invoke("python3", []string{"-c", fmt.Sprintf(
+		"import runpy,sys; sys.argv=['failer']; runpy.run_path(%q)", script)}, "", true, "")
+	if err != nil {
+		if strings.Contains(err.Error(), "invoke deadline") {
+			t.Errorf("a non-deadline death must not claim a deadline; got: %s", err)
+		}
 	}
 }


### PR DESCRIPTION
Refs #161 (reporter: @jblu42) — the extra-care protocol applies: the issue stays OPEN for your confirmation; not closed on submit.

## Summary

@jblu42 hit exactly this against a local Ollama model (Quen3.5 via the OpenAI-compatible endpoint): enhance runs ~1 min/unit, the 30-minute invoke deadline fires after ~20-40 entries, the watchdog kills the Python process and closes the pipes — and the operator sees:

```
Error: failed to read stdout: read |0: file already closed
```

with nothing naming the deadline, the `OPENANT_INVOKE_TIMEOUT` override (PR #237's mitigation, merged 2026-08-14), or the checkpoint-resume path. The reporter's own follow-up diagnosed the mechanism correctly (elapsed-time, not entry-count — the failure point tracks exactly 30 minutes). That diagnosis was right, and this fix makes the error say so at the point of failure.

**The fix:** when `ctx.Err() == DeadlineExceeded` on the stdout-read error path AND the ExitError wait path (which surface races), the error message names the invoke deadline with its **effective value**, the `OPENANT_INVOKE_TIMEOUT` override, and the checkpoint-resume path. The gate is `ctx.Err() == DeadlineExceeded` — never error text/type — so every surface of the kill (pipe close, ExitError, a descendant-held pipe tripping WaitDelay) converges on the same diagnosis, and a non-deadline death (user interrupt per #313, a crash) is never mis-diagnosed as a timeout (the negative control pins this).

**Sibling sweep** (the need-check's C5, all resolved): the stderr copier swallows read errors (no sibling error surfaces); the WaitDelay descendant case still hits the ctx-gated stdout path; the server-side `InvokeCtx` paths use their own cancellation semantics (no 30m deadline, no #161 class); exit-code consumers read the ExitCode field, not the message; the checkpoint-resume hint is true for every stage that can realistically hit the deadline (parse/analyze/enhance/verify/dynamic-test all checkpoint); the effective value in the message confirms an override took effect.

**The experimentation gate** (the extra-care protocol's §4.3): a live Ollama reproduction is infeasible in this environment (no local Ollama) — substituted per the need-check ruling with a REAL hung subprocess through the REAL watchdog, shrunk via the PUBLIC `OPENANT_INVOKE_TIMEOUT` env override (which regression-tests #237's surface in the same run), asserting diagnosis-PRESENCE (the deadline + the override + the resume hint) rather than the racy literal string, plus the negative control: a non-deadline death never claims a deadline.

The default-deadline redesign was deliberately NOT attempted — that is a maintainer design decision (the override + checkpoints are the operational answer for slow local models).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `go test ./internal/python/ -run 'TestInvoke' -count=1 -v` | all PASS (incl. the 2 new: the deadline names its cause + the negative control) |
| Go all packages | `go test ./... -count=1` | all ok |
| hygiene | `go vet ./internal/python/` + `gofmt` | clean |
| Python side | `PYTHONPATH=<core> pytest tests/ -q` (untouched) | 3340 passed, 0 failed |

</details>

Refs #161