### PR TITLE
fix(checkpoint): case-only unit IDs no longer silently lose checkpoints — save-time disambiguation + id-keyed restore (#317)

### DIFF
--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -20,9 +20,11 @@ Usage:
     cp.cleanup()                          # remove dir on success
 """
 
+import hashlib
 import json
 import os
 import shutil
+import threading
 import sys
 from datetime import datetime, timezone
 
@@ -39,6 +41,122 @@ SUMMARY_FILE = "_summary.json"
 # and from the Go DetectFallback scan, or a resume would over-count "completed"
 # units by the number of sidecars.
 _RESERVED_FILES = frozenset({SUMMARY_FILE, FINGERPRINT_FILE})
+
+# #317: save() runs in worker threads (the enhancer's and the analyzer's
+# ThreadPoolExecutor pools), so the exists-then-write disambiguation has a
+# TOCTOU race: two case siblings in flight could both see bare-not-exists
+# and both write it (last wins — the collision for that run). A module-level
+# lock held across resolve+write; microseconds against multi-second LLM
+# calls. Covers every phase — the verifier and dynamic tester save through
+# StepCheckpoint.save too.
+_save_lock = threading.Lock()
+
+
+def disambiguated_checkpoint_path(ckpt_dir: str, unit_id: str) -> str:
+    """The collision-safe checkpoint filepath for ``unit_id`` (#317).
+
+    The bare ``safe_filename(unit_id) + ".json"`` when free or already holding
+    THIS unit's data (a resume/refresh overwrites its own file); when the
+    name is taken by a DIFFERENT unit's checkpoint — the case-insensitive
+    filesystem collision (``pkg/Foo.py:run`` vs ``pkg/foo.py:run``) — the
+    case-sensitive hash suffix disambiguates (the long-name mechanism,
+    capped so name + .json fits the 255-char limit). On case-SENSITIVE
+    filesystems the check never fires for a case-only pair: two real files,
+    the naming scheme unchanged.
+
+    HOME STABILITY: once a unit's data lives at the suffixed path (its
+    disambiguated home), later saves keep writing THERE even when the bare
+    name has freed up (the sibling's file deleted, the dir moved to a
+    case-sensitive fs) — otherwise the fresh result would land at the bare
+    name and ORPHAN the suffixed twin, and the two same-id files would
+    resolve by listdir order (arbitrary) — the non-convergence class #317
+    fixed, resurrected (wave round-1 finding).
+    """
+    safe = safe_filename(unit_id)
+    if len(safe) > 233:
+        # The truncated regime: safe_filename already appended the
+        # case-sensitive hash (name -> prefix[:233] + _ + 16 hex of the FULL
+        # id), so the name is INJECTIVE — a different unit cannot reach it.
+        # Disambiguation is a no-op here BY CONSTRUCTION; the early-out
+        # states it instead of leaving it to the 233-constant coupling
+        # between the two files (wave round-1: the coupling was load-
+        # bearing and nothing said so).
+        return os.path.join(ckpt_dir, safe + ".json")
+    bare = os.path.join(ckpt_dir, safe + ".json")
+    h = hashlib.sha256(unit_id.encode()).hexdigest()[:16]
+    stem = safe[: 255 - len(".json") - len(h) - 1]
+    home = os.path.join(ckpt_dir, f"{stem}_{h}.json")
+
+    def _holds_this_unit(path):
+        try:
+            existing = read_json(path)
+        except Exception:
+            # a corrupt/foreign .json must not crash every later save of
+            # this unit — unreadable reads as no id (the garbage is
+            # overwrite-able; write_json is atomic).
+            return False
+        return isinstance(existing, dict) and existing.get("id") == unit_id
+
+    if os.path.exists(bare):
+        try:
+            existing = read_json(bare)
+        except Exception:
+            existing = None
+        existing_id = existing.get("id") if isinstance(existing, dict) else None
+        if existing_id == unit_id:
+            return bare  # its own file — overwrite in place
+        if existing_id is not None:
+            return home  # a sibling's — this unit's disambiguated home
+        # corrupt bare: the HOME STABILITY probe still applies (wave r2 —
+        # returning bare here while this unit already lives at its home
+        # would recreate the two-same-id-files state the sibling's
+        # corruption just made room for).
+        if os.path.exists(home) and _holds_this_unit(home):
+            return home
+        return bare  # overwrite the garbage
+    # the bare name is free — but this unit may already live at its
+    # suffixed home (the sibling that held the bare name is gone): keep
+    # writing THERE, or the twin orphans.
+    if os.path.exists(home) and _holds_this_unit(home):
+        return home
+    return bare
+
+
+def save_checkpoint_under_lock(ckpt_dir: str, unit_id: str, data: dict) -> str:
+    """Resolve + write a unit's checkpoint under the #317 save lock (the
+    TOCTOU guard for worker-thread saves). The caller is responsible for
+    setting data["id"]; this stamps it."""
+    with _save_lock:
+        filepath = disambiguated_checkpoint_path(ckpt_dir, unit_id)
+        data["id"] = unit_id
+        write_json(filepath, data)
+    return filepath
+
+
+def id_keyed_checkpoint_map(ckpt_dir: str) -> dict:
+    """Map every checkpoint file's ``id`` (from its CONTENT) to its path.
+
+    #317: completion detection is content-based; restoration must be too —
+    a filename-computed lookup strands old-scheme files (detected complete,
+    restore no-ops -> empty contexts -> fewer findings) and restores the
+    WRONG unit's data when the computed name is taken by a sibling. One
+    listdir + read pass; unreadable files are skipped (detection's own
+    convention).
+    """
+    mapping = {}
+    if not os.path.isdir(ckpt_dir):
+        return mapping
+    for name in os.listdir(ckpt_dir):
+        if not name.endswith(".json") or name in _RESERVED_FILES:
+            continue
+        p = os.path.join(ckpt_dir, name)
+        try:
+            data = read_json(p)
+        except Exception:
+            continue
+        if isinstance(data, dict) and data.get("id"):
+            mapping[data["id"]] = p
+    return mapping
 
 
 def analyze_result_is_error(res) -> bool:
@@ -173,12 +291,17 @@ class StepCheckpoint:
         Args:
             unit_id: The unit identifier.
             data: Dict to persist (must include 'id' key).
+
+        #317: collision-safe via ``disambiguated_checkpoint_path`` — on a
+        case-insensitive filesystem (macOS default, Windows) two unit IDs
+        differing only in case (ordinary Go exported/unexported pairs)
+        compute the same filename; the second save silently overwrote the
+        first, and the lost unit was re-analyzed and re-paid on every
+        resume. On case-SENSITIVE filesystems the naming scheme is
+        unchanged (the check never fires for a case-only pair).
         """
         self.ensure_dir()
-        filename = self._safe_filename(unit_id) + ".json"
-        filepath = os.path.join(self.dir, filename)
-        data["id"] = unit_id  # ensure id is always present
-        write_json(filepath, data)
+        save_checkpoint_under_lock(self.dir, unit_id, data)
 
     # ------------------------------------------------------------------
     # Backend-identity adopt gate (I2, minimal)

--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -28,7 +28,7 @@ import threading
 import sys
 from datetime import datetime, timezone
 
-from utilities.safe_filename import safe_filename
+from utilities.safe_filename import SAFE_FILENAME_MAX_LEN, safe_filename
 from utilities.file_io import read_json, write_json
 from core.backend_identity import FINGERPRINT_FILE
 from pathlib import Path
@@ -48,7 +48,11 @@ _RESERVED_FILES = frozenset({SUMMARY_FILE, FINGERPRINT_FILE})
 # and both write it (last wins — the collision for that run). A module-level
 # lock held across resolve+write; microseconds against multi-second LLM
 # calls. Covers every phase — the verifier and dynamic tester save through
-# StepCheckpoint.save too.
+# StepCheckpoint.save too. SINGLE-PROCESS SCOPE (panel round-3): this is a
+# threading lock — two CONCURRENT CLI invocations writing the same checkpoint
+# dir (an unsupported shape: they would also race every results file in the
+# output dir) are NOT serialized by it. Within one process (the supported
+# shape: a single run's worker pools) it fully orders resolve+write.
 _save_lock = threading.Lock()
 
 
@@ -73,7 +77,7 @@ def disambiguated_checkpoint_path(ckpt_dir: str, unit_id: str) -> str:
     fixed, resurrected (wave round-1 finding).
     """
     safe = safe_filename(unit_id)
-    if len(safe) > 233:
+    if len(safe) > SAFE_FILENAME_MAX_LEN:
         # The truncated regime: safe_filename already appended the
         # case-sensitive hash (name -> prefix[:233] + _ + 16 hex of the FULL
         # id), so the name is INJECTIVE — a different unit cannot reach it.
@@ -104,6 +108,22 @@ def disambiguated_checkpoint_path(ckpt_dir: str, unit_id: str) -> str:
             existing = None
         existing_id = existing.get("id") if isinstance(existing, dict) else None
         if existing_id == unit_id:
+            # Panel round-3 (self-heal): if BOTH the bare name and this
+            # unit's suffixed home hold the same id (a dual-stale-file
+            # state — fable judged it code-unreachable, sonnet asked for
+            # the class to self-heal "however it arises"), consolidate to
+            # the NEWER file and delete the superseded twin — otherwise
+            # the id-keyed restore's last-wins could keep serving the
+            # stale one indefinitely. mtime decides freshness; both
+            # files provably hold this unit's id.
+            if os.path.exists(home) and _holds_this_unit(home):
+                try:
+                    if os.path.getmtime(home) > os.path.getmtime(bare):
+                        _atomic_unlink(bare)
+                        return home
+                    _atomic_unlink(home)
+                except OSError:
+                    pass  # best-effort: the ordinary overwrite still lands
             return bare  # its own file — overwrite in place
         if existing_id is not None:
             return home  # a sibling's — this unit's disambiguated home
@@ -120,6 +140,15 @@ def disambiguated_checkpoint_path(ckpt_dir: str, unit_id: str) -> str:
     if os.path.exists(home) and _holds_this_unit(home):
         return home
     return bare
+
+
+def _atomic_unlink(path: str) -> None:
+    """Best-effort remove; a missing file (case-insensitive fs aliasing,
+    concurrent cleanup) is success. Under _save_lock at every caller."""
+    try:
+        os.unlink(path)
+    except FileNotFoundError:
+        pass
 
 
 def save_checkpoint_under_lock(ckpt_dir: str, unit_id: str, data: dict) -> str:

--- a/libs/openant-core/tests/test_issue317_case_collision.py
+++ b/libs/openant-core/tests/test_issue317_case_collision.py
@@ -495,3 +495,47 @@ def test_corrupt_sibling_bare_file_keeps_home_stability():
         assert len(foo_files) == 1, foo_files  # still ONE foo file: the home
         loaded = ck.load()
         assert loaded["pkg/foo.py:run"]["result"]["v"] == 2
+
+
+def test_dual_same_id_files_self_heal_to_the_newer(tmp_path):
+    """Panel round-3 (sonnet item 1): a dual-stale-file state — the bare
+    name AND the suffixed home both holding this unit's id — consolidates
+    on the next disambiguated save: the NEWER file wins, the superseded twin
+    is removed, and the id-keyed restore can no longer serve the stale one."""
+    import hashlib
+    import json as _json
+    import os as _os
+
+    import core.checkpoint as _ck
+
+    d = str(tmp_path / "cp")
+    _os.makedirs(d, exist_ok=True)
+    unit = "pkg/Foo.py:run"
+
+    def _write(p, data):
+        with open(p, "w") as f:
+            _json.dump(data, f)
+
+    safe = _ck.safe_filename(unit)
+    bare = _os.path.join(d, safe + ".json")
+    h = hashlib.sha256(unit.encode()).hexdigest()[:16]
+    stem = safe[: 255 - len(".json") - len(h) - 1]
+    home = _os.path.join(d, f"{stem}_{h}.json")
+
+    # home newer, bare stale: consolidation keeps home, removes bare
+    _write(bare, {"id": unit, "result": "STALE"})
+    _write(home, {"id": unit, "result": "FRESH"})
+    _os.utime(home, None)
+    path = _ck.disambiguated_checkpoint_path(d, unit)
+    assert path == home, "the newer home must win"
+    assert not _os.path.exists(bare), "the superseded stale twin must be removed"
+    assert _ck.id_keyed_checkpoint_map(d)[unit] == home
+
+    # bare newer, home stale: keeps bare, removes home
+    _write(bare, {"id": unit, "result": "FRESH2"})
+    _write(home, {"id": unit, "result": "STALE2"})
+    _os.utime(bare, None)
+    path = _ck.disambiguated_checkpoint_path(d, unit)
+    assert path == bare, "the newer bare must win"
+    assert not _os.path.exists(home), "the superseded stale twin must be removed"
+    assert _ck.id_keyed_checkpoint_map(d)[unit] == bare

--- a/libs/openant-core/tests/test_issue317_case_collision.py
+++ b/libs/openant-core/tests/test_issue317_case_collision.py
@@ -1,0 +1,497 @@
+"""#317: case-only unit IDs must not silently lose checkpoints.
+
+The sanitiser (`utilities/safe_filename.py`) preserves case, so two unit IDs differing only in
+case (``pkg/Foo.py:run`` vs ``pkg/foo.py:run`` — 593 real pairs in ordinary Go dependencies
+via the exported/unexported convention) compute the SAME filename. On a case-insensitive
+filesystem (macOS default, Windows) the second save overwrites the first: one unit's
+checkpoint silently lost, and — because ``load()`` then reports one unit where two were
+saved — it is re-analyzed and re-PAID on every resume (the run never converges for the pair).
+
+The issue's own warning (the migration hazard): completion DETECTION is content-based
+(``_load_completed_units``: listdir + each file's id) but RESTORATION is filename-computed
+(``context_enhancer``: ``join(dir, safe_filename(unit_id))`` + exists-check). Any naming
+change alone strands pre-existing checkpoints — detected complete, restore no-ops, empty
+contexts, FEWER findings (the false-negative direction).
+
+The fix:
+- ``StepCheckpoint.save`` disambiguates on collision: if the computed filename exists and its
+  content's ``id`` differs from the unit being saved, append the case-sensitive 16-hex hash
+  suffix (the existing long-name mechanism, capped at 255). On case-SENSITIVE filesystems the
+  exists-with-different-id check never fires for a case-only pair (two real files) — zero
+  behavior change there.
+- The three filename-computed restore paths in ``context_enhancer`` become ID-KEYED: one
+  listdir pass building ``{id: path}`` from file contents — the same read detection already
+  does. This fixes the migration stranding (old-scheme files restore by content), the
+  B-restores-A's-context hazard the disambiguation would otherwise introduce on a later
+  resume (B's bare computed name exists but holds A's data), and the detection/restore
+  asymmetry the issue flagged.
+"""
+import json
+import os
+import sys
+import tempfile
+import threading
+from pathlib import Path
+
+import pytest
+
+CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from core.checkpoint import StepCheckpoint  # noqa: E402
+
+
+def _fs_is_case_insensitive(d) -> bool:
+    """Runtime probe: create two case-variant names and check whether they
+    collide. The case-only repro physically cannot fire on a case-SENSITIVE
+    filesystem — tests that assert the suffix must branch on this, or they
+    go red on Linux CI where the behavior is CORRECT (two bare files)."""
+    probe = os.path.join(d, "CaseProbe_317")
+    with open(probe, "w") as f:
+        f.write("x")
+    try:
+        return os.path.exists(os.path.join(d, "caseprobe_317"))
+    finally:
+        os.unlink(probe)
+
+
+def _files_in(ck):
+    """List the checkpoint dir of a StepCheckpoint (self.dir is
+    <parent>/<step>_checkpoints)."""
+    return sorted(os.listdir(ck.dir))
+
+
+def test_case_pair_both_saved_and_loaded():
+    """The issue's executed repro, as the RED: 'pkg/Foo.py:run' and
+    'pkg/foo.py:run' — both must survive save() and come back from load()."""
+    with tempfile.TemporaryDirectory() as d:
+        ck = StepCheckpoint("analyze", d)
+        ck.save("pkg/Foo.py:run", {"id": "pkg/Foo.py:run", "result": {"verdict": "SAFE"}})
+        ck.save("pkg/foo.py:run", {"id": "pkg/foo.py:run", "result": {"verdict": "SAFE2"}})
+        loaded = ck.load()
+        assert set(loaded) == {"pkg/Foo.py:run", "pkg/foo.py:run"}, (
+            f"a case-only pair silently lost a unit; files={_files_in(ck)}")
+        # each unit's own data, not the other's
+        assert loaded["pkg/Foo.py:run"]["result"]["verdict"] == "SAFE"
+        assert loaded["pkg/foo.py:run"]["result"]["verdict"] == "SAFE2"
+
+
+def test_case_pair_never_repaid_across_resumes():
+    """The convergence consequence: after a completed pair, a resumed run's
+    adoption must see BOTH units — the pair stops re-paying."""
+    from core.checkpoint import analyze_result_is_error
+
+    with tempfile.TemporaryDirectory() as d:
+        ck = StepCheckpoint("analyze", d)
+        ck.save("pkg/Foo.py:run", {"id": "pkg/Foo.py:run",
+                                    "result": {"finding": "safe", "verdict": "SAFE"}})
+        ck.save("pkg/foo.py:run", {"id": "pkg/foo.py:run",
+                                    "result": {"finding": "safe", "verdict": "SAFE"}})
+        loaded = ck.load()
+        adoptable = {uid for uid, cp in loaded.items()
+                     if not analyze_result_is_error(cp.get("result", {}))}
+        assert adoptable == {"pkg/Foo.py:run", "pkg/foo.py:run"}
+
+
+def test_save_disambiguation_only_on_collision():
+    """The hash suffix appears ONLY for the colliding unit — the naming scheme
+    is unchanged for every non-colliding ID, and on case-SENSITIVE filesystems
+    the exists-with-different-id check never fires for a case-only pair at
+    all (two real files, the pre-fix behavior byte-identical) — the wave's
+    platform-parity requirement, asserted via the runtime probe so Linux CI
+    executes the body rather than skipping."""
+    with tempfile.TemporaryDirectory() as d:
+        insensitive = _fs_is_case_insensitive(d)
+        ck = StepCheckpoint("analyze", d)
+        ck.save("plain.py:run", {"id": "plain.py:run", "result": {}})
+        ck.save("pkg/Foo.py:run", {"id": "pkg/Foo.py:run", "result": {}})
+        ck.save("pkg/foo.py:run", {"id": "pkg/foo.py:run", "result": {}})
+        names = [f for f in _files_in(ck) if f.endswith(".json")]
+        assert "plain.py_run.json" in names
+        assert "pkg__Foo.py_run.json" in names
+        if insensitive:
+            # the second of the pair took the suffix
+            assert any(n.startswith("pkg__foo.py_run_") for n in names), names
+        else:
+            # case-sensitive: two bare files, no disambiguation fired
+            assert "pkg__foo.py_run.json" in names, names
+            assert not any(n.startswith("pkg__foo.py_run_") for n in names), names
+        # a re-save of the SAME id (resume/refresh) overwrites its own file,
+        # not the sibling's — no third file appears
+        ck.save("pkg/foo.py:run", {"id": "pkg/foo.py:run", "result": {"v": 2}})
+        ck.save("pkg/Foo.py:run", {"id": "pkg/Foo.py:run", "result": {"v": 2}})
+        after = [f for f in _files_in(ck) if f.endswith(".json")]
+        # 3 either way: [plain + Foo-bare + foo-suffixed] on insensitive fs,
+        # [plain + Foo-bare + foo-bare] on sensitive fs — the platform parity
+        assert len(after) == 3, after
+
+
+def test_restore_is_id_keyed_not_filename_keyed():
+    """Wave round-1: the source-grep pin was leaky (an OR satisfied by a dead
+    helper; one spelling pinned of three). The spelling-proof form: NO
+    filename computed from ANY unit id at any restore site — pin the pattern
+    itself, every variable spelling."""
+    import inspect
+    from utilities import context_enhancer
+
+    src = inspect.getsource(context_enhancer)
+    assert "f\"{self._safe_filename(" not in src, (
+        "a filename-computed checkpoint lookup remains in the enhancer")
+
+
+def test_old_scheme_files_still_restore_by_content():
+    """The migration shape: a checkpoint written under the OLD scheme
+    (bare name, uppercase-bearing id) is still restored on the NEW code —
+    the detection/restore symmetry this fix establishes."""
+    from utilities.context_enhancer import ContextEnhancer
+    with tempfile.TemporaryDirectory() as d:
+        # an OLD-scheme file: the bare safe_filename of an uppercase id
+        old_name = "pkg__Foo.py_run.json"
+        payload = {"id": "pkg/Foo.py:run", "agent_context": {"note": "old"},
+                   "code": "x = 1"}
+        with open(os.path.join(d, old_name), "w") as f:
+            json.dump(payload, f)
+        # the enhancer's restore: find the id's checkpoint by content
+        enhancer = ContextEnhancer.__new__(ContextEnhancer)
+        m = enhancer._id_keyed_checkpoint_map(d) if hasattr(
+            enhancer, "_id_keyed_checkpoint_map") else None
+        if m is None:
+            pytest.fail("the id-keyed map helper is absent")
+        assert m.get("pkg/Foo.py:run") == os.path.join(d, old_name)
+
+
+def test_sanitizer_alias_pair_collides_on_every_filesystem():
+    """The fs-independent guard (the load-bearing test on Linux CI, where
+    the case-only repro physically cannot fire): the sanitizer is many-to-one
+    BEYOND case — ':' and space both map to '_', so 'a:b:c' and 'a b:c'
+    produce byte-identical names on EVERY filesystem. The exists-with-
+    different-id disambiguation cures this class too; both units must
+    survive."""
+    with tempfile.TemporaryDirectory() as d:
+        ck = StepCheckpoint("analyze", d)
+        ck.save("src/a:b:c", {"id": "src/a:b:c", "result": {"verdict": "SAFE"}})
+        ck.save("src/a b:c", {"id": "src/a b:c", "result": {"verdict": "SAFE2"}})
+        loaded = ck.load()
+        assert set(loaded) == {"src/a:b:c", "src/a b:c"}, _files_in(ck)
+        assert loaded["src/a:b:c"]["result"]["verdict"] == "SAFE"
+        assert loaded["src/a b:c"]["result"]["verdict"] == "SAFE2"
+
+
+def test_corrupt_existing_file_does_not_break_save():
+    """The need-check gap: a hand-damaged/foreign .json at the computed name
+    must not crash every later save of that unit (unreadable reads as no-id;
+    the garbage is overwritten — write_json is atomic)."""
+    with tempfile.TemporaryDirectory() as d:
+        ck = StepCheckpoint("analyze", d)
+        ck.ensure_dir()
+        garbage = os.path.join(ck.dir, "pkg__bad.py_run.json")
+        with open(garbage, "w") as f:
+            f.write("{not json at all")
+        ck.save("pkg/bad.py:run", {"id": "pkg/bad.py:run", "result": {"v": 1}})
+        loaded = ck.load()
+        assert "pkg/bad.py:run" in loaded
+        assert loaded["pkg/bad.py:run"]["result"]["v"] == 1
+
+
+def test_suffix_at_the_255_boundary():
+    """An ID whose safe name is exactly 233 chars (never truncated by
+    safe_filename) colliding with a sibling gets stem[:233] + _ + 16 hex +
+    .json = exactly 255 — at the filesystem limit, still writable."""
+    from utilities.safe_filename import safe_filename
+    # safe("src/" + X*224 + ":Run") = "src__" + 224 + "_Run" = 233 exactly
+    base = "x" * 224
+    long_id = f"src/{base}:Run"
+    sibling = f"src/{base}:run"
+    assert len(safe_filename(long_id)) == 233
+    with tempfile.TemporaryDirectory() as d:
+        insensitive = _fs_is_case_insensitive(d)
+        ck = StepCheckpoint("analyze", d)
+        ck.save(long_id, {"id": long_id, "result": {"v": 1}})
+        ck.save(sibling, {"id": sibling, "result": {"v": 2}})
+        loaded = ck.load()
+        assert set(loaded) == {long_id, sibling}
+        names = [n for n in _files_in(ck) if n.endswith(".json")]
+        for n in names:
+            assert len(n) <= 255
+        if insensitive:
+            # the suffixed sibling lands exactly at the limit
+            suffixed = [n for n in names if len(n) == 255]
+            assert suffixed, names  # 233 + 1 + 16 + 5 = 255
+        else:
+            # case-sensitive: two distinct bare names
+            assert len(names) == 2 and all(len(n) == 238 for n in names), names
+
+
+def test_long_case_pair_needs_no_disambiguation():
+    """The >233-char branch: safe_filename truncates long IDs and appends the
+    case-sensitive hash, so a long case pair gets DIFFERENT hashes — distinct
+    names without the disambiguation ever firing. Documents that branch as
+    intentionally dead for case pairs."""
+    with tempfile.TemporaryDirectory() as d:
+        base = "y" * 240
+        long_id = f"src/{base}:Run"
+        sibling = f"src/{base}:run"
+        ck = StepCheckpoint("analyze", d)
+        ck.save(long_id, {"id": long_id, "result": {"v": 1}})
+        ck.save(sibling, {"id": sibling, "result": {"v": 2}})
+        loaded = ck.load()
+        assert set(loaded) == {long_id, sibling}
+        # distinct truncated+hashed names on every filesystem
+        names = [n for n in _files_in(ck) if n.endswith(".json")]
+        assert len(names) == 2, names
+
+
+def test_threaded_case_pair_saves_do_not_lose_a_unit():
+    """The need-check's TOCTOU finding: save() runs in ThreadPoolExecutor
+    workers — two case siblings saved CONCURRENTLY must both land (the
+    module-level save lock serializes the resolve+write pair). Without the
+    lock both could see bare-not-exists and clobber; the lock makes the
+    convergence claim clean rather than eventual."""
+    with tempfile.TemporaryDirectory() as d:
+        ck = StepCheckpoint("analyze", d)
+        barrier = threading.Barrier(2)
+
+        def save(uid, v):
+            barrier.wait()  # maximize the interleaving
+            ck.save(uid, {"id": uid, "result": {"verdict": v}})
+
+        threads = [threading.Thread(target=save, args=(u, v))
+                  for u, v in (("pkg/Foo.py:run", "SAFE"), ("pkg/foo.py:run", "SAFE2"))]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join()
+        loaded = ck.load()
+        assert set(loaded) == {"pkg/Foo.py:run", "pkg/foo.py:run"}, _files_in(ck)
+        assert loaded["pkg/Foo.py:run"]["result"]["verdict"] == "SAFE"
+        assert loaded["pkg/foo.py:run"]["result"]["verdict"] == "SAFE2"
+
+
+# ---------------------------------------------------------------------------
+# wave round-1: the home-stability pin, the truncated early-out, the
+# deterministic lock pin, the behavioral restore
+# ---------------------------------------------------------------------------
+
+def test_no_orphan_when_the_bare_twin_frees_up():
+    """Wave r1 (persistence axis): once a unit lives at its suffixed home,
+    a later save with the bare name FREE (the sibling's file deleted, the
+    dir moved to a case-sensitive fs) must keep writing the HOME — else the
+    fresh result lands at the bare name, the suffixed twin orphans, and the
+    two same-id files resolve by listdir order (arbitrary): the
+    non-convergence class resurrected."""
+    with tempfile.TemporaryDirectory() as d:
+        if not _fs_is_case_insensitive(d):
+            pytest.skip("the orphan scenario needs the collision to fire first")
+        ck = StepCheckpoint("analyze", d)
+        ck.save("pkg/Foo.py:run", {"id": "pkg/Foo.py:run", "result": {"v": 1}})
+        ck.save("pkg/foo.py:run", {"id": "pkg/foo.py:run", "result": {"v": 1}})
+        # the sibling's bare file goes away (hand deletion / fs move)
+        os.unlink(os.path.join(ck.dir, "pkg__Foo.py_run.json"))
+        # a later save of the surviving unit: the bare name is now free
+        ck.save("pkg/foo.py:run", {"id": "pkg/foo.py:run", "result": {"v": 2}})
+        names = [n for n in _files_in(ck) if n.endswith(".json")]
+        # no orphan: the unit's home still holds it, updated — ONE foo file
+        foo_files = [n for n in names if "foo" in n]
+        assert len(foo_files) == 1, names
+        loaded = ck.load()
+        assert loaded["pkg/foo.py:run"]["result"]["v"] == 2
+
+
+def test_truncated_regime_returns_the_injective_name():
+    """Wave r1 (test axis): the >233-char regime is INJECTIVE by construction
+    (safe_filename already appended the full id's hash) — the resolver's
+    early-out states the invariant instead of leaving it to the 233-constant
+    coupling between the two files. Pin: the truncated name comes back
+    unchanged, collision or not."""
+    from core.checkpoint import disambiguated_checkpoint_path
+    from utilities.safe_filename import safe_filename
+    with tempfile.TemporaryDirectory() as d:
+        long_id = "src/" + "y" * 240 + ":Run"
+        assert len(safe_filename(long_id)) > 233  # the truncated regime
+        p = disambiguated_checkpoint_path(d, long_id)
+        assert p == os.path.join(d, safe_filename(long_id) + ".json")
+        # even with a file present at that name (the same id's home)
+        ck = StepCheckpoint("analyze", d)
+        ck.save(long_id, {"id": long_id, "result": {"v": 1}})
+        p2 = disambiguated_checkpoint_path(ck.dir, long_id)
+        assert p2 == os.path.join(ck.dir, safe_filename(long_id) + ".json")
+
+
+def test_save_lock_deterministic(monkeypatch):
+    """Wave r2: the r1 version spawned NO threads (a sequential save whose
+    barrier timed out — the lock could be deleted and it stayed green).
+    The real shape: two threads rendezvous INSIDE the hooked exists check.
+    WITHOUT the lock, both observe bare-not-exists together and both write
+    the bare name (a unit lost — red). WITH the lock, the second thread
+    blocks ON THE LOCK while the first is inside the gate; the first's
+    barrier times out (it is alone), it completes, and the second then sees
+    the bare file taken and suffixes — green, serialized."""
+    import core.checkpoint as cp
+
+    with tempfile.TemporaryDirectory() as d:
+        if not _fs_is_case_insensitive(d):
+            pytest.skip("the collision is unreachable on a case-sensitive fs")
+        gate = threading.Barrier(2, timeout=2)
+        real_exists = os.path.exists
+        gate_armed = True
+
+        def hooked_exists(p):
+            if gate_armed and (p.endswith("pkg__Foo.py_run.json")
+                               or p.endswith("pkg__foo.py_run.json")):
+                try:
+                    gate.wait()  # rendezvous: both threads see "free"
+                except threading.BrokenBarrierError:
+                    pass  # alone at the gate (the lock held us off) — serialized
+            return real_exists(p)
+
+        monkeypatch.setattr(cp.os.path, "exists", hooked_exists)
+        ck = StepCheckpoint("analyze", d)
+
+        results = {}
+
+        def save(uid, v):
+            try:
+                ck.save(uid, {"id": uid, "result": {"verdict": v}})
+                results[uid] = "ok"
+            except Exception as e:  # pragma: no cover
+                results[uid] = f"error: {e}"
+
+        threads = [threading.Thread(target=save, args=(u, v))
+                   for u, v in (("pkg/Foo.py:run", "SAFE"),
+                                ("pkg/foo.py:run", "SAFE2"))]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join(timeout=30)
+        gate_armed = False
+        loaded = ck.load()
+        # both units landed, each with its own data — the lock serialized
+        assert set(loaded) == {"pkg/Foo.py:run", "pkg/foo.py:run"}, _files_in(ck)
+        assert loaded["pkg/Foo.py:run"]["result"]["verdict"] == "SAFE"
+        assert loaded["pkg/foo.py:run"]["result"]["verdict"] == "SAFE2"
+        names = [n for n in _files_in(ck) if n.endswith(".json")]
+        suffixed = [n for n in names if n.startswith("pkg__foo.py_run_") or
+                    n.startswith("pkg__Foo.py_run_")]
+        assert len(suffixed) == 1, names  # one bare + one suffixed
+
+
+def test_behavioral_restore_case_pair_via_enhance(monkeypatch, tmp_path):
+    """Wave r1 (test axis): the three rewired restore sites had NO
+    behavioral coverage (the grep pin + a helper-level map test only).
+    The real path: a case-pair dataset resumed through the actual
+    single-shot enhance loop — each unit must get its OWN context (the
+    B-not-A hazard), and no unit may be re-enhanced."""
+    import sys as _sys
+    sys.path.insert(0, str(Path(__file__).resolve().parent))  # for the helpers
+    from test_enhance_resilience import _fake_binding, _dataset
+    from utilities.context_enhancer import ContextEnhancer
+
+    cp_dir = str(tmp_path / "enhance_checkpoints")
+    os.makedirs(cp_dir, exist_ok=True)
+    # pre-populate: BOTH members of a case pair, each with its OWN context
+    for uid, marker in (("pkg/Foo.py:run", "FOO-CTX"),
+                        ("pkg/foo.py:run", "foo-CTX")):
+        from core.checkpoint import save_checkpoint_under_lock
+        save_checkpoint_under_lock(cp_dir, uid, {
+            "id": uid, "context_key": "llm_context",
+            "llm_context": {"reasoning": marker, "confidence": 0.9}})
+    names = sorted(n for n in os.listdir(cp_dir) if n.endswith(".json"))
+    assert len(names) == 2, names  # the collision disambiguated
+
+    enh = ContextEnhancer(binding=_fake_binding(), tracker=None)
+    seen = []
+
+    def fake_enhance(unit, by_id):
+        seen.append(unit.get("id"))
+        unit["llm_context"] = {"reasoning": "re-enhanced", "confidence": 0.9}
+        return unit
+
+    monkeypatch.setattr(enh, "enhance_unit", fake_enhance)
+    ds = {"units": [
+        {"id": "pkg/Foo.py:run", "code": "def run(): pass"},
+        {"id": "pkg/foo.py:run", "code": "def run(): pass"},
+    ]}
+    out = enh.enhance_dataset(ds, workers=1, checkpoint_path=cp_dir)
+    # NOTHING re-enhanced (both restored from their own checkpoints)
+    assert seen == [], f"restored units were re-enhanced: {seen}"
+    ctxs = {u["id"]: u.get("llm_context", {}).get("reasoning")
+            for u in out["units"]}
+    assert ctxs == {"pkg/Foo.py:run": "FOO-CTX",
+                    "pkg/foo.py:run": "foo-CTX"}, ctxs  # each its OWN
+
+
+def test_behavioral_restore_case_pair_via_agentic(monkeypatch, tmp_path):
+    """Wave r2: the agent_context site (:641) and the usage-summary site
+    (:682) live in enhance_dataset_agentic — the r1 behavioral test covered
+    only the single-shot llm_context path. The real agentic loop, a case
+    pair, each pre-populated with its OWN context: nothing re-enhanced, each
+    unit restored with its own data."""
+    from unittest.mock import MagicMock
+
+    from utilities import context_enhancer as ce
+    from utilities.context_enhancer import ContextEnhancer
+
+    cp_dir = str(tmp_path / "enhance_checkpoints")
+    os.makedirs(cp_dir, exist_ok=True)
+    from core.checkpoint import save_checkpoint_under_lock
+    for uid, marker in (("pkg/Foo.py:run", "FOO-AGENT"),
+                        ("pkg/foo.py:run", "foo-AGENT")):
+        save_checkpoint_under_lock(cp_dir, uid, {
+            "id": uid, "context_key": "agent_context",
+            "agent_context": {"reasoning": marker, "confidence": 0.9},
+            "usage": {"input_tokens": 7, "output_tokens": 3, "cost_usd": 0.01}})
+    names = sorted(n for n in os.listdir(cp_dir) if n.endswith(".json"))
+    assert len(names) == 2, names
+
+    import sys as _sys2
+    if str(Path(__file__).resolve().parent) not in _sys2.path:
+        _sys2.path.insert(0, str(Path(__file__).resolve().parent))
+    from test_enhance_resilience import _fake_binding
+    from utilities.llm_client import TokenTracker
+    enh = ContextEnhancer(binding=_fake_binding(), tracker=TokenTracker())
+    fake_index = MagicMock()
+    fake_index.get_statistics.return_value = {
+        "total_functions": 0, "total_files": 0}
+    monkeypatch.setattr(ce, "load_index_from_file", lambda *a, **k: fake_index)
+    seen = []
+
+    def fake_agent(unit, index, binding, tracker, verbose):
+        seen.append(unit.get("id"))
+        unit["agent_context"] = {"reasoning": "re-enhanced", "confidence": 0.9}
+        return unit
+
+    monkeypatch.setattr(ce, "enhance_unit_with_agent", fake_agent)
+    ds = {"units": [
+        {"id": "pkg/Foo.py:run", "code": "def run(): pass"},
+        {"id": "pkg/foo.py:run", "code": "def run(): pass"},
+    ]}
+    out = enh.enhance_dataset_agentic(
+        dataset=ds, analyzer_output_path=None, repo_path=None,
+        workers=1, checkpoint_path=cp_dir)
+    assert seen == [], f"restored units were re-enhanced: {seen}"
+    ctxs = {u["id"]: u.get("agent_context", {}).get("reasoning")
+            for u in out["units"]}
+    assert ctxs == {"pkg/Foo.py:run": "FOO-AGENT",
+                    "pkg/foo.py:run": "foo-AGENT"}, ctxs
+
+
+def test_corrupt_sibling_bare_file_keeps_home_stability():
+    """Wave r2: the corrupt-bare branch must still probe the suffixed home —
+    returning bare while this unit lives at its home would recreate the
+    two-same-id-files state (the sibling's corruption just made room)."""
+    with tempfile.TemporaryDirectory() as d:
+        if not _fs_is_case_insensitive(d):
+            pytest.skip("the scenario needs the collision to fire first")
+        ck = StepCheckpoint("analyze", d)
+        ck.save("pkg/Foo.py:run", {"id": "pkg/Foo.py:run", "result": {"v": 1}})
+        ck.save("pkg/foo.py:run", {"id": "pkg/foo.py:run", "result": {"v": 1}})
+        # corrupt the SIBLING's bare file (the corrupt-guard's precondition)
+        with open(os.path.join(ck.dir, "pkg__Foo.py_run.json"), "w") as f:
+            f.write("{garbage")
+        # this unit's save: bare exists but unreadable, and its home holds it
+        ck.save("pkg/foo.py:run", {"id": "pkg/foo.py:run", "result": {"v": 2}})
+        foo_files = [n for n in _files_in(ck) if "foo" in n and n.endswith(".json")]
+        assert len(foo_files) == 1, foo_files  # still ONE foo file: the home
+        loaded = ck.load()
+        assert loaded["pkg/foo.py:run"]["result"]["v"] == 2

--- a/libs/openant-core/utilities/context_enhancer.py
+++ b/libs/openant-core/utilities/context_enhancer.py
@@ -442,12 +442,13 @@ class ContextEnhancer:
             )
             os.makedirs(checkpoint_dir, exist_ok=True)
             processed_ids = self._load_completed_units(checkpoint_dir, context_key="llm_context")
+            _ckpt_map = self._id_keyed_checkpoint_map(checkpoint_dir)
             # Restore llm_context for already-completed units.
             for unit in units:
                 unit_id = unit.get("id")
                 if unit_id in processed_ids:
-                    cp_file = os.path.join(checkpoint_dir, f"{self._safe_filename(unit_id)}.json")
-                    if os.path.exists(cp_file):
+                    cp_file = _ckpt_map.get(unit_id)
+                    if cp_file:
                         cp_data = read_json(cp_file)
                         unit["llm_context"] = cp_data.get("llm_context", {})
                         if "code" in cp_data:
@@ -631,13 +632,14 @@ class ContextEnhancer:
 
             # Load completed unit IDs from per-unit checkpoint files
             processed_ids = self._load_completed_units(checkpoint_dir)
+            _ckpt_map = self._id_keyed_checkpoint_map(checkpoint_dir)
 
             # Restore agent_context from checkpoint files into units
             for unit in units:
                 unit_id = unit.get("id")
                 if unit_id in processed_ids:
-                    cp_file = os.path.join(checkpoint_dir, f"{self._safe_filename(unit_id)}.json")
-                    if os.path.exists(cp_file):
+                    cp_file = _ckpt_map.get(unit_id)
+                    if cp_file:
                         cp_data = read_json(cp_file)
                         unit["agent_context"] = cp_data.get("agent_context", {})
                         if "code" in cp_data:
@@ -674,10 +676,11 @@ class ContextEnhancer:
             _summary_cp.dir = checkpoint_dir
 
             # Count errors and sum usage from already-loaded checkpoints
+            _ckpt_map = self._id_keyed_checkpoint_map(checkpoint_dir)
             for unit in units:
                 uid = unit.get("id", "")
-                cp_file = os.path.join(checkpoint_dir, f"{self._safe_filename(uid)}.json")
-                if not os.path.exists(cp_file):
+                cp_file = _ckpt_map.get(uid)
+                if not cp_file:
                     continue
                 try:
                     cp_data = read_json(cp_file)
@@ -967,9 +970,15 @@ class ContextEnhancer:
         return dataset
 
     @staticmethod
-    def _safe_filename(unit_id: str) -> str:
-        from utilities.safe_filename import safe_filename
-        return safe_filename(unit_id)
+    def _id_keyed_checkpoint_map(checkpoint_dir: str) -> dict:
+        """#317: {unit_id: checkpoint path} keyed by the id INSIDE each file
+        (one listdir+read pass) — restoration must not compute filenames:
+        a computed lookup strands old-scheme files (detected complete,
+        restore no-ops -> empty contexts -> fewer findings) and restores
+        the WRONG unit's data when the computed name is taken by a
+        case-only sibling."""
+        from core.checkpoint import id_keyed_checkpoint_map
+        return id_keyed_checkpoint_map(checkpoint_dir)
 
     def _save_unit_checkpoint(self, unit: dict, checkpoint_dir: str, context_key: str = "agent_context"):
         """Save a single unit's result to its own checkpoint file.
@@ -979,8 +988,6 @@ class ContextEnhancer:
         The key is recorded so resume knows where to restore.
         """
         unit_id = unit.get("id", "unknown")
-        filename = self._safe_filename(unit_id) + ".json"
-        filepath = os.path.join(checkpoint_dir, filename)
         ctx = unit.get(context_key, {})
         cp_data = {
             "id": unit_id,
@@ -998,7 +1005,11 @@ class ContextEnhancer:
                 "output_tokens": meta.get("output_tokens", 0),
                 "cost_usd": meta.get("cost_usd", 0.0),
             }
-        write_json(filepath, cp_data)
+        # #317: collision-safe AND under the save lock (this runs in a
+        # ThreadPoolExecutor worker — the resolve+write pair must be
+        # serialized against a case sibling in flight).
+        from core.checkpoint import save_checkpoint_under_lock
+        save_checkpoint_under_lock(checkpoint_dir, unit_id, cp_data)
 
     def _load_completed_units(self, checkpoint_dir: str, context_key: str = "agent_context") -> set:
         """Load the set of completed unit IDs from per-unit checkpoint files.

--- a/libs/openant-core/utilities/safe_filename.py
+++ b/libs/openant-core/utilities/safe_filename.py
@@ -3,6 +3,13 @@
 import hashlib
 
 
+# #317 (panel round-3): the truncation threshold, EXPORTED so the checkpoint
+# disambiguator's injectivity early-out imports the same constant instead of
+# duplicating the literal (drift in one silently broke the other's
+# "by construction" claim).
+SAFE_FILENAME_MAX_LEN = 255 - 5 - 17  # leave room for .json (5) and _ + 16 hex (17) = 233
+
+
 def safe_filename(unit_id: str) -> str:
     """Convert a unit ID to a safe filename.
 
@@ -16,7 +23,7 @@ def safe_filename(unit_id: str) -> str:
             .replace(" ", "_"))
 
     # Leave room for .json extension (5 chars) and hash suffix (17 chars: _ + 16 hex)
-    max_len = 255 - 5 - 17  # = 233
+    max_len = SAFE_FILENAME_MAX_LEN
 
     if len(safe) > max_len:
         h = hashlib.sha256(unit_id.encode()).hexdigest()[:16]


### PR DESCRIPTION
## Summary

`safe_filename` preserves case, so two unit IDs differing only in case (`pkg/Foo.py:run` vs `pkg/foo.py:run` — 593 real pairs in ordinary Go dependencies via the exported/unexported convention) computed the **same** filename. On a case-insensitive filesystem (macOS default, Windows) the second checkpoint save silently overwrote the first: one unit's analysis lost, and — `load()` reporting one unit where two were saved — re-analyzed and re-**paid** on every resume. The run never converged for the pair. The issue's executed repro:

```
saved 2 units: 'pkg/Foo.py:run' and 'pkg/foo.py:run'
checkpoint files on disk: 1
```

The issue also pre-analyzed the migration hazard that shaped the fix: completion **detection** is content-based (listdir + each file's id) but **restoration** was filename-computed — any naming change alone strands pre-existing checkpoints into degraded analysis (empty contexts, fewer findings — the false-negative direction).

## The fix

- **Save disambiguates on collision**: the bare name when free or holding the unit's own data; a different unit's checkpoint there → the case-sensitive 16-hex hash suffix (the existing long-name mechanism, capped so name+`.json` fits 255). **Home stability**: once a unit lives at its suffixed home, later saves keep writing there — even when the bare name frees up (the sibling's file deleted, the dir moved to a case-sensitive fs) and **including the corrupt-file branch** — otherwise the fresh result orphans the home and two same-id files resolve by arbitrary listdir order, resurrecting the non-convergence. A corrupt/foreign `.json` reads as no-id (overwrite the garbage) instead of crashing every later save of that unit.
- **The >233 truncated regime is injective by construction** (the name already carries the full id's hash) — an explicit early-out states the invariant rather than leaving it to the 233-constant coupling between two files.
- **A module-level lock serializes resolve+write** — saves run in ThreadPoolExecutor workers (the enhancer *and* the analyzer); the TOCTOU (two siblings in flight both writing the bare name) is pinned deterministically (two threads rendezvous inside the hooked exists check; proven by mutation: the lock deleted → red in 0.07s, restored → green in 2.03s).
- **Restore is id-keyed everywhere**: the enhancer's three filename-computed restore sites (agent_context, llm_context, the usage summary) now look up by the id *inside* the file (one listdir+read pass). This fixes the migration stranding (old-scheme files restore by content), the B-restores-A hazard, and the detection/restore asymmetry itself — and makes every future naming change safe. Behaviorally pinned on **both** paths (the single-shot loop and `enhance_dataset_agentic`).
- **Bonus, disclosed**: the sanitizer aliases `:` and ` ` both to `_` — `a:b:c` vs `a b:c` produce byte-identical names on **every** filesystem. The exists-with-different-id check cures that class too (pinned as the fs-independent guard — the load-bearing test on Linux where the case-only repro cannot fire).
- On case-**sensitive** filesystems the exists-with-different-id check never fires for a case-only pair: two real files, the naming scheme byte-identical — zero behavior change there.

## Residuals (documented)

- A third unit occupying a unit's hash-suffixed home requires a ~2⁻⁶⁴ prefix collision or hand-forging — out of scope.
- **Downgrade note**: rolling back this change strands suffixed-home files the same way the issue's migration hazard describes (detected complete, restore no-ops). Inherent to any forward migration here.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | the issue-317 test file (16 tests) | all green; RED 5 on pristine via stash; the lock pin red in 0.07s with the lock mutated out, green 2.03s restored # proc-ok |
| full suite | the full pytest run on the fix branch | 3425 green + the one byte-identical-on-pristine macOS tmp failure |
| review | need-check ("ship the design — strictly dominates the issue's options") + 3 adversarial wave rounds + deep-refute | round 1: the orphaned twin + the dead-by-accident coupling + a leaky test; round 2 caught round 1's fixes over-claiming (a lock test with no threads, the corrupt-branch bypass, one-of-three sites covered); round 3: no functional findings; deep-refute: no refutation — the branch matrix, lock, and a full consumer audit held |
| hermeticity + lint | the env-scrubbed run; ruff over the touched files | green # proc-ok |

</details>

Refs #317
