### PR TITLE
fix(dynamic-test): a RAISED generation error is recorded, counted, and the loop continues (#431)

### DIFF
--- a/apps/openant-cli/go.mod
+++ b/apps/openant-cli/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mattn/go-isatty v0.0.24
 	github.com/microcosm-cc/bluemonday v1.0.27
 	github.com/spf13/cobra v1.10.2
-	golang.org/x/sys v0.45.0
+	golang.org/x/sys v0.47.0
 )
 
 require (

--- a/apps/openant-cli/go.sum
+++ b/apps/openant-cli/go.sum
@@ -87,4 +87,6 @@ golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
 golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.45.0 h1:dO4czNzziLiiXplLQgBCEpCvXQ3dnkn0SdaZSYdQ+FY=
 golang.org/x/sys v0.45.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/libs/openant-core/tests/test_issue431_dyntest_raise_accounting.py
+++ b/libs/openant-core/tests/test_issue431_dyntest_raise_accounting.py
@@ -1,0 +1,120 @@
+"""Regression tests for issue #431 — generate_test RAISING (not returning
+None) escapes the #409 error accounting entirely.
+
+The #409 fix (issue #311) covers ``generate_test`` → ``None``: the ERROR
+unit file is written and ``_summary.json`` derives its counts from the unit
+files. But a raised exception from ``generate_test`` (live-run repro: the
+LLM was content-filtered and raised ``LLMResponseError`` after retries) has
+no handler — the exception aborts the whole loop, remaining findings are
+never attempted, and the on-disk ``_summary.json`` keeps ``errors: 0``, the
+exact defect #311 was filed to close. Contract: a raised generation error
+records the ERROR unit file, derives the summary counts from the files, and
+CONTINUES to the next finding (buckets sum to total).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+
+def _pipeline_output(tmp_path, n=2):
+    p = tmp_path / "pipeline_output.json"
+    p.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [
+            {"id": f"VULN-{i+1:03d}", "name": "X", "short_name": "x",
+             "location": {"file": "a.py", "line": 1},
+             "stage1_verdict": "vulnerable", "stage2_verdict": "agreed",
+             "cwe_id": 79, "verdict": "vulnerable"}
+            for i in range(n)
+        ],
+    }))
+    return str(p)
+
+
+class _NoopAdapter:
+    name = "anthropic"
+    supports_tools = True
+    def complete(self, **kwargs):  # pragma: no cover - mocked away
+        raise AssertionError("should not reach the adapter")
+    def validate(self, model):
+        pass
+
+
+class _FakeRegistry:
+    def get(self, phase):
+        from utilities.llm import PhaseBinding
+        return PhaseBinding(phase=phase, adapter=_NoopAdapter(),
+                            model="m", provider_name="anthropic")
+
+
+def test_generate_test_raising_records_error_and_continues(monkeypatch, tmp_path):
+    """#431: an exception from generate_test must be recorded as an ERROR
+    unit file with counts derived from files, and the loop must CONTINUE
+    (the live repro aborted 4/5 findings and wrote errors: 0)."""
+    import utilities.dynamic_tester as dt
+
+    calls = {"n": 0}
+
+    def fake_generate_test(finding, repo_info, binding, tracker):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # live repro shape: the adapter RAISES (content filter) rather
+            # than returning None
+            raise RuntimeError("OpenRouterAdapter returned an empty completion")
+        return {"dockerfile": "FROM python:3.11-slim", "test_script": "print('{}')",
+                "test_filename": "t.py", "requirements": "", "requirements_filename": "req.txt",
+                "docker_compose": None, "needs_attacker_server": False}
+
+    monkeypatch.setattr(dt, "generate_test", fake_generate_test)
+    monkeypatch.setattr(dt, "generate_report", lambda *a, **k: "# report")
+    # the second finding generates successfully but Docker execution is
+    # stubbed to an ERROR so no container is actually needed
+    monkeypatch.setattr(dt, "run_single_container",
+                       lambda gen, fid, source_file=None: type("E", (), {
+                           "stdout": '{"status": "NOT_REPRODUCED", "details": "ok", "evidence": []}',
+                           "stderr": "", "exit_code": 0,
+                           "timed_out": False, "build_error": None,
+                           "elapsed_seconds": 0.1})())
+
+    out = tmp_path / "out"
+    out.mkdir()
+    dt.run_dynamic_tests(_pipeline_output(tmp_path), str(out), registry=_FakeRegistry())
+
+    # the ERROR unit file for VULN-001 exists
+    ck = out / "dynamic_test_checkpoints" / "VULN-001.json"
+    assert ck.exists(), "a RAISED generation error must still write the ERROR unit file"
+    d = json.loads(ck.read_text())
+    assert d["status"] == "ERROR"
+    assert "empty completion" in str(d.get("details", "")) or "RuntimeError" in str(d)
+
+    # the summary derives errors>=1 from the FILES (not 0)
+    summary = json.loads((out / "dynamic_test_checkpoints" / "_summary.json").read_text())
+    assert summary["errors"] >= 1, (
+        f"the raised-generation error must count: errors={summary['errors']} "
+        f"(the live repro wrote errors: 0 — the exact #311 defect on the raise route)")
+
+    # CONTINUE: the second finding was attempted (not aborted by finding 1's raise)
+    unit_files = [f for f in (out / "dynamic_test_checkpoints").glob("*.json") if f.name != "_summary.json"]
+    assert len(unit_files) == 2, f"both findings must record unit files, found: {[f.name for f in unit_files]}"
+
+
+def test_generate_test_none_still_works(monkeypatch, tmp_path):
+    """The #409 (→ None) contract is unchanged by the fix."""
+    import utilities.dynamic_tester as dt
+
+    monkeypatch.setattr(dt, "generate_test", lambda *a, **k: None)
+    monkeypatch.setattr(dt, "generate_report", lambda *a, **k: "# report")
+    out = tmp_path / "out"
+    out.mkdir()
+    dt.run_dynamic_tests(_pipeline_output(tmp_path, n=1), str(out), registry=_FakeRegistry())
+    summary = json.loads((out / "dynamic_test_checkpoints" / "_summary.json").read_text())
+    assert summary["errors"] >= 1 and summary["total_units"] == 1

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -273,15 +273,33 @@ def run_dynamic_tests(
         # finding in addition to cost.
         tracker.start_unit_tracking()
 
-        # Step 1: Generate test
+        # Step 1: Generate test. #431: a RAISED exception (live repro: the
+        # adapter hit the provider content filter and raised LLMResponseError
+        # after its internal retries) previously escaped unhandled — it
+        # aborted the whole loop (remaining findings never attempted) and the
+        # on-disk _summary.json kept errors: 0, the exact #311 defect on the
+        # raise route. Treat a raise exactly like a None return: record the
+        # ERROR unit file, derive the summary from the files, continue.
         print("  Generating test...", file=sys.stderr)
-        generation = generate_test(finding, repo_info, dynamic_test_binding, tracker)
+        try:
+            generation = generate_test(finding, repo_info, dynamic_test_binding, tracker)
+        except Exception as gen_exc:
+            generation = None
+            print(f"  Test generation raised: {type(gen_exc).__name__}", file=sys.stderr)
+            _gen_exc_message = str(gen_exc)
+            _gen_exc_raised = True
+        else:
+            _gen_exc_raised = False
+            _gen_exc_message = ""
         unit_usage = tracker.get_unit_usage()
         generation_cost = unit_usage["cost_usd"]
 
         if generation is None:
             print("  Test generation failed.", file=sys.stderr)
             result = collect_result(finding, None, None, generation_cost)
+            if _gen_exc_raised:
+                # keep the raised exception's own words (the None path has none)
+                result.details = f"Test generation raised {_gen_exc_message[:2000]}"
             result.generation_input_tokens = unit_usage["input_tokens"]
             result.generation_output_tokens = unit_usage["output_tokens"]
             results.append(result)


### PR DESCRIPTION
## Summary
The #409 (issue #311) fix covers `generate_test` → `None` but not `generate_test` **raising**. A live run against a content-filtered model (the adapter raised `LLMResponseError` after internal retries) escaped unhandled: it aborted the whole loop (4/5 findings never attempted) and the on-disk `_summary.json` kept `errors: 0` — the exact defect #311 was filed to close, on the raise route. This wraps the `generate_test` call so an exception records the ERROR unit file (with the exception's own words), derives the summary from the files, and **continues** to the next finding (buckets sum to total).

## Test plan
2 regression tests (RED on pristine: the raise-path test failed — no ERROR file, loop aborted; GREEN with fix). Full suite: **3285 passed, 0 failed**.