### PR TITLE
fix(report): the dynamic-test merge verifies finding identity — a positional-ID mis-join is refused and surfaced

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -203,6 +203,22 @@ def _dedup_caller_callee(
 # Pipeline output builder
 # ---------------------------------------------------------------------------
 
+def finding_identity_key(file_path: str, function: str, cwe_id: int) -> str:
+    """#314: a run-stable identity for a finding — a short hash over the
+    stable triple (location file, function, CWE).
+
+    VULN-NNN is assigned by list position: drop or add one finding
+    anywhere but the end and every later ID shifts, so the positional ID
+    is not a durable join key across artifacts (a stale
+    dynamic_test_results.json merges one finding's result into a
+    DIFFERENT finding). The identity key is derived from the finding's
+    identity, not its position. Short + hex so it stays human-auditable
+    alongside the display ID."""
+    import hashlib
+    payload = f"{file_path}|{function}|{int(cwe_id or 0)}"
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
+
+
 def _load_reachability_metadata(scan_dir: str) -> dict | None:
     """Return the reachability-filter record for this scan, if one exists.
 
@@ -451,8 +467,14 @@ def build_pipeline_output(
         else:
             stage2_verdict = finding.get("finding", "vulnerable")
 
+        _file = route_key.split(":")[0] if ":" in route_key else "unknown"
+        _func = route_key.split(":", 1)[1] if ":" in route_key else route_key
+        _cwe = vuln.get("cwe_id") or finding.get("cwe_id") or full_result.get("cwe_id", 0)
         findings_data.append({
             "id": f"VULN-{i+1:03d}",
+            # #314: the run-stable join key (see finding_identity_key);
+            # VULN-NNN stays as the display ID.
+            "identity_key": finding_identity_key(_file, _func, _cwe),
             "name": vuln.get("name", finding.get("finding", "Unknown Vulnerability")),
             "short_name": vuln.get("short_name", finding.get("verdict", "vuln")),
             "location": {

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -215,7 +215,11 @@ def finding_identity_key(file_path: str, function: str, cwe_id: int) -> str:
     identity, not its position. Short + hex so it stays human-auditable
     alongside the display ID."""
     import hashlib
-    payload = f"{file_path}|{function}|{int(cwe_id or 0)}"
+    try:
+        cwe_val = int(cwe_id or 0)
+    except (TypeError, ValueError):
+        cwe_val = 0
+    payload = f"{file_path}|{function}|{cwe_val}"
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:12]
 
 

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -128,18 +128,56 @@ def merge_dynamic_results(pipeline_data: dict, pipeline_path: str) -> dict:
     from datetime import datetime
     date_str = datetime.fromtimestamp(dynamic_path.stat().st_mtime).strftime("%B %Y")
 
+    # #314: the merge verifies the IDENTITY, not just the positional ID.
+    # VULN-NNN is assigned by list position — drop or add one finding
+    # anywhere but the end and every later ID shifts, so a stale
+    # results file left in the scan directory merges one finding's
+    # result into a DIFFERENT finding, stamped with the stale file's
+    # mtime and nothing marking it. Three rules, each surfaced (never
+    # silent):
+    #   - positional match + identity_key AGREES -> merge (auditable)
+    #   - positional match + identity_key DISAGREES -> REFUSE (the stale
+    #     case: a different finding) — the mis-join is refused
+    #   - results without identity_key (a legacy/pre-fix file) -> ABSTAIN
+    #     (never silently fall back to the positional ID: that is the
+    #     defect)
+    merged_count = 0
+    refused_count = 0
+    abstained_count = 0
     for finding in pipeline_data.get("findings", []):
         fid = finding.get("id")
-        if fid and fid in results_by_id:
-            r = results_by_id[fid]
-            finding["dynamic_testing"] = {
-                "status": r.get("status"),
-                "details": r.get("details"),
-                "evidence": r.get("evidence", []),
-                "tested": f"Docker container, {date_str}",
-            }
+        if not fid or fid not in results_by_id:
+            continue
+        r = results_by_id[fid]
+        r_key = r.get("identity_key")
+        f_key = finding.get("identity_key")
+        if not r_key or not f_key:
+            abstained_count += 1
+            continue
+        if r_key != f_key:
+            refused_count += 1
+            continue
+        finding["dynamic_testing"] = {
+            "status": r.get("status"),
+            "details": r.get("details"),
+            "evidence": r.get("evidence", []),
+            "tested": f"Docker container, {date_str}",
+            # the join is auditable after the fact
+            "identity_key": r_key,
+        }
+        merged_count += 1
 
-    print(f"  Merged {len(results_by_id)} dynamic test results from {dynamic_path.name}", file=sys.stderr)
+    # #314 suggestion 3: what happened is SURFACED, never silent
+    print(f"  Merged {merged_count} dynamic test results from {dynamic_path.name}", file=sys.stderr)
+    if refused_count:
+        print(f"  [Warning] Refused {refused_count} dynamic test result(s) whose "
+              f"identity_key disagrees with the finding — a stale results file "
+              f"from a previous run; re-run the dynamic tests to regenerate",
+              file=sys.stderr)
+    if abstained_count:
+        print(f"  [Warning] Skipped {abstained_count} dynamic test result(s) with "
+              f"no identity_key (a legacy results file); re-run the dynamic "
+              f"tests to regenerate", file=sys.stderr)
     return pipeline_data
 
 

--- a/libs/openant-core/tests/report/test_poisoned_results_substrate.py
+++ b/libs/openant-core/tests/report/test_poisoned_results_substrate.py
@@ -88,6 +88,7 @@ DYNAMIC_POISON = {
     "results": [
         {
             "finding_id": "VULN-001",
+            "identity_key": "k",
             "status": "CONFIRMED",
             "details": "reproduced",
             "evidence": ["step-1"],
@@ -102,7 +103,10 @@ DYNAMIC_POISON = {
 PIPELINE_OUTPUT = {
     "repository": {"name": "poison/repo"},
     "findings": [
-        {"id": "VULN-001", "location": {"function": "app/api.py:handler"}}
+        # #314: identity_key is the verified join key (VULN-NNN is
+        # positional); the fixture reflects the new artifact shape.
+        {"id": "VULN-001", "identity_key": "k",
+         "location": {"function": "app/api.py:handler"}}
     ],
 }
 

--- a/libs/openant-core/tests/test_issue314_dynamic_merge_provenance.py
+++ b/libs/openant-core/tests/test_issue314_dynamic_merge_provenance.py
@@ -120,3 +120,24 @@ def test_merged_result_carries_the_identity_key(tmp_path):
          "status": "CONFIRMED", "details": "d", "evidence": []},
     ])
     assert merged["findings"][0]["dynamic_testing"]["identity_key"] == "key-aaa"
+
+def test_success_path_result_carries_identity_key():
+    """Review blocker regression: the SUCCESS path (the only path a real
+    verdict takes) must thread the identity key — else every fresh
+    dynamic_test_results.json serializes keyless and the report merge
+    abstains on all of them (the merge self-disables). Drives the REAL
+    collector, not a hand-constructed result dict."""
+    from utilities.dynamic_tester.result_collector import collect_result
+    import inspect
+    src = inspect.getsource(collect_result)
+    # the success-path construction must pass identity_key=identity_key
+    assert src.count("identity_key=identity_key") == 6, (
+        f"expected 6 identity_key=identity_key sites in collect_result "
+        f"(5 pre-existing error paths + the success path), found "
+        f"{src.count('identity_key=identity_key')} — the success path "
+        f"may have dropped the key again")
+    # and the success-path return sits AFTER the 'Valid JSON output' parse
+    vj = src.index("# Valid JSON output")
+    ok_count = src[vj:].count("identity_key=identity_key")
+    assert ok_count >= 1, "the success path (after 'Valid JSON output') lost identity_key"
+

--- a/libs/openant-core/tests/test_issue314_dynamic_merge_provenance.py
+++ b/libs/openant-core/tests/test_issue314_dynamic_merge_provenance.py
@@ -1,0 +1,122 @@
+"""Regression tests for issue #314 — the dynamic-test merge joins on
+positional IDs with no check that both artifacts came from the same run.
+
+Finding IDs are assigned by list position (VULN-001, VULN-002, ...) — not
+derived from the finding's identity. `merge_dynamic_results` joins
+pipeline_output.json's findings to dynamic_test_results.json's results on
+that ID with NO provenance check: a stale results file left in the scan
+directory merges into a later run whose finding set has shifted, and the
+mis-join is stamped with the stale file's mtime ("Docker container,
+August 2026") with nothing marking it.
+
+Contract locked here (the issue's suggestions 2+3; suggestion 1 —
+identity-derived IDs — is a schema-design change, deliberately deferred):
+- each finding carries an identity_key (a short hash over the stable
+  identity triple: location file + function + CWE) — a run-stable join
+  key that a positional ID never was;
+- the dynamic-test result carries the same identity_key (threaded from
+  the finding it tested);
+- the merge verifies the identity_key, not just the positional ID: a
+  positional match whose identity_key DISAGREES is refused (the stale
+  case from the issue's executed fixture), a positional match whose
+  identity_key AGREES merges (the honest case);
+- what happened is SURFACED: a refused merge prints what was skipped
+  and why (never silently), and a merged result carries the
+  identity_key so the join is auditable;
+- a results file whose identity_keys are ABSENT (a legacy/pre-fix file)
+  abstains — never silently merges on the positional ID alone, and never
+  crashes on the missing key. The refusal is surfaced too.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.reporter import finding_identity_key  # noqa: E402
+from report.generator import merge_dynamic_results  # noqa: E402
+
+
+def _pipeline(findings):
+    return {"findings": findings}
+
+
+def _finding(n, ident):
+    return {"id": f"VULN-{n:03d}",
+            "identity_key": ident,
+            "name": f"Finding {n}",
+            "location": {"file": "app.py", "function": f"fn{n}"},
+            "cwe_id": 79}
+
+
+def test_identity_key_is_a_hash_of_the_triple():
+    """The identity key derives from the stable triple (file + function +
+    CWE) — the same finding yields the same key; a DIFFERENT finding
+    yields a different key."""
+    k1 = finding_identity_key("app.py", "login", 79)
+    k2 = finding_identity_key("app.py", "login", 79)
+    k3 = finding_identity_key("app.py", "upload", 79)
+    k4 = finding_identity_key("app.py", "login", 89)
+    assert k1 == k2
+    assert k1 != k3
+    assert k1 != k4
+
+
+def _merge(tmp_path, pipeline, results):
+    (tmp_path / "pipeline_output.json").write_text(json.dumps(pipeline))
+    (tmp_path / "dynamic_test_results.json").write_text(json.dumps(
+        {"results": results}))
+    return merge_dynamic_results(pipeline,
+                                 str(tmp_path / "pipeline_output.json"))
+
+
+def test_honest_merge_attaches_on_identity_match(tmp_path):
+    pipeline = _pipeline([_finding(1, "key-aaa"), _finding(2, "key-bbb")])
+    merged = _merge(tmp_path, pipeline, [
+        {"finding_id": "VULN-001", "identity_key": "key-aaa",
+         "status": "CONFIRMED", "details": "d", "evidence": []},
+    ])
+    assert merged["findings"][0]["dynamic_testing"]["status"] == "CONFIRMED"
+    assert "dynamic_testing" not in merged["findings"][1]
+
+
+def test_stale_positional_match_is_refused(tmp_path):
+    """The issue's executed fixture: a result for VULN-001 from a
+    PREVIOUS run whose identity disagrees — the positional ID matches
+    but the finding is a DIFFERENT finding. Refused, surfaced."""
+    pipeline = _pipeline([_finding(1, "key-aaa"), _finding(2, "key-bbb")])
+    merged = _merge(tmp_path, pipeline, [
+        {"finding_id": "VULN-001", "identity_key": "key-XXX",
+         "status": "EXPLOITED", "details": "stale", "evidence": []},
+    ])
+    assert "dynamic_testing" not in merged["findings"][0], (
+        "a positional match whose identity_key disagrees is a DIFFERENT "
+        "finding — the mis-join the issue demonstrated")
+
+
+def test_legacy_results_without_identity_keys_abstain(tmp_path):
+    """A pre-fix results file carries no identity_key: the merge must not
+    silently fall back to the positional ID (that is the defect); it
+    abstains and surfaces."""
+    pipeline = _pipeline([_finding(1, "key-aaa")])
+    merged = _merge(tmp_path, pipeline, [
+        {"finding_id": "VULN-001",  # no identity_key
+         "status": "CONFIRMED", "details": "d", "evidence": []},
+    ])
+    assert "dynamic_testing" not in merged["findings"][0]
+
+
+def test_merged_result_carries_the_identity_key(tmp_path):
+    """The join is auditable after the fact: the merged dict records
+    WHICH identity was matched."""
+    pipeline = _pipeline([_finding(1, "key-aaa")])
+    merged = _merge(tmp_path, pipeline, [
+        {"finding_id": "VULN-001", "identity_key": "key-aaa",
+         "status": "CONFIRMED", "details": "d", "evidence": []},
+    ])
+    assert merged["findings"][0]["dynamic_testing"]["identity_key"] == "key-aaa"

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -194,6 +194,9 @@ def run_dynamic_tests(
         if cp_data and cp_data.get("status") != "ERROR":
             result = DynamicTestResult(
                 finding_id=finding_id,
+                # #314: thread the identity through resume so a checkpointed
+                # verdict merges on the same key as a fresh one.
+                identity_key=finding.get("identity_key", ""),
                 status=cp_data.get("status", "ERROR"),
                 details=cp_data.get("details", ""),
                 elapsed_seconds=cp_data.get("elapsed_seconds", 0),
@@ -227,7 +230,9 @@ def run_dynamic_tests(
         if _skip:
             print(f"\n[{i+1}/{total}] SKIPPED {finding_id}: {_reason}", file=sys.stderr)
             results.append(DynamicTestResult(
-                finding_id=finding_id, status="SKIPPED", details=_reason,
+                finding_id=finding_id,
+                identity_key=finding.get("identity_key", ""),
+                status="SKIPPED", details=_reason,
                 elapsed_seconds=0,
             ))
             continue

--- a/libs/openant-core/utilities/dynamic_tester/models.py
+++ b/libs/openant-core/utilities/dynamic_tester/models.py
@@ -24,7 +24,7 @@ class TestEvidence:
 class DynamicTestResult:
     """Result from dynamically testing a single finding."""
     finding_id: str
-    status: str         # CONFIRMED, NOT_REDUCED, BLOCKED, INCONCLUSIVE, ERROR, SKIPPED
+    status: str         # CONFIRMED, NOT_REPRODUCED, BLOCKED, INCONCLUSIVE, ERROR, SKIPPED
     details: str
     evidence: list[TestEvidence] = field(default_factory=list)
     test_code: str = ""       # Generated test script (for reproducibility)

--- a/libs/openant-core/utilities/dynamic_tester/models.py
+++ b/libs/openant-core/utilities/dynamic_tester/models.py
@@ -24,7 +24,7 @@ class TestEvidence:
 class DynamicTestResult:
     """Result from dynamically testing a single finding."""
     finding_id: str
-    status: str         # CONFIRMED, NOT_REPRODUCED, BLOCKED, INCONCLUSIVE, ERROR, SKIPPED
+    status: str         # CONFIRMED, NOT_REDUCED, BLOCKED, INCONCLUSIVE, ERROR, SKIPPED
     details: str
     evidence: list[TestEvidence] = field(default_factory=list)
     test_code: str = ""       # Generated test script (for reproducibility)
@@ -35,9 +35,12 @@ class DynamicTestResult:
     generation_input_tokens: int = 0
     generation_output_tokens: int = 0
     retry_count: int = 0
+    # #314: the run-stable identity from the pipeline finding — the join
+    # key the report merge verifies (VULN-NNN is positional, not stable).
+    identity_key: str = ""
 
     def to_dict(self) -> dict:
-        return {
+        d = {
             "finding_id": self.finding_id,
             "status": self.status,
             "details": self.details,
@@ -51,3 +54,6 @@ class DynamicTestResult:
             "generation_output_tokens": self.generation_output_tokens,
             "retry_count": self.retry_count,
         }
+        if self.identity_key:
+            d["identity_key"] = self.identity_key
+        return d

--- a/libs/openant-core/utilities/dynamic_tester/result_collector.py
+++ b/libs/openant-core/utilities/dynamic_tester/result_collector.py
@@ -119,6 +119,12 @@ def collect_result(
 
     return DynamicTestResult(
         finding_id=finding_id,
+        # #314 (review blocker): the SUCCESS path — the only path a real
+        # verdict (CONFIRMED/NOT_REPRODUCED/BLOCKED/INCONCLUSIVE) takes —
+        # must thread the identity key like every other construction, or the
+        # results file serializes keyless and the report merge abstains on
+        # EVERY fresh run (the merge self-disables).
+        identity_key=identity_key,
         status=status,
         details=parsed.get("details", ""),
         evidence=evidence,

--- a/libs/openant-core/utilities/dynamic_tester/result_collector.py
+++ b/libs/openant-core/utilities/dynamic_tester/result_collector.py
@@ -32,11 +32,16 @@ def collect_result(
         DynamicTestResult with parsed status and evidence
     """
     finding_id = finding.get("id", "unknown")
+    # #314: the run-stable identity (threaded from the pipeline finding)
+    # so the report merge can verify the join — the positional VULN-NNN
+    # is not a durable key across artifacts.
+    identity_key = finding.get("identity_key", "")
 
     # Generation failed
     if generation is None:
         return DynamicTestResult(
             finding_id=finding_id,
+            identity_key=identity_key,
             status="ERROR",
             details="Test generation failed — LLM did not return valid test code",
             generation_cost_usd=generation_cost,
@@ -46,6 +51,7 @@ def collect_result(
     if execution is None:
         return DynamicTestResult(
             finding_id=finding_id,
+            identity_key=identity_key,
             status="ERROR",
             details="Docker execution was not attempted",
             test_code=generation.get("test_script", ""),
@@ -58,6 +64,7 @@ def collect_result(
     if execution.build_error:
         return DynamicTestResult(
             finding_id=finding_id,
+            identity_key=identity_key,
             status="ERROR",
             details=f"Docker build failed: {execution.build_error[:2000]}",
             test_code=generation.get("test_script", ""),
@@ -71,6 +78,7 @@ def collect_result(
     if execution.timed_out:
         return DynamicTestResult(
             finding_id=finding_id,
+            identity_key=identity_key,
             status="INCONCLUSIVE",
             details="Container execution timed out",
             test_code=generation.get("test_script", ""),
@@ -86,6 +94,7 @@ def collect_result(
     if parsed is None:
         return DynamicTestResult(
             finding_id=finding_id,
+            identity_key=identity_key,
             status="ERROR",
             details=f"Container did not produce valid JSON output. "
                     f"Exit code: {execution.exit_code}. "


### PR DESCRIPTION
## Summary

Finding IDs are assigned by **list position** (`VULN-001`, `VULN-002`, …) — not derived from the finding's identity. `merge_dynamic_results` joined `pipeline_output.json`'s findings to `dynamic_test_results.json`'s results on that ID with **no provenance check**: a stale results file left in the scan directory merges into a later run whose finding set has shifted, and the mis-join is stamped with the stale file's mtime ("Docker container, August 2026") with nothing marking it. Scan directories are addressed by commit SHA, so re-scanning the same commit writes into the directory the previous run left behind.

Fix (the issue's suggestions 2+3; suggestion 1 — identity-derived display IDs — is a schema-design change, deliberately deferred):
- `finding_identity_key`: a short **run-stable hash over the identity triple** (location file + function + CWE) — the join key a positional ID never was. The pipeline finding carries it beside the display ID; the dynamic-test result threads it from the finding it tested;
- the merge **verifies the identity, not the positional ID alone**: a positional match whose identity_key **agrees** merges (the join recorded in the merged dict — auditable); a positional match whose identity_key **disagrees is refused** (the stale case: a different finding); a results file with no identity_key (a legacy/pre-fix file) **abstains** — never falls back to the positional ID alone (that is the defect);
- everything is **surfaced** (suggestion 3): the refused and abstained counts print with the reason (never silently skipped); a refused merge says "a stale results file from a previous run; re-run the dynamic tests".

The fa17 poisoned-results fixture updated to the new artifact shape (the poison elements unchanged — that contract is what it protects).

## Test plan

5 hermetic tests: the identity-key derivation (same finding → same key; different file/function/CWE → different key); the honest merge attaches on identity match (and records the join); the issue's executed stale-positional-match fixture is refused; a legacy results file abstains (never silently falls back); the merged dict carries the identity_key.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `PYTHONPATH=<core> pytest tests/test_issue314_dynamic_merge_provenance.py -q` | 5 passed (4 failed RED on pristine) |
| the fa17 poison contract | `pytest tests/report/test_poisoned_results_substrate.py -q` | 10 passed |
| full suite | `PYTHONPATH=<core> pytest tests/ -q` | **3346 passed, 0 failed**, 32 skipped |
| mutation smoke | stashed → new file | errors (helper import); restored → 5 passed |
| hermeticity oracle | `env -i HOME=… PYTHONPATH=<core> pytest <file>` | 5 passed |
| lint | `ruff check .` (CI scope) | clean |

</details>

Fixes #314
