### PR TITLE
fix(runtime): deterministic installs — requirements.txt (the exact CI pins) before the editable install; deps hash covers both files

### DIFF
--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -294,7 +294,16 @@ func depsHash(corePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sum := sha256.Sum256(append([]byte(corePath+"\x00"), pyproject...))
+	// #59: the staleness key covers requirements.txt too — installOpenant
+	// now installs it (the exact CI pins), so a pin change must trigger a
+	// reinstall the same way a pyproject change does. A MISSING file is not
+	// an error (the dev-layout degrade path): hash the corePath+pyproject
+	// alone, matching the old key.
+	reqs, reqsErr := os.ReadFile(filepath.Join(corePath, "requirements.txt"))
+	if reqsErr != nil {
+		reqs = nil // degrade: the dev layout without requirements.txt
+	}
+	sum := sha256.Sum256(append(append([]byte(corePath+"\x00"), pyproject...), reqs...))
 	return hex.EncodeToString(sum[:]), nil
 }
 
@@ -382,11 +391,45 @@ func isOpenantImportable(pythonPath string) bool {
 }
 
 // installOpenant runs `python -m pip install -e <corePath>`.
-func installOpenant(pythonPath, corePath string) error {
+// installOpenantCmds builds the commands installOpenant runs (the test seam).
+func installOpenantCmds(pythonPath, corePath string) []*exec.Cmd {
+	// #59 (ar7casper): end-user installs must be DETERMINISTIC — CI runs
+	// `pip install -r requirements.txt && pip install ".[dev]"`, where
+	// requirements.txt carries the EXACT pins. An end user running `openant
+	// scan` today resolves pyproject.toml's FLOOR pins (>=), pulling whatever
+	// PyPI currently serves — so a user hits anthropic==1.2.1 while CI tested
+	// ==1.2.0, and an upstream SDK change lands on users without ever being
+	// exercised in CI. Mirror CI: requirements.txt first (the exact pins),
+	// then the editable install (which must not upgrade what was pinned — pip
+	// does not downgrade pinned deps unless the pin conflicts, and
+	// pyproject's floors are compatible with the pins by construction).
+	reqs := filepath.Join(corePath, "requirements.txt")
+	cmds := []*exec.Cmd{}
+	if _, err := os.Stat(reqs); err == nil {
+		reqCmd := exec.Command(pythonPath, "-m", "pip", "install", "-r", reqs)
+		reqCmd.Stdout = os.Stderr // pip output goes to stderr so it doesn't pollute JSON stdout
+		reqCmd.Stderr = os.Stderr
+		cmds = append(cmds, reqCmd)
+	}
+	// A dev layout without requirements.txt degrades to the old behavior
+	// (the editable install alone) — the staleness check must not error
+	// every run.
 	cmd := exec.Command(pythonPath, "-m", "pip", "install", "-e", corePath)
 	cmd.Stdout = os.Stderr // pip output goes to stderr so it doesn't pollute JSON stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmds = append(cmds, cmd)
+	return cmds
+}
+
+// installOpenant mirrors CI: requirements.txt (the exact pins) first, then
+// the editable install.
+func installOpenant(pythonPath, corePath string) error {
+	for _, c := range installOpenantCmds(pythonPath, corePath) {
+		if err := c.Run(); err != nil {
+			return fmt.Errorf("pip install failed (%v): %w", c.Args, err)
+		}
+	}
+	return nil
 }
 
 // PipUninstall returns an *exec.Cmd that runs `python -m pip uninstall openant -y`.

--- a/apps/openant-cli/internal/python/runtime_install_test.go
+++ b/apps/openant-cli/internal/python/runtime_install_test.go
@@ -1,0 +1,110 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// #59 (ar7casper, the extra-care protocol): end-user installs must be
+// deterministic — requirements.txt (the exact pins CI uses) is installed
+// first, then the editable install; the deps staleness hash covers BOTH
+// files so a change to either triggers a reinstall.
+// ---------------------------------------------------------------------------
+
+func TestInstallCommandRunsRequirementsThenEditable(t *testing.T) {
+	cmds := installOpenantCmds("python3", t.TempDir())
+	// a temp dir has no requirements.txt — the degrade path is 1 cmd (the old behavior)
+	_ = cmds
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("x==1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmds = installOpenantCmds("python3", dir)
+	if len(cmds) != 2 {
+		t.Fatalf("expected requirements+editable (2 commands), got %d", len(cmds))
+	}
+	reqArgs := cmds[0].Args
+	foundReqs := false
+	for _, a := range reqArgs {
+		if a == "-r" {
+			foundReqs = true
+		}
+	}
+	if !foundReqs {
+		t.Errorf("the FIRST command must install requirements.txt (the exact CI pins); got %v", reqArgs)
+	}
+	foundEditable := false
+	for _, a := range cmds[1].Args {
+		if a == "-e" {
+			foundEditable = true
+		}
+	}
+	if !foundEditable {
+		t.Errorf("the SECOND command must install the editable package; got %v", cmds[1].Args)
+	}
+}
+
+func TestInstallCommandDegradedWithoutRequirements(t *testing.T) {
+	cmds := installOpenantCmds("python3", t.TempDir())
+	if len(cmds) != 1 {
+		t.Fatalf("a dir without requirements.txt degrades to the editable install alone (1 command), got %d", len(cmds))
+	}
+}
+
+func TestDepsHashCoversRequirementsTxt(t *testing.T) {
+	dir := t.TempDir()
+	req := filepath.Join(dir, "requirements.txt")
+	if err := os.WriteFile(req, []byte("anthropic==1.2.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("name='x'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h1, err := depsHash(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(req, []byte("anthropic==1.3.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h2, err := depsHash(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 == h2 {
+		t.Errorf("a requirements.txt change must trigger a reinstall (the hash must cover both files)")
+	}
+}
+
+func TestDepsHashStillCoversCorePath(t *testing.T) {
+	// the pre-existing key: two worktrees with identical files must NOT share one hash
+	a := t.TempDir()
+	b := t.TempDir()
+	for _, d := range []string{a, b} {
+		if err := os.WriteFile(filepath.Join(d, "pyproject.toml"), []byte("name='x'\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "requirements.txt"), []byte("anthropic==1.2.0\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ha, _ := depsHash(a)
+	hb, _ := depsHash(b)
+	if ha == hb {
+		t.Errorf("corePath must stay in the key (the two-worktrees-silent-import hazard)")
+	}
+}
+
+func TestDepsHashMissingRequirementsAbstains(t *testing.T) {
+	// a core dir without requirements.txt (a dev layout that dropped it?):
+	// the staleness check must degrade gracefully, not error every run
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("name='x'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := depsHash(dir); err != nil {
+		t.Errorf("a missing requirements.txt must not error the staleness check (the caller skips on error — an error every run would break installs): %v", err)
+	}
+}


### PR DESCRIPTION
Hi @ar7casper — your analysis was right (the floor-vs-exact divergence is a real reproducibility gap), and this implements your three-part proposal as written.

## Summary

`installOpenant` ran `pip install -e <corePath>`, resolving `pyproject.toml`'s **floor pins** — whatever PyPI currently serves. CI runs `pip install -r requirements.txt` (the **exact pins**). A user running `openant scan` today gets `anthropic==1.2.1` while CI tested `==1.2.0`; three months from now a fresh install could pull an SDK the project never tested — SDK constructor shifts, default-model swaps, response-shape changes landing on users without ever being exercised in CI.

Fix (the issue's proposal, all three parts):
- `installOpenant` installs **requirements.txt first** (the exact CI pins), then the editable install — the mirror of what CI does. The editable pass does not upgrade what was pinned (pyproject's floors are compatible with the pins by construction). A dev layout without requirements.txt **degrades** to the old behavior (the editable install alone);
- `depsHash` covers **both** `pyproject.toml` AND `requirements.txt`: a pin change triggers a reinstall the same way a pyproject change does. The `corePath` key component is preserved (the two-worktrees hazard), and a missing requirements.txt is not an error;
- `installOpenant` extracted into `installOpenantCmds` (the command-builder seam) so the composed install is directly testable.

**Pre-submission experimentation** (the new gate): the real fixed binary driven end-to-end (`openant parse` on a live fixture → units extracted, full artifacts written) against the accumulated merged state — no previous fix's regression tests hurt (the #295/#312/#303 suites green).

## Test plan

5 Go tests: the composed install (requirements first, then editable — the command sequence); the degraded path (no requirements.txt → 1 command); the deps-hash covers requirements.txt (a pin change triggers); corePath still in the key (the two-worktrees hazard preserved); a missing requirements.txt abstains (not an error every run).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `go test ./internal/python/ -run 'TestInstallCommand|TestDepsHash' -count=1 -v` | 5 PASS |
| Go all packages | `go test ./... -count=1` | all ok |
| hygiene | `go vet ./internal/python/` + `gofmt` | clean |
| merged-state Python suite | the full pytest run | 3340/3340 green |
| step-10.5 gate | the real fixed binary `parse` end-to-end | 2 units extracted, full artifacts written |
| hermeticity | the env-scrubbed run | green |

</details>

Fixes #59
