### PR TITLE
fix(enhance): SIGINT during enhance propagates as an interrupt — not a silent swallow

### DIFF
--- a/libs/openant-core/tests/test_issue417_enhance_interrupt.py
+++ b/libs/openant-core/tests/test_issue417_enhance_interrupt.py
@@ -1,0 +1,121 @@
+"""Regression tests for issue #417 — SIGINT during enhance is silently
+swallowed today: all four KeyboardInterrupt handlers in
+utilities/context_enhancer.py catch, log, and ``return dataset``, so the
+pipeline continues (analyze → verify → report) and the Go layer never sees
+an interrupt (empty-stdout short-circuit never fires → no exit 130).
+
+Issue #313/#411 fixed the ANALYZE stage's identical swallow by re-raising
+after checkpoints; these tests lock the same contract for ENHANCE
+(single-shot and agentic, sequential and parallel): after the interrupt is
+observed and per-unit checkpoints are already on disk, the enhancer RAISES
+KeyboardInterrupt so the caller (the scan pipeline) can surface it as an
+interrupt — not complete the scan as if nothing happened.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+import json
+
+import pytest
+
+
+def _analyzer_output(tmp_path, n: int = 6) -> str:
+    """A minimal analyzer_output.json the agentic path can index."""
+    p = tmp_path / "analyzer_output.json"
+    p.write_text(json.dumps({
+        "functions": {f"mod.py:unit_{i}": {"code": f"def unit_{i}(): return {i}\\n", "file_path": "mod.py", "name": f"unit_{i}"} for i in range(n)},
+        "callGraph": {}, "reverseCallGraph": {},
+    }))
+    return str(p)
+
+
+def _dataset(n: int = 6) -> dict:
+    """A minimal dataset with n units — the loop processes dataset['units']."""
+    return {
+        "units": [
+            {"id": f"mod.py:unit_{i}", "name": f"unit_{i}", "code": f"def unit_{i}(): return {i}\n"}
+            for i in range(n)
+        ]
+    }
+
+
+def _stub_binding():
+    class B:
+        phase = "enhance"
+        provider_name = "test"
+        model = "stub-model"
+    return B()
+
+
+def _tracker():
+    from utilities.llm_client import TokenTracker
+    return TokenTracker()
+
+
+def test_agentic_sequential_interrupt_propagates(monkeypatch, tmp_path):
+    """The agentic enhance loop's SEQUENTIAL path must RAISE KeyboardInterrupt
+    after the interrupt — returning the dataset lets the scan continue as if
+    the user never pressed Ctrl+C (issue #417's exact live-run repro)."""
+    import utilities.context_enhancer as ce
+
+    state = {"calls": 0}
+
+    def fake_agent(unit, index, binding, tracker, verbose):
+        state["calls"] += 1
+        if state["calls"] == 2:
+            raise KeyboardInterrupt
+        unit.setdefault("agent_context", {})["security_classification"] = "neutral"
+
+    monkeypatch.setattr(ce, "enhance_unit_with_agent", fake_agent)
+
+    enhancer = ce.ContextEnhancer(_stub_binding(), tracker=_tracker())
+    with pytest.raises(KeyboardInterrupt):
+        enhancer.enhance_dataset_agentic(
+            _dataset(), analyzer_output_path=_analyzer_output(tmp_path), workers=1)
+
+
+def test_agentic_parallel_interrupt_propagates(monkeypatch, tmp_path):
+    """The agentic PARALLEL path carries the same contract: the handler
+    cancels pending futures, then re-raises (never returns the dataset)."""
+    import utilities.context_enhancer as ce
+
+    state = {"calls": 0}
+
+    def fake_agent(unit, index, binding, tracker, verbose):
+        state["calls"] += 1
+        if state["calls"] == 2:
+            raise KeyboardInterrupt
+        unit.setdefault("agent_context", {})["security_classification"] = "neutral"
+
+    monkeypatch.setattr(ce, "enhance_unit_with_agent", fake_agent)
+
+    enhancer = ce.ContextEnhancer(_stub_binding(), tracker=_tracker())
+    with pytest.raises(KeyboardInterrupt):
+        enhancer.enhance_dataset_agentic(
+            _dataset(), analyzer_output_path=_analyzer_output(tmp_path), workers=2)
+
+
+def test_single_shot_interrupt_propagates(monkeypatch):
+    """The single-shot enhance loop (both paths) carries the same contract."""
+    import utilities.context_enhancer as ce
+
+    state = {"calls": 0}
+
+    def fake_enhance_unit(self, unit, all_units):
+        state["calls"] += 1
+        if state["calls"] == 2:
+            raise KeyboardInterrupt
+        unit.setdefault("llm_context", {})["security_classification"] = "neutral"
+
+    monkeypatch.setattr(ce.ContextEnhancer, "enhance_unit", fake_enhance_unit)
+
+    enhancer = ce.ContextEnhancer(_stub_binding(), tracker=_tracker())
+    with pytest.raises(KeyboardInterrupt):
+        enhancer.enhance_dataset(_dataset(), workers=1)

--- a/libs/openant-core/tests/test_issue417_enhance_interrupt.py
+++ b/libs/openant-core/tests/test_issue417_enhance_interrupt.py
@@ -102,8 +102,28 @@ def test_agentic_parallel_interrupt_propagates(monkeypatch, tmp_path):
             _dataset(), analyzer_output_path=_analyzer_output(tmp_path), workers=2)
 
 
+def test_single_shot_parallel_interrupt_propagates(monkeypatch):
+    """The single-shot PARALLEL path (the fourth handler) carries the same
+    contract — after cancelling pending futures, it re-raises."""
+    import utilities.context_enhancer as ce
+
+    state = {"calls": 0}
+
+    def fake_enhance_unit(self, unit, all_units):
+        state["calls"] += 1
+        if state["calls"] == 2:
+            raise KeyboardInterrupt
+        unit.setdefault("llm_context", {})["security_classification"] = "neutral"
+
+    monkeypatch.setattr(ce.ContextEnhancer, "enhance_unit", fake_enhance_unit)
+
+    enhancer = ce.ContextEnhancer(_stub_binding(), tracker=_tracker())
+    with pytest.raises(KeyboardInterrupt):
+        enhancer.enhance_dataset(_dataset(), workers=2)
+
+
 def test_single_shot_interrupt_propagates(monkeypatch):
-    """The single-shot enhance loop (both paths) carries the same contract."""
+    """The single-shot enhance loop's sequential path carries the contract."""
     import utilities.context_enhancer as ce
 
     state = {"calls": 0}

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -493,7 +493,12 @@ class ContextEnhancer:
                         progress_callback(uid, classification, elapsed)
             except KeyboardInterrupt:
                 self._log("warning", "Interrupted — progress saved to checkpoints")
-                return dataset
+                # #417: stop swallowing the interrupt. The per-unit checkpoints
+                # are already on disk and logged; returning the dataset let the
+                # pipeline continue (analyze → verify → report) and the Go layer
+                # never saw an interrupt (empty-stdout short-circuit never
+                # fires → no exit 130) — the analyze stage's #313 fix, mirrored.
+                raise
         else:
             executor = ThreadPoolExecutor(max_workers=workers)
             futures = {executor.submit(_process_one, unit): unit for unit in units_to_process}
@@ -506,7 +511,10 @@ class ContextEnhancer:
                 self._log("warning", "Interrupted — cancelling pending work...")
                 executor.shutdown(wait=False, cancel_futures=True)
                 self._log("info", "Progress saved to checkpoints")
-                return dataset
+                # #417: same contract as the sequential path — after cancelling
+                # pending work and logging the checkpoint state, RE-RAISE so
+                # the interrupt reaches the caller (never complete the scan).
+                raise
             executor.shutdown(wait=False)
 
         # Recompute stats from unit results (thread-safe)
@@ -813,7 +821,12 @@ class ContextEnhancer:
                         progress_callback(uid, classification, elapsed)
             except KeyboardInterrupt:
                 self._log("warning", "Interrupted — progress saved to checkpoints")
-                return dataset
+                # #417: stop swallowing the interrupt. The per-unit checkpoints
+                # are already on disk and logged; returning the dataset let the
+                # pipeline continue (analyze → verify → report) and the Go layer
+                # never saw an interrupt (empty-stdout short-circuit never
+                # fires → no exit 130) — the analyze stage's #313 fix, mirrored.
+                raise
         else:
             # Parallel mode
             executor = ThreadPoolExecutor(max_workers=workers)
@@ -829,7 +842,10 @@ class ContextEnhancer:
                 self._log("warning", "Interrupted — cancelling pending work...")
                 executor.shutdown(wait=False, cancel_futures=True)
                 self._log("info", "Progress saved to checkpoints")
-                return dataset
+                # #417: same contract as the sequential path — after cancelling
+                # pending work and logging the checkpoint state, RE-RAISE so
+                # the interrupt reaches the caller (never complete the scan).
+                raise
             executor.shutdown(wait=False)
 
         # Auto-retry failed units with transient errors (rate limit, connection,


### PR DESCRIPTION
## Summary
All four KeyboardInterrupt handlers in `utilities/context_enhancer.py` caught the interrupt, logged, and `return dataset` — the pipeline continued through analyze → verify → report and the Go layer's empty-stdout interrupt short-circuit never fired (no exit 130). Issue #313 fixed the ANALYZE stage's identical swallow (`core/analyzer.py`); this mirrors it for ENHANCE. Fixes #417.

**Live-run repro:** a directed scan on a security-sandbox corpus sent SIGINT at 80/160 enhance units — the interrupt was fully absorbed; all 160 units processed and the run completed normally. With this fix the handlers re-raise after the checkpoint log, so the interrupt reaches the caller.

## Test plan
3 regression tests (agentic sequential + parallel, single-shot) monkeypatch the enhance worker to raise `KeyboardInterrupt` and assert the enhancer RAISES it (not returns).
- On pristine master: **3 failed** (DID NOT RAISE — the swallow at every site).
- With the fix: **3 passed**; full suite **3218 passed, 0 failed** (no regression — the per-unit error-isolation guard is untouched; KeyboardInterrupt is BaseException and passes the except Exception guards unchanged).