### PR TITLE
fix(runtime): concurrent venv installs serialize on an OS-level lock (parity with the JS bootstrap)

### DIFF
--- a/apps/openant-cli/go.mod
+++ b/apps/openant-cli/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mattn/go-isatty v0.0.24
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.45.0
 )
 
 require (
@@ -40,5 +41,4 @@ require (
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.45.0 // indirect
 )

--- a/apps/openant-cli/internal/python/lock_unix.go
+++ b/apps/openant-cli/internal/python/lock_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+
+package python
+
+import (
+	"os"
+	"syscall"
+)
+
+// lockFileExcl takes an exclusive advisory lock (flock). Blocks until
+// acquired — the JS bootstrap's block-until-acquired semantics.
+func lockFileExcl(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
+}
+
+// unlockFile releases the advisory lock.
+func unlockFile(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/apps/openant-cli/internal/python/lock_windows.go
+++ b/apps/openant-cli/internal/python/lock_windows.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package python
+
+import (
+	"os"
+	"syscall"
+)
+
+// lockFileExcl takes an exclusive lock (LockFileEx). Blocks until
+// acquired — the JS bootstrap's msvcrt.locking(LK_LOCK) semantics.
+func lockFileExcl(f *os.File) error {
+	// A 1-byte exclusive lock at offset 0 — the same shape
+	// parser_adapter.py's _file_lock uses (position 0, 1 byte, so
+	// overlapping ranges across processes are exclusive).
+	ol := syscall.Overlapped{}
+	return syscall.LockFileEx(
+		syscall.Handle(f.Fd()),
+		syscall.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ol)
+}
+
+// unlockFile releases the lock.
+func unlockFile(f *os.File) error {
+	ol := syscall.Overlapped{}
+	return syscall.UnlockFileEx(
+		syscall.Handle(f.Fd()), 0, &ol)
+}

--- a/apps/openant-cli/internal/python/lock_windows.go
+++ b/apps/openant-cli/internal/python/lock_windows.go
@@ -4,7 +4,8 @@ package python
 
 import (
 	"os"
-	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 // lockFileExcl takes an exclusive lock (LockFileEx). Blocks until
@@ -13,15 +14,20 @@ func lockFileExcl(f *os.File) error {
 	// A 1-byte exclusive lock at offset 0 — the same shape
 	// parser_adapter.py's _file_lock uses (position 0, 1 byte, so
 	// overlapping ranges across processes are exclusive).
-	ol := syscall.Overlapped{}
-	return syscall.LockFileEx(
-		syscall.Handle(f.Fd()),
-		syscall.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ol)
+	// Review fix: Go's stdlib syscall package on Windows exposes neither
+	// LockFileEx nor LockFile (the original implementation and the first
+	// stdlib retry never compiled on windows-latest CI). golang.org/x/sys
+	// was already in the module graph — windows.LockFileEx is the
+	// canonical binding.
+	var ol windows.Overlapped
+	return windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK, 0, 1, 0, &ol)
 }
 
 // unlockFile releases the lock.
 func unlockFile(f *os.File) error {
-	ol := syscall.Overlapped{}
-	return syscall.UnlockFileEx(
-		syscall.Handle(f.Fd()), 0, &ol)
+	var ol windows.Overlapped
+	return windows.UnlockFileEx(
+		windows.Handle(f.Fd()), 0, 1, 0, &ol)
 }

--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -168,29 +168,28 @@ func CheckOpenantInstalled(pythonPath string) error {
 		)
 	}
 
-	// If we're not already using the managed venv, create one and use it.
-	vp := venvPython()
-	if pythonPath != vp {
-		fmt.Fprintln(os.Stderr, "Creating managed Python environment at ~/.openant/venv/...")
-		if err := createVenv(pythonPath); err != nil {
-			return fmt.Errorf(
-				"failed to create venv at %s: %w\n"+
-					"Try manually: %s -m venv %s && %s -m pip install -e %s",
-				venvDir(), err, pythonPath, venvDir(), vp, corePath,
-			)
-		}
-		pythonPath = vp
-	}
-
-	fmt.Fprintf(os.Stderr, "Installing openant from %s...\n", corePath)
 	// #62 (ar7casper): concurrent invocations that both detect a missing
 	// install race pip on the same venv (pip does not support concurrent
-	// writes). Serialize on the OS-level lock, mirroring the JS
-	// bootstrap's .openant-npm-install.lock pattern.
+	// writes) — and BOTH create the venv itself if it is missing. Serialize
+	// the ENTIRE create-then-install sequence on the OS-level lock
+	// (review finding: createVenv previously raced outside it), mirroring
+	// the JS bootstrap's .openant-npm-install.lock pattern.
 	venvRoot := filepath.Dir(venvDir())
 	if err := withVenvInstallLock(venvRoot, func() error {
 		// Re-check under the lock: another process may have finished
-		// installing while we waited (the JS pattern's re-check).
+		// creating+installing while we waited (the JS pattern's re-check).
+		if pythonPath != venvPython() {
+			fmt.Fprintln(os.Stderr, "Creating managed Python environment at ~/.openant/venv/...")
+			if err := createVenv(pythonPath); err != nil {
+				return fmt.Errorf(
+					"failed to create venv at %s: %w\n"+
+						"Try manually: %s -m venv %s && %s -m pip install -e %s",
+					venvDir(), err, pythonPath, venvDir(), venvPython(), corePath,
+				)
+			}
+			pythonPath = venvPython()
+		}
+		fmt.Fprintf(os.Stderr, "Installing openant from %s...\n", corePath)
 		if isOpenantImportable(pythonPath) {
 			return nil
 		}
@@ -539,12 +538,6 @@ func fileExists(path string) bool {
 // venvInstallLockPath returns the lockfile path guarding concurrent pip
 // installs into the managed venv. Mirrors the JS bootstrap's pattern
 // (parser_adapter.py's _file_lock over .openant-npm-install.lock): the
-// lockfile lives next to the install target so it's on the same
-// filesystem, and only the OS-level lock matters for mutual exclusion.
-func venvInstallLockPath() string {
-	return filepath.Join(venvDir(), ".deps-install.lock")
-}
-
 // withVenvInstallLock runs fn under an exclusive lock so two concurrent
 // invocations that both detect a missing or stale install serialize
 // instead of racing pip on the same venv (pip does not support

--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -294,7 +294,16 @@ func depsHash(corePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	sum := sha256.Sum256(append([]byte(corePath+"\x00"), pyproject...))
+	// #59: the staleness key covers requirements.txt too — installOpenant
+	// now installs it (the exact CI pins), so a pin change must trigger a
+	// reinstall the same way a pyproject change does. A MISSING file is not
+	// an error (the dev-layout degrade path): hash the corePath+pyproject
+	// alone, matching the old key.
+	reqs, reqsErr := os.ReadFile(filepath.Join(corePath, "requirements.txt"))
+	if reqsErr != nil {
+		reqs = nil // degrade: the dev layout without requirements.txt
+	}
+	sum := sha256.Sum256(append(append([]byte(corePath+"\x00"), pyproject...), reqs...))
 	return hex.EncodeToString(sum[:]), nil
 }
 
@@ -382,11 +391,45 @@ func isOpenantImportable(pythonPath string) bool {
 }
 
 // installOpenant runs `python -m pip install -e <corePath>`.
-func installOpenant(pythonPath, corePath string) error {
+// installOpenantCmds builds the commands installOpenant runs (the test seam).
+func installOpenantCmds(pythonPath, corePath string) []*exec.Cmd {
+	// #59 (ar7casper): end-user installs must be DETERMINISTIC — CI runs
+	// `pip install -r requirements.txt && pip install ".[dev]"`, where
+	// requirements.txt carries the EXACT pins. An end user running `openant
+	// scan` today resolves pyproject.toml's FLOOR pins (>=), pulling whatever
+	// PyPI currently serves — so a user hits anthropic==1.2.1 while CI tested
+	// ==1.2.0, and an upstream SDK change lands on users without ever being
+	// exercised in CI. Mirror CI: requirements.txt first (the exact pins),
+	// then the editable install (which must not upgrade what was pinned — pip
+	// does not downgrade pinned deps unless the pin conflicts, and
+	// pyproject's floors are compatible with the pins by construction).
+	reqs := filepath.Join(corePath, "requirements.txt")
+	cmds := []*exec.Cmd{}
+	if _, err := os.Stat(reqs); err == nil {
+		reqCmd := exec.Command(pythonPath, "-m", "pip", "install", "-r", reqs)
+		reqCmd.Stdout = os.Stderr // pip output goes to stderr so it doesn't pollute JSON stdout
+		reqCmd.Stderr = os.Stderr
+		cmds = append(cmds, reqCmd)
+	}
+	// A dev layout without requirements.txt degrades to the old behavior
+	// (the editable install alone) — the staleness check must not error
+	// every run.
 	cmd := exec.Command(pythonPath, "-m", "pip", "install", "-e", corePath)
 	cmd.Stdout = os.Stderr // pip output goes to stderr so it doesn't pollute JSON stdout
 	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	cmds = append(cmds, cmd)
+	return cmds
+}
+
+// installOpenant mirrors CI: requirements.txt (the exact pins) first, then
+// the editable install.
+func installOpenant(pythonPath, corePath string) error {
+	for _, c := range installOpenantCmds(pythonPath, corePath) {
+		if err := c.Run(); err != nil {
+			return fmt.Errorf("pip install failed (%v): %w", c.Args, err)
+		}
+	}
+	return nil
 }
 
 // PipUninstall returns an *exec.Cmd that runs `python -m pip uninstall openant -y`.

--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -183,7 +183,19 @@ func CheckOpenantInstalled(pythonPath string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "Installing openant from %s...\n", corePath)
-	if err := installOpenant(pythonPath, corePath); err != nil {
+	// #62 (ar7casper): concurrent invocations that both detect a missing
+	// install race pip on the same venv (pip does not support concurrent
+	// writes). Serialize on the OS-level lock, mirroring the JS
+	// bootstrap's .openant-npm-install.lock pattern.
+	venvRoot := filepath.Dir(venvDir())
+	if err := withVenvInstallLock(venvRoot, func() error {
+		// Re-check under the lock: another process may have finished
+		// installing while we waited (the JS pattern's re-check).
+		if isOpenantImportable(pythonPath) {
+			return nil
+		}
+		return installOpenant(pythonPath, corePath)
+	}); err != nil {
 		return fmt.Errorf(
 			"failed to install openant from %s:\n  %w\n"+
 				"Try manually: %s -m pip install -e %s",
@@ -351,10 +363,16 @@ func checkDepsStaleWith(pythonPath string, coreFinder func() (string, error)) er
 	}
 
 	fmt.Fprintln(os.Stderr, "Dependencies changed, updating openant installation...")
-	// Known limitation: concurrent invocations that both detect stale deps
-	// will race to pip-install into the same venv. pip does not support
-	// concurrent writes; an OS-level lock would be needed to close this gap.
-	if err := installOpenant(pythonPath, corePath); err != nil {
+	// #62 (ar7casper): the known limitation is closed — concurrent
+	// invocations serialize on the OS-level lock (mirroring the JS
+	// bootstrap), and staleness is re-checked under it.
+	venvRoot := filepath.Dir(venvDir())
+	if err := withVenvInstallLock(venvRoot, func() error {
+		if stale2, _, err2 := depsStaleness(corePath); err2 == nil && !stale2 {
+			return nil
+		}
+		return installOpenant(pythonPath, corePath)
+	}); err != nil {
 		return fmt.Errorf(
 			"failed to update openant dependencies: %w\n"+
 				"Try manually: %s -m pip install -e %s",
@@ -516,4 +534,39 @@ func findOpenantCore() (string, error) {
 func fileExists(path string) bool {
 	info, err := os.Stat(path)
 	return err == nil && !info.IsDir()
+}
+
+// venvInstallLockPath returns the lockfile path guarding concurrent pip
+// installs into the managed venv. Mirrors the JS bootstrap's pattern
+// (parser_adapter.py's _file_lock over .openant-npm-install.lock): the
+// lockfile lives next to the install target so it's on the same
+// filesystem, and only the OS-level lock matters for mutual exclusion.
+func venvInstallLockPath() string {
+	return filepath.Join(venvDir(), ".deps-install.lock")
+}
+
+// withVenvInstallLock runs fn under an exclusive lock so two concurrent
+// invocations that both detect a missing or stale install serialize
+// instead of racing pip on the same venv (pip does not support
+// concurrent writes: corrupted RECORD files, partial wheel extraction,
+// broken .dist-info metadata).
+//
+// The lock is the same cross-platform shape the JS bootstrap uses
+// (msvcrt.locking on Windows, flock elsewhere) via Go's build-tag
+// split: lock_unix.go / lock_windows.go.
+func withVenvInstallLock(venvDir string, fn func() error) error {
+	lockPath := filepath.Join(venvDir, ".deps-install.lock")
+	if err := os.MkdirAll(venvDir, 0o755); err != nil {
+		return err
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if err := lockFileExcl(f); err != nil {
+		return err
+	}
+	defer unlockFile(f)
+	return fn()
 }

--- a/apps/openant-cli/internal/python/runtime_install_test.go
+++ b/apps/openant-cli/internal/python/runtime_install_test.go
@@ -1,0 +1,110 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// #59 (ar7casper, the extra-care protocol): end-user installs must be
+// deterministic — requirements.txt (the exact pins CI uses) is installed
+// first, then the editable install; the deps staleness hash covers BOTH
+// files so a change to either triggers a reinstall.
+// ---------------------------------------------------------------------------
+
+func TestInstallCommandRunsRequirementsThenEditable(t *testing.T) {
+	cmds := installOpenantCmds("python3", t.TempDir())
+	// a temp dir has no requirements.txt — the degrade path is 1 cmd (the old behavior)
+	_ = cmds
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "requirements.txt"), []byte("x==1\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cmds = installOpenantCmds("python3", dir)
+	if len(cmds) != 2 {
+		t.Fatalf("expected requirements+editable (2 commands), got %d", len(cmds))
+	}
+	reqArgs := cmds[0].Args
+	foundReqs := false
+	for _, a := range reqArgs {
+		if a == "-r" {
+			foundReqs = true
+		}
+	}
+	if !foundReqs {
+		t.Errorf("the FIRST command must install requirements.txt (the exact CI pins); got %v", reqArgs)
+	}
+	foundEditable := false
+	for _, a := range cmds[1].Args {
+		if a == "-e" {
+			foundEditable = true
+		}
+	}
+	if !foundEditable {
+		t.Errorf("the SECOND command must install the editable package; got %v", cmds[1].Args)
+	}
+}
+
+func TestInstallCommandDegradedWithoutRequirements(t *testing.T) {
+	cmds := installOpenantCmds("python3", t.TempDir())
+	if len(cmds) != 1 {
+		t.Fatalf("a dir without requirements.txt degrades to the editable install alone (1 command), got %d", len(cmds))
+	}
+}
+
+func TestDepsHashCoversRequirementsTxt(t *testing.T) {
+	dir := t.TempDir()
+	req := filepath.Join(dir, "requirements.txt")
+	if err := os.WriteFile(req, []byte("anthropic==1.2.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("name='x'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h1, err := depsHash(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(req, []byte("anthropic==1.3.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	h2, err := depsHash(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if h1 == h2 {
+		t.Errorf("a requirements.txt change must trigger a reinstall (the hash must cover both files)")
+	}
+}
+
+func TestDepsHashStillCoversCorePath(t *testing.T) {
+	// the pre-existing key: two worktrees with identical files must NOT share one hash
+	a := t.TempDir()
+	b := t.TempDir()
+	for _, d := range []string{a, b} {
+		if err := os.WriteFile(filepath.Join(d, "pyproject.toml"), []byte("name='x'\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "requirements.txt"), []byte("anthropic==1.2.0\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ha, _ := depsHash(a)
+	hb, _ := depsHash(b)
+	if ha == hb {
+		t.Errorf("corePath must stay in the key (the two-worktrees-silent-import hazard)")
+	}
+}
+
+func TestDepsHashMissingRequirementsAbstains(t *testing.T) {
+	// a core dir without requirements.txt (a dev layout that dropped it?):
+	// the staleness check must degrade gracefully, not error every run
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pyproject.toml"), []byte("name='x'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := depsHash(dir); err != nil {
+		t.Errorf("a missing requirements.txt must not error the staleness check (the caller skips on error — an error every run would break installs): %v", err)
+	}
+}

--- a/apps/openant-cli/internal/python/runtime_lock_test.go
+++ b/apps/openant-cli/internal/python/runtime_lock_test.go
@@ -1,0 +1,80 @@
+package python
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// #62 (ar7casper, the extra-care protocol): concurrent venv installs must
+// serialize on an OS-level lock, mirroring the JS bootstrap's pattern.
+// ---------------------------------------------------------------------------
+
+func TestVenvInstallLockIsExclusive(t *testing.T) {
+	dir := t.TempDir()
+	acquired := make(chan struct{}, 1)
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- withVenvInstallLock(dir, func() error {
+			acquired <- struct{}{}
+			<-release
+			return nil
+		})
+	}()
+	<-acquired // the first locker holds the lock
+	secondEntered := make(chan struct{})
+	go func() {
+		_ = withVenvInstallLock(dir, func() error { return nil })
+		close(secondEntered)
+	}()
+	select {
+	case <-secondEntered:
+		t.Errorf("the second locker entered while the first held the lock")
+	case <-time.After(200 * time.Millisecond):
+		// still blocked — correct
+	}
+	close(release)
+	<-firstDone
+	<-secondEntered
+}
+
+func TestVenvInstallLockReleasesOnExit(t *testing.T) {
+	dir := t.TempDir()
+	if err := withVenvInstallLock(dir, func() error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	// after release, a second acquisition completes immediately
+	done := make(chan error, 1)
+	go func() { done <- withVenvInstallLock(dir, func() error { return nil }) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatal(err)
+		}
+		// entered immediately — correct
+	case <-time.After(2 * time.Second):
+		t.Errorf("the lock did not release on exit")
+	}
+}
+
+func TestVenvInstallLockBodyRunsUnderTheLock(t *testing.T) {
+	dir := t.TempDir()
+	probe := make(chan struct{})
+	err := withVenvInstallLock(dir, func() error {
+		// the lockfile must EXIST while the body runs — the lock target
+		// is the same filesystem as the venv (the JS pattern's "next to
+		// the install target").
+		if _, err := os.Stat(filepath.Join(dir, ".deps-install.lock")); err != nil {
+			t.Errorf("the lockfile must exist under the lock: %v", err)
+		}
+		close(probe)
+		return nil
+	})
+	<-probe
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Depends-on: #421 (stacked on #59's deterministic installs — the lock wraps the composed install; merge #421 first)

Hi @ar7casper — the inconsistency you identified is real, and this closes it with your Option 1 (the no-new-dependency shape).

## Summary

Two concurrent invocations that both detect a missing or stale install race pip on the same `~/.openant/venv`, and pip does not support concurrent writes: corrupted RECORD files, partial wheel extraction, broken `.dist-info` metadata. The JS bootstrap (#37's pattern, `.openant-npm-install.lock`) serializes cleanly; the venv install did not — and the code comment named the gap as a Known limitation, with the stated rationale that Go's stdlib lacks a portable flock. Two invocations in separate terminals (or `openant scan A & openant scan B`) hit exactly this.

Fix (the issue's Option 1, the no-new-dependency shape):
- `withVenvInstallLock`: block-until-acquired exclusive lock over `<venv-parent>/.deps-install.lock` — the lockfile lives next to the install target so it is always on the same filesystem, mirroring the JS pattern. The cross-platform mechanism is the same shape the JS bootstrap uses (`msvcrt.locking` on Windows / `flock` elsewhere) via a Go build-tag split: `lock_unix.go` / `lock_windows.go` — **no third-party dependency**;
- **both** install call sites wire through it with the JS pattern's **re-check-under-the-lock**: `CheckOpenantInstalled` re-checks `isOpenantImportable` under the lock (another process may have finished installing while we waited); `checkDepsStaleWith` re-checks staleness under the lock (another process may have refreshed deps);
- the Known limitation comment in `checkDepsStaleWith` replaced by the closed note.

**Pre-submission experimentation** (the gate): the real fixed binary driven end-to-end (`openant parse` on a live fixture → units extracted, full artifacts written) against the accumulated state — no previous fix hurt, including #59's deterministic installs, which this stacks on (the lock wraps the composed install).

## Test plan

3 Go tests: the lock is EXCLUSIVE (a second locker blocks while the first holds it); the lock RELEASES on exit (a second acquisition enters immediately); the lockfile EXISTS under the lock (the same-filesystem-as-the-target property the JS pattern guarantees).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | `go test ./internal/python/ -run 'TestVenvInstallLock' -count=1 -v` | 3 PASS |
| Go all packages | `go test ./... -count=1` | all ok |
| hygiene | `go vet ./internal/python/` + `gofmt` | clean |
| merged-state suite | the full pytest run | 3340/3340 green |
| step-10.5 gate | the real fixed binary `parse` end-to-end | 2 units extracted, full artifacts written |

</details>

Fixes #62
