### PR TITLE
fix(cli): extract _excluded_languages_for_report — the #305 test de-faked (campaign self-audit)

### DIFF
--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -58,6 +58,24 @@ def _unit_start_line(unit: dict) -> int:
     return start_line
 
 
+def _excluded_languages_for_report(summary: dict) -> list[str]:
+    """#305 (wave catch BLOCKER 1+2): the scan summary's excluded_languages
+    is a {lang: reason} DICT everywhere in Python — the Go consumer
+    unmarshals []string, so an unconverted dict would break the JSON
+    unmarshal outright. Format it as a list; and an operator --languages
+    opt-out ("not requested via --languages") is a legitimate scoping
+    choice, NOT a degradation — only involuntary exclusions reach the
+    report/SARIF."""
+    excl = (summary or {}).get("excluded_languages") or {}
+    if isinstance(excl, dict):
+        return sorted(
+            f"{lang} ({reason})" for lang, reason in excl.items()
+            if "not requested" not in str(reason))
+    if isinstance(excl, list):
+        return [str(x) for x in excl]
+    return []
+
+
 def _step_report_rows(step_reports: list[dict],
                       skip_reasons: dict | None = None) -> list[dict]:
     """Project step reports into the Go consumer's row shape (#305).
@@ -1184,20 +1202,7 @@ Format your response as HTML (use <h3>, <p>, <ul>, <li>, <strong> tags). Do not 
                 if sr.get("step") == "scan":
                     _summary = sr.get("summary", {})
                     _skip_reasons = _summary.get("steps_skipped_reasons", {}) or {}
-                    # wave catches (#305): excluded_languages is a {lang:
-                    # reason} DICT everywhere in Python — the Go consumer
-                    # expects a list, so an unconverted dict would break the
-                    # JSON unmarshal outright. Format it; and an operator
-                    # --languages opt-out ("not requested via --languages")
-                    # is a legitimate scoping choice, NOT a degradation —
-                    # only involuntary exclusions reach the report/SARIF.
-                    _excl = _summary.get("excluded_languages") or {}
-                    if isinstance(_excl, dict):
-                        _excluded_langs = sorted(
-                            f"{lang} ({reason})" for lang, reason in _excl.items()
-                            if "not requested" not in str(reason))
-                    elif isinstance(_excl, list):
-                        _excluded_langs = [str(x) for x in _excl]
+                    _excluded_langs = _excluded_languages_for_report(_summary)
                     break
             step_reports_data = _step_report_rows(_all_steps, _skip_reasons)
 

--- a/libs/openant-core/tests/test_issue305_sarif_invocations.py
+++ b/libs/openant-core/tests/test_issue305_sarif_invocations.py
@@ -123,13 +123,11 @@ def test_excluded_languages_projection_is_a_list_and_filters_optouts():
                            "swift": "no parser for .swift files",
                        }}}, f)
 
-    # replicate the projection's extraction (the inline loop in
-    # cmd_report_data) — the contract: a formatted LIST, opt-outs dropped
-    _excl = _load_step_reports(d)[0]["summary"]["excluded_languages"]
-    _excluded_langs: list = []
-    if isinstance(_excl, dict):
-        _excluded_langs = sorted(
-            f"{lang} ({reason})" for lang, reason in _excl.items()
-            if "not requested" not in str(reason))
-    assert _excluded_langs == ["swift (no parser for .swift files)"]
-    assert isinstance(_excluded_langs, list)  # json.dumps-safe for []string
+    # the REAL helper (the self-audit of this campaign's tests caught this
+    # as a replica-of-inline-code fake: the test used to re-implement the
+    # loop, so a change to the production loop left the test green)
+    from openant.cli import _excluded_languages_for_report
+    summary = _load_step_reports(d)[0]["summary"]
+    excluded = _excluded_languages_for_report(summary)
+    assert excluded == ["swift (no parser for .swift files)"]
+    assert isinstance(excluded, list)  # json.dumps-safe for []string


### PR DESCRIPTION
## Summary

A self-audit of every test file the campaign authored (enumerated exhaustively, not sampled) found one genuine **replica-of-inline-code fake**: test_issue305's excluded-languages test re-implemented the projection loop's extraction inline, so a change to the production loop would have left the test green — the exact class the #305 wave itself caught for `start_line` (fixed then by extracting `_unit_start_line`). Extract `_excluded_languages_for_report` (the same remedy), and the test now drives the REAL helper.

The audit context: this is campaign hygiene from the same campaign that produced PRs #347-#413; the full audit table (26 files, the classification of each source-level test, and the one genuine fake) lives in the campaign workspace.

## Test plan

The 6 existing tests unchanged in contract; the excluded-languages test now drives the real helper instead of a replica.

<details>
<summary>Verification evidence</summary>

| check | command | result |
|---|---|---|
| the file | `pytest tests/test_issue305_sarif_invocations.py -q` | 6 passed |
| full suite | `pytest tests/ -q` | 3340 passed, 0 failed, 32 skipped |
| lint | `ruff check .` | clean |

</details>