### PR TITLE
fix(checkpoint): deterministic mtimes in the dual-file self-heal test — the Windows clock-tick flake

### DIFF
--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -118,6 +118,10 @@ def disambiguated_checkpoint_path(ckpt_dir: str, unit_id: str) -> str:
             # files provably hold this unit's id.
             if os.path.exists(home) and _holds_this_unit(home):
                 try:
+                    # TIE-BREAK: equal mtimes (one clock tick on Windows)
+                    # fall through to the bare overwrite — both files
+                    # provably hold this unit's id, so the dual state heals
+                    # either way; only WHICH copy survives is arbitrary.
                     if os.path.getmtime(home) > os.path.getmtime(bare):
                         _atomic_unlink(bare)
                         return home

--- a/libs/openant-core/tests/test_issue317_case_collision.py
+++ b/libs/openant-core/tests/test_issue317_case_collision.py
@@ -522,10 +522,15 @@ def test_dual_same_id_files_self_heal_to_the_newer(tmp_path):
     stem = safe[: 255 - len(".json") - len(h) - 1]
     home = _os.path.join(d, f"{stem}_{h}.json")
 
-    # home newer, bare stale: consolidation keeps home, removes bare
+    # home newer, bare stale: consolidation keeps home, removes bare.
+    # EXPLICIT mtimes (panel round-3 flake): on Windows the three writes can
+    # land inside one clock tick (the merge-commit CI run observed EQUAL
+    # st_mtime values), so wall-clock ordering is nondeterministic — set
+    # the times directly.
     _write(bare, {"id": unit, "result": "STALE"})
     _write(home, {"id": unit, "result": "FRESH"})
-    _os.utime(home, None)
+    _os.utime(bare, (1_700_000_000, 1_700_000_000))
+    _os.utime(home, (1_700_010_000, 1_700_010_000))
     path = _ck.disambiguated_checkpoint_path(d, unit)
     assert path == home, "the newer home must win"
     assert not _os.path.exists(bare), "the superseded stale twin must be removed"
@@ -534,7 +539,8 @@ def test_dual_same_id_files_self_heal_to_the_newer(tmp_path):
     # bare newer, home stale: keeps bare, removes home
     _write(bare, {"id": unit, "result": "FRESH2"})
     _write(home, {"id": unit, "result": "STALE2"})
-    _os.utime(bare, None)
+    _os.utime(home, (1_700_000_000, 1_700_000_000))
+    _os.utime(bare, (1_700_010_000, 1_700_010_000))
     path = _ck.disambiguated_checkpoint_path(d, unit)
     assert path == bare, "the newer bare must win"
     assert not _os.path.exists(home), "the superseded stale twin must be removed"


### PR DESCRIPTION
The self-heal regression test added in #438's round-3 relied on wall-clock ordering between three writes ~ms apart. The merge-commit windows-latest run observed EQUAL st_mtime values (one clock tick), so the mtime comparison saw equals and the heal kept the stale copy — the same test passed the PR-branch CI run by clock luck.

Fix: explicit `os.utime` timestamps set the ordering deterministically; the equal-mtime tie-break in the self-heal branch is now documented (bare wins; both files hold the id, so the dual state heals either way).

Full file: 17 passed on macos locally; suite green. Master is red on windows-latest from the flake — this un-reds it.