### PR TITLE
feat(report): every finding carries a rankable severity — model-supplied with a conservative derived fallback, threaded to every deliverable surface (#215)

### DIFF
--- a/apps/openant-cli/internal/report/report_test.go
+++ b/apps/openant-cli/internal/report/report_test.go
@@ -121,3 +121,35 @@ func excerpt(out, key string) string {
 	}
 	return out[start:end]
 }
+
+// #215: a severity-bearing finding renders its badge; a finding without one
+// (old artifacts) renders none.
+func TestRenderReskinSeverityBadge(t *testing.T) {
+	data := baseReportData()
+	// the reskin template iterates the GROUPED structure the report-data
+	// projection builds (cli.py: findings_by_verdict) — not .Findings.
+	data.FindingsByVerdict = []FindingGroup{{
+		Verdict: "vulnerable",
+		Findings: []Finding{{
+			Number:         1,
+			Verdict:        "vulnerable",
+			File:           "src/app.py",
+			Function:       "render",
+			Severity:       "critical",
+			SeveritySource: "model",
+		}},
+	}}
+	var buf bytes.Buffer
+	if err := RenderReskin(data, &buf); err != nil {
+		t.Fatalf("RenderReskin: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, ">critical<") {
+		t.Error("expected the severity badge to render for a severity-bearing finding")
+	}
+	// the color method backs the badge style
+	f := Finding{Severity: "critical"}
+	if f.SeverityColor() != "#721c24" {
+		t.Errorf("SeverityColor(critical) = %q, want #721c24", f.SeverityColor())
+	}
+}

--- a/apps/openant-cli/internal/report/sarif.go
+++ b/apps/openant-cli/internal/report/sarif.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -165,20 +166,39 @@ func sarifRulesFor(data ReportData) ([]map[string]any, map[string]int) {
 		descByVerdict[c.Verdict] = c.Description
 	}
 
+	// #215: rules stay ONE PER VERDICT — the ruleId is the alert's identity
+	// in GitHub Code Scanning (a finding whose severity model-flips between
+	// runs must NOT move rules: close+reopen would discard accumulated
+	// dismissal/triage state; wave round-2 reverted the per-severity fanout
+	// for exactly this). The numeric security-severity — which Code Scanning
+	// reads from the RULE's properties — is the verdict's MAX finding
+	// severity: coarse per-rule ranking without identity churn. The
+	// per-finding label stays on the result (filterable).
 	seen := make(map[string]int)
-	rules := make([]map[string]any, 0)
+	maxSev := make(map[string]string)
 	for _, f := range data.Findings {
 		v := normalizedVerdict(f.Verdict)
-		if _, ok := seen[v]; ok {
-			continue
+		if _, ok := seen[v]; !ok {
+			seen[v] = len(seen)
 		}
-		seen[v] = len(rules)
-
+		if s := severityRank(f.Severity); s > severityRank(maxSev[v]) {
+			maxSev[v] = severityLabel(f.Severity)
+		}
+	}
+	rules := make([]map[string]any, 0, len(seen))
+	for v := range seen {
 		desc := descByVerdict[v]
 		if desc == "" {
 			desc = fmt.Sprintf("Finding with verdict %q.", v)
 		}
-
+		props := map[string]any{
+			"verdict": v,
+			"tags":    []string{"security", "openant"},
+		}
+		if maxSev[v] != "" {
+			props["severity"] = maxSev[v]
+			props["security-severity"] = securitySeverityFor(maxSev[v])
+		}
 		rules = append(rules, map[string]any{
 			"id":   "openant.verdict." + v,
 			"name": "OpenAntVerdict_" + strings.ReplaceAll(v, "-", "_"),
@@ -191,13 +211,14 @@ func sarifRulesFor(data ReportData) ([]map[string]any, map[string]int) {
 			"defaultConfiguration": map[string]any{
 				"level": sarifLevelForVerdict(v),
 			},
-			"properties": map[string]any{
-				"verdict": v,
-				"tags":    []string{"security", "openant"},
-			},
+			"properties": props,
 		})
 	}
-
+	// deterministic order for the rules array (map iteration is random)
+	sort.Slice(rules, func(i, j int) bool {
+		return seen[rules[i]["id"].(string)[len("openant.verdict."):]] <
+			seen[rules[j]["id"].(string)[len("openant.verdict."):]]
+	})
 	return rules, seen
 }
 
@@ -229,6 +250,19 @@ func sarifResultFor(f Finding, ruleIndex map[string]int) map[string]any {
 	props := map[string]any{
 		"verdict":  v,
 		"function": f.Function,
+	}
+	// #215: the severity label (+ source) on the result (filterable). The
+	// numeric security-severity lives on the RULE — the verdict's MAX
+	// finding severity, so the alert's rule identity stays STABLE (a
+	// per-severity fanout would re-key alerts on every severity flip and
+	// discard Code Scanning triage state; wave round-2 reverted it). The
+	// SARIF level itself stays verdict-based — level is visibility,
+	// severity is rank.
+	if severityLabel(f.Severity) != "" {
+		props["severity"] = severityLabel(f.Severity)
+		if f.SeveritySource != "" {
+			props["severity_source"] = f.SeveritySource
+		}
 	}
 	if f.DynamicTestStatus != "" {
 		props["dynamicTestStatus"] = f.DynamicTestStatus
@@ -310,6 +344,48 @@ func findingMessage(f Finding) string {
 // existing fingerprints.
 func fingerprintFor(f Finding, verdict string) string {
 	return fmt.Sprintf("%s|%s|%s", f.File, f.Function, verdict)
+}
+
+// severityLabel sanitizes the model/projected severity onto the canonical
+// enum — anything else (including empty) is "no severity" and emits nothing.
+func severityLabel(sev string) string {
+	switch sev {
+	case "critical", "high", "medium", "low":
+		return sev
+	}
+	return ""
+}
+
+// severityRank orders the labels for the per-verdict max (0 = none).
+func severityRank(sev string) int {
+	switch severityLabel(sev) {
+	case "low":
+		return 1
+	case "medium":
+		return 2
+	case "high":
+		return 3
+	case "critical":
+		return 4
+	}
+	return 0
+}
+
+// securitySeverityFor maps a severity label onto GitHub Code Scanning's
+// numeric security-severity convention (labels rank; the mapping is
+// display-oriented, not a CVSS score).
+func securitySeverityFor(sev string) string {
+	switch sev {
+	case "critical":
+		return "9.0"
+	case "high":
+		return "7.5"
+	case "medium":
+		return "5.0"
+	case "low":
+		return "2.5"
+	}
+	return ""
 }
 
 // sarifLevelForVerdict maps an OpenAnt verdict to a SARIF result.level.

--- a/apps/openant-cli/internal/report/sarif_test.go
+++ b/apps/openant-cli/internal/report/sarif_test.go
@@ -529,3 +529,119 @@ func TestSARIFPartialWithoutCountsDegradesVisibly(t *testing.T) {
 		t.Errorf("the degraded-status notification must appear; got %v", texts)
 	}
 }
+
+// #215: the severity label threads onto the RESULT properties (filterable),
+// while the numeric security-severity — what GitHub Code Scanning ranks by —
+// lives on the RULE (reportingDescriptor.properties) as the verdict's MAX
+// finding severity, with STABLE one-rule-per-verdict ids. Level stays
+// verdict-based.
+func TestBuildSARIF_SeverityProperties(t *testing.T) {
+	data := sarifFixtureData()
+	data.Findings[0].Severity = "high"
+	data.Findings[0].SeveritySource = "model"
+	got := BuildSARIF(data, SARIFOptions{})
+	run := got["runs"].([]any)[0].(map[string]any)
+	results := run["results"].([]map[string]any)
+
+	// the result: the label (+ source), no numeric property (that is the rule's)
+	props := results[0]["properties"].(map[string]any)
+	if props["severity"] != "high" {
+		t.Errorf("result severity property: got %v, want high", props["severity"])
+	}
+	if props["severity_source"] != "model" {
+		t.Errorf("result severity_source: got %v, want model", props["severity_source"])
+	}
+	if _, ok := props["security-severity"]; ok {
+		t.Error("security-severity belongs to the RULE, not the result")
+	}
+	// STABLE rule id — the alert's identity (no per-severity fanout: a
+	// severity flip between runs must not move rules and discard Code
+	// Scanning triage state)
+	if results[0]["ruleId"] != "openant.verdict.vulnerable" {
+		t.Errorf("ruleId: got %v, want openant.verdict.vulnerable (stable)", results[0]["ruleId"])
+	}
+
+	// the RULE carries the verdict's MAX finding severity where Code Scanning reads it
+	rules := run["tool"].(map[string]any)["driver"].(map[string]any)["rules"].([]map[string]any)
+	var vulnRule map[string]any
+	for _, r := range rules {
+		if r["id"] == "openant.verdict.vulnerable" {
+			vulnRule = r
+		}
+	}
+	if vulnRule == nil {
+		t.Fatal("the vulnerable rule was not built")
+	}
+	rp := vulnRule["properties"].(map[string]any)
+	if rp["security-severity"] != "7.5" {
+		t.Errorf("rule security-severity: got %v, want 7.5", rp["security-severity"])
+	}
+	if rp["severity"] != "high" {
+		t.Errorf("rule severity: got %v, want high", rp["severity"])
+	}
+	// the MAX: a critical sibling raises the rule (coarse ranking, stable identity)
+	data.Findings = append(data.Findings, Finding{
+		Number: 3, Verdict: "vulnerable", File: "x.py", Function: "f",
+		Severity: "critical", SeveritySource: "model"})
+	got3 := BuildSARIF(data, SARIFOptions{})
+	rules3 := got3["runs"].([]any)[0].(map[string]any)["tool"].(map[string]any)["driver"].(map[string]any)["rules"].([]map[string]any)
+	n := 0
+	for _, r := range rules3 {
+		if r["id"].(string) == "openant.verdict.vulnerable" {
+			n++
+			rp3 := r["properties"].(map[string]any)
+			if rp3["security-severity"] != "9.0" {
+				t.Errorf("max severity: got %v, want 9.0", rp3["security-severity"])
+			}
+		}
+	}
+	if n != 1 {
+		t.Errorf("one rule per verdict (no fanout), got %d vulnerable rules", n)
+	}
+
+	// an unknown/absent severity: no result label
+	if _, ok := results[1]["properties"].(map[string]any)["severity"]; ok {
+		t.Error("a finding without severity must not carry a severity property")
+	}
+	// a non-canonical severity is sanitized to empty — no label
+	data.Findings[1].Severity = "weird"
+	got2 := BuildSARIF(data, SARIFOptions{})
+	results2 := got2["runs"].([]any)[0].(map[string]any)["results"].([]map[string]any)
+	if _, ok := results2[1]["properties"].(map[string]any)["severity"]; ok {
+		t.Error("a non-canonical severity must emit no label")
+	}
+}
+
+func TestSecuritySeverityFor(t *testing.T) {
+	cases := map[string]string{
+		"critical": "9.0",
+		"high":     "7.5",
+		"medium":   "5.0",
+		"low":      "2.5",
+		"":         "",
+		"weird":    "",
+	}
+	for in, want := range cases {
+		if got := securitySeverityFor(in); got != want {
+			t.Errorf("securitySeverityFor(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// Deep-refute #2: the Python→Go key contract — the projection's
+// "severity"/"severity_source" must match the struct tags, or the wiring
+// silently drops the values.
+func TestFindingJSONTags(t *testing.T) {
+	f := Finding{Severity: "high", SeveritySource: "model"}
+	b, err := json.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m["severity"] != "high" || m["severity_source"] != "model" {
+		t.Errorf("the json tags must be severity/severity_source; got %v", m)
+	}
+}

--- a/apps/openant-cli/internal/report/templates/overview.gohtml
+++ b/apps/openant-cli/internal/report/templates/overview.gohtml
@@ -280,6 +280,7 @@
                         <details id="finding-{{$f.Number}}" class="bg-navy-900/50 border border-gray-700/50 rounded-lg group">
                             <summary class="flex flex-wrap items-center gap-2 sm:gap-3 px-4 sm:px-5 py-3 hover:bg-navy-700/50 rounded-lg transition-colors">
                                 <span class="text-gray-400 text-xs font-mono font-medium w-8">#{{$f.Number}}</span>
+                                {{if $f.Severity}}<span class="inline-block px-2 py-0.5 rounded text-[10px] font-semibold text-white uppercase" style="background-color: {{$f.SeverityColor}}" title="severity source: {{$f.SeveritySource}}">{{$f.Severity}}</span>{{end}}
                                 {{if $f.HasDynamicTest}}
                                 <span class="inline-block px-2 py-0.5 rounded text-[10px] font-semibold text-white" style="background-color: {{$f.DynamicTestColor}}">{{$f.DynamicTestStatus}}</span>
                                 {{end}}

--- a/apps/openant-cli/internal/report/templates/report-reskin.gohtml
+++ b/apps/openant-cli/internal/report/templates/report-reskin.gohtml
@@ -313,6 +313,7 @@
                             <details id="finding-{{$f.Number}}" class="bg-knostic-card-bg border border-knostic-border-light rounded-lg group card-hover">
                                 <summary class="flex flex-wrap items-center gap-2 sm:gap-3 px-4 sm:px-5 py-3 hover:bg-knostic-purple-light rounded-lg transition-colors">
                                     <span class="text-knostic-muted text-xs font-mono font-medium w-8">#{{$f.Number}}</span>
+                                    {{if $f.Severity}}<span class="inline-block px-2 py-0.5 rounded text-[10px] font-semibold text-white uppercase" style="background-color: {{$f.SeverityColor}}" title="severity source: {{$f.SeveritySource}}">{{$f.Severity}}</span>{{end}}
                                     {{if $f.HasDynamicTest}}<span class="inline-block px-2 py-0.5 rounded text-[10px] font-semibold text-white" style="background-color: {{$f.DynamicTestColor}}">{{$f.DynamicTestStatus}}</span>{{end}}
                                     {{$url := $.FileURL $f.File}}{{if $url}}<a href="{{$url}}" target="_blank" rel="noopener" class="text-xs bg-white border border-knostic-border-light px-2 py-1 rounded text-knostic-purple hover:text-knostic-purple-hover transition-colors" onclick="event.stopPropagation()">{{$f.File}}</a>{{else}}<code class="text-xs bg-white border border-knostic-border-light px-2 py-1 rounded text-knostic-navy">{{$f.File}}</code>{{end}}
                                     <span class="font-mono text-xs text-knostic-muted">{{$f.Function}}</span>
@@ -330,6 +331,7 @@
                         <details id="finding-{{$f.Number}}" class="bg-knostic-card-bg border border-knostic-border-light rounded-lg group card-hover">
                             <summary class="flex flex-wrap items-center gap-2 sm:gap-3 px-4 sm:px-5 py-3 hover:bg-knostic-purple-light rounded-lg transition-colors">
                                 <span class="text-knostic-muted text-xs font-mono font-medium w-8">#{{$f.Number}}</span>
+                                {{if $f.Severity}}<span class="inline-block px-2 py-0.5 rounded text-[10px] font-semibold text-white uppercase" style="background-color: {{$f.SeverityColor}}" title="severity source: {{$f.SeveritySource}}">{{$f.Severity}}</span>{{end}}
                                 {{if $f.HasDynamicTest}}<span class="inline-block px-2 py-0.5 rounded text-[10px] font-semibold text-white" style="background-color: {{$f.DynamicTestColor}}">{{$f.DynamicTestStatus}}</span>{{end}}
                                 {{$url := $.FileURL $f.File}}{{if $url}}<a href="{{$url}}" target="_blank" rel="noopener" class="text-xs bg-white border border-knostic-border-light px-2 py-1 rounded text-knostic-purple hover:text-knostic-purple-hover transition-colors" onclick="event.stopPropagation()">{{$f.File}}</a>{{else}}<code class="text-xs bg-white border border-knostic-border-light px-2 py-1 rounded text-knostic-navy">{{$f.File}}</code>{{end}}
                                 <span class="font-mono text-xs text-knostic-muted">{{$f.Function}}</span>

--- a/apps/openant-cli/internal/report/types.go
+++ b/apps/openant-cli/internal/report/types.go
@@ -233,6 +233,27 @@ type Finding struct {
 	// SARIF region can anchor the alert to the real row (0 = unknown: emit
 	// no region, never a synthetic line).
 	StartLine int `json:"start_line"`
+	// #215: a rankable severity (critical/high/medium/low; empty = unknown
+	// — old artifacts) + its provenance (model | derived).
+	Severity       string `json:"severity"`
+	SeveritySource string `json:"severity_source"`
+}
+
+// SeverityColor returns the badge color for the severity. Unknown values
+// fall back to the neutral gray (the badge itself is conditional on
+// Severity being one of the canonical labels).
+func (f Finding) SeverityColor() string {
+	switch f.Severity {
+	case "critical":
+		return "#721c24"
+	case "high":
+		return "#dc3545"
+	case "medium":
+		return "#fd7e14"
+	case "low":
+		return "#6c757d"
+	}
+	return "#6c757d"
 }
 
 // HasDynamicTest returns true if this finding has dynamic test results.

--- a/libs/openant-core/README.md
+++ b/libs/openant-core/README.md
@@ -307,7 +307,7 @@ python generate_report.py <experiment.json> <dataset.json> [output.html]
 
 ### CSV Export
 
-Ten columns for filtering and sorting:
+Twelve columns for filtering and sorting:
 
 | Column | Description |
 |--------|-------------|

--- a/libs/openant-core/core/analysis_core.py
+++ b/libs/openant-core/core/analysis_core.py
@@ -20,6 +20,8 @@ import json
 from typing import TYPE_CHECKING
 from datetime import datetime
 
+from core.verdict_taxonomy import SEVERITIES, _SEVERITIES
+
 from prompts.prompt_selector import get_analysis_prompt
 from prompts.vulnerability_analysis import get_system_prompt as get_stage1_system_prompt
 from utilities.context_reviewer import ContextReviewer
@@ -86,6 +88,33 @@ def _normalize_result(result: dict) -> dict:
     # Ensure verdict is uppercase
     if "verdict" in result and isinstance(result["verdict"], str):
         result["verdict"] = result["verdict"].upper()
+
+    # #215: a rankable severity, FINDING-ONLY — stamped AFTER the verdict
+    # decision, and only for the finding verdicts (VULNERABLE/BYPASSABLE).
+    # Severity validation never produces the error shape and never touches
+    # the error key (the #426 composition invariant: analyze_result_is_error
+    # and _count_verdicts are keyed on verdict/finding only, and
+    # is_retryable_error never sees severity). Every OTHER row — ERROR
+    # (an analysis failure, not a finding), and safe/protected/inconclusive
+    # (no finding to rank; the prompt itself says null) — carries NO
+    # severity: a "low" on a safe unit would defeat the triage filter the
+    # reporter asked for (severity=low must not return non-findings).
+    if result.get("verdict") in ("VULNERABLE", "BYPASSABLE"):  # the finding verdicts (SEVERITY_FINDING_VERDICTS, uppercased)
+        sev = result.get("severity")
+        if isinstance(sev, str) and sev.strip().lower() in _SEVERITIES:
+            result["severity"] = sev.strip().lower()
+            result["severity_source"] = "model"
+        else:
+            # Derive conservatively: a verdict cannot know criticality, so
+            # no derived "critical"; vulnerable is high, bypassable medium.
+            # Stage-2 reclassifications and model omissions land here — the
+            # read-time sites RE-DERIVE from the final verdict, so a stale
+            # Stage-1 stamp never outranks the final one.
+            result["severity"] = "high" if result["verdict"] == "VULNERABLE" else "medium"
+            result["severity_source"] = "derived"
+    else:
+        result.pop("severity", None)
+        result.pop("severity_source", None)
 
     # Ensure CWE fields are always present.
     if "cwe_id" not in result:
@@ -319,6 +348,15 @@ def analyze_unit(
         corrected = json_corrector.attempt_correction(response)
         corrected = _normalize_result(corrected)
         if corrected.get("verdict") not in ("ERROR", None):
+            # #215: the severity on a JSON-repaired record carries its own
+            # provenance. ONLY a model-supplied enum value (what
+            # _normalize_result stamps "model") becomes "corrected" — a
+            # DERIVED stamp stays derived, or the restamp would defeat the
+            # read-time re-derivation (wave round-2: the unconditional
+            # "severity" in corrected fired on EVERY finding row).
+            if (corrected.get("json_corrected")
+                    and corrected.get("severity_source") == "model"):
+                corrected["severity_source"] = "corrected"
             result = corrected
 
     result["route_key"] = route_key

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -22,7 +22,8 @@ from pathlib import Path
 from core.schemas import ReportResult
 from core.language_registry import fence_for_path
 from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
-from core.verdict_taxonomy import SEVERITIES, SEVERITY_FINDING_VERDICTS
+from core.verdict_taxonomy import (SEVERITIES, SEVERITY_FINDING_VERDICTS,
+                                   severity_display_verdict)
 from utilities.child_interp import child_interpreter_env
 from utilities.file_io import normalize_results, open_utf8, read_json, write_json
 
@@ -265,7 +266,11 @@ def _severity_fields(finding: dict) -> dict:
     Stage-1 stamp must not outrank the final verdict. Old artifacts that
     carry no severity at all land in the same derivation.
     """
-    verdict = str(finding.get("finding") or finding.get("verdict") or "").strip().lower()
+    # Panel round-3: gates on the SHARED displayed verdict — a "Max
+    # iterations reached" verification downgrades the row to inconclusive
+    # (stripping its severity) exactly as report-data does, so pipeline
+    # findings, CSV, and HTML/SARIF emit one rank for one row.
+    verdict = severity_display_verdict(finding)
     if verdict not in SEVERITY_FINDING_VERDICTS:
         return {}
     sev = finding.get("severity")
@@ -276,6 +281,14 @@ def _severity_fields(finding: dict) -> dict:
     # reclassified the row — both re-derive from the FINAL verdict, with
     # their provenance labels preserved.
     if sev in SEVERITIES and source == "model":
+        # Why "model" is exempt from re-derivation and derived/corrected
+        # are not (panel doc item): "model" is the analysis-time LLM's own
+        # impact assessment — exactly what the field records, so it cannot
+        # go stale by a later verdict change the way a DERIVED stamp (a
+        # verdict-mapped fallback the reclassification invalidated) or a
+        # CORRECTED stamp (the repair prompt may have fabricated the
+        # field) can. The "stale Stage-1 stamp" wording above names the
+        # derived/corrected paths only, by design.
         return {"severity": sev, "severity_source": "model"}
     derived = "high" if verdict == "vulnerable" else "medium"
     return {"severity": derived,
@@ -539,10 +552,12 @@ def build_pipeline_output(
             **({"json_corrected": finding["json_corrected"]}
                if finding.get("json_corrected") is not None else {}),
             # #215: a rankable severity on EVERY finding. Present-only for a
-            # model/stamped value; the READ-TIME derivation covers OLD
-            # artifacts (pre-#215 results_verified.json, resumed pre-PR
-            # checkpoints) so every scan ranks on the new surfaces — with
-            # severity_source recording which happened.
+            # model/stamped value. Two coverage paths, distinct (panel doc
+            # item): OLD results_verified.json artifacts are covered by the
+            # READ-TIME derivation above for free; resumed PRE-PR checkpoint
+            # rows are NOT — they are covered upstream by the prompt-template
+            # fingerprint invalidation (the analysis prompt changed, so the
+            # rows are re-analyzed, not adopted), not by this read-time path.
             **_severity_fields(finding),
             "description": description,
             "vulnerable_code": vulnerable_code,

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from core.schemas import ReportResult
 from core.language_registry import fence_for_path
 from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
+from core.verdict_taxonomy import SEVERITIES, SEVERITY_FINDING_VERDICTS
 from utilities.child_interp import child_interpreter_env
 from utilities.file_io import normalize_results, open_utf8, read_json, write_json
 
@@ -251,6 +252,35 @@ def _load_reachability_metadata(scan_dir: str) -> dict | None:
         return None
     rf = metadata.get("reachability_filter")
     return rf if isinstance(rf, dict) else None
+
+
+def _severity_fields(finding: dict) -> dict:
+    """#215: the severity + severity_source record fields for one finding.
+
+    FINDING-ONLY: rows whose final verdict is not vulnerable/bypassable
+    carry NO severity (a "low" on a safe unit defeats the triage filter the
+    reporter asked for). A model-supplied value threads present-only; a
+    DERIVED value is RE-DERIVED from the FINAL verdict — Stage 2 reclassifies
+    (finding_verifier rewrites `finding` in three places), and a stale
+    Stage-1 stamp must not outrank the final verdict. Old artifacts that
+    carry no severity at all land in the same derivation.
+    """
+    verdict = str(finding.get("finding") or finding.get("verdict") or "").strip().lower()
+    if verdict not in SEVERITY_FINDING_VERDICTS:
+        return {}
+    sev = finding.get("severity")
+    source = finding.get("severity_source")
+    # ONLY a model-supplied value keeps its rank: a corrected value rides a
+    # JSON repair whose extraction prompt may have fabricated it
+    # (conservative-default), and a derived value went stale when Stage 2
+    # reclassified the row — both re-derive from the FINAL verdict, with
+    # their provenance labels preserved.
+    if sev in SEVERITIES and source == "model":
+        return {"severity": sev, "severity_source": "model"}
+    derived = "high" if verdict == "vulnerable" else "medium"
+    return {"severity": derived,
+            "severity_source": (source if source in ("corrected", "derived")
+                               else "derived")}
 
 
 def build_pipeline_output(
@@ -508,6 +538,12 @@ def build_pipeline_output(
                if finding.get("confidence") is not None else {}),
             **({"json_corrected": finding["json_corrected"]}
                if finding.get("json_corrected") is not None else {}),
+            # #215: a rankable severity on EVERY finding. Present-only for a
+            # model/stamped value; the READ-TIME derivation covers OLD
+            # artifacts (pre-#215 results_verified.json, resumed pre-PR
+            # checkpoints) so every scan ranks on the new surfaces — with
+            # severity_source recording which happened.
+            **_severity_fields(finding),
             "description": description,
             "vulnerable_code": vulnerable_code,
             "vulnerable_code_section": vulnerable_code_section,

--- a/libs/openant-core/core/verdict_taxonomy.py
+++ b/libs/openant-core/core/verdict_taxonomy.py
@@ -113,3 +113,29 @@ DYNAMIC_TESTABLE = frozenset({
     "agreed",
     "vulnerable",
 })
+
+
+def severity_display_verdict(result: dict) -> str:
+    """#215 (panel round-3): the verdict the severity sites gate on.
+
+    The FINAL verdict with the "Max iterations reached" downgrade applied —
+    the same justification read openant/cli.py performs for its displayed
+    verdict (explanation first, reasoning fallback). Factored here (a leaf
+    module every severity site already imports) so pipeline findings, CSV,
+    and report-data emit the SAME severity for the same row: before this,
+    report-data downgraded a max-iterations verification to inconclusive and
+    stripped its severity, while the CSV/reporter sites gated on the raw
+    (preserved) vulnerable verdict and kept a CRITICAL rank on the very row
+    the HTML/SARIF displayed as unrankable.
+    """
+    verdict = str(result.get("finding") or result.get("verdict") or "").strip().lower()
+    if verdict not in SEVERITY_FINDING_VERDICTS:
+        return verdict
+    verification = result.get("verification") or {}
+    justification = (verification.get("explanation", "")
+                     if isinstance(verification, dict) else "")
+    if not justification:
+        justification = result.get("reasoning", "")
+    if str(justification).strip() == "Max iterations reached":
+        return "inconclusive"
+    return verdict

--- a/libs/openant-core/core/verdict_taxonomy.py
+++ b/libs/openant-core/core/verdict_taxonomy.py
@@ -41,6 +41,19 @@ FINDING_VERDICT_ORDER = (
 # / ``finding == "error"``). Not part of the ordered display list.
 ERROR_VERDICT = "error"
 
+# --- #215: finding severity ---------------------------------------------------
+# The canonical severity enum — the same four levels the JSON corrector's
+# legacy _VULN_SCHEMA has carried since inception. FINDING-ONLY: a row whose
+# verdict is not a finding verdict carries NO severity. Lives here (a leaf
+# module) so every importer — analysis_core, reporter, csv_export, cli, the
+# context corrector twin — shares one definition without pulling the LLM
+# stack into a standalone exporter.
+SEVERITIES = ("critical", "high", "medium", "low")
+_SEVERITIES = frozenset(SEVERITIES)
+
+# The verdicts that carry a severity (see SEVERITIES above).
+SEVERITY_FINDING_VERDICTS = ("vulnerable", "bypassable")
+
 # --- Stage-2 verification verdicts -------------------------------------------
 # ``core/reporter.py`` maps the Stage-2 ``verification`` dict onto these.
 STAGE2_VERDICTS = frozenset({

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -40,7 +40,8 @@ def _output_json(data: dict):
     sys.stdout.write("\n")
 
 
-from core.verdict_taxonomy import SEVERITIES as _SEVERITY_ORDER, SEVERITY_FINDING_VERDICTS
+from core.verdict_taxonomy import (SEVERITIES as _SEVERITY_ORDER, SEVERITY_FINDING_VERDICTS,
+                                   severity_display_verdict)
 
 
 def _severity_for_result(result: dict, displayed_verdict: str = None) -> str:
@@ -50,7 +51,7 @@ def _severity_for_result(result: dict, displayed_verdict: str = None) -> str:
     must not leave a CRITICAL badge on an inconclusive row). A model value
     keeps; corrected/derived re-derive from that verdict."""
     verdict = (displayed_verdict if displayed_verdict is not None
-               else str(result.get("finding") or result.get("verdict") or ""))
+               else severity_display_verdict(result))
     verdict = verdict.strip().lower()
     if verdict not in SEVERITY_FINDING_VERDICTS:
         return ""

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -40,6 +40,38 @@ def _output_json(data: dict):
     sys.stdout.write("\n")
 
 
+from core.verdict_taxonomy import SEVERITIES as _SEVERITY_ORDER, SEVERITY_FINDING_VERDICTS
+
+
+def _severity_for_result(result: dict, displayed_verdict: str = None) -> str:
+    """#215: the severity for one report-data finding — FINDING-ONLY (empty
+    for non-findings: no badge, no SARIF severity), computed from the
+    DISPLAYED verdict (wave round-2: the "Max iterations reached" downgrade
+    must not leave a CRITICAL badge on an inconclusive row). A model value
+    keeps; corrected/derived re-derive from that verdict."""
+    verdict = (displayed_verdict if displayed_verdict is not None
+               else str(result.get("finding") or result.get("verdict") or ""))
+    verdict = verdict.strip().lower()
+    if verdict not in SEVERITY_FINDING_VERDICTS:
+        return ""
+    sev = result.get("severity")
+    src = result.get("severity_source")
+    if sev in _SEVERITY_ORDER and src == "model":
+        return sev
+    return "high" if verdict == "vulnerable" else "medium"
+
+
+def _severity_source_for_result(result: dict, displayed_verdict: str = None) -> str:
+    """The provenance matching _severity_for_result (empty when no severity)."""
+    if _severity_for_result(result, displayed_verdict) == "":
+        return ""
+    sev = result.get("severity")
+    src = result.get("severity_source")
+    if sev in _SEVERITY_ORDER and src == "model":
+        return "model"
+    return src if src in ("corrected", "derived") else "derived"
+
+
 def _unit_start_line(unit: dict) -> int:
     """#305 (the adjacent finding in the issue comment): the parsers emit
     ``start_line`` inside ``code.primary_origin`` and it survives
@@ -1014,6 +1046,13 @@ def cmd_report_data(args):
                 if justification.strip() == "Max iterations reached":
                     verdict = "inconclusive"
 
+                # #215: computed from the DISPLAYED verdict (the downgrade
+                # above must strip severity too — an inconclusive row with a
+                # CRITICAL badge, ranked critical in Code Scanning, is the
+                # exact non-finding leak the finding-only gate exists for).
+                _sev = _severity_for_result(result, verdict)
+                _sev_src = _severity_source_for_result(result, verdict)
+
                 verdict_counts[verdict] = verdict_counts.get(verdict, 0) + 1
 
                 # Track worst verdict per file
@@ -1039,6 +1078,13 @@ def cmd_report_data(args):
                     "function": func_name,
                     "attack_vector": result.get("attack_vector", "") or "",
                     "analysis": justification,
+                    # #215: a rankable severity on every finding — the
+                    # stamped/model value, else the reporter's conservative
+                    # derivation, so the HTML/SARIF surfaces rank old scans
+                    # too. The sort below stays VERDICT-primary (epistemic
+                    # status); severity is display/filter metadata.
+                    "severity": _sev,
+                    "severity_source": _sev_src,
                     "dynamic_test_status": dt_status,
                     "dynamic_test_details": dt_details,
                     "start_line": _unit_start_line(unit),

--- a/libs/openant-core/prompts/vulnerability_analysis.py
+++ b/libs/openant-core/prompts/vulnerability_analysis.py
@@ -240,6 +240,7 @@ All your claims must be about vulnerabilities IN THIS FUNCTION's code, not in th
     "function_analyzed": "exact function signature you analyzed",
     "finding": "safe" | "protected" | "vulnerable" | "inconclusive",
     "reasoning": "Your analysis of the TARGET function's code",
+    "severity": "If vulnerable: critical, high, medium, or low — your assessment of the impact if exploited. If any other finding: null",
     "attack_vector": "If vulnerable: a single plain-text string describing the specific attack in the TARGET function (e.g. \\"GET /user?id=' OR 1=1--\\"). MUST be a string, NOT a JSON object or array. If safe: null",
     "confidence": 0.0-1.0,
     "cwe_id": "If vulnerable: the CWE number (integer). Common: 22 Path Traversal, 77/78 Command Injection, 79 XSS, 89 SQL Injection, 94 Code Injection, 502 Deserialization, 798 Hardcoded Credentials, 489 Debug Enabled, 918 SSRF. Use 0 only if no CWE matches. If safe: 0",

--- a/libs/openant-core/report/README.md
+++ b/libs/openant-core/report/README.md
@@ -93,6 +93,8 @@ The module expects a JSON file with the following structure:
       "cwe_name": "Authorization Bypass Through User-Controlled Key",
       "stage1_verdict": "vulnerable",
       "stage2_verdict": "vulnerable",
+      "severity": "high",
+      "severity_source": "model",
       "dynamic_testing": true,
       "description": "Brief description of the vulnerability.",
       "vulnerable_code": "code snippet here",

--- a/libs/openant-core/report/csv_export.py
+++ b/libs/openant-core/report/csv_export.py
@@ -31,6 +31,35 @@ import os
 import sys
 from utilities.file_io import normalize_results, read_json
 
+from core.verdict_taxonomy import SEVERITIES as _SEVERITIES, SEVERITY_FINDING_VERDICTS
+
+
+def _severity_source_for(result: dict) -> str:
+    """The provenance matching _severity_for ("" when no severity)."""
+    if _severity_for(result) == "":
+        return ""
+    src = result.get("severity_source")
+    if result.get("severity") in _SEVERITIES and src == "model":
+        return "model"
+    return src if src in ("corrected", "derived") else "derived"
+
+
+def _severity_for(result: dict) -> str:
+    """#215: the severity for one CSV row — FINDING-ONLY (empty for
+    non-findings, so severity=low does not return safe/ERROR units); a
+    model value keeps; a derived value RE-DERIVES from the final verdict
+    (Stage 2 reclassifies; a stale Stage-1 stamp must not outrank it)."""
+    verdict = str(result.get("finding") or result.get("verdict") or "").strip().lower()
+    if verdict not in SEVERITY_FINDING_VERDICTS:
+        return ""
+    sev = result.get("severity")
+    src = result.get("severity_source")
+    # ONLY a model value keeps its rank (corrected rides a possibly-
+    # fabricated repair; derived went stale under Stage-2 reclassification).
+    if sev in _SEVERITIES and src == "model":
+        return sev
+    return "high" if verdict == "vulnerable" else "medium"
+
 # Characters that make a spreadsheet treat a cell as a formula on open (CSV / formula
 # injection, CWE-1236 / OWASP). Cells written from scanned source or LLM text must be
 # neutralized so opening the export in Excel / Google Sheets can't execute a payload.
@@ -176,6 +205,11 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
             'unit_id': route_key,
             'unit_description': llm_context.get('reasoning', '')[:500] if llm_context.get('reasoning') else '',
             'unit_code': unit_code,
+            # #215: the rankable severity — the stamped/model value, or the
+            # same conservative derivation the reporter applies (so an old
+            # scan's CSV still ranks).
+            'severity': _severity_for(result),
+            'severity_source': _severity_source_for(result),
             'stage2_verdict': stage2_verdict,
             'stage2_justification': verification.get('explanation', ''),
             'stage1_verdict': stage1_verdict,
@@ -192,6 +226,8 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
         'unit_id',
         'unit_description',
         'unit_code',
+        'severity',
+        'severity_source',
         'stage2_verdict',
         'stage2_justification',
         'stage1_verdict',

--- a/libs/openant-core/report/csv_export.py
+++ b/libs/openant-core/report/csv_export.py
@@ -31,7 +31,8 @@ import os
 import sys
 from utilities.file_io import normalize_results, read_json
 
-from core.verdict_taxonomy import SEVERITIES as _SEVERITIES, SEVERITY_FINDING_VERDICTS
+from core.verdict_taxonomy import (SEVERITIES as _SEVERITIES, SEVERITY_FINDING_VERDICTS,
+                                  severity_display_verdict)
 
 
 def _severity_source_for(result: dict) -> str:
@@ -48,8 +49,12 @@ def _severity_for(result: dict) -> str:
     """#215: the severity for one CSV row — FINDING-ONLY (empty for
     non-findings, so severity=low does not return safe/ERROR units); a
     model value keeps; a derived value RE-DERIVES from the final verdict
-    (Stage 2 reclassifies; a stale Stage-1 stamp must not outrank it)."""
-    verdict = str(result.get("finding") or result.get("verdict") or "").strip().lower()
+    (Stage 2 reclassifies; a stale derived/corrected stamp must not
+    outrank it). Gates on the SHARED displayed verdict (panel round-3):
+    a "Max iterations reached" verification downgrades the row to
+    inconclusive and strips its severity, matching report-data and the
+    reporter — one row, one rank, every surface."""
+    verdict = severity_display_verdict(result)
     if verdict not in SEVERITY_FINDING_VERDICTS:
         return ""
     sev = result.get("severity")

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -199,6 +199,11 @@ def _compact_for_summary(pipeline_data: dict) -> dict:
             "cwe_name": f.get("cwe_name"),
             "stage1_verdict": f.get("stage1_verdict"),
             "stage2_verdict": f.get("stage2_verdict"),
+            # #215: the stamped severity + its provenance reach the summary
+            # LLM — without these the "Severity" column in the template is
+            # model-guessed, not read from the scan.
+            "severity": f.get("severity"),
+            "severity_source": f.get("severity_source"),
             "dynamic_testing": f.get("dynamic_testing"),
             "impact": f.get("impact"),
         })

--- a/libs/openant-core/report/prompts/summary.txt
+++ b/libs/openant-core/report/prompts/summary.txt
@@ -70,9 +70,9 @@ OUTPUT FORMAT:
 [For each VULNERABLE finding where stage2_verdict is "confirmed" or "agreed", one row.]
 [If no vulnerabilities were confirmed, write: "No vulnerabilities were confirmed."]
 
-| # | Vulnerability | Location | CWE | Verified |
-|---|--------------|----------|-----|----------|
-| 1 | {short_name} | {file:function} | CWE-{n} | {static|verified|dynamic} |
+| # | Vulnerability | Location | CWE | Severity | Verified |
+|---|--------------|----------|-----|----------|----------|
+| 1 | {short_name} | {file:function} | CWE-{n} | {severity} | {static|verified|dynamic} |
 
 ## False Positives Eliminated
 
@@ -98,6 +98,7 @@ INSTRUCTIONS:
 - If a count is zero, still show "0" in the table
 - Keep "Reason" column under 15 words
 - "Verified" column: "dynamic" if dynamic_testing exists for that finding, "verified" if stage2_verdict is "confirmed" or "agreed" (Stage 2 attacker simulation passed), else "static"
+- "Severity" column: the finding's `severity` field from the input data (critical / high / medium / low); if absent, write the empty cell
 - Language comes from repository.language
 - Commit SHA comes from repository.commit_sha; if null or missing, write "Not available"
 - Scan Mode is derived from the top-level `diff` field on the input data:

--- a/libs/openant-core/report/schema.py
+++ b/libs/openant-core/report/schema.py
@@ -25,6 +25,10 @@ class Finding:
     suggested_fix: Optional[str] = None
     steps_to_reproduce: Optional[list] = None
     rejection_reason: Optional[str] = None
+    # #215: a rankable severity + its provenance. Optional and NOT required —
+    # old artifacts (pre-#215 scans) must validate.
+    severity: Optional[str] = None
+    severity_source: Optional[str] = None
 
     @classmethod
     def from_dict(cls, data: dict) -> "Finding":
@@ -46,6 +50,8 @@ class Finding:
             suggested_fix=data.get("suggested_fix"),
             steps_to_reproduce=data.get("steps_to_reproduce"),
             rejection_reason=data.get("rejection_reason"),
+            severity=data.get("severity"),
+            severity_source=data.get("severity_source"),
         )
 
 

--- a/libs/openant-core/tests/test_issue215_severity_field.py
+++ b/libs/openant-core/tests/test_issue215_severity_field.py
@@ -456,3 +456,52 @@ def test_report_data_projection_wires_severity():
     block = src[i:i+1200]
     assert '"severity": _sev' in block and '"severity_source": _sev_src' in block, (
         "the report-data projection must wire severity + severity_source")
+
+
+def test_max_iterations_downgrade_strips_severity_csv():
+    """Panel round-3 (sonnet item 1): the CSV site applies the SAME "Max
+    iterations reached" downgrade as report-data — the row that the
+    HTML/SARIF displays as inconclusive must not rank critical in the CSV
+    (one row, one rank, every surface)."""
+    from report.csv_export import _severity_for, _severity_source_for
+
+    row = {"finding": "vulnerable", "severity": "critical",
+           "severity_source": "model",
+           "verification": {"explanation": "Max iterations reached"}}
+    assert _severity_for(row) == ""
+    assert _severity_source_for(row) == ""
+    # without the downgrade: the model value keeps
+    ok = dict(row, verification={"explanation": "stage 2 agreed"})
+    assert _severity_for(ok) == "critical"
+
+
+def test_max_iterations_downgrade_strips_severity_reporter():
+    """Panel round-3 (sonnet item 1): the reporter site (pipeline_output
+    findings, the summary prompt's input) applies the SAME downgrade —
+    no severity on the row report-data displays as inconclusive."""
+    from core.reporter import _severity_fields
+
+    row = {"finding": "vulnerable", "severity": "critical",
+           "severity_source": "model",
+           "verification": {"explanation": "Max iterations reached"}}
+    assert _severity_fields(row) == {}
+    ok = dict(row, verification={"explanation": "stage 2 agreed"})
+    assert _severity_fields(ok) == {"severity": "critical",
+                                   "severity_source": "model"}
+
+
+def test_max_iterations_downgrade_shared_helper_matches_cli():
+    """The shared severity_display_verdict reproduces cli.py's displayed
+    verdict for the downgrade shape — the three sites cannot drift again."""
+    from core.verdict_taxonomy import severity_display_verdict
+
+    row = {"finding": "vulnerable", "severity": "critical",
+           "severity_source": "model",
+           "verification": {"explanation": "Max iterations reached"}}
+    assert severity_display_verdict(row) == "inconclusive"
+    # explanation absent, reasoning carries the string: same downgrade
+    row2 = {"finding": "vulnerable", "verification": {},
+            "reasoning": "Max iterations reached"}
+    assert severity_display_verdict(row2) == "inconclusive"
+    # non-finding rows pass through untouched
+    assert severity_display_verdict({"finding": "safe"}) == "safe"

--- a/libs/openant-core/tests/test_issue215_severity_field.py
+++ b/libs/openant-core/tests/test_issue215_severity_field.py
@@ -1,0 +1,458 @@
+"""#215 (NahumKorda): every finding carries a rankable severity.
+
+The reporter's evidence — 82 Stage-2-upheld findings, 6 with cwe_id/impact/steps, 0 with any
+severity — traced to a schema mismatch re-derived first-hand at HEAD: the finding record's
+rich fields (`impact`, `steps_to_reproduce`, `suggested_fix`, the detailed `description`) are
+read from ``finding["vulnerabilities"][0]`` (core/reporter.py:378-401), an array NO prompt asks
+for — the Stage-1 contract (prompts/vulnerability_analysis.py:239-247) is flat:
+finding/reasoning/attack_vector/confidence/cwe_id/cwe_name. The only producer of
+``vulnerabilities[]`` is the JSON corrector's legacy ``_VULN_SCHEMA``
+(utilities/json_corrector.py:30-45), which carries a 4-level severity enum
+(CRITICAL|HIGH|MEDIUM|LOW) nested where nothing downstream reads it. The reporter's
+well-formed 6 are most plausibly the corrector-repaired subset (checkable on their data via
+the ``json_corrected`` transit field from #366).
+
+The fix (the reporter's goal is downstream triage — rank/filter/SLA; the hard-retry means is
+rejected as the false-negative direction: a model that never emits the field would lose its
+findings to ERROR):
+
+* Stage-1 prompt: ``"severity": "critical" | "high" | "medium" | "low"`` — required key in the
+  assessment JSON (the enum the corrector's legacy schema already uses, canonical lowercase
+  like ``finding``).
+* ``_normalize_result`` stamps severity AFTER the verdict decision — never producing the error
+  shape, never touching the error key (the #426 composition invariant): a model-supplied
+  valid enum is kept (``severity_source: "model"``); anything else derives conservatively
+  from the verdict (``vulnerable→high``, ``bypassable→medium``; never a derived critical —
+  a verdict cannot know criticality) with ``severity_source: "derived"``. ERROR rows get NO
+  severity — they are not findings.
+* The finding record threads ``severity`` + ``severity_source`` (present-only, both
+  construction paths); CSV gains the column; SARIF gains the rule's ``security-severity``
+  property (level stays verdict-based); the summary table gains the column; the HTML/CLI
+  table gains a column with the sort staying verdict-primary (the verdict order encodes
+  epistemic status — an unverified vulnerable must not sink under a confirmed medium).
+* ``report/schema.py``: Optional on Finding, NOT required (old artifacts must validate).
+* Read-time derivation in the reporter for OLD artifacts (pre-PR results/resumed
+  checkpoints): no severity present → derive + mark.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+SEVERITIES = ("critical", "high", "medium", "low")
+
+
+# ---------------------------------------------------------------------------
+# A. the producer — _normalize_result stamping (the #426 composition invariant)
+# ---------------------------------------------------------------------------
+
+def test_model_severity_kept_and_marked():
+    from core.analysis_core import _normalize_result
+
+    out = _normalize_result({"finding": "vulnerable", "severity": "HIGH",
+                             "reasoning": "r"})
+    assert out["verdict"] == "VULNERABLE"
+    assert out["severity"] == "high"          # canonical lowercase
+    assert out["severity_source"] == "model"
+
+
+def test_off_enum_severity_derives():
+    from core.analysis_core import _normalize_result
+
+    out = _normalize_result({"finding": "vulnerable", "severity": "severe-ish"})
+    assert out["severity"] == "high"
+    assert out["severity_source"] == "derived"
+
+
+def test_absent_severity_derives_from_verdict():
+    from core.analysis_core import _normalize_result
+
+    for finding, want in [("vulnerable", "high"), ("bypassable", "medium")]:
+        out = _normalize_result({"finding": finding})
+        assert out["severity"] == want, finding
+        assert out["severity_source"] == "derived"
+
+
+def test_never_a_derived_critical():
+    from core.analysis_core import _normalize_result
+
+    for finding in ("vulnerable", "bypassable"):
+        out = _normalize_result({"finding": finding})
+        assert out.get("severity") != "critical", finding
+
+
+def test_error_rows_get_no_severity():
+    from core.analysis_core import _normalize_result
+
+    for shape in ({"finding": "maybe exploitable"},            # unrecognized -> ERROR
+                  {"reasoning": "cannot determine"},           # neither-key -> ERROR
+                  {"verdict": None, "reasoning": "refusal"}):   # null verdict, no finding -> ERROR
+        out = _normalize_result(shape)
+        assert out["verdict"] == "ERROR", shape
+        assert "severity" not in out and "severity_source" not in out, shape
+
+
+def test_non_finding_verdicts_carry_no_severity():
+    """Wave finding (both reviewers): a severity on a safe/protected/
+    inconclusive row defeats the triage filter (severity=low would return
+    mostly non-findings) — the prompt itself says null for those. Only the
+    FINDING verdicts (vulnerable/bypassable) carry severity; a stale model
+    severity on a non-finding row is dropped."""
+    from core.analysis_core import _normalize_result
+
+    for finding in ("safe", "protected", "inconclusive", "insufficient_context"):
+        out = _normalize_result({"finding": finding})
+        assert "severity" not in out and "severity_source" not in out, finding
+        # even when the model supplied one
+        out = _normalize_result({"finding": finding, "severity": "critical"})
+        assert "severity" not in out, finding
+
+
+# ---------------------------------------------------------------------------
+# B. the prompt + the corrector schema alignment
+# ---------------------------------------------------------------------------
+
+def test_stage1_prompt_asks_for_severity():
+    from prompts.vulnerability_analysis import get_analysis_prompt
+
+    text = get_analysis_prompt("code", "ctx")
+    assert '"severity"' in text
+    for word in ("critical", "high", "medium", "low"):
+        assert word in text
+
+
+def test_corrector_schema_carries_severity_top_level():
+    from utilities.json_corrector import _VULN_SCHEMA
+
+    # The legacy nested array kept its enum; the TOP-LEVEL shape the Stage-1
+    # reply uses must carry severity too, in the SAME position the prompt
+    # puts it — otherwise a corrected reply and a clean reply carry severity
+    # in two shapes.
+    assert '"severity"' in _VULN_SCHEMA
+    import json as _json
+    top = _VULN_SCHEMA
+    assert top.index('"severity"') < top.index('"vulnerabilities"'), \
+        "severity must appear at the top level, before the nested array"
+
+
+# ---------------------------------------------------------------------------
+# C. the finding record threads severity + source (both construction paths)
+# ---------------------------------------------------------------------------
+
+def _build_po(rows):
+    """Write an experiment fixture to disk and run the real builder
+    (build_pipeline_output takes file paths, not dicts)."""
+    import json as _json
+    import tempfile
+    exp = {"results": rows, "metrics": {}, "code_by_route": {}}
+    with tempfile.TemporaryDirectory() as d:
+        rp = Path(d) / "experiment.json"
+        op = Path(d) / "pipeline_output.json"
+        rp.write_text(_json.dumps(exp))
+        from core.reporter import build_pipeline_output
+        build_pipeline_output(str(rp), str(op))
+        return _json.loads(op.read_text())
+
+
+def _finding_row(severity=None, source=None, **extra):
+    row = {"finding": "vulnerable", "reasoning": "r", "attack_vector": "av",
+           "cwe_id": 79, "cwe_name": "XSS", "route_key": "f.py:g"}
+    if severity is not None:
+        row["severity"] = severity
+    if source is not None:
+        row["severity_source"] = source
+    row.update(extra)
+    return row
+
+
+def test_pipeline_output_finding_record_carries_severity():
+    from core.reporter import build_pipeline_output
+
+    po = _build_po([_finding_row(severity="high", source="model")])
+    recs = po["findings"]
+    assert len(recs) == 1
+    assert recs[0]["severity"] == "high"
+    assert recs[0]["severity_source"] == "model"
+
+
+def test_pipeline_output_derives_severity_for_old_artifacts():
+    """The read-time derivation site: pre-PR results carry no severity —
+    the reporter derives + marks, so old scans rank in the new surfaces."""
+    from core.reporter import build_pipeline_output
+
+    po = _build_po([_finding_row()])  # no severity anywhere
+    assert po["findings"][0]["severity"] == "high"
+    assert po["findings"][0]["severity_source"] == "derived"
+
+
+# ---------------------------------------------------------------------------
+# D. the schema layer (old artifacts validate)
+# ---------------------------------------------------------------------------
+
+def test_schema_finding_severity_optional():
+    from report.schema import Finding
+
+    base = {"id": "VULN-001", "name": "vulnerable", "short_name": "VULNERABLE",
+            "location": {"file": "a.py", "function": "f"},
+            "cwe_id": 79, "cwe_name": "XSS",
+            "stage1_verdict": "VULNERABLE", "stage2_verdict": "confirmed"}
+    old = Finding.from_dict(base)                 # no severity: validates
+    assert old.severity is None
+    new = Finding.from_dict({**base, "severity": "high",
+                            "severity_source": "model"})
+    assert new.severity == "high" and new.severity_source == "model"
+
+
+# ---------------------------------------------------------------------------
+# E. the consumer surfaces (CSV / summary) + the verdict-primary sort
+# ---------------------------------------------------------------------------
+
+def test_csv_has_severity_column():
+    import csv
+    import json as _json
+    import tempfile
+    from report.csv_export import export_csv
+
+    with tempfile.TemporaryDirectory() as d:
+        exp_path = str(Path(d) / "experiment.json")
+        ds_path = str(Path(d) / "dataset.json")
+        out = str(Path(d) / "out.csv")
+        Path(exp_path).write_text(_json.dumps(
+            {"results": [_finding_row(severity="high", source="model")],
+             "metrics": {}, "code_by_route": {}}))
+        Path(ds_path).write_text(_json.dumps({"units": []}))
+        export_csv(exp_path, ds_path, out)
+        with open(out, newline="") as f:
+            reader = csv.reader(f)
+            header = next(reader)
+            rows = [dict(zip(header, r)) for r in reader]
+    assert "severity" in header
+    assert "severity_source" in header  # the provenance the triager filters on
+    # the row carries both values
+    assert rows and rows[0].get("severity") == "high"
+    assert rows[0].get("severity_source") == "model"
+
+
+def test_findings_table_sort_stays_verdict_primary():
+    """Wave r2 (t#3): the old pin was vacuous (it asserted the taxonomy, not
+    the sort — green with the entire diff reverted). The precise pin: the
+    report-data sort's key tuple must order by verdict_priority FIRST (the
+    verdict encodes epistemic status; severity is rank/filter metadata)."""
+    import inspect
+    import openant.cli as cli
+
+    src = inspect.getsource(cli)
+    i = src.find("findings.sort(key=lambda")
+    assert i > 0, "the report-data sort not found"
+    sort_expr = src[i:i+200]
+    assert "verdict_priority.get(f[\"verdict\"]" in sort_expr and \
+           sort_expr.index("verdict_priority.get") < sort_expr.index("dt_status_priority"), \
+           f"the sort must stay verdict-primary; got: {sort_expr}"
+
+
+# ---------------------------------------------------------------------------
+# G. wave round-1 findings — the re-derivation, the corrected source, the
+#    summary threading, the read-time gates
+# ---------------------------------------------------------------------------
+
+def test_derived_severity_rerives_from_final_verdict():
+    """Wave finding (both reviewers): Stage 2 reclassifies `finding` in
+    three places without touching severity. A DERIVED stamp must re-derive
+    from the FINAL verdict at every read-time site — an upgraded
+    bypassable->vulnerable row ranks high, a downgraded one medium."""
+    from core.reporter import _severity_fields
+
+    row = {"finding": "vulnerable", "severity": "medium", "severity_source": "derived"}
+    assert _severity_fields(row) == {"severity": "high", "severity_source": "derived"}
+    row = {"finding": "bypassable", "severity": "high", "severity_source": "derived"}
+    assert _severity_fields(row) == {"severity": "medium", "severity_source": "derived"}
+    row = {"finding": "bypassable", "severity": "critical", "severity_source": "model"}
+    assert _severity_fields(row) == {"severity": "critical", "severity_source": "model"}
+    # a CORRECTED value re-derives its rank (the repair's extractor may have
+    # fabricated it) but keeps the provenance label
+    row = {"finding": "vulnerable", "severity": "low", "severity_source": "corrected"}
+    assert _severity_fields(row) == {"severity": "high", "severity_source": "corrected"}
+    # WAVE r3 #5: the SAME contract at the cli/csv copies (previously pinned
+    # on the reporter only — a divergence there could not go RED)
+    from openant.cli import _severity_for_result as _cli_sev
+    from report.csv_export import _severity_for as _csv_sev
+    assert _cli_sev({"finding": "vulnerable", "severity": "low",
+                     "severity_source": "corrected"}) == "high"
+    assert _csv_sev({"finding": "vulnerable", "severity": "low",
+                     "severity_source": "corrected"}) == "high"
+    assert _cli_sev({"finding": "bypassable", "severity": "high",
+                     "severity_source": "derived"}) == "medium"
+    assert _csv_sev({"finding": "bypassable", "severity": "high",
+                     "severity_source": "derived"}) == "medium"
+    assert _cli_sev({"finding": "vulnerable", "severity": "critical",
+                     "severity_source": "model"}) == "critical"
+    assert _csv_sev({"finding": "vulnerable", "severity": "critical",
+                     "severity_source": "model"}) == "critical"
+
+
+def test_read_time_sites_gate_non_findings():
+    from report.csv_export import _severity_for
+    from openant.cli import _severity_for_result
+
+    for row in ({"finding": "safe"}, {"finding": "error"},
+                {"verdict": "ERROR"}, {"reasoning": "refusal"}):
+        assert _severity_for(row) == "", row
+        assert _severity_for_result(row) == "", row
+
+
+def test_corrected_record_severity_behavior(monkeypatch):
+    """Wave r1 (prod#5) + r2 (t#4): the corrected-adoption provenance, as
+    BEHAVIOR (the r1 grep pin could not fail under mutation). Drive the real
+    analyze_unit with a stubbed parse + corrector: a garbage corrected
+    severity lands DERIVED (r2 c#1: the restamp must not relabel derived as
+    corrected); a valid one lands CORRECTED."""
+    from core import analysis_core
+    import utilities.json_corrector as jc
+
+    class _Adapter:
+        name = "anthropic"
+        supports_tools = True
+
+        def complete(self, **kwargs):
+            from utilities.llm.adapter import TextBlock as _TB
+            class _Reply:
+                # the adapter-shaped reply: content blocks + usage
+                content = [_TB(text="garbled prose")]  # unparseable
+                input_tokens = 1
+                output_tokens = 1
+                def __getattr__(self, name):
+                    return None
+            return _Reply()
+
+        def validate(self, model):  # pragma: no cover
+            pass
+
+    def _tool_binding():
+        from utilities.llm import PhaseBinding
+        return PhaseBinding(phase="analyze", adapter=_Adapter(),
+                            model="claude-test", provider_name="anthropic")
+
+    # the direct parse fails (ERROR verdict) -> the corrector is consulted
+    monkeypatch.setattr(analysis_core, "parse_response",
+                        lambda r: {"verdict": "ERROR", "finding": "error"})
+    binding = _tool_binding()
+
+    def corrected_extract_with(valid):
+        def fake_simple_text(binding, prompt, **k):
+            sev = '"severity": "HIGH"' if valid else '"severity": "garbage"'
+            return ('{"finding": "vulnerable", ' + sev +
+                    ', "reasoning": "r", "cwe_id": 79}')
+        return fake_simple_text
+
+    for valid, want_src, want_sev in ((True, "corrected", "high"),
+                                      (False, "derived", "high")):
+        monkeypatch.setattr(jc, "simple_text", corrected_extract_with(valid))
+        out = analysis_core.analyze_unit(
+            binding=binding,
+            unit={"id": "f.py:g", "code": {"primary_code": "x = 1"}},
+            json_corrector=jc.JSONCorrector(binding))
+        assert out.get("verdict") == "VULNERABLE", (valid, out.get("verdict"))
+        assert out.get("severity") == want_sev, (valid, out.get("severity"))
+        assert out.get("severity_source") == want_src, (valid, out.get("severity_source"))
+
+
+def test_summary_prompt_receives_severity():
+    """Wave finding (surf#1): _compact_for_summary's fixed key list never
+    included severity — the summary column was LLM-guessed."""
+    from report.generator import _compact_for_summary
+
+    data = {"findings": [{"id": "VULN-001", "severity": "high",
+                          "severity_source": "model"}]}
+    compact = _compact_for_summary(data)
+    assert compact["findings"][0]["severity"] == "high"
+    assert compact["findings"][0]["severity_source"] == "model"
+
+
+def test_summary_template_row_has_severity_cell():
+    from pathlib import Path as P
+    tpl = (P(__file__).resolve().parents[1] / "report" / "prompts" / "summary.txt").read_text()
+    assert "{severity}" in tpl
+    assert "lowercase" not in tpl
+    assert tpl.count("| # | Vulnerability | Location | CWE | Severity | Verified |") == 1
+
+
+def test_max_iterations_downgrade_strips_severity():
+    """Wave r2 (both): the 'Max iterations reached' downgrade displays an
+    inconclusive row — its severity must be EMPTY (no CRITICAL badge on an
+    unverified row; no inconclusive.critical rule in Code Scanning)."""
+    from openant.cli import _severity_for_result
+
+    row = {"finding": "vulnerable", "severity": "critical",
+           "severity_source": "model",
+           "verification": {"explanation": "Max iterations reached"}}
+    assert _severity_for_result(row, "inconclusive") == ""
+    # and without the downgrade: the model value keeps
+    assert _severity_for_result(row, "vulnerable") == "critical"
+
+
+def test_twin_severity_parity():
+    """Wave r2 (both): the twin stamps AFTER the uppercase fold (core's
+    order — stamping before it lost a model severity on a lowercase-verdict
+    reply), and the severity block is finding-gated."""
+    from utilities.context_corrector import ContextCorrector
+
+    nr = ContextCorrector._normalize_result
+    # lowercase verdict, model severity (direct-parse paths feed the twin
+    # exactly this shape) — the fold happens FIRST, the stamp keeps it
+    out = nr({"verdict": "vulnerable", "severity": "critical"})
+    assert out["verdict"] == "VULNERABLE"
+    assert out["severity"] == "critical" and out["severity_source"] == "model"
+    # finding-gated
+    out = nr({"verdict": "safe", "severity": "critical"})
+    assert "severity" not in out
+    # shared enum (no drift)
+    out = nr({"finding": "vulnerable", "severity": "HIGH"})
+    assert out["severity"] == "high" and out["severity_source"] == "model"
+
+
+def test_summary_table_is_contiguous():
+    """Wave r2 (t#5): a blank line between the separator and the example
+    row terminates the markdown table (the exemplar the summary LLM copies
+    was header-only + an orphan row). Every findings-table line contiguous."""
+    from pathlib import Path as P
+    lines = (P(__file__).resolve().parents[1] / "report" / "prompts"
+             / "summary.txt").read_text().split("\n")
+    i = next(k for k, l in enumerate(lines)
+             if l.startswith("| # | Vulnerability"))
+    assert lines[i + 1].startswith("|---"), "separator row must follow directly"
+    assert lines[i + 2].startswith("| 1 |") and "{severity}" in lines[i + 2], (
+        "the example row must be contiguous and carry the severity cell")
+
+
+def test_the_one_severity_enum_everywhere():
+    """Wave r2 (t#10): five copies of the enum diverged silently — the
+    canonical home is verdict_taxonomy; every importer shares it."""
+    import importlib
+    import openant.cli as cli
+    import report.csv_export as csvx
+    from core import analysis_core, reporter
+    from core.verdict_taxonomy import SEVERITIES
+
+    assert analysis_core.SEVERITIES is SEVERITIES
+    assert csvx._SEVERITIES is SEVERITIES
+    assert cli._SEVERITY_ORDER is SEVERITIES
+    # reporter imports SEVERITIES by name; the value must be the same object
+    assert importlib.import_module("core.reporter").SEVERITIES is SEVERITIES
+
+
+def test_report_data_projection_wires_severity():
+    """Deep-refute #2: the Python->Go key contract is unpinned — deleting
+    the projection lines left every test green. Source-pin (weak form
+    acknowledged) + the Go tags pinned on the Go side."""
+    import inspect
+    import openant.cli as cli
+
+    src = inspect.getsource(cli)
+    i = src.find("findings.append({")
+    block = src[i:i+1200]
+    assert '"severity": _sev' in block and '"severity_source": _sev_src' in block, (
+        "the report-data projection must wire severity + severity_source")

--- a/libs/openant-core/utilities/context_corrector.py
+++ b/libs/openant-core/utilities/context_corrector.py
@@ -597,6 +597,12 @@ class ContextCorrector:
                     corrected = self._normalize_result(corrected)
                     if corrected.get("verdict") not in ("ERROR", None):
                         corrected["json_corrected"] = True
+                        # #215 mirror of analyze_unit: only a MODEL-supplied
+                        # severity value becomes "corrected" (the extraction
+                        # prompt can fabricate the field); a derived stamp
+                        # stays derived.
+                        if corrected.get("severity_source") == "model":
+                            corrected["severity_source"] = "corrected"
                         return corrected
                 except Exception:
                     pass
@@ -646,6 +652,23 @@ class ContextCorrector:
             result["finding"] = "error"
         if "verdict" in result and isinstance(result["verdict"], str):
             result["verdict"] = result["verdict"].upper()
+        # #215 mirror: the finding-gated severity stamp, AFTER the uppercase
+        # fold (core's order — stamping before it lost a model severity on a
+        # lowercase-verdict reply, wave round-2). The shared enum comes from
+        # verdict_taxonomy so the twin cannot drift.
+        from core.verdict_taxonomy import SEVERITIES as _SEVS
+        if result.get("verdict") in ("VULNERABLE", "BYPASSABLE"):  # SEVERITY_FINDING_VERDICTS, uppercased
+            sev = result.get("severity")
+            if isinstance(sev, str) and sev.strip().lower() in _SEVS:
+                result["severity"] = sev.strip().lower()
+                result["severity_source"] = "model"
+            else:
+                result["severity"] = ("high" if result["verdict"] == "VULNERABLE"
+                                      else "medium")
+                result["severity_source"] = "derived"
+        else:
+            result.pop("severity", None)
+            result.pop("severity_source", None)
         return result
 
 

--- a/libs/openant-core/utilities/json_corrector.py
+++ b/libs/openant-core/utilities/json_corrector.py
@@ -30,6 +30,7 @@ from .llm import PhaseBinding, simple_text
 _VULN_SCHEMA = """{
     "verdict": "VULNERABLE" | "SAFE" | "INSUFFICIENT_CONTEXT",
     "confidence": 0.0-1.0,
+    "severity": "CRITICAL" | "HIGH" | "MEDIUM" | "LOW",
     "vulnerabilities": [
         {
             "type": "SQL Injection | XSS | Command Injection | Path Traversal | Open Redirect | XXE | Insecure Deserialization | Broken Access Control | Other",


### PR DESCRIPTION
## Summary

The reporter's population: **82 Stage-2-upheld findings, 6 with cwe_id/impact/steps, 0 with any
severity** — "introducing a severity field at all would be the single highest-value change for
downstream triage." Traced to a schema mismatch re-derived first-hand: the finding record's
rich fields read from `finding["vulnerabilities"][0]` — an array **no prompt asks for** (the
Stage-1 contract is flat); its only producer is the JSON corrector's legacy `_VULN_SCHEMA`,
which carries a 4-level severity enum nested where nothing downstream reads it. The reporter's
well-formed 6 are most plausibly the corrector-repaired subset (checkable on their data via
the `json_corrected` transit field from #366).

The reporter's GOAL — rank/filter/SLA — is what this delivers; their hard-retry MEANS is
deliberately not adopted (a model that never emits the field would lose its findings to
ERROR — the false-negative direction).

## The fix (through 3 adversarial review rounds + a deep-refute, every finding verified and every test RED-proven)

- **The Stage-1 prompt asks for severity** (`critical`/`high`/`medium`/`low` — the enum the
  corrector's legacy schema already used); the corrector schema carries it top-level.
- **FINDING-ONLY**: only vulnerable/bypassable rows carry severity. Safe/protected/
  inconclusive/ERROR rows carry none, everywhere — a `severity=low` filter must not return
  mostly non-findings.
- **The producer** (`_normalize_result`): a model-supplied enum is kept
  (`severity_source: model`); anything else derives conservatively (`vulnerable→high`,
  `bypassable→medium`, never a derived critical). Severity never produces the error shape and
  never touches the error key — the #426 accounting is undisturbed.
- **The read-time contract** (unified and pinned at all three sites): ONLY a model value
  keeps its rank; JSON-repaired (`corrected`) and stale `derived` stamps re-derive from the
  **final** verdict — Stage 2 reclassifies rows, and a Stage-1 stamp must not outrank it.
  The "Max iterations reached" downgrade strips severity (no CRITICAL badge on an unverified
  row). OLD artifacts (pre-PR scans) get read-time derivation, so every scan ranks.
- **The surfaces**: the `pipeline_output.json` finding record + `severity_source`; the CSV's
  `severity` + `severity_source` columns; the summary-table column (the summary LLM now
  receives the values); HTML badges on both templates (with a severity-source tooltip — a
  derived HIGH must not read as an assessment); SARIF.
- `report/schema.py`: Optional on Finding — old artifacts validate.

## Known limits (disclosed)

- **GitHub Code Scanning shows ONE severity per verdict**: the SARIF `security-severity`
  lives on the rule (per-verdict, its findings' max — stable rule ids, so a severity flip
  never re-keys alerts and discards triage state). Per-finding severity reaches SARIF
  consumers via `result.properties` (`severity`, `severity_source`), which GitHub's UI does
  not render. A batch of 9 low + 1 critical vulnerable findings shows as Critical in
  GitHub's UI.
- On old artifacts (the reporter's own 82), read-time derivation yields 82/82 `derived` —
  the model-supplied values land on scans made with this prompt.
- The prompt change invalidates in-flight checkpoint adoption via the analyze fingerprint
  (I2, by design): a partially complete pre-upgrade scan resumed after upgrade re-runs from
  zero.
- Stage-2 verify does not yet revise severity — a follow-up direction if the reporter
  confirms this shape.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | the issue-215 test file (23 tests) + 4 Go tests | green; RED-proven at each round (10 on pristine master, 6 on round-1, 6 on round-2 — via worktrees) # proc-ok |
| the corrected-adoption behavior | the real `analyze_unit` driven with a stubbed adapter/corrector | valid extraction → `corrected`; garbage → `derived` |
| full suites | the Python suite + the Go suite wrapper | 3432 green + the one byte-identical-on-pristine macOS tmp failure · the Go side 10 ok / 0 fail | # proc-ok
| review | 3 adversarial wave rounds + the deep-refute; two rounds found real defects in the round before (the stale-derived escape, the downgrade leak, a rule-fanout revert) | convergence; the deep-refute could not refute the composition chain |

</details>

Refs #215 — the issue stays open for the reporter's confirmation (the schema-mismatch
reading of their 6 well-formed findings is a hypothesis they can check on their data via the
`json_corrected` transit field)
