### PR TITLE
fix(analyze): an unrecognized or absent Stage-1 verdict routes to the error accounting — not a silently uncountable one (#316, #324)

### DIFF
--- a/libs/openant-core/core/analysis_core.py
+++ b/libs/openant-core/core/analysis_core.py
@@ -36,14 +36,24 @@ def _normalize_result(result: dict) -> dict:
     Handles cases where the model returns 'finding' instead of 'verdict',
     or uses different casing/naming conventions.
     """
-    # Normalize finding -> verdict
-    if "verdict" not in result and "finding" in result:
+    # Normalize finding -> verdict. A verdict only counts as present when it
+    # is an EFFECTIVE string — {"verdict": null} is the #324 refusal shape
+    # with the key present (a null verdict crashed _count_verdicts' fallback).
+    verdict = result.get("verdict")
+    has_verdict = isinstance(verdict, str) and verdict.strip() != ""
+    if not has_verdict and "finding" in result:
         finding = result["finding"]
         if not isinstance(finding, str):
             # A non-string finding (list/dict/null/number) is a malformed model reply,
             # not a verdict — map it to ERROR so the error / manual-review accounting
             # counts it, instead of a garbage verdict (e.g. "['VULNERABLE']" from
             # str(finding).upper()) that silently escapes that accounting.
+            # #316: stamp BOTH keys (verdict + finding) — the finding-keyed
+            # consumers (_summary_callback, _count_verdicts) would otherwise
+            # disagree with the verdict-keyed ones. Raw value preserved for
+            # manual review.
+            result["raw_finding"] = finding
+            result["finding"] = "error"
             result["verdict"] = "ERROR"
         else:
             finding_to_verdict = {
@@ -54,7 +64,24 @@ def _normalize_result(result: dict) -> dict:
                 "inconclusive": "INCONCLUSIVE",
                 "insufficient_context": "INSUFFICIENT_CONTEXT",
             }
-            result["verdict"] = finding_to_verdict.get(finding.lower(), finding.upper())
+            verdict = finding_to_verdict.get(finding.lower(), "ERROR")
+            if verdict == "ERROR" and finding.lower() != "error":
+                # #316: an unrecognized finding string is a malformed model
+                # reply, not a verdict. Map it to ERROR — counted in `errors`,
+                # retried on resume, manual-review-visible — instead of the
+                # upper-case passthrough that escaped every accounting (the
+                # non-string branch above chose the same direction).
+                result["raw_finding"] = finding
+                result["finding"] = "error"
+            result["verdict"] = verdict
+    elif not has_verdict:
+        # #324: a parsed object with neither an effective verdict NOR a
+        # finding (a JSON-shaped refusal, e.g. {"reasoning": ...}) is not an
+        # analysis. Stamp the one error shape so it is counted in `errors`
+        # (units_analyzed stops overstating) and re-analyzed on resume
+        # instead of adopted as complete.
+        result["verdict"] = "ERROR"
+        result["finding"] = "error"
 
     # Ensure verdict is uppercase
     if "verdict" in result and isinstance(result["verdict"], str):

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 from core.schemas import AnalyzeResult, AnalysisMetrics, UsageInfo
 from core import tracking
-from core.checkpoint import StepCheckpoint
+from core.checkpoint import StepCheckpoint, analyze_result_is_error
 from core.progress import ProgressReporter
 
 # Import existing analysis machinery
@@ -234,10 +234,7 @@ def _run_detection(units, binding: PhaseBinding, json_corrector, app_context, wo
     code_by_route = {}
     units_to_process = []
 
-    def _cp_is_error(cp_data):
-        res = cp_data.get("result", {}) if cp_data else {}
-        return res.get("verdict") == "ERROR" or res.get("finding") == "error"
-
+    # Hoisted to module level (testable; mirrors checkpoint.py's predicates).
     for i, unit in enumerate(units):
         uid = unit.get("id", f"unit_{i}")
         cp_data = checkpointed.get(uid)
@@ -337,6 +334,54 @@ def _interrupt_report(results, total):
         f"({not_started} not started); progress saved to checkpoints")
 
 
+def _cp_is_error(cp_data):
+    """Is this checkpointed unit an error (must be re-analyzed, not adopted)?
+
+    Delegates to ``checkpoint.analyze_result_is_error`` — the one shared
+    predicate (load_ids / status / the summary seed below all use it; four
+    hand-copies drifted within one PR).
+    """
+    res = cp_data.get("result", {}) if cp_data else {}
+    return analyze_result_is_error(res)
+
+
+def _seed_summary(existing: dict) -> dict:
+    """Seed the _summary.json counters from checkpointed rows.
+
+    Counts as completed ONLY the rows adoption will keep: an errored row
+    (``analyze_result_is_error``) is re-analyzed and its outcome is owned by
+    ``_summary_callback`` — seeding it here (as completed OR as an error)
+    double-counts on resume (completed + errors > total; the pre-existing
+    verdict=="ERROR" over-count, which #316/#324 was extending to the
+    neither-key shape). Usage tokens accumulate over ALL rows — the spend
+    happened regardless of the row's fate.
+
+    Returns: completed, input_tokens, output_tokens, cost_usd,
+    unpriced_models (the #216 marker).
+    """
+    completed = 0
+    input_tokens = 0
+    output_tokens = 0
+    cost_usd = 0.0
+    unpriced: set = set()
+    for _cp in existing.values():
+        if not analyze_result_is_error(_cp.get("result") or {}):
+            completed += 1
+        _usage = _cp.get("usage", {})
+        input_tokens += _usage.get("input_tokens", 0)
+        output_tokens += _usage.get("output_tokens", 0)
+        cost_usd += _usage.get("cost_usd", 0.0)
+        # #216: restore the incomplete-cost marker from per-unit records.
+        unpriced.update(_usage.get("unpriced_models") or [])
+    return {
+        "completed": completed,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "cost_usd": cost_usd,
+        "unpriced_models": unpriced,
+    }
+
+
 def _count_verdicts(results):
     """Count verdict categories from a results list."""
     counts = {
@@ -353,11 +398,27 @@ def _count_verdicts(results):
         # checkpoint-resume semantics own those units).
         if r is None:
             continue
-        finding = r.get("finding", r.get("verdict", "error").lower())
-        if finding in counts:
-            counts[finding] += 1
-        elif r.get("verdict") == "ERROR":
+        # #324/null-verdict: an INEFFECTIVE finding (absent/None/non-string/
+        # empty) falls back to the verdict, which must itself be an effective
+        # string — the eager ``.lower()`` default crashed post-LLM-spend on
+        # ``{"verdict": null}``.
+        finding = r.get("finding")
+        verdict = r.get("verdict")
+        if not isinstance(finding, str) or not finding.strip():
+            finding = verdict if isinstance(verdict, str) and verdict.strip() else None
+        if finding is None:
+            # Neither an effective finding nor an effective verdict — the
+            # malformed shape (#324; null/empty verdicts): an error, not a
+            # silent drop.
             counts["errors"] += 1
+        elif finding.lower() in counts:
+            counts[finding.lower()] += 1
+        elif verdict == "ERROR" or finding.lower() == "error":
+            # finding=="error" without verdict=="ERROR" (a legacy
+            # half-stamped row): agree with analyze_result_is_error, which
+            # classifies it as an error.
+            counts["errors"] += 1
+        # else: an unrecognized verdict — the documented F13 gap (dropped).
     return counts
 
 
@@ -587,32 +648,20 @@ def run_analysis(
     # Initialize summary tracking for _summary.json
     # Count checkpointed units to seed the counters and sum existing usage
     _existing = checkpoint.load()
-    _summary_completed = 0
-    _summary_errors = 0
     _summary_error_breakdown = {}
-    _summary_input_tokens = 0
-    _summary_output_tokens = 0
-    _summary_cost_usd = 0.0
-    _summary_unpriced: set[str] = set()
     # #293 adjudication: analyze has NO third state — "inconclusive" is a
     # first-class COMPLETED verdict (verdict_taxonomy FINDING_VERDICT_ORDER;
     # the Stage-1 prompt's own enum), not a degenerate no-verdict marker like
     # verify's verification.incomplete or enhance's INCOMPLETE_CLASSIFICATION.
     # The third bucket stays 0 here but is still emitted for shape consistency.
     _summary_incomplete = 0
-    for _uid, _cp in _existing.items():
-        _r = _cp.get("result", {})
-        if _r.get("verdict") == "ERROR" or _r.get("finding") == "error":
-            _summary_errors += 1
-            _summary_error_breakdown["api"] = _summary_error_breakdown.get("api", 0) + 1
-        else:
-            _summary_completed += 1
-        _cp_usage = _cp.get("usage", {})
-        _summary_input_tokens += _cp_usage.get("input_tokens", 0)
-        _summary_output_tokens += _cp_usage.get("output_tokens", 0)
-        _summary_cost_usd += _cp_usage.get("cost_usd", 0.0)
-        # #216: restore the incomplete-cost marker from per-unit records.
-        _summary_unpriced.update(_cp_usage.get("unpriced_models") or [])
+    _seed = _seed_summary(_existing)
+    _summary_completed = _seed["completed"]
+    _summary_errors = 0  # errored rows are re-analyzed; _summary_callback owns them
+    _summary_input_tokens = _seed["input_tokens"]
+    _summary_output_tokens = _seed["output_tokens"]
+    _summary_cost_usd = _seed["cost_usd"]
+    _summary_unpriced: set[str] = _seed["unpriced_models"]
 
     def _usage_dict():
         usage = {"input_tokens": _summary_input_tokens,

--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -41,6 +41,43 @@ SUMMARY_FILE = "_summary.json"
 _RESERVED_FILES = frozenset({SUMMARY_FILE, FINGERPRINT_FILE})
 
 
+def analyze_result_is_error(res) -> bool:
+    """Is an analyze-style ``result`` an error (retried, never adopted as complete)?
+
+    The single shared predicate for every resume-facing consumer
+    (``StepCheckpoint.load_ids``, ``StepCheckpoint.status``, and
+    ``analyzer._cp_is_error`` / the summary seed loop). Four hand-copies of
+    the two-arm test drifted within one PR — keep them in agreement here.
+
+    Error shapes:
+      * ``verdict == "ERROR"`` or ``finding == "error"`` — the explicit error;
+      * neither an EFFECTIVE verdict nor an EFFECTIVE finding — a malformed
+        model reply (#324's JSON-shaped refusal). "Effective" = a non-empty
+        string: a ``{"verdict": null}`` refusal carries the key but no
+        verdict, and must not be counted completed.
+
+    Verdict-first: a row where both keys are present and disagree is
+    classified by its verdict ("ERROR" wins). ``_count_verdicts`` is
+    finding-first — a legacy ``{"verdict": "ERROR", "finding": "vulnerable"}``
+    row is an error here (retried) but counted vulnerable there; the retried
+    outcome replaces it, so the disagreement is transient. An
+    unrecognized-but-effective verdict (``"SAY WHAT"``) is NOT an error here
+    — that drop is the documented F13 partition gap, deliberately out of
+    scope (#316/#324).
+    """
+    if not isinstance(res, dict):
+        # A hand-edited/corrupt "result": null row must not crash the
+        # classifier (status() is the Go CLI's checkpoint-status source).
+        return True
+    verdict = res.get("verdict")
+    finding = res.get("finding")
+    if verdict == "ERROR" or finding == "error":
+        return True
+    has_verdict = isinstance(verdict, str) and verdict.strip() != ""
+    has_finding = isinstance(finding, str) and finding.strip() != ""
+    return not (has_verdict or has_finding)
+
+
 class StepCheckpoint:
     """Manages per-unit checkpoint files for a pipeline step."""
 
@@ -113,7 +150,11 @@ class StepCheckpoint:
                     continue
                 # Analyze: result.verdict/finding
                 result = data.get("result", {})
-                if result.get("verdict") == "ERROR" or result.get("finding") == "error":
+                if "result" in data and analyze_result_is_error(result):
+                    # #324: neither-key / ineffective-verdict rows are
+                    # malformed replies, not completed units. Scoped to
+                    # analyze-style rows ("result" key present) — the other
+                    # three phases never write it.
                     continue
                 # Verify: verification empty or correct_finding == "error"
                 if "verification" in data:
@@ -391,8 +432,7 @@ class StepCheckpoint:
 
             # Analyze-style: result.verdict or result.finding
             elif "result" in data:
-                res = data.get("result", {})
-                if res.get("verdict") == "ERROR" or res.get("finding") == "error":
+                if analyze_result_is_error(data.get("result", {})):
                     is_error = True
                     err_type = "analysis_error"
 

--- a/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
+++ b/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
@@ -24,6 +24,13 @@ whose verdict is unrecognized (neither a known bucket nor verdict=="ERROR") from
 ALL buckets, so metrics built from such rows already have sum(buckets) < total. That
 pre-existing gap is documented by `test_count_verdicts_drops_unrecognized_verdict`
 below and is explicitly out of F13's scope.
+
+#316/#324 UPDATE: the NEITHER-KEY shape (a result with no `verdict` and no
+`finding`) is no longer dropped — `_normalize_result` stamps the one error
+shape at the producer, and `_count_verdicts` routes the shape to `errors`
+(the legacy singular-"error" default could never match the "errors" key).
+Unrecognized VERDICT strings (e.g. "SOMETHING_WEIRD") and the mapped-but-
+bucketless `insufficient_context` remain the documented gap above.
 """
 import json
 import sys
@@ -103,12 +110,16 @@ def test_count_verdicts_drops_unrecognized_verdict():
     """DOCUMENTS the pre-existing partition gap F13 does NOT close: a row with an
     unrecognized verdict is dropped from every bucket, so the produced metrics
     already under-sum `total`. Kept as a red-flag guard: if a future change makes
-    _count_verdicts total-preserving, update F13's scope note."""
+    _count_verdicts total-preserving, update F13's scope note.
+
+    #316/#324: the NEITHER-KEY shape is now partitioned into `errors` (see the
+    scope note above); the unrecognized-VERDICT drop remains the gap."""
     rows = [
         {"finding": "vulnerable"},
         {"verdict": "ERROR"},
         {"verdict": "SOMETHING_WEIRD"},  # neither a bucket nor "ERROR" -> dropped
+        {"reasoning": "no verdict keys"},  # neither-key -> counted as an error (#324)
     ]
     counts = _count_verdicts(rows)
-    assert sum(counts.values()) == 2          # only 2 of 3 rows partitioned
-    assert sum(counts.values()) < len(rows)   # the gap is real, and out of F13 scope
+    assert sum(counts.values()) == 3          # 3 of 4 rows partitioned
+    assert sum(counts.values()) < len(rows)   # the unrecognized-verdict gap is real

--- a/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
+++ b/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
@@ -284,9 +284,6 @@ def test_summary_seed_agrees_with_adoption(tmp_path):
     assert completed + errors == 3  # == total: the invariant holds
     # usage accumulates over ALL rows (the spend happened)
     # (usage seeding is exercised below with a usage-bearing checkpoint)
-    import json as _json
-    from utilities.file_io import write_json
-    import os
     ck3 = StepCheckpoint("analyze", str(tmp_path / "s"))
     ck3.save("u", {"id": "u", "result": {"verdict": "SAFE", "finding": "safe"},
                    "usage": {"input_tokens": 10, "output_tokens": 5, "cost_usd": 0.25,

--- a/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
+++ b/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
@@ -1,0 +1,480 @@
+"""#316 + #324: a Stage-1 verdict every consumer recognizes, or an error.
+
+Two producers escaped the error accounting:
+
+* #316 -- ``_normalize_result``'s string branch mapped an UNRECOGNIZED finding
+  string (``"maybe exploitable"``) to an upper-cased passthrough verdict
+  (``"MAYBE EXPLOITABLE"``): not a counter bucket, not ``"ERROR"`` (so never
+  retried on resume), not in the vulnerable set (so never disclosed). The
+  non-string branch ten lines above already chose the opposite direction --
+  map to ERROR -- with a comment naming exactly this failure. The JSON
+  corrector had two twin synthesis sites (``finding.upper()``,
+  ``mapping.get(..., finding.upper())``) feeding the same escape.
+* #324 -- a parsed object with NEITHER ``verdict`` NOR ``finding`` (a
+  JSON-shaped refusal like ``{"reasoning": ...}``) kept neither key:
+  ``_cp_is_error`` adopted it as complete on resume, and ``_count_verdicts``
+  counted it in no bucket (the singular ``"error"`` default can never match
+  the ``"errors"`` key), so ``units_analyzed`` overstated.
+
+The fix (both issues, one PR -- their sinks are shared): the producers stamp
+the one error shape (``verdict="ERROR"``, ``finding="error"``, raw value
+preserved under ``raw_finding``), and the four consumer predicates
+(``analyzer._cp_is_error``, ``analyzer._count_verdicts``, the two copies in
+``checkpoint.py`` -- ``load_ids`` and ``status``) fail closed on the
+neither-key shape so legacy checkpoints are re-analyzed, not adopted.
+
+Documented residuals (deliberately NOT changed here):
+* an unrecognized VERDICT string (``{"verdict": "SOMETHING_WEIRD"}``) is
+  still dropped by ``_count_verdicts`` -- the F13-documented gap.
+* ``insufficient_context`` is mapped but has no counter bucket (a
+  results-partition question, not a coverage loss -- #293 rules it
+  completed).
+* legacy checkpoints carrying a PRE-fix garbage verdict (finding present,
+  unrecognized) are still adopted; post-fix runs never write that shape.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from core.analysis_core import _normalize_result, parse_response  # noqa: E402
+from core.analyzer import _count_verdicts  # noqa: E402
+from core.checkpoint import StepCheckpoint, analyze_result_is_error  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# A. producer -- _normalize_result / parse_response
+# ---------------------------------------------------------------------------
+
+def test_unrecognized_finding_string_routes_to_error():
+    """#316: the upper-case passthrough is gone; the row lands in the error
+    accounting (counted, retried on resume) with the raw text preserved."""
+    out = _normalize_result({"finding": "maybe exploitable"})
+    assert out["verdict"] == "ERROR"
+    assert out["finding"] == "error"
+    assert out["raw_finding"] == "maybe exploitable"
+
+
+def test_recognized_findings_still_map():
+    """Guard: the six mapped findings map exactly as before -- no ERROR, no
+    raw_finding, no finding rewrite."""
+    for finding, verdict in [
+        ("vulnerable", "VULNERABLE"),
+        ("safe", "SAFE"),
+        ("protected", "PROTECTED"),
+        ("bypassable", "BYPASSABLE"),
+        ("inconclusive", "INCONCLUSIVE"),
+        ("insufficient_context", "INSUFFICIENT_CONTEXT"),
+        ("Vulnerable", "VULNERABLE"),  # casing normalization intact
+    ]:
+        out = _normalize_result({"finding": finding})
+        assert out["verdict"] == verdict, finding
+        assert "raw_finding" not in out, finding
+        if finding.islower():
+            assert out["finding"] == finding
+        else:
+            assert out["finding"].lower() == finding.lower()
+
+
+def test_neither_key_stamps_error():
+    """#324: a JSON-shaped refusal is not an analysis -- stamp the one error
+    shape so every downstream consumer sees it."""
+    out = _normalize_result({"reasoning": "cannot determine", "confidence": 0})
+    assert out["verdict"] == "ERROR"
+    assert out["finding"] == "error"
+
+
+def test_verdict_present_passthrough_unchanged():
+    """Guard: a reply that already carries a verdict keeps it (the residual
+    for unrecognized VERDICT strings is #324's documented gap, unchanged)."""
+    assert _normalize_result({"verdict": "SAFE"})["verdict"] == "SAFE"
+    assert _normalize_result({"verdict": "weird"})["verdict"] == "WEIRD"
+
+
+def test_nonstring_finding_stamps_error_shape():
+    """The wrinkle the fix closes: a verdict-only ERROR stamp disagrees with
+    the finding-keyed consumers (_summary_callback, _count_verdicts) -- the
+    non-string branch stamps BOTH keys, raw preserved."""
+    out = _normalize_result({"finding": ["VULNERABLE"]})
+    assert out["verdict"] == "ERROR"
+    assert out["finding"] == "error"
+    assert out["raw_finding"] == ["VULNERABLE"]
+
+
+def test_parse_response_garbage_finding_is_error_accounted():
+    """End-to-end through the real parse: the issue's executed example."""
+    out = parse_response('{"finding": "maybe exploitable", "reasoning": "unclear"}')
+    assert out["verdict"] == "ERROR"
+    assert out["finding"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# B. consumers -- _count_verdicts / _cp_is_error / checkpoint mirrors
+# ---------------------------------------------------------------------------
+
+def test_count_verdicts_neither_key_counts_as_error():
+    """#324: the neither-key row is partitioned into errors, not dropped."""
+    rows = [
+        {"finding": "vulnerable", "verdict": "VULNERABLE"},
+        {"verdict": "ERROR"},
+        {"reasoning": "cannot determine"},  # neither key -- was counted nowhere
+    ]
+    counts = _count_verdicts(rows)
+    assert counts["errors"] == 2
+    assert sum(counts.values()) == len(rows)  # the partition closes
+
+
+def test_count_verdicts_unrecognized_verdict_still_dropped():
+    """Residual, pinned: an unrecognized VERDICT string remains the
+    F13-documented gap (see test_results_bucket_reconciliation)."""
+    rows = [{"verdict": "SOMETHING_WEIRD"}]
+    counts = _count_verdicts(rows)
+    assert sum(counts.values()) == 0
+
+
+def test_count_verdicts_producer_error_shape_counts():
+    """The producer's new output shape lands in errors via the verdict arm."""
+    rows = [{"finding": "error", "verdict": "ERROR", "raw_finding": "maybe exploitable"}]
+    counts = _count_verdicts(rows)
+    assert counts["errors"] == 1
+
+
+def test_cp_is_error_neither_key_retried():
+    """#324: a neither-key checkpoint is a malformed reply, not a completed
+    unit — re-analyzed, never adopted. Exercises the real module-level
+    predicate (hoisted from run() so this is testable, mirroring
+    checkpoint.py's copies)."""
+    from core.analyzer import _cp_is_error
+
+    assert _cp_is_error({"result": {"reasoning": "cannot determine"}}) is True
+    assert _cp_is_error({"result": {"verdict": "VULNERABLE"}}) is False
+    # Legacy residual, pinned: a PRE-fix garbage-verdict row (finding present,
+    # unrecognized; verdict neither ERROR nor a bucket) is still adopted —
+    # post-fix runs never write that shape.
+    assert _cp_is_error(
+        {"result": {"finding": "maybe exploitable", "verdict": "MAYBE EXPLOITABLE"}}
+    ) is False
+
+
+def test_null_and_empty_verdicts_are_the_error_shape():
+    """Wave finding (bug-hunt): {"verdict": null} is the #324 refusal with
+    the key present — it must be treated as no verdict, not adopted as
+    complete / crashed on. Pre-fix, _count_verdicts' eager .lower() default
+    raised AttributeError AFTER the full Stage-1 spend."""
+    # producer: null verdict + valid finding -> the finding is the substance
+    out = _normalize_result({"verdict": None, "finding": "vulnerable"})
+    assert out["verdict"] == "VULNERABLE"
+    # producer: null verdict alone -> the error shape
+    out = _normalize_result({"verdict": None, "reasoning": "cannot determine"})
+    assert out["verdict"] == "ERROR" and out["finding"] == "error"
+    # producer: empty-string verdict -> the error shape
+    out = _normalize_result({"verdict": "   "})
+    assert out["verdict"] == "ERROR" and out["finding"] == "error"
+    # counter: the crash shapes are now partitioned, not raised
+    counts = _count_verdicts([
+        {"verdict": None, "finding": "vulnerable"},  # counted via finding
+        {"verdict": None},                           # was an AttributeError
+        {"verdict": ""},                             # was a silent drop
+    ])
+    assert counts["vulnerable"] == 1
+    assert counts["errors"] == 2
+    # predicate: not adopted as complete
+    from core.analyzer import _cp_is_error
+
+    assert _cp_is_error({"result": {"verdict": None}}) is True
+
+
+def test_count_verdicts_fallback_shapes_preserved():
+    """Guard: the pre-fix partition semantics for ordinary shapes hold."""
+    counts = _count_verdicts([
+        {"verdict": "SAFE"},             # finding falls back to verdict
+        {"finding": "safe"},             # finding direct
+        {"verdict": "SOMETHING_WEIRD"},  # F13-documented drop, still dropped
+    ])
+    assert counts["safe"] == 2
+    assert sum(counts.values()) == 2
+
+
+def _write_checkpoint(tmp_path, rows):
+    """Write analyze-style checkpoint rows; returns the manager (dir built in)."""
+    ck = StepCheckpoint("analyze", str(tmp_path))
+    for uid, result in rows:
+        ck.save(uid, {"id": uid, "result": result})
+    return ck
+
+
+def test_load_ids_skips_neither_key(tmp_path):
+    """Mirror 1: the resume-completed set must not adopt a neither-key row."""
+    ck = _write_checkpoint(tmp_path, [
+        ("good", {"verdict": "VULNERABLE", "finding": "vulnerable"}),
+        ("neither", {"reasoning": "cannot determine"}),
+        ("err", {"verdict": "ERROR"}),
+    ])
+    ids = ck.load_ids(skip_errors=True)
+    assert "good" in ids
+    assert "err" not in ids
+    assert "neither" not in ids  # #324: retried, not adopted
+
+
+def test_status_counts_neither_key_as_analysis_error(tmp_path):
+    """Mirror 2: checkpoint status classifies the neither-key row as an
+    analysis error (visible in error accounting, not completed)."""
+    ck = _write_checkpoint(tmp_path, [
+        ("good", {"verdict": "VULNERABLE", "finding": "vulnerable"}),
+        ("neither", {"reasoning": "cannot determine"}),
+    ])
+    status = StepCheckpoint.status(ck.dir)
+    assert status["completed"] == 1
+    assert status["errors"] == 1
+    assert status["error_breakdown"].get("analysis_error") == 1
+
+
+def test_load_ids_keeps_non_analyze_phases(tmp_path):
+    """Wave finding (all three reviewers): the neither-key arm must be
+    scoped to analyze rows — verify/enhance/dynamic-test checkpoints carry
+    no "result" key, and load_ids' four-phase contract must hold."""
+    # verify shape (finding_verifier.py:931-935)
+    ck_v = StepCheckpoint("verify", str(tmp_path / "v"))
+    ck_v.save("u1", {"id": "u1", "verification": {"agree": True, "correct_finding": "safe"},
+                     "finding": "safe", "verification_note": "n"})
+    assert ck_v.load_ids(skip_errors=True) == {"u1"}
+    # enhance shape (context_enhancer.py:985-989)
+    ck_e = StepCheckpoint("enhance", str(tmp_path / "e"))
+    ck_e.save("u2", {"id": "u2", "context_key": "llm_context",
+                     "llm_context": {"ok": True}})
+    assert ck_e.load_ids(skip_errors=True) == {"u2"}
+    # dynamic-test shape (models.py:42-58)
+    ck_d = StepCheckpoint("dynamic-test", str(tmp_path / "d"))
+    ck_d.save("u3", {"id": "u3", "finding_id": "f1", "status": "SUCCESS"})
+    assert ck_d.load_ids(skip_errors=True) == {"u3"}
+    # status() agrees on a verify row
+    st = StepCheckpoint.status(ck_v.dir)
+    assert st["completed"] == 1 and st["errors"] == 0
+
+
+def test_summary_seed_agrees_with_adoption(tmp_path):
+    """Wave round-2 finding (both reviewers, confirmed by execution): the
+    seed must count ONLY what adoption keeps. An errored row is re-analyzed
+    and its outcome is owned by _summary_callback — seeding it too
+    double-counts (completed + errors > total). This drives the REAL
+    extracted seed (_seed_summary) over REAL checkpoint files and replays
+    the resume arithmetic end to end."""
+    from core.analyzer import _seed_summary
+
+    ck = _write_checkpoint(tmp_path, [
+        ("good", {"verdict": "SAFE", "finding": "safe"}),
+        ("neither", {"reasoning": "cannot determine"}),  # re-analyzed
+        ("err", {"verdict": "ERROR", "finding": "error"}),  # re-analyzed
+    ])
+    existing = ck.load()
+    seed = _seed_summary(existing)
+    # adoption: only the good row is kept; the other two are re-processed
+    adopted = {uid for uid, cp in existing.items()
+               if not analyze_result_is_error(cp.get("result") or {})}
+    assert adopted == {"good"}
+    assert seed["completed"] == 1  # only what adoption keeps
+    # resume: the two re-analyzed units' outcomes are counted by the
+    # callback (say one succeeds, one errors again)
+    completed = seed["completed"] + 1
+    errors = 0 + 1
+    assert completed + errors == 3  # == total: the invariant holds
+    # usage accumulates over ALL rows (the spend happened)
+    ck2 = _write_checkpoint(tmp_path / "u", [
+        ("good", {"verdict": "SAFE", "finding": "safe"}),
+    ])
+    # (usage seeding is exercised below with a usage-bearing checkpoint)
+    import json as _json
+    from utilities.file_io import write_json
+    import os
+    ck3 = StepCheckpoint("analyze", str(tmp_path / "s"))
+    ck3.save("u", {"id": "u", "result": {"verdict": "SAFE", "finding": "safe"},
+                   "usage": {"input_tokens": 10, "output_tokens": 5, "cost_usd": 0.25,
+                             "unpriced_models": ["m1"]}})
+    seed3 = _seed_summary(ck3.load())
+    assert seed3["completed"] == 1
+    assert seed3["input_tokens"] == 10 and seed3["output_tokens"] == 5
+    assert seed3["cost_usd"] == 0.25
+    assert seed3["unpriced_models"] == {"m1"}
+
+
+def test_analyze_result_is_error_none_and_corrupt_shapes():
+    """Wave round-2 (bug-hunt): a hand-edited "result": null must not crash
+    the classifier (status() is the Go CLI's checkpoint-status source)."""
+    assert analyze_result_is_error(None) is True
+    assert analyze_result_is_error({"verdict": "SAFE", "finding": "safe"}) is False
+
+
+def test_counter_agrees_with_predicate_on_error_finding():
+    """Wave round-2 (bug-hunt): a legacy half-stamped row (finding=="error",
+    no verdict) — the counter and the predicate must agree it is an error."""
+    counts = _count_verdicts([{"finding": "error"}])
+    assert counts["errors"] == 1
+
+
+def test_both_keys_disagreement_residual_pinned():
+    """Wave round-2 finding (both reviewers): a row with BOTH keys present
+    but disagreeing ({"verdict": "SAFE", "finding": "garbage"}) is adopted
+    (effective verdict short-circuits the finding branch) and counted in no
+    bucket (finding-first counter drops it). PRE-EXISTING family, NOT
+    produced by the fixed producers, deliberately out of scope (#316/#324
+    fix the unrecognized/absent verdicts). Pinned so a future fix updates
+    this consciously — see FOLLOW-UPS."""
+    out = _normalize_result({"verdict": "SAFE", "finding": "garbage"})
+    assert out["verdict"] == "SAFE" and out["finding"] == "garbage"
+    counts = _count_verdicts([out])
+    assert sum(counts.values()) == 0  # dropped — the documented residual
+    assert analyze_result_is_error(out) is False  # adopted on resume
+
+
+# ---------------------------------------------------------------------------
+# C. the JSON corrector's two synthesis sites
+# ---------------------------------------------------------------------------
+
+class _ToolAdapter:
+    name = "anthropic"
+    supports_tools = True
+
+    def complete(self, **kwargs):  # pragma: no cover - never called
+        raise AssertionError("adapter.complete must not be called here")
+
+    def validate(self, model):  # pragma: no cover
+        pass
+
+
+def _tool_binding():
+    from utilities.llm import PhaseBinding
+
+    return PhaseBinding(
+        phase="analyze",
+        adapter=_ToolAdapter(),
+        model="claude-test",
+        provider_name="anthropic",
+    )
+
+
+def _correct(raw_response, extracted, monkeypatch):
+    """Run attempt_correction with a stubbed extractor LLM (monkeypatched —
+    a bare assignment would leak module state into later tests)."""
+    import utilities.json_corrector as jc
+
+    def fake_simple_text(binding, prompt, **kwargs):
+        return json.dumps(extracted)
+
+    monkeypatch.setattr(jc, "simple_text", fake_simple_text)
+    return JSONCorrector(_tool_binding()).attempt_correction(raw_response)
+
+
+from utilities.json_corrector import JSONCorrector  # noqa: E402
+
+
+def test_corrector_unrecognized_finding_becomes_error(monkeypatch):
+    """#316 site (b): the mapping default is ERROR, so a correction that
+    recovers only a garbage finding is reported as a FAILED correction."""
+    out = _correct("prose with no json", {"finding": "maybe exploitable", "reasoning": "r"}, monkeypatch)
+    assert out.get("verdict") == "ERROR"
+    assert out.get("json_corrected") is False
+
+
+def test_corrector_recognized_finding_still_recovers(monkeypatch):
+    """Guard: a real recovery still passes its gate."""
+    out = _correct("prose with no json", {"finding": "vulnerable", "reasoning": "r"}, monkeypatch)
+    assert out.get("verdict") == "VULNERABLE"
+    assert out.get("json_corrected") is True
+
+
+def test_corrector_offenum_correct_finding_becomes_error(monkeypatch):
+    """#316 site (a): correct_finding maps through the verify enum; anything
+    off-enum is ERROR (rejected), not a synthesized verdict. Pins
+    json_corrected=False so the ERROR comes from the new failure gate, not
+    the canonical error dict's fall-through."""
+    out = _correct("prose with no json", {"agree": False, "correct_finding": "not sure, maybe"}, monkeypatch)
+    assert out.get("verdict") == "ERROR"
+    assert out.get("json_corrected") is False
+
+
+def test_corrector_enum_correct_finding_still_recovers(monkeypatch):
+    """Guard: the verify-enum values still derive a verdict (site a)."""
+    out = _correct("prose with no json", {"agree": False, "correct_finding": "vulnerable"}, monkeypatch)
+    assert out.get("verdict") == "VULNERABLE"
+
+
+# ---------------------------------------------------------------------------
+# D. context_corrector's private twin
+# ---------------------------------------------------------------------------
+
+def test_context_corrector_unrecognized_finding_routes_to_error():
+    """The third _normalize_result copy (the insufficient-context re-analysis
+    path) inherits the same treatment."""
+    from utilities.context_corrector import ContextCorrector
+
+    out = ContextCorrector._normalize_result({"finding": "maybe exploitable"})
+    assert out["verdict"] == "ERROR"
+
+
+def test_context_corrector_twin_full_mirror():
+    """Wave finding (bug-hunt): the twin claims parity with
+    analysis_core._normalize_result — pin the FULL contract, not just the
+    verdict (co-stamped finding, raw preserved, non-string guard, the
+    neither-key arm, null-verdict validity)."""
+    from utilities.context_corrector import ContextCorrector
+
+    nr = ContextCorrector._normalize_result
+    out = nr({"finding": "maybe exploitable"})
+    assert out["verdict"] == "ERROR" and out["finding"] == "error"
+    assert out["raw_finding"] == "maybe exploitable"
+    # non-string finding: no AttributeError, the error shape
+    out = nr({"finding": ["VULNERABLE"]})
+    assert out["verdict"] == "ERROR" and out["finding"] == "error"
+    assert out["raw_finding"] == ["VULNERABLE"]
+    # neither key: the #324 arm exists in the twin too
+    out = nr({"reasoning": "cannot determine"})
+    assert out["verdict"] == "ERROR" and out["finding"] == "error"
+    # null verdict with a valid finding: the finding is the substance
+    out = nr({"verdict": None, "finding": "vulnerable"})
+    assert out["verdict"] == "VULNERABLE"
+    # recognized mapping intact
+    assert nr({"finding": "insufficient_context"})["verdict"] == "INSUFFICIENT_CONTEXT"
+
+
+def test_context_corrector_error_break_stamps_failure(monkeypatch, tmp_path):
+    """Wave round-2 finding (both reviewers): the ERROR-gate break must
+    stamp the failure on the RETURNED original (every other break in the
+    loop does) and preserve the garbage reply — experiment.py reads
+    correction_status. Drives the real correct() with the LLM seams
+    stubbed."""
+    import utilities.context_corrector as cc
+
+    monkeypatch.setattr(
+        cc, "parse_missing_context_with_llm", lambda binding, r: "the config loader"
+    )
+    monkeypatch.setattr(
+        cc, "search_files_for_context",
+        lambda binding, mc, sf, fi: [{"relative_path": "cfg.py", "content": "x = 1"}],
+    )
+    # the re-analysis reply carries an unrecognized finding
+    monkeypatch.setattr(
+        cc, "simple_text", lambda binding, prompt, **k: '{"finding": "not sure, maybe"}'
+    )
+
+    class _Tracker:
+        def get_totals(self):
+            return {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}
+
+    corrector = cc.ContextCorrector(_tool_binding(), str(tmp_path), tracker=_Tracker())
+    original = {"verdict": "INSUFFICIENT_CONTEXT", "finding": "insufficient_context",
+                "reasoning": "r"}
+    out = corrector.attempt_correction(original, "code()", lambda c, f: "prompt")
+
+    # the ORIGINAL is returned (the ERROR re-analysis is not adopted)
+    assert out["verdict"] == "INSUFFICIENT_CONTEXT"
+    # ...stamped as a failed correction with the garbage reply preserved
+    assert out["correction_attempted"] is True
+    assert out["correction_status"] == "reanalysis_unrecognized_verdict"
+    assert out["raw_finding"] == "not sure, maybe"
+    assert corrector.correction_stats["failures"] == 1
+    assert corrector.correction_stats["successes"] == 0

--- a/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
+++ b/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
@@ -36,7 +36,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
 if CORE not in sys.path:
@@ -284,9 +283,6 @@ def test_summary_seed_agrees_with_adoption(tmp_path):
     errors = 0 + 1
     assert completed + errors == 3  # == total: the invariant holds
     # usage accumulates over ALL rows (the spend happened)
-    ck2 = _write_checkpoint(tmp_path / "u", [
-        ("good", {"verdict": "SAFE", "finding": "safe"}),
-    ])
     # (usage seeding is exercised below with a usage-bearing checkpoint)
     import json as _json
     from utilities.file_io import write_json
@@ -360,16 +356,14 @@ def _tool_binding():
 def _correct(raw_response, extracted, monkeypatch):
     """Run attempt_correction with a stubbed extractor LLM (monkeypatched —
     a bare assignment would leak module state into later tests)."""
-    import utilities.json_corrector as jc
-
     def fake_simple_text(binding, prompt, **kwargs):
         return json.dumps(extracted)
 
-    monkeypatch.setattr(jc, "simple_text", fake_simple_text)
-    return JSONCorrector(_tool_binding()).attempt_correction(raw_response)
+    monkeypatch.setattr(_json_corrector, "simple_text", fake_simple_text)
+    return _json_corrector.JSONCorrector(_tool_binding()).attempt_correction(raw_response)
 
 
-from utilities.json_corrector import JSONCorrector  # noqa: E402
+import utilities.json_corrector as _json_corrector  # noqa: E402
 
 
 def test_corrector_unrecognized_finding_becomes_error(monkeypatch):
@@ -410,9 +404,9 @@ def test_corrector_enum_correct_finding_still_recovers(monkeypatch):
 def test_context_corrector_unrecognized_finding_routes_to_error():
     """The third _normalize_result copy (the insufficient-context re-analysis
     path) inherits the same treatment."""
-    from utilities.context_corrector import ContextCorrector
+    import utilities.context_corrector as _context_corrector
 
-    out = ContextCorrector._normalize_result({"finding": "maybe exploitable"})
+    out = _context_corrector.ContextCorrector._normalize_result({"finding": "maybe exploitable"})
     assert out["verdict"] == "ERROR"
 
 
@@ -421,9 +415,9 @@ def test_context_corrector_twin_full_mirror():
     analysis_core._normalize_result — pin the FULL contract, not just the
     verdict (co-stamped finding, raw preserved, non-string guard, the
     neither-key arm, null-verdict validity)."""
-    from utilities.context_corrector import ContextCorrector
+    import utilities.context_corrector as _context_corrector
 
-    nr = ContextCorrector._normalize_result
+    nr = _context_corrector.ContextCorrector._normalize_result
     out = nr({"finding": "maybe exploitable"})
     assert out["verdict"] == "ERROR" and out["finding"] == "error"
     assert out["raw_finding"] == "maybe exploitable"

--- a/libs/openant-core/utilities/context_corrector.py
+++ b/libs/openant-core/utilities/context_corrector.py
@@ -524,6 +524,19 @@ class ContextCorrector:
                 new_result["prompt_length"] = len(prompt)
                 new_result["response_length"] = len(response)
 
+                if new_result.get("verdict") == "ERROR":
+                    # #316 (mirror): the re-analysis recovered no
+                    # recognizable verdict — a FAILED correction, not
+                    # "Correction successful! New verdict: ERROR". Stamp the
+                    # failure on the returned original (every other break in
+                    # this loop does; experiment.py reads correction_status)
+                    # and preserve the garbage reply for manual review.
+                    current_result["correction_attempted"] = True
+                    current_result["correction_status"] = "reanalysis_unrecognized_verdict"
+                    if new_result.get("raw_finding") is not None:
+                        current_result["raw_finding"] = new_result["raw_finding"]
+                    print(f"      Correction failed: re-analysis produced no recognizable verdict", file=sys.stderr)
+                    break
                 if new_result.get("verdict") != "INSUFFICIENT_CONTEXT":
                     # Correction successful
                     new_result["correction_status"] = "success"
@@ -598,8 +611,19 @@ class ContextCorrector:
 
     @staticmethod
     def _normalize_result(result: dict) -> dict:
-        """Normalize finding -> verdict and ensure uppercase."""
-        if "verdict" not in result and "finding" in result:
+        """Normalize finding -> verdict and ensure uppercase.
+
+        #316/#324 mirror of ``core.analysis_core._normalize_result``: an
+        unrecognized, non-string, or absent finding/verdict routes to the
+        one error shape (verdict=ERROR, finding="error", raw preserved) —
+        never a synthesized verdict. (Both-keys-disagreement rows are not
+        reconciled here — same as the core function, a present effective
+        verdict short-circuits the finding branch; that family is the
+        documented F13 residual.)
+        """
+        verdict = result.get("verdict")
+        has_verdict = isinstance(verdict, str) and verdict.strip() != ""
+        if not has_verdict and "finding" in result:
             finding = result["finding"]
             mapping = {
                 "vulnerable": "VULNERABLE", "safe": "SAFE",
@@ -607,7 +631,19 @@ class ContextCorrector:
                 "inconclusive": "INCONCLUSIVE",
                 "insufficient_context": "INSUFFICIENT_CONTEXT",
             }
-            result["verdict"] = mapping.get(finding.lower(), finding.upper())
+            if not isinstance(finding, str):
+                result["raw_finding"] = finding
+                result["finding"] = "error"
+                result["verdict"] = "ERROR"
+            else:
+                v = mapping.get(finding.lower(), "ERROR")
+                if v == "ERROR" and finding.lower() != "error":
+                    result["raw_finding"] = finding
+                    result["finding"] = "error"
+                result["verdict"] = v
+        elif not has_verdict:
+            result["verdict"] = "ERROR"
+            result["finding"] = "error"
         if "verdict" in result and isinstance(result["verdict"], str):
             result["verdict"] = result["verdict"].upper()
         return result

--- a/libs/openant-core/utilities/json_corrector.py
+++ b/libs/openant-core/utilities/json_corrector.py
@@ -260,7 +260,22 @@ class JSONCorrector:
                 if "correct_finding" in extracted and isinstance(extracted["correct_finding"], str):
                     extracted["correct_finding"] = extracted["correct_finding"].lower()
                     if "verdict" not in extracted:
-                        extracted["verdict"] = extracted["correct_finding"].upper()
+                        # #316: an off-enum correct_finding is a malformed
+                        # reply, not a verdict — map through the verify enum
+                        # (_VERIFY_SCHEMA's five) and route anything else to
+                        # ERROR (the caller's not-in-("ERROR", None) gate
+                        # then rejects the correction) instead of
+                        # synthesizing a verdict no consumer recognizes.
+                        _verify_finding_to_verdict = {
+                            "safe": "SAFE",
+                            "protected": "PROTECTED",
+                            "bypassable": "BYPASSABLE",
+                            "vulnerable": "VULNERABLE",
+                            "inconclusive": "INCONCLUSIVE",
+                        }
+                        extracted["verdict"] = _verify_finding_to_verdict.get(
+                            extracted["correct_finding"], "ERROR"
+                        )
 
                 # Normalize finding -> verdict
                 if "verdict" not in extracted and "finding" in extracted:
@@ -271,10 +286,26 @@ class JSONCorrector:
                         "inconclusive": "INCONCLUSIVE",
                         "insufficient_context": "INSUFFICIENT_CONTEXT",
                     }
-                    extracted["verdict"] = mapping.get(finding.lower(), finding.upper())
+                    if not isinstance(finding, str):
+                        # Mirror of analysis_core._normalize_result: a
+                        # non-string finding is a malformed reply — the one
+                        # error shape, not a crash on .lower().
+                        extracted["verdict"] = "ERROR"
+                    else:
+                        # #316: an unrecognized finding string maps to ERROR — a
+                        # failed correction is visible and retried; a synthesized
+                        # verdict is silently uncountable.
+                        extracted["verdict"] = mapping.get(finding.lower(), "ERROR")
 
             # Validate the extracted data has the caller's required fields
-            if all(k in extracted for k in required_keys):
+            if vuln_mode and str(extracted.get("verdict", "")).upper() == "ERROR":
+                # #316: the correction recovered no recognizable verdict (the
+                # mappers' ERROR default) — report failure, not "successful!",
+                # so the log matches what the caller adopts. Case-insensitive:
+                # the extracted verdict is only upper-cased later, by
+                # _normalize_result.
+                print(f"      JSON correction failed: recovered no recognizable verdict", file=sys.stderr)
+            elif all(k in extracted for k in required_keys):
                 extracted["json_corrected"] = True
                 print(f"      JSON correction successful! keys={list(extracted.keys())}", file=sys.stderr)
                 return extracted

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -51,8 +51,8 @@ def get_stage1_consistency_prompt(findings: list, code_samples: dict) -> str:
         # it stays one inert line. reasoning is prior-stage LLM output (untrusted) and
         # was interpolated raw beside the (now-fenced) code — give it its own
         # length-adaptive fence so it can't inject prompt directives. verdict is
-        # model-derived (analysis_core maps a non-enum finding through .upper(), so a
-        # newline survives) — collapse it too.
+        # model-derived (a raw verdict string still passes through analysis_core's
+        # normalization, so a newline survives) — collapse it too.
         rk_label = collapse_inline(route_key) or "unknown"
         verdict_label = collapse_inline(f.get('verdict', 'unknown')) or "unknown"
         reasoning = str(f.get("reasoning", "N/A"))[:300]


### PR DESCRIPTION
## Summary

A Stage-1 verdict the pipeline does not recognize used to vanish silently, three different ways:

- **#316** — `_normalize_result`'s string branch mapped an unrecognized finding string
  (`"maybe exploitable"`) to an upper-cased passthrough verdict (`"MAYBE EXPLOITABLE"`): not a
  counter bucket, not `"ERROR"` (so never retried on resume), not in the vulnerable set (so
  never disclosed). The non-string branch ten lines above already mapped to ERROR with a
  comment naming exactly this failure; the string branch never got the same treatment. The JSON
  corrector had two twin synthesis sites feeding the same escape.
- **#324** — a parsed object with **neither** verdict **nor** finding (a JSON-shaped refusal)
  kept neither key: `_cp_is_error` adopted it as complete on resume, and `_count_verdicts`
  counted it in no bucket (the singular `"error"` default can never match the `"errors"` key),
  so `units_analyzed` overstated.

Both issues reach the same sinks and conclude *"a consumer-side fix closes both; a producer-side
fix closes neither"* — this is the joint fix.

## The fix

**Producers stamp the one error shape** (`verdict="ERROR"`, `finding="error"`, raw value
preserved under `raw_finding` for manual review): an unrecognized finding string, a non-string
finding, a neither-key refusal, and a null/empty verdict (a `{"verdict": null}` refusal is the
#324 shape with the key present). The corrector's two synthesis sites map through their enums
with an ERROR default, and a vuln-mode correction that recovers no recognizable verdict is
reported as a failed correction, not "successful!". The `context_corrector`'s private
`_normalize_result` twin inherits the full treatment.

**Consumers fail closed, once**: a new shared predicate `checkpoint.analyze_result_is_error`
now backs all four copies that had drifted — `analyzer._cp_is_error` (hoisted to module level),
`_count_verdicts`, `checkpoint.load_ids`, `checkpoint.status` — plus the `_summary.json` seed
loop. A legacy neither-key checkpoint is re-analyzed, not adopted; the counter routes it to
`errors` so the partition does not lose the row; `load_ids` keeps its four-phase contract (the
arm is scoped to analyze rows — verify/enhance/dynamic-test checkpoints carry no `result` key).

**The resume arithmetic is exact**: the summary seed counts only what adoption keeps (an
errored row is re-analyzed and owned by `_summary_callback` — seeding it too double-counted;
`completed + errors == total_units` now holds at completion where the pre-existing
`verdict=="ERROR"` over-count did not).

## Design decisions (deliberate, documented)

- A well-formed reply with a garbage verdict now triggers one JSON-correction LLM call — the
  same treatment a parse failure gets: the corrector may legitimately recover a real verdict
  from the same text, and the result is re-gated on ERROR and rejected.
- No in-run retry for these rows (no `error` key): a semantic refusal may be deterministic;
  the retry is resume-owned.
- The new errors are bucketed under the summary's existing `"api"` breakdown label.

## Residuals (pre-existing, pinned by tests, deliberately out of scope)

- An unrecognized **verdict** string (`{"verdict": "SOMETHING_WEIRD"}`) is still dropped by
  `_count_verdicts` — the documented F13 partition gap, unchanged.
- `insufficient_context` is mapped but has no counter bucket (#293 rules it completed — a
  results-partition question, not a coverage loss).
- Both-keys-disagreement rows (`{"verdict": "SAFE", "finding": "garbage"}`) are adopted and
  dropped — not produced by the fixed producers; the live producer of that family
  (`stage1_consistency`'s verdict-only rewrite) is filed separately as #425.
- Legacy pre-fix garbage-verdict checkpoints are still adopted (escape hatch: delete the
  checkpoint dir).

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | the issue-316/324 test file (26 tests) | 26 green (RED on pristine: the file cannot even collect — the extracted seed does not exist there) # proc-ok |
| full suite | the full pytest run on the fix branch | 3400 green / 1 failed — that 1 fails byte-identically on pristine master (a macOS `/private/var` tmp artifact, environment-only) |
| mutation smoke | pristine sources restored, the test file re-run | the defect shapes fail; restored: green # proc-ok |
| hermeticity | the env-scrubbed run (fake HOME) | 26 green |
| the real binary | `openant parse <fixture> --output ... --level all`, built from this branch | 2 units extracted, all outputs written — no regression |
| the integrated analyze flow | the real `parse_response` → `_count_verdicts` → the shared predicate, on the two issues' exact reply shapes | the malformed replies land in `errors` (partition closes), are retried on resume, and the checkpoint-completed set excludes them |
| lint | the CI lint scope over the seven touched files | green |
| review | a three-round adversarial wave (e2e + test-validity + bug-hunt lenses) | round 1: 6 findings (the unscoped `load_ids` arm — all three reviewers independently; the null-verdict crash; the seed's fourth predicate copy; the context-corrector partial mirror) — all fixed; round 2: the seed double-count + the unstamped break — fixed; round 3: no findings |

</details>

Fixes #316
Fixes #324
