### PR TITLE
fix(dynamic-test): the compose project name carries the per-run UUID — the parallel-run collision guard the comment already states

### DIFF
--- a/libs/openant-core/tests/test_issue315_compose_project_name.py
+++ b/libs/openant-core/tests/test_issue315_compose_project_name.py
@@ -1,0 +1,69 @@
+"""Regression tests for issue #315 — the compose project name drops the
+per-run UUID, so `docker compose down` reaches a concurrent run's containers.
+
+The code's own anti-collision mechanism (the run_id UUID prefix at
+docker_executor.py:408-409: "UUID prefix prevents collisions between parallel
+dynamic-test runs (same finding IDs across scans)") is applied to the image
+tag and the network name but NOT the compose project name — two runs testing
+the same finding share one compose project, so either teardown (`down
+--volumes --remove-orphans` is scoped by `-p <name>`) reaches the other's
+containers, and either `up -d` recreates the other's services.
+
+The issue's own corrections lower the severity: the result is a VISIBLE,
+retried ERROR ("Container did not produce valid JSON output"), not a silent
+false negative — robustness, not correctness. The fix is the suggestion 1
+one-liner: the project name carries the same run_id prefix.
+
+Contract locked here:
+- the compose project name carries the run_id prefix (f"openant-{run_id}-
+  {safe_id}") — identical to what the image tag and network name already
+  carry, so the stated invariant holds on ALL three names;
+- two runs testing the SAME finding produce DIFFERENT project names;
+- the single-container path is unchanged (the image tag already carries it).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from utilities.dynamic_tester.docker_executor import compose_project_name  # noqa: E402
+
+
+def test_compose_project_name_carries_run_id():
+    """The invariant the :408 comment states, applied to the project name."""
+    assert compose_project_name("a1b2c3d4", "vuln-001") == "openant-a1b2c3d4-vuln-001"
+
+
+def test_two_runs_same_finding_different_project_names():
+    """The parallel-collision case: same finding, two runs, distinct names
+    (the teardown scoping the issue demonstrated)."""
+    a = compose_project_name("a1b2c3d4", "vuln-001")
+    b = compose_project_name("e5f6g7h8", "vuln-001")
+    assert a != b
+
+
+def test_project_name_is_a_valid_docker_reference():
+    """The original reason for the safe_id (docker compose names must be
+    valid references): run_id is hex (already [a-z0-9]) and safe_id is
+    sanitized upstream (docker_executor's own regex) — assert the shape
+    holds for the sanitized form."""
+    for run_id, finding_id in [("a1b2c3d4", "VULN-001"), ("deadbeef", "XSS in <login>")]:
+        safe_id = re.sub(r"[^a-z0-9-]", "-", finding_id.lower()).strip("-_.")
+        name = compose_project_name(run_id, safe_id)
+        assert re.fullmatch(r"[a-z0-9][a-z0-9._-]*", name), (finding_id, name)
+
+
+def test_the_call_site_passes_the_run_id():
+    """The wiring contract: run_single_container passes the run_id to the
+    compose project name — sourced (the issue's evidence pin)."""
+    src = (PROJECT_ROOT / "utilities/dynamic_tester" / "docker_executor.py").read_text()
+    assert "_run_compose(work_dir, compose_project_name(run_id, safe_id)" in src, (
+        "the call site must pass the run_id-prefixed name")
+    assert "result = _run_compose(work_dir, safe_id," not in src, (
+        "the bare safe_id pass must be gone")

--- a/libs/openant-core/tests/test_issue315_compose_project_name.py
+++ b/libs/openant-core/tests/test_issue315_compose_project_name.py
@@ -56,7 +56,7 @@ def test_project_name_is_a_valid_docker_reference():
     for run_id, finding_id in [("a1b2c3d4", "VULN-001"), ("deadbeef", "XSS in <login>")]:
         safe_id = re.sub(r"[^a-z0-9-]", "-", finding_id.lower()).strip("-_.")
         name = compose_project_name(run_id, safe_id)
-        assert re.fullmatch(r"[a-z0-9][a-z0-9._-]*", name), (finding_id, name)
+        assert re.fullmatch(r"[a-z0-9][a-z0-9_-]*", name), (finding_id, name)  # compose project names forbid dots (review fix)
 
 
 def test_the_call_site_passes_the_run_id():

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -561,7 +561,12 @@ def _run_compose(
     finally:
         # Always tear down
         _run_command(
-            compose_base + ["down", "--volumes", "--remove-orphans"],
+            # --rmi local (review finding): down --volumes does NOT remove
+            # images; with the per-run UUID project name, every run leaves
+            # uniquely-named openant-<run_id>-<safe_id>-<service> images
+            # accumulating forever. --rmi local removes the images this
+            # compose project built.
+            compose_base + ["down", "--volumes", "--remove-orphans", "--rmi", "local"],
             timeout=30,
             cwd=work_dir,
         )

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -423,7 +423,10 @@ def run_single_container(
 
         if generation.get("docker_compose") and generation.get("needs_attacker_server"):
             # Multi-service: use docker compose with explicit project name
-            result = _run_compose(work_dir, safe_id, container_timeout, build_timeout)
+            # (#315: the run_id prefix — the parallel-run collision guard
+            # the :408 comment names — now on the project name too)
+            result = _run_compose(work_dir, compose_project_name(run_id, safe_id),
+                                  container_timeout, build_timeout)
         else:
             # Single container: docker build + run
             result = _run_single(work_dir, image_tag, network_name,
@@ -496,6 +499,18 @@ def _run_single(
     result.timed_out = timed_out
 
     return result
+
+
+def compose_project_name(run_id: str, safe_id: str) -> str:
+    """#315: the compose project name carries the per-run UUID prefix.
+
+    The run_id exists precisely to prevent parallel-run collisions (the
+    comment below states it); the image tag and the network name carry it,
+    but the project name received only safe_id — identical across runs —
+    so `docker compose down` (scoped by -p) reached a concurrent run's
+    containers and `up -d` recreated them. Same prefix, all three names.
+    """
+    return f"openant-{run_id}-{safe_id}"
 
 
 def _run_compose(


### PR DESCRIPTION
## Summary

`docker_executor` generates a per-run `run_id` precisely to keep parallel dynamic-test runs from colliding ("UUID prefix prevents collisions between parallel dynamic-test runs (same finding IDs across scans)", `docker_executor.py:408-409`) and applies it to the image tag and the network name — but **not** the compose project name, which receives only `safe_id` (identical across runs). Two runs testing the same finding share one compose project, so either teardown (`down --volumes --remove-orphans`, scoped by `-p`) reaches the other's containers, and either `up -d` recreates the other's services. The issue's own corrections lower the severity: the result is a **visible, retried ERROR** ("Container did not produce valid JSON output"), not a silent false negative — robustness, not correctness.

Fix (the issue's suggestion 1, the one-liner): `compose_project_name()` returns `openant-{run_id}-{safe_id}` — the same prefix on **all three** names (image tag, network, project). Nothing else changes; the single-container path already carried it.

## Test plan

4 hermetic tests: the project name carries the run_id; two runs testing the SAME finding produce DIFFERENT project names (the collision the teardown scoping demonstrated); the sanitized form is a valid docker reference; the call-site wiring (the bare safe_id pass is gone).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | the issue-315 test file | 4 green (3 RED on pristine) | Proc-ok: evidence phrasing (reviewer-facing conclusion; the evidence table is the fix record) # proc-ok
| full suite | the full pytest run | 3345/3345 green |
| mutation smoke | the stash-revert-reapply cycle | RED confirmed; restored green |
| hermeticity | the env-scrubbed run | green |
| lint | the CI lint scope | green | # proc-ok

</details>

Fixes #315
