### PR TITLE
fix(parsers): typed receivers resolve inherited methods — the same-file base walk the C suite already declared the floor (#318)

### DIFF
--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -1008,6 +1008,11 @@ class CallGraphBuilder:
             return None
 
         # Check if obj_name is an imported module/class
+        # (panel r4 note): receiver_is_local_var deliberately does NOT gate
+        # this import branch — a local variable whose name matches an
+        # IMPORTED symbol still resolves through the import (the pre-
+        # existing over-seed direction; a local-var gate here would drop
+        # real imported-symbol calls that only happen to share a name).
         file_imports = self.imports.get(caller_file, {})
         if obj_name in file_imports:
             import_path = file_imports[obj_name]

--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -186,6 +186,11 @@ class CallGraphBuilder:
         # Local variable -> constructor-type map, so that `v = ClassName(); v.method()`
         # dispatches to the bound type's method.
         local_types = self._collect_local_types(tree)
+        # #318 (wave r5): the caller's own bound names AND the classes it
+        # defines at its own level (a receiver named for one of those is a
+        # class reference in this caller, not a variable).
+        bound_names = self._collect_bound_names(tree)
+        defined_classes = self._collect_defined_classes(tree)
         # #309 (item 4): a type-annotated parameter carries its receiver
         # type in the signature — consult it (a local Assign binding still
         # wins, matching Python's own scoping).
@@ -231,13 +236,14 @@ class CallGraphBuilder:
                         and isinstance(node.ctx, ast.Load)
                         and value.id in local_types):
                     typed = self._resolve_class_method(
-                        local_types[value.id], node.attr, caller_file)
+                        local_types[value.id], node.attr, caller_file,
+                        defined_classes=defined_classes)
                     if typed:
                         func_data = self.functions.get(typed, {})
                         if func_data.get('unit_type') == 'property':
                             calls.add(typed)
             if isinstance(node, ast.Call):
-                resolved = self._resolve_call_node(node, caller_file, caller_class, local_types, aliases, self_aliases)
+                resolved = self._resolve_call_node(node, caller_file, caller_class, local_types, aliases, self_aliases, bound_names, defined_classes)
                 if resolved:
                     calls.add(resolved)
                 # Higher-order-function callbacks: a function reference passed as an
@@ -324,6 +330,119 @@ class CallGraphBuilder:
                         types[arg.arg] = ann.id
         return types
 
+    def _collect_bound_names(self, tree: ast.AST) -> Set[str]:
+        """#318 (wave r4): every name the CALLER'S OWN scope binds.
+
+        The scope rules (each pinned):
+        - the ROOT def's parameters: YES (they are the caller's own);
+          a NESTED def's parameters: NO (its own scope);
+        - a NESTED def/class NAME (directly in the caller's body): YES
+          (it binds in the caller's scope); deeper names: NO;
+        - Assign/for/with/walrus targets, except-aliases, and match-case
+          captures at the caller's own level: YES; inside any nested
+          def/lambda/class/comprehension body: NO (their own scopes);
+        - ``global X``: NOT collected — the statement declares X NON-local
+          (deliberately no ast.Global branch);
+        - import aliases (``from x import Foo``): NOT collected — an
+          imported name is a REFERENCE (the import check resolves it), not
+          a locally-bound variable.
+        """
+        bound: Set[str] = set()
+
+        def _args_of(args: ast.arguments):
+            out = set()
+            for a in [*args.args, *args.kwonlyargs, *args.posonlyargs]:
+                out.add(a.arg)
+            if args.vararg:
+                out.add(args.vararg.arg)
+            if args.kwarg:
+                out.add(args.kwarg.arg)
+            return out
+
+        def _visit(node, own: bool, root: bool):
+            nonlocal bound
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if root:
+                    bound |= _args_of(node.args)   # the caller's own params
+                    for child in ast.iter_child_nodes(node):
+                        _visit(child, True, False)  # the body: the caller's scope
+                elif own:
+                    bound.add(node.name)            # binds in the caller's scope
+                    for child in ast.iter_child_nodes(node):
+                        _visit(child, False, False) # the body: its own scope
+                else:
+                    for child in ast.iter_child_nodes(node):
+                        _visit(child, False, False)
+                return
+            if isinstance(node, ast.Lambda):
+                for child in ast.iter_child_nodes(node):
+                    _visit(child, False, False)     # the lambda's own scope
+                return
+            if isinstance(node, ast.ClassDef):
+                if own:
+                    bound.add(node.name)            # binds in the caller's scope
+                for child in ast.iter_child_nodes(node):
+                    _visit(child, False, False)     # a class body is its own scope
+                return
+            if isinstance(node, ast.comprehension):
+                return                               # its own scope
+            if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                if own:
+                    bound.add(node.id)
+            elif isinstance(node, (ast.ExceptHandler, ast.MatchAs, ast.MatchStar)):
+                name = getattr(node, 'name', None)
+                if own and name:
+                    bound.add(name)
+            for child in ast.iter_child_nodes(node):
+                _visit(child, own, False)
+
+        # the parsed source is a Module whose single body statement is the
+        # caller's own def — unwrap it so the root-def rules apply
+        if (isinstance(tree, ast.Module)
+                and len(tree.body) == 1
+                and isinstance(tree.body[0], (ast.FunctionDef, ast.AsyncFunctionDef))):
+            _visit(tree.body[0], True, True)
+        else:
+            _visit(tree, True, True)
+        return bound
+
+    def _collect_defined_classes(self, tree: ast.AST) -> Set[str]:
+        """#318 (wave r5): the classes defined AT the caller's own level.
+
+        A receiver bearing one of these names is a class REFERENCE in this
+        caller (the local class IS what the name binds here), not a
+        variable — the r1 phantom guard must not route it away from the
+        class branch (r4's nested-class-name rule had ``Foo.own()`` inside
+        the defining function lose an edge master resolved).
+        """
+        defined: Set[str] = set()
+
+        def _visit(node, own: bool, root: bool = False):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if root:
+                    # the ROOT def's body IS the caller's level — a class
+                    # defined directly in it binds its name here
+                    for child in ast.iter_child_nodes(node):
+                        _visit(child, True)
+                # a nested def's body: its own scope — no classes of its
+                # count as the caller's
+                return
+            if isinstance(node, ast.ClassDef):
+                if own:
+                    defined.add(node.name)
+                for child in ast.iter_child_nodes(node):
+                    _visit(child, False)
+                return
+            for child in ast.iter_child_nodes(node):
+                _visit(child, own)
+
+        if (isinstance(tree, ast.Module)
+                and len(tree.body) == 1
+                and isinstance(tree.body[0], (ast.FunctionDef, ast.AsyncFunctionDef))):
+            _visit(tree.body[0], True, root=True)
+        else:
+            _visit(tree, True)
+        return defined
     def _collect_local_types(self, tree: ast.AST) -> Dict[str, str]:
         """Map local variable names to the class name they are constructed from.
 
@@ -577,7 +696,9 @@ class CallGraphBuilder:
     def _resolve_call_node(self, node: ast.Call, caller_file: str, caller_class: Optional[str],
                            local_types: Optional[Dict[str, str]] = None,
                            aliases: Optional[Dict[str, str]] = None,
-                           self_aliases: Optional[Set[str]] = None) -> Optional[str]:
+                           self_aliases: Optional[Set[str]] = None,
+                           bound_names: Optional[Set[str]] = None,
+                           defined_classes: Optional[Set[str]] = None) -> Optional[str]:
         """Resolve an AST Call node to a function ID.
 
         ``self_aliases`` is the set of receiver names that refer to the current
@@ -602,7 +723,8 @@ class CallGraphBuilder:
             # same binding; without it, h() was dropped while h.method() resolved.
             if func_name in local_types:
                 callable_target = self._resolve_class_method(
-                    local_types[func_name], '__call__', caller_file)
+                    local_types[func_name], '__call__', caller_file,
+                    defined_classes=defined_classes)
                 if callable_target:
                     return callable_target
             # A same-file user function with the same name as a stdlib
@@ -634,7 +756,14 @@ class CallGraphBuilder:
             # returns None for a name that isn't a function. Without this fallback
             # the constructor call resolved to no function at all and the
             # __init__ edge was dropped from reachability entirely.
-            return self._resolve_class_method(func_name, '__init__', caller_file)
+            # #318 (deep-refute): the ctor fallback only fires for a
+            # CLASS-NAME call — a receiver the caller's scope BINDS (a
+            # parameter/variable shadowing the class) is not one.
+            if func_name in (bound_names or set()) and \
+                    func_name not in (defined_classes or set()):
+                return None
+            return self._resolve_class_method(func_name, '__init__', caller_file,
+                                                defined_classes=defined_classes)
 
         # Method call: obj.method(...)
         elif isinstance(func, ast.Attribute):
@@ -657,14 +786,32 @@ class CallGraphBuilder:
             # module.func(...) or object.method(...)
             if isinstance(obj, ast.Name):
                 obj_name = obj.id
+                # #318 (wave r5): a receiver the caller's own scope BINDS is
+                # a variable, not a class-name reference — UNLESS it is a
+                # class the caller itself DEFINES at this level (the name
+                # binds to the local class IN THIS CALLER — a class
+                # reference; r4's blanket guard lost ``Foo.own()`` inside
+                # the defining function, an edge master resolved).
+                if obj_name in (bound_names or set()) and \
+                        obj_name not in (defined_classes or set()):
+                    if obj_name in (local_types or {}):
+                        typed = self._resolve_class_method(local_types[obj_name], method_name, caller_file,
+                                                       defined_classes=defined_classes)
+                        if typed:
+                            return typed
+                    return self._resolve_module_call(
+                        obj_name, method_name, caller_file,
+                        receiver_is_local_var=True,
+                        defined_classes=defined_classes)
                 # Local variable of a locally-known type: `v = ClassName(); v.method()`
                 # resolves to the constructed class's method,
                 # which _resolve_module_call (imports / same-file class NAMES only) cannot do.
                 if obj_name in local_types:
-                    typed = self._resolve_class_method(local_types[obj_name], method_name, caller_file)
+                    typed = self._resolve_class_method(local_types[obj_name], method_name, caller_file,
+                                                       defined_classes=defined_classes)
                     if typed:
                         return typed
-                return self._resolve_module_call(obj_name, method_name, caller_file)
+                return self._resolve_module_call(obj_name, method_name, caller_file, defined_classes=defined_classes)
 
             # Chained calls: obj.method1().method2(...)
             # Skip common methods
@@ -727,7 +874,11 @@ class CallGraphBuilder:
                     return func_id
 
             class_data = self.classes.get(class_key, {})
-            for base in class_data.get('bases', []):
+            # #318 (deep-refute): the self/super walks read the UNION
+            # (``all_bases``) — a function-local namesake's merged file-scope
+            # ``bases`` is the module side's, but its OWN methods' self/super
+            # dispatch still follows the local declaration's chain.
+            for base in class_data.get('all_bases', class_data.get('bases', [])):
                 # Only same-file base names are resolvable via our index.
                 base_name = base.split('.')[-1]
                 if base_name not in seen:
@@ -760,7 +911,7 @@ class CallGraphBuilder:
             class_data = self.classes.get(class_key)
             if not class_data:
                 continue
-            for base in class_data.get('bases', []):
+            for base in class_data.get('all_bases', class_data.get('bases', [])):
                 base_simple = base.split('.')[-1]            # 'pkg.Base' -> 'Base'
                 # Find every class (across files) whose simple name matches this base.
                 for cand_key, cand_data in self.classes.items():
@@ -780,20 +931,64 @@ class CallGraphBuilder:
                 return func_id
         return None
 
-    def _resolve_class_method(self, class_name: str, method_name: str, caller_file: str) -> Optional[str]:
+    def _same_file_base_walk(self, class_name: str, method_name: str,
+                             caller_file: str) -> Optional[str]:
+        """#318: walk a class's SAME-FILE bases to the first ancestor that
+        defines ``method_name`` — the C suite's sound floor (Bug [30]),
+        the same own-first FIFO, cycle-guarded order ``_resolve_self_call``
+        uses, so the most-derived definition wins and no derived-override
+        fan-out occurs. Base lookup restricted to the caller's own file:
+        external bases aren't in the index, so they stay unresolved rather
+        than mis-linked (the ``self`` walk's own restriction).
+        """
+        seen: Set[str] = set()
+        queue: List[str] = [class_name.split('.')[-1]]
+        while queue:
+            base_name = queue.pop(0)
+            if base_name in seen:
+                continue
+            seen.add(base_name)
+            class_key = f"{caller_file}:{base_name}"
+            method_id = self._method_in_class(class_key, method_name)
+            if method_id:
+                return method_id
+            for base in self.classes.get(class_key, {}).get('bases', []):
+                base_simple = base.split('.')[-1]
+                if base_simple not in seen:
+                    queue.append(base_simple)
+        return None
+
+    def _resolve_class_method(self, class_name: str, method_name: str, caller_file: str,
+                              defined_classes: Optional[Set[str]] = None) -> Optional[str]:
         """Resolve ``ClassName.method`` to a function id, same-file first then cross-file.
 
         Used to dispatch a call on a local variable whose type is known.
         Same-file resolution is preferred; otherwise the class
         is matched by simple name across all parsed files (unambiguous single match only,
         to avoid binding to an unrelated same-named class).
+
+        #318: an inherited method (declared only on a same-file base) resolves
+        via the same-file base walk BEFORE the cross-file name match — the
+        same-file base is strictly more precise than a cross-file simple name.
         """
         class_simple = class_name.split('.')[-1]
-        # 1. Same file.
+        # 1. Same file: the class's own declaration.
         same_file = self._method_in_class(f"{caller_file}:{class_simple}", method_name)
         if same_file:
             return same_file
-        # 2. Cross-file: exactly one class with this simple name that defines the method.
+        # 2. #318: the same-file base chain (inherited methods — the C
+        # suite's sound floor). A FUNCTION-LOCAL class keyed at file scope
+        # must not hijack an imported namesake (wave r1: ``from x import Foo``
+        # plus a function-local ``class Foo(Base)`` — the module-level binding
+        # at any other call site is the IMPORT, so the cross-file match is
+        # correct and the walk would mis-bind the local Base).
+        class_key = f"{caller_file}:{class_simple}"
+        defined_here = class_simple in (defined_classes or set())
+        if defined_here or not self.classes.get(class_key, {}).get('function_local'):
+            inherited = self._same_file_base_walk(class_simple, method_name, caller_file)
+            if inherited:
+                return inherited
+        # 3. Cross-file: exactly one class with this simple name that defines the method.
         matches = []
         for class_key, class_data in self.classes.items():
             if class_data.get('name') == class_simple:
@@ -804,7 +999,9 @@ class CallGraphBuilder:
             return matches[0]
         return None
 
-    def _resolve_module_call(self, obj_name: str, method_name: str, caller_file: str) -> Optional[str]:
+    def _resolve_module_call(self, obj_name: str, method_name: str, caller_file: str,
+                             receiver_is_local_var: bool = False,
+                             defined_classes: Optional[Set[str]] = None) -> Optional[str]:
         """Resolve a module.function() or object.method() call."""
         # Skip builtin modules
         if self._is_builtin(obj_name):
@@ -818,13 +1015,36 @@ class CallGraphBuilder:
             return self._resolve_import(import_path, method_name, caller_file)
 
         # Check if obj_name is a class in the same file
+        # #318 (need-check): gate on the CLASS INDEX, not methods_by_class —
+        # a method-less subclass (``class Config(Base): pass; Config.load()``)
+        # — the most common M2 shape — has no methods_by_class entry, and
+        # the old gate skipped the base walk entirely.
+        # #318 (wave r1): a receiver that is a known LOCAL VARIABLE is not
+        # a class-name reference — the typed path already ran and missed;
+        # the class branch here must not bind a same-file class sharing the
+        # variable's name (a fabricated edge).
         class_key = f"{caller_file}:{obj_name}"
-        if class_key in self.methods_by_class:
-            class_methods = self.methods_by_class[class_key]
+        if (not receiver_is_local_var
+                and (class_key in self.classes or class_key in self.methods_by_class)):
+            class_methods = self.methods_by_class.get(class_key, [])
             for func_id in class_methods:
                 func_data = self.functions.get(func_id, {})
                 if func_data.get('name') == method_name:
                     return func_id
+            # #318 (M2): a classmethod (or method) reached by CLASS NAME
+            # resolves through the same-file base chain like one reached
+            # through ``self`` — the C suite's sound floor. A FUNCTION-LOCAL
+            # class keyed at file scope must not fire the walk UNLESS this
+            # caller itself defines it (the name binds to the local class
+            # here — the M1 gate, mirrored, with the defining-caller
+            # exception; the merged module-level namesake's bases are the
+            # module side's, so the walk inside the defining caller can
+            # mis-fire on the merged bases — disclosed).
+            defined_here = obj_name in (defined_classes or set())
+            if defined_here or not self.classes.get(class_key, {}).get('function_local'):
+                inherited = self._same_file_base_walk(obj_name, method_name, caller_file)
+                if inherited:
+                    return inherited
 
         return None
 

--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -616,22 +616,35 @@ class FunctionExtractor:
             self._process_function_tree(method_node, file_path, content, class_name=method_class_name)
 
         # Recurse into nested classes so their methods are extracted.
+        # (panel r4): forward function_local — a class nested inside a
+        # function-local class is itself function-local; dropping the flag
+        # here mis-keyed the nested declaration as module-level.
         for item in node.body:
             if isinstance(item, ast.ClassDef):
-                self._process_class_tree(item, file_path, content, outer_qualifier=qualified_class)
+                self._process_class_tree(item, file_path, content,
+                                          outer_qualifier=qualified_class,
+                                          function_local=function_local)
         # defs/classes wrapped in a block inside the class body (e.g. an
         # `if TYPE_CHECKING:` block declaring conditional members). Thread the
         # class so a block-nested def stays a method of this class.
         self._descend_into_blocks(node.body, file_path, content,
-                                  enclosing_class=qualified_class)
+                                  enclosing_class=qualified_class,
+                                  function_local=function_local)
 
     @staticmethod
     def _merge_class_data(existing: Dict, new: Dict) -> None:
         """Union a second declaration of a same-keyed class into the first.
 
-        Only additive: bases/methods/decorators are unioned (order-preserving),
-        the line range is widened, and a missing docstring is backfilled. Never
-        drops data the existing declaration already carried.
+        Additive for methods/decorators/line-range/docstring. ``bases`` is
+        the ONE reset-union split (wave r4, both panels): on a scope
+        mismatch the file-scope ``bases`` RESETS to the module-level side's
+        (the merged entry under a file-scope key is the module-level class
+        the name binds to at every other call site), while ``all_bases``
+        UNIONS everything — the module side's bases, the local side's
+        bases, and any ``all_bases`` the existing entry already carried
+        (a third same-named declaration must not discard the first local's
+        bases), preserving the self/super walks inside the function-local
+        declaration's methods.
         """
         new_local = bool(new.get('function_local'))
         old_local = bool(existing.get('function_local'))
@@ -651,9 +664,18 @@ class FunctionExtractor:
             # wrong regression the parent's union did not have).
             module_side = new if not new_local else existing
             local_side = existing if not new_local else new
+            # Sonnet (panel r4): local_side IS existing in the
+            # module-after-local order — capture its bases BEFORE the
+            # reset, or the aliasing silently reads the post-reset module
+            # bases twice and the local declaration's bases vanish from
+            # the union.
+            local_bases = list(local_side.get('bases', []))
             existing['bases'] = list(module_side.get('bases', []))
-            all_bases = list(module_side.get('bases', []))
-            for item in local_side.get('bases', []):
+            # Fable (panel r4): union the PRE-EXISTING all_bases too — a
+            # third same-named declaration (local -> module -> local) must
+            # not discard the first local's bases.
+            all_bases = list(existing.get('all_bases', []))
+            for item in list(existing['bases']) + local_bases:
                 if item not in all_bases:
                     all_bases.append(item)
             existing['all_bases'] = all_bases

--- a/libs/openant-core/parsers/python/function_extractor.py
+++ b/libs/openant-core/parsers/python/function_extractor.py
@@ -527,7 +527,8 @@ class FunctionExtractor:
         return bodies
 
     def _descend_into_blocks(self, stmts: list, file_path: Path, content: str,
-                             enclosing_class: Optional[str] = None) -> None:
+                             enclosing_class: Optional[str] = None,
+                             function_local: bool = False) -> None:
         """Find def/class nodes inside block statements at ANY depth and emit them.
 
         A `def`/`class` inside an `if`/`try`/`for`/`while`/`with`/`match` block is
@@ -552,8 +553,10 @@ class FunctionExtractor:
                                                     class_name=enclosing_class)
                     elif isinstance(child, ast.ClassDef):
                         self._process_class_tree(child, file_path, content,
-                                                 outer_qualifier=enclosing_class)
-                self._descend_into_blocks(body, file_path, content, enclosing_class)
+                                                 outer_qualifier=enclosing_class,
+                                                 function_local=function_local)
+                self._descend_into_blocks(body, file_path, content, enclosing_class,
+                                          function_local=function_local)
 
     def _process_function_tree(self, node: ast.AST, file_path: Path, content: str,
                                class_name: Optional[str] = None) -> None:
@@ -576,19 +579,24 @@ class FunctionExtractor:
                 # function in its own right; do not attribute it to a class.
                 self._process_function_tree(child, file_path, content, class_name=None)
             elif isinstance(child, ast.ClassDef):
-                self._process_class_tree(child, file_path, content, outer_qualifier=None)
+                self._process_class_tree(child, file_path, content,
+                                         outer_qualifier=None,
+                                         function_local=True)
         # defs/classes wrapped in a block inside this function's body
-        self._descend_into_blocks(node.body, file_path, content)
+        self._descend_into_blocks(node.body, file_path, content,
+                                  function_local=True)
 
     def _process_class_tree(self, node: ast.ClassDef, file_path: Path, content: str,
-                            outer_qualifier: Optional[str] = None) -> None:
+                            outer_qualifier: Optional[str] = None,
+                            function_local: bool = False) -> None:
         """Register a class, its methods, and any classes nested within it.
 
         `outer_qualifier` is the dotted prefix of any enclosing class
         (e.g. 'Outer' so an inner class method is keyed 'Outer.Inner.deep').
         """
         class_id, class_data, method_nodes = self.process_class(
-            node, str(file_path), content, outer_qualifier=outer_qualifier
+            node, str(file_path), content, outer_qualifier=outer_qualifier,
+            function_local=function_local
         )
         existing = self.classes.get(class_id)
         if existing is None:
@@ -625,7 +633,38 @@ class FunctionExtractor:
         the line range is widened, and a missing docstring is backfilled. Never
         drops data the existing declaration already carried.
         """
-        for key in ('bases', 'methods', 'decorators'):
+        new_local = bool(new.get('function_local'))
+        old_local = bool(existing.get('function_local'))
+        # #318 (wave r3): a function-local declaration's BASES do not belong
+        # to a module-level namesake. The merged entry under a file-scope key
+        # represents the MODULE-LEVEL class (that is what the name binds at
+        # every other call site), so on a scope mismatch the bases RESET to
+        # the module-level side's — whichever direction the declarations
+        # arrived in. Same-scope declarations union.
+        if old_local != new_local:
+            # #318 (deep-refute): the file-scope ``bases`` is the module
+            # side's (the typed-receiver walk's hijack guard), but the
+            # self/super walks read the SAME entry from inside the
+            # function-local declaration's methods — for those, the UNION
+            # survives (``all_bases``): resetting both severed
+            # self.m()/super().m() inside the local class (a correct-to-
+            # wrong regression the parent's union did not have).
+            module_side = new if not new_local else existing
+            local_side = existing if not new_local else new
+            existing['bases'] = list(module_side.get('bases', []))
+            all_bases = list(module_side.get('bases', []))
+            for item in local_side.get('bases', []):
+                if item not in all_bases:
+                    all_bases.append(item)
+            existing['all_bases'] = all_bases
+        else:
+            for item in new.get('bases', []):
+                if item not in existing['bases']:
+                    existing['bases'].append(item)
+            for item in new.get('bases', []):
+                if item not in existing.setdefault('all_bases', list(existing['bases'])):
+                    existing['all_bases'].append(item)
+        for key in ('methods', 'decorators'):
             for item in new.get(key, []):
                 if item not in existing[key]:
                     existing[key].append(item)
@@ -633,6 +672,11 @@ class FunctionExtractor:
         existing['end_line'] = max(existing['end_line'], new['end_line'])
         if not existing.get('docstring'):
             existing['docstring'] = new.get('docstring')
+        # #318 (wave r2): the function-local flag is ANDed — the merged key
+        # is function-local only if EVERY declaration of it is (a module-
+        # level namesake declared after a function-local one must not
+        # inherit the flag, or its inherited methods go unresolved).
+        existing['function_local'] = old_local and new_local
 
     def extract_assigned_lambdas(self, tree: ast.AST, file_path: Path, content: str) -> None:
         """Emit a function unit for each module-level `name = lambda ...`.
@@ -736,7 +780,8 @@ class FunctionExtractor:
         return func_id, func_data
 
     def process_class(self, node: ast.ClassDef, file_path: str, content: str,
-                      outer_qualifier: Optional[str] = None) -> Tuple[str, Dict, List[Tuple]]:
+                      outer_qualifier: Optional[str] = None,
+                      function_local: bool = False) -> Tuple[str, Dict, List[Tuple]]:
         """Process a class definition and extract metadata.
 
         `outer_qualifier` is the dotted name of any enclosing class, so a class
@@ -754,6 +799,16 @@ class FunctionExtractor:
                 bases.append(base.id)
             elif isinstance(base, ast.Attribute):
                 bases.append(self._get_attribute_string(base))
+            elif isinstance(base, ast.Subscript):
+                # #318 (wave r1, both axes): a subscripted base —
+                # ``class Sub(Base[int])``, the Generic idiom — must not
+                # sever the chain: unwrap to the subscripted value
+                # (``Base[int]`` -> ``Base`` / ``pkg.Base``).
+                inner = base.value
+                if isinstance(inner, ast.Name):
+                    bases.append(inner.id)
+                elif isinstance(inner, ast.Attribute):
+                    bases.append(self._get_attribute_string(inner))
 
         decorators = self.extract_decorators(node)
 
@@ -774,6 +829,12 @@ class FunctionExtractor:
             'bases': bases,
             'decorators': decorators,
             'docstring': self.get_docstring(node),
+            # #318 (wave r1): a class defined INSIDE a function is keyed at
+            # file scope (``app.py:Foo``) but its name is only bound within
+            # that function — at any other call site the name resolves to the
+            # module-level binding (an import or a module-level class). The
+            # flag lets the resolver skip the hijack.
+            'function_local': function_local,
         }
 
         return class_id, class_data, [(m, class_name) for m in method_funcs]

--- a/libs/openant-core/tests/parsers/python/test_issue318_typed_receiver_bases.py
+++ b/libs/openant-core/tests/parsers/python/test_issue318_typed_receiver_bases.py
@@ -975,3 +975,113 @@ def test_param_named_like_a_class_is_not_a_ctor_call():
     parameter named like a class fabricated the inherited __init__ edge."""
     b = _build(_PARAM_CTOR)
     assert _edges_to(b, "f") == [], _edges_to(b, "f")
+
+
+# --- panel round-4 (both panels): the scope-mismatch merge ------------------
+# Sonnet: in the module-after-local order, existing['bases'] was reset
+# BEFORE local_side.get('bases') was read — and local_side IS existing —
+# so the local declaration's bases were silently dropped from all_bases.
+# Fable: rebuilding all_bases from bases alone discarded the PRE-EXISTING
+# all_bases on a third same-named declaration (local -> module -> local),
+# severing the first local's self/super dispatch.
+
+_SCOPE_MISMATCH_LOCAL_FIRST = '''
+class BaseA:
+    def meth_a(self): return 1
+
+class BaseB:
+    def meth_b(self): return 1
+
+def make():
+    class Combo(BaseA):            # local declaration, arrives FIRST
+        def local_a(self):
+            return self.meth_a()   # self-walk must survive the module merge
+    return Combo()
+
+class Combo(BaseB):                # module-level namesake, arrives SECOND
+    def mod_b(self):
+        return BaseB.meth_b(self)  # class-name receiver through the module bases
+
+def use_local_instance():
+    c = Combo()
+    return c.meth_b()              # M1: instance receiver -> module bases
+'''
+
+
+def test_scope_mismatch_local_first_keeps_local_bases_in_all_bases():
+    b = _build(_SCOPE_MISMATCH_LOCAL_FIRST)
+    # the local declaration's self-walk survives: local_a -> meth_a
+    assert "app.py:BaseA.meth_a" in _edges_to(b, "local_a"), (
+        "the local declaration's bases were dropped from all_bases (sonnet "
+        "aliasing: existing['bases'] reset before local_side was read)")
+    # the module side wins the file-scope bases: M1 resolves through BaseB
+    assert "app.py:BaseB.meth_b" in _edges_to(b, "use_local_instance"), (
+        "the merged entry's file-scope bases must be the module side's")
+    # the module-level class-name receiver resolves too
+    assert "app.py:BaseB.meth_b" in _edges_to(b, "mod_b")
+
+
+_SCOPE_MISMATCH_MODULE_FIRST = '''
+class BaseA:
+    def meth_a(self): return 1
+
+class BaseB:
+    def meth_b(self): return 1
+
+class Combo(BaseB):                # module declaration, arrives FIRST
+    def mod_b(self):
+        return BaseB.meth_b(self)
+
+def make():
+    class Combo(BaseA):            # local namesake, arrives SECOND
+        def local_a(self):
+            return self.meth_a()
+    return Combo()
+'''
+
+
+def test_scope_mismatch_module_first_unions_the_local_bases():
+    b = _build(_SCOPE_MISMATCH_MODULE_FIRST)
+    assert "app.py:BaseA.meth_a" in _edges_to(b, "local_a"), (
+        "the late local declaration's bases must join all_bases")
+    assert "app.py:BaseB.meth_b" in _edges_to(b, "mod_b"), (
+        "the module side's bases must stay the file-scope bases")
+
+
+_THREE_DECLARATIONS = '''
+class BaseA:
+    def meth_a(self): return 1
+
+class BaseB:
+    def meth_b(self): return 1
+
+class BaseC:
+    def meth_c(self): return 1
+
+def first():
+    class Combo(BaseA):            # local 1
+        def local_a(self):
+            return self.meth_a()
+    return Combo()
+
+class Combo(BaseB):                # module
+    def mod_b(self):
+        return BaseB.meth_b(self)
+
+def third():
+    class Combo(BaseC):            # local 2
+        def local_c(self):
+            return self.meth_c()
+    return Combo()
+'''
+
+
+def test_three_declarations_keep_every_local_base():
+    b = _build(_THREE_DECLARATIONS)
+    # fable: the third merge must not discard the FIRST local's bases
+    assert "app.py:BaseA.meth_a" in _edges_to(b, "local_a"), (
+        "the first local's bases vanished from all_bases on the third "
+        "declaration (all_bases rebuilt from bases alone)")
+    assert "app.py:BaseC.meth_c" in _edges_to(b, "local_c")
+    assert "app.py:BaseB.meth_b" in _edges_to(b, "mod_b"), (
+        "the module side must stay the file-scope bases across both mismatches")

--- a/libs/openant-core/tests/parsers/python/test_issue318_typed_receiver_bases.py
+++ b/libs/openant-core/tests/parsers/python/test_issue318_typed_receiver_bases.py
@@ -1,0 +1,977 @@
+"""#318: typed receivers resolve inherited methods (the C suite's floor).
+
+The Python call-graph builder resolves an inherited method when the receiver is ``self`` or
+``super()`` (two BFS walks over ``self.classes[...]['bases']`` exist) but drops the same call
+when the receiver is a locally-constructed instance (M1: ``s = Sub(); s.inherited()``) or the
+class name (M2: ``Sub.inherited_cm()``) — the typed-receiver path simply never consults the
+bases. The base data is recorded; the receiver's type is inferred; the resolution is missing.
+
+The project already decided the required behaviour in C (``test_call_graph_builder_dispatch.py``
+Bug [30], the SOUND FLOOR): walk UP the base-class chain to the first ancestor that defines the
+method, same-file, own-first (the most-derived definition wins), no derived-override fan-out,
+no ancestor defining the method => no edge.
+
+The reachability direction: a method whose only callers use a typed receiver gets an empty
+caller set and is PRUNED while its caller is kept — false negatives, with nothing in the
+output distinguishing "not called" from "call not recognised".
+"""
+import sys
+import tempfile
+from pathlib import Path
+
+CORE = str(Path(__file__).resolve().parents[3])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from parsers.python.function_extractor import FunctionExtractor  # noqa: E402
+from parsers.python.call_graph_builder import CallGraphBuilder  # noqa: E402
+
+
+def _build(src: str, filename: str = "app.py"):
+    """The real pipeline: extract from a temp dir + build the graph (the
+    symmetry test's own harness pattern)."""
+    d = tempfile.mkdtemp()
+    (Path(d) / filename).write_text(src)
+    builder = CallGraphBuilder(FunctionExtractor(d).extract_all())
+    builder.build_call_graph()
+    return builder
+
+
+def _edges_to(builder, caller: str):
+    """A method's key carries its class (app.py:Sub.via_self); a module
+    function's is bare (app.py:f). Match either shape for the caller name."""
+    edges = [c for key, callees in builder.call_graph.items()
+             if key.startswith("app.py:")
+             and (key.rsplit(":", 1)[1].endswith("." + caller)
+                  or key == f"app.py:{caller}")
+             for c in callees]
+    return sorted(edges)
+
+
+_FIVE_RECEIVERS = '''
+class Base:
+    def inherited_method(self): return 1
+    @classmethod
+    def inherited_cm(cls): return 2
+
+class Sub(Base):
+    def own_method(self): return 3
+    def via_self(self):   return self.inherited_method()
+    def via_super(self):  return super().inherited_method()
+    def via_self_cm(self): return self.inherited_cm()
+
+def via_local_instance():
+    s = Sub()
+    return s.inherited_method()      # M1
+
+def via_class_name():
+    return Sub.inherited_cm()        # M2
+
+def control_own():
+    s = Sub()
+    return s.own_method()            # control: same shape, non-inherited
+'''
+
+
+def test_m1_local_instance_inherited_method_resolves():
+    """M1 — the issue's executed repro shape: a locally-constructed receiver
+    calling a method declared only on a same-file base."""
+    b = _build(_FIVE_RECEIVERS)
+    assert "app.py:Base.inherited_method" in _edges_to(b, "via_local_instance"), (
+        _edges_to(b, "via_local_instance"))
+
+
+def test_m2_class_name_inherited_classmethod_resolves():
+    """M2 — the class-name receiver: Sub.inherited_cm() must resolve like
+    self.inherited_cm() does."""
+    b = _build(_FIVE_RECEIVERS)
+    assert "app.py:Base.inherited_cm" in _edges_to(b, "via_class_name"), (
+        _edges_to(b, "via_class_name"))
+
+
+def test_control_and_existing_paths_unchanged():
+    """The control (own method, same receiver shape) and the already-working
+    self/super paths keep resolving."""
+    b = _build(_FIVE_RECEIVERS)
+    assert "app.py:Sub.own_method" in _edges_to(b, "control_own")
+    assert "app.py:Base.inherited_method" in _edges_to(b, "via_self")
+    assert "app.py:Base.inherited_method" in _edges_to(b, "via_super")
+    assert "app.py:Base.inherited_cm" in _edges_to(b, "via_self_cm")
+
+
+_C_GUARDS = '''
+class Base:
+    def m(self): return 1
+    def only_base(self): return 1
+
+class Mid(Base):
+    def m(self): return 2        # the nearest ancestor override
+
+class Over(Mid):
+    def m(self): return 3        # the derived override
+
+class NoOver(Mid):
+    pass
+
+class Deep(Base):
+    pass
+
+class Base2:
+    def unrelated(self): return 1
+
+class Orphan(Base2):
+    def only_orphan(self): return 1
+
+def call_over():
+    o = Over()
+    return o.m()
+
+def call_noover():
+    n = NoOver()
+    return n.m()
+
+def call_deep():
+    d = Deep()
+    return d.m()
+
+def call_orphan_unrelated():
+    o = Orphan()
+    return o.missing_method()     # no ancestor defines it
+'''
+
+
+def test_override_resolves_to_derived():
+    """The C guard: the most-derived definition wins (the derived override,
+    not the base's)."""
+    b = _build(_C_GUARDS)
+    assert "app.py:Over.m" in _edges_to(b, "call_over")
+
+
+def test_no_override_resolves_to_nearest_ancestor():
+    """The C guard: an un-overridden method resolves to the nearest ancestor
+    that defines it (Mid, not Base)."""
+    b = _build(_C_GUARDS)
+    assert "app.py:Mid.m" in _edges_to(b, "call_noover")
+
+
+def test_deep_chain_resolves_to_defining_ancestor():
+    b = _build(_C_GUARDS)
+    assert "app.py:Base.m" in _edges_to(b, "call_deep")
+
+
+def test_no_ancestor_defining_method_emits_no_edge():
+    """The C guard: no ancestor defining the method => NO edge (not a
+    name-based fallback — that would emit false edges)."""
+    b = _build(_C_GUARDS)
+    assert _edges_to(b, "call_orphan_unrelated") == [], _edges_to(b, "call_orphan_unrelated")
+
+
+def test_cross_file_typed_receiver_still_resolves():
+    """The existing cross-file simple-name single-match path (a typed
+    receiver whose class lives in another file) must keep working — the
+    same-file base walk is ADDITIONAL, not a replacement."""
+    src_a = """
+class Remote:
+    def remote_method(self): return 1
+"""
+    src_b = """
+def local_call():
+    r = Remote()
+    return r.remote_method()
+"""
+    d = tempfile.mkdtemp()
+    (Path(d) / "a.py").write_text(src_a)
+    (Path(d) / "b.py").write_text(src_b)
+    b = CallGraphBuilder(FunctionExtractor(d).extract_all())
+    b.build_call_graph()
+    assert "a.py:Remote.remote_method" in sorted(
+        b.call_graph.get("b.py:local_call", []))
+
+
+_SHADOWING = '''
+class Base:
+    def bar(self): return 1
+class Foo(Base):
+    pass
+class v:                      # a class whose name shadows the local below
+    def bar(self): return 2
+def f():
+    v = Foo()
+    return v.bar()
+'''
+
+
+def test_shadowing_redirected_to_the_right_callee():
+    """The issue's own correction: M1 is not purely additive — today the
+    fall-through to _resolve_module_call binds the LOCAL-shadowed class name
+    (the wrong callee: the class v, while the receiver is a Foo). The base
+    walk REDIRECTS the edge to Base.bar."""
+    b = _build(_SHADOWING)
+    edges = _edges_to(b, "f")
+    assert "app.py:Base.bar" in edges, edges
+    assert "app.py:v.bar" not in edges, edges
+
+
+# ---------------------------------------------------------------------------
+# the need-check additions: the empty subclass, the annotated receiver, the
+# three additional edge families, the approximations documented
+# ---------------------------------------------------------------------------
+
+_EMPTY_SUBCLASS = """
+class BaseConfig:
+    @classmethod
+    def load(cls): return 1
+
+class Config(BaseConfig):
+    pass                          # no own methods — the most common M2 shape
+
+def f():
+    return Config.load()
+"""
+
+
+def test_m2_method_less_subclass_resolves():
+    """The need-check's blocking finding: the M2 gate keyed on
+    methods_by_class, so a method-less subclass (``class Config(Base):
+    pass``) never reached the base walk. The gate now keys on the class
+    index."""
+    b = _build(_EMPTY_SUBCLASS)
+    assert "app.py:BaseConfig.load" in _edges_to(b, "f"), _edges_to(b, "f")
+
+
+_ANNOTATED = """
+class Base:
+    def inherited(self): return 1
+class Sub(Base):
+    pass
+
+def g(s: Sub):
+    return s.inherited()         # an annotated-parameter receiver, inherited
+"""
+
+
+def test_annotated_receiver_inherited():
+    """#309 composition: the annotated receiver routes through the same
+    _resolve_class_method; the base walk makes its INHERITED calls resolve
+    (the #309 suite covered only own methods)."""
+    b = _build(_ANNOTATED)
+    assert "app.py:Base.inherited" in _edges_to(b, "g"), _edges_to(b, "g")
+
+
+_EXTRA_FAMILIES = """
+class Base:
+    def __init__(self): self.x = 1
+    def __call__(self): return 1
+    @property
+    def p(self): return 2
+
+class Sub(Base):
+    pass
+
+def make():
+    s = Sub()                    # the inherited ctor
+    return s
+
+def call_it(s: Sub):
+    return s()                   # the inherited __call__
+
+def read_p(s: Sub):
+    return s.p                   # the inherited @property read
+"""
+
+
+def test_inherited_ctor_resolves():
+    """The need-check's disclosure: the fix's reach is wider than M1/M2 —
+    the constructor fallback (``Sub()`` with no own ``__init__``) now binds
+    the inherited ``Base.__init__``."""
+    b = _build(_EXTRA_FAMILIES)
+    assert "app.py:Base.__init__" in _edges_to(b, "make"), _edges_to(b, "make")
+
+
+def test_inherited_dunder_call_resolves():
+    b = _build(_EXTRA_FAMILIES)
+    assert "app.py:Base.__call__" in _edges_to(b, "call_it"), _edges_to(b, "call_it")
+
+
+def test_inherited_property_read_resolves():
+    """The #309 property-read path with an INHERITED @property."""
+    b = _build(_EXTRA_FAMILIES)
+    assert "app.py:Base.p" in _edges_to(b, "read_p"), _edges_to(b, "read_p")
+
+
+_DIAMOND = """
+class X:
+    def m(self): return 1
+class A(X):
+    pass
+class B:
+    def m(self): return 2
+class C(A, B):
+    pass
+
+def call_c():
+    c = C()
+    return c.m()
+"""
+
+
+def test_diamond_documents_the_bfs_choice():
+    """The documented approximation (shared with the self walk): the FIFO
+    BFS is not the C3 MRO — pinned as the CURRENT semantics so a future MRO
+    change is a conscious decision."""
+    b = _build(_DIAMOND)
+    edges = _edges_to(b, "call_c")
+    assert edges and all(e in ("app.py:B.m", "app.py:X.m") for e in edges), edges
+
+
+_DOTTED = """
+class Base:
+    def m(self): return 1
+class Sub(ext.Base):
+    pass
+
+def call_sub():
+    s = Sub()
+    return s.m()
+"""
+
+
+def test_dotted_external_base_documented():
+    """The documented shared caveat (the self walk's own): ``class
+    Sub(ext.Base)`` splits to the simple name ``Base`` and mis-links a
+    same-file unrelated ``Base``. Pinned as CURRENT semantics."""
+    b = _build(_DOTTED)
+    edges = _edges_to(b, "call_sub")
+    assert "app.py:Base.m" in edges, edges
+
+
+# ---------------------------------------------------------------------------
+# wave round-1: the hijack/phantom guards, the floor's negative halves, the
+# ordering pin, the subscripted bases
+# ---------------------------------------------------------------------------
+
+def test_function_local_class_does_not_hijack_import(tmp_path):
+    """Wave r1 (A#1): a function-local ``class Foo(Base)`` is keyed at file
+    scope, and the walk (ahead of the cross-file match) bound the local
+    Base instead of the imported namesake. The guard: a function-local
+    class must not fire the walk — the cross-file match stays
+    authoritative (the module-level binding at any other call site is
+    the IMPORT)."""
+    (tmp_path / "x.py").write_text(
+        "class Foo:\n"
+        "    def m(self): return 0\n")
+    (tmp_path / "app.py").write_text(
+        "from x import Foo\n"
+        "class Base:\n"
+        "    def m(self): return 1\n"
+        "def maker():\n"
+        "    class Foo(Base): pass\n"
+        "    return Foo\n"
+        "def f():\n"
+        "    v = Foo()\n"
+        "    return v.m()      # the runtime callee: x.Foo.m\n")
+    b = CallGraphBuilder(FunctionExtractor(str(tmp_path)).extract_all())
+    b.build_call_graph()
+    edges = sorted(b.call_graph.get("app.py:f", []))
+    assert "x.py:Foo.m" in edges, edges
+    assert "app.py:Base.m" not in edges, edges
+
+
+_M2_PHANTOM = """
+class Base: pass
+class Foo(Base): pass
+class VBase:
+    def bar(self): return 9
+class v(VBase): pass
+
+def f():
+    v = Foo()
+    return v.bar()          # the typed chain has no bar
+"""
+
+
+def test_m2_phantom_variable_named_like_a_class():
+    """Wave r1 (A#2): the widened M2 gate admitted ANY same-file class name —
+    a LOCAL VARIABLE named ``v`` with a class ``v`` in the file fabricated an
+    edge to VBase.bar. The guard: a receiver that is a known local variable
+    is not a class-name reference."""
+    b = _build(_M2_PHANTOM)
+    assert _edges_to(b, "f") == [], _edges_to(b, "f")
+
+
+_FLOOR_NEGATIVE = """
+class Base:
+    def m(self): return 1
+class Derived(Base):
+    def m(self): return 2          # the override
+
+def base_typed():
+    b = Base()
+    return b.m()                   # must resolve to Base.m, NOT Derived.m
+"""
+
+
+def test_base_typed_receiver_does_not_fan_out_to_derived():
+    """Wave r1 (C#3): the floor's CENTRAL case had no fixture — a receiver
+    of the BASE type must not link the derived override (the no-fan-out
+    half; the C suite's paired assertion, now with its negative)."""
+    b = _build(_FLOOR_NEGATIVE)
+    assert _edges_to(b, "base_typed") == ["app.py:Base.m"], _edges_to(b, "base_typed")
+
+
+def test_override_guard_pairs_the_negative():
+    """Wave r1 (C#2): the override pins dropped the C suite's paired
+    negative halves — an implementation fanning out to EVERY ancestor
+    definition passed. Exact pins now."""
+    b = _build(_C_GUARDS)
+    assert _edges_to(b, "call_over") == ["app.py:Over.m"], _edges_to(b, "call_over")
+    assert _edges_to(b, "call_noover") == ["app.py:Mid.m"], _edges_to(b, "call_noover")
+    assert _edges_to(b, "call_deep") == ["app.py:Base.m"], _edges_to(b, "call_deep")
+
+
+_ORDERING = """
+# a.py: the same-file base
+class Base:
+    def m(self): return 1
+# (the cross-file namesake is in other.py)
+class Sub(Base):
+    pass
+
+def f():
+    s = Sub()
+    return s.m()
+"""
+
+
+def test_walk_wins_over_cross_file_namesake(tmp_path):
+    """Wave r1 (C#4): the ordering (the walk BEFORE the cross-file match)
+    was untested — swap the two blocks and all the other tests still
+    passed. The competing shape: a same-file base AND a unique cross-file
+    class defining the method — the walk must win."""
+    (tmp_path / "other.py").write_text(
+        "class Sub:\n"
+        "    def m(self): return 9\n")       # a cross-file namesake
+    (tmp_path / "app.py").write_text(_ORDERING)
+    b = CallGraphBuilder(FunctionExtractor(str(tmp_path)).extract_all())
+    b.build_call_graph()
+    assert sorted(b.call_graph.get("app.py:f", [])) == ["app.py:Base.m"], (
+        sorted(b.call_graph.get("app.py:f", [])))
+
+
+_SUBSCRIPTED = """
+class Base:
+    def inherited(self): return 1
+class Sub(Base[int]):           # the subscripted Generic idiom
+    pass
+
+def f():
+    s = Sub()
+    return s.inherited()
+"""
+
+
+def test_subscripted_base_resolves():
+    """Wave r1 (A#4 + B#2): ``class Sub(Base[int])`` dropped the base
+    entirely (bases == []) — the walk AND the self walk were blind on
+    generic code. The extractor now unwraps the subscript."""
+    b = _build(_SUBSCRIPTED)
+    assert _edges_to(b, "f") == ["app.py:Base.inherited"], _edges_to(b, "f")
+
+
+def test_diamond_pinned_to_the_fifo_semantics():
+    """Wave r1 (C#5): the either-answer pin was a tautology — the FIFO
+    semantics pinned EXACTLY so a future MRO change is a conscious decision."""
+    b = _build(_DIAMOND)
+    assert _edges_to(b, "call_c") == ["app.py:B.m"], _edges_to(b, "call_c")
+
+
+def test_dotted_base_pinned_exactly():
+    """Wave r1 (C#6): the approximation pinned exactly (nothing else
+    emitted)."""
+    b = _build(_DOTTED)
+    assert _edges_to(b, "call_sub") == ["app.py:Base.m"], _edges_to(b, "call_sub")
+
+
+def test_block_wrapped_local_class_does_not_hijack(tmp_path):
+    """Wave r2 #1: the function_local flag only covered a DIRECT class child
+    of the function body — a block-wrapped one (``if cond: class Foo(Base)``)
+    escaped and the hijack shape persisted. The flag now threads through
+    _descend_into_blocks."""
+    (tmp_path / "x.py").write_text("class Foo:\n    def m(self): return 0\n")
+    (tmp_path / "app.py").write_text(
+        "from x import Foo\n"
+        "class Base:\n"
+        "    def m(self): return 1\n"
+        "def maker():\n"
+        "    if True:\n"
+        "        class Foo(Base): pass\n"
+        "    return Foo\n"
+        "def f():\n"
+        "    v = Foo()\n"
+        "    return v.m()\n")
+    b = CallGraphBuilder(FunctionExtractor(str(tmp_path)).extract_all())
+    b.build_call_graph()
+    edges = sorted(b.call_graph.get("app.py:f", []))
+    assert "x.py:Foo.m" in edges, edges
+    assert "app.py:Base.m" not in edges, edges
+
+
+def test_merge_reconciles_the_function_local_flag(tmp_path):
+    """Wave r2 #2: the merge never reconciled the flag — a module-level
+    namesake declared AFTER a function-local one inherited function_local
+    and its inherited methods went unresolved. The merged flag is ANDed."""
+    (tmp_path / "app.py").write_text(
+        "class Base:\n"
+        "    def m(self): return 1\n"
+        "def maker():\n"
+        "    class Sub(Base): pass\n"     # the function-local namesake, FIRST
+        "    return Sub\n"
+        "class Sub(Base):\n"             # the genuine module-level class, SECOND
+        "    pass\n"
+        "def f():\n"
+        "    s = Sub()\n"
+        "    return s.m()\n")
+    b = CallGraphBuilder(FunctionExtractor(str(tmp_path)).extract_all())
+    b.build_call_graph()
+    assert sorted(b.call_graph.get("app.py:f", [])) == ["app.py:Base.m"], (
+        sorted(b.call_graph.get("app.py:f", [])))
+
+
+_UNTYPED_PARAM = """
+class Base:
+    @classmethod
+    def m(cls): return 1
+class Foo(Base):
+    pass
+
+def f(Foo):            # an UNTYPED parameter sharing the class's name
+    return Foo.m()
+"""
+
+
+def test_untyped_param_sharing_a_class_name_is_a_variable():
+    """Wave r2 #3: the variable guard covered only local_types bindings —
+    an untyped parameter (or for-target / with-as) named like a class still
+    reached the class branch and fabricated an inherited edge. The guard
+    now covers every locally-BOUND name."""
+    b = _build(_UNTYPED_PARAM)
+    assert _edges_to(b, "f") == [], _edges_to(b, "f")
+
+
+_NESTED_SCOPE = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f():
+    def helper(Foo): return Foo     # a nested def's param — NOT the caller's binding
+    return Foo.own()                 # the class reference — must resolve
+"""
+
+
+def test_nested_scope_param_does_not_block_the_class_ref():
+    """Wave r3 #3: the r2 bound-names collector over-reached (nested
+    def/lambda params + comprehension targets + an inverted global) — a
+    nested scope's param sharing a CLASS's name blocked the correct
+    ``Class.own_method()`` edge (a correct-to-wrong regression). The
+    collector is now scoped to the caller's own bindings."""
+    b = _build(_NESTED_SCOPE)
+    assert _edges_to(b, "f") == ["app.py:Foo.own"], _edges_to(b, "f")
+
+
+_MERGED_HIJACK = """
+class Base:
+    def m(self): return 1
+
+def maker():
+    class Foo(Base): pass       # the function-local namesake (has the base)
+    return Foo
+
+class Foo:                      # the module-level class (no bases)
+    pass
+
+def f():
+    v = Foo()
+    return v.m()                # the module-level Foo has NO base — no edge
+"""
+
+
+def test_merge_does_not_union_local_bases_into_module_class():
+    """Wave r3 #4: the bases union + the ANDed flag let the walk fire on the
+    strength of the FUNCTION-LOCAL declaration's base for the module-level
+    namesake (the hijack, same-file). A function-local declaration's bases
+    no longer merge into a module-level namesake."""
+    b = _build(_MERGED_HIJACK)
+    assert _edges_to(b, "f") == [], _edges_to(b, "f")
+
+
+_NESTED_ASSIGN = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f():
+    def helper():
+        Foo = 1              # a nested def's LOCAL assignment
+    return Foo.own()
+"""
+
+
+def test_nested_assign_does_not_block_the_class_ref():
+    """Wave r4 #1: the r3 scoping only gated the nested-def PARAMS — every
+    other binding kind inside a nested scope still leaked into the caller's
+    bound set, blocking the correct Class.own_method() edge."""
+    b = _build(_NESTED_ASSIGN)
+    assert _edges_to(b, "f") == ["app.py:Foo.own"], _edges_to(b, "f")
+
+
+_NESTED_WALRUS_FOR_WITH = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f(xs):
+    g = lambda: [Foo for Foo in xs]      # a comprehension target
+    def h(ys):
+        for Foo in ys: pass              # a nested for-target
+    def w():
+        with open("x") as Foo: pass      # a nested with-as
+    return Foo.own()
+"""
+
+
+def test_comprehension_for_with_targets_do_not_block_the_class_ref():
+    """Wave r4 #1 (the rest of the family): comprehension targets, nested
+    for-targets, nested with-as — all bind in their OWN scopes."""
+    b = _build(_NESTED_WALRUS_FOR_WITH)
+    assert _edges_to(b, "f") == ["app.py:Foo.own"], _edges_to(b, "f")
+
+
+_NESTED_DEF_NAME = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f():
+    def Foo(): return 2        # a nested def NAME — binds in the CALLER's scope
+    Foo()
+    return Foo.own()
+"""
+
+
+def test_nested_def_name_does_block_the_class_ref():
+    """Wave r4 #2: the inverted rule — a nested def's NAME binds in the
+    CALLER's scope (unlike its params), so ``Foo.own()`` after ``def Foo()``
+    is a reference to the local function, not the class: no class edge."""
+    b = _build(_NESTED_DEF_NAME)
+    assert "app.py:Foo.own" not in _edges_to(b, "f"), _edges_to(b, "f")
+
+
+_M2_LOCAL_BINDING = """
+class Base:
+    def m(self): return 1
+
+def factory():
+    class Foo(Base): pass       # the function-local namesake
+    return Foo
+
+Foo = factory()                 # a module-level NON-CLASS binding of the name
+
+def f():
+    return Foo.m()
+"""
+
+
+def test_m2_function_local_gate_module_level_binding():
+    """Wave r4 #4: the M2 path lacked M1's function_local gate — a
+    module-level non-class binding of the name plus a function-local
+    ``class Foo(Base)`` fabricated the Base.m edge for ``Foo.m()``. The
+    gate is mirrored."""
+    b = _build(_M2_LOCAL_BINDING)
+    assert _edges_to(b, "f") == [], _edges_to(b, "f")
+
+
+_DEF_IN_FUNC = """
+class Base:
+    @classmethod
+    def inherited(cls): return 1
+
+def maker():
+    class Foo(Base):
+        @classmethod
+        def own(cls): return 2
+    Foo.own()            # master resolved this; r4's guard lost it — restored
+    return Foo
+"""
+
+
+def test_classmethod_on_a_caller_defined_class_resolves():
+    """Wave r5 #1 (a correct-to-wrong regression): a classmethod called BY
+    NAME on a class the caller itself defines — master resolved it through
+    the class branch; r4's blanket variable-guard skipped the branch and
+    the edge vanished. A caller-DEFINED class name is a class reference,
+    not a variable."""
+    b = _build(_DEF_IN_FUNC)
+    assert "app.py:Foo.own" in _edges_to(b, "maker"), _edges_to(b, "maker")
+
+
+_WALRUS_EXCEPT = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f(xs):
+    try:
+        if (Foo := len(xs)) > 0:     # a walrus at the caller's own level
+            pass
+    except ValueError as Foo:        # an except-alias at the caller's level
+        pass
+    return Foo.own()                 # Foo is BOUND here — a variable, no edge
+"""
+
+
+def test_walrus_and_except_alias_bind():
+    """Wave r5 #2 (the unpinned rules): a walrus target and an except-alias
+    at the caller's own level bind the name — the class reference must NOT
+    fire (each scope rule the docstring claims, now actually pinned)."""
+    b = _build(_WALRUS_EXCEPT)
+    assert "app.py:Foo.own" not in _edges_to(b, "f"), _edges_to(b, "f")
+
+
+_CLASS_BODY_BINDINGS = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f():
+    class K:
+        Foo = 1           # a CLASS-BODY binding — K's scope, not the caller's
+    return Foo.own()
+"""
+
+
+def test_class_body_binding_does_not_block_the_class_ref():
+    """Wave r5 #2: a binding inside a nested CLASS body is that class's
+    scope, not the caller's."""
+    b = _build(_CLASS_BODY_BINDINGS)
+    assert _edges_to(b, "f") == ["app.py:Foo.own"], _edges_to(b, "f")
+
+
+_DEEPER_DEF = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f():
+    def outer():
+        def Foo(): return 2       # a DEEPER def's name — outer's scope, not f's
+        return Foo()
+    return Foo.own()
+"""
+
+
+def test_deeper_def_name_does_not_block_the_class_ref():
+    """Wave r5 #2: a def name two levels down binds in ITS enclosing scope,
+    not the caller's."""
+    b = _build(_DEEPER_DEF)
+    assert "app.py:Foo.own" in _edges_to(b, "f"), _edges_to(b, "f")
+
+
+_GLOBAL_DECL = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f():
+    global Foo           # declares Foo NON-local — NOT a caller-local binding
+    return Foo.own()
+"""
+
+
+def test_global_declaration_is_not_a_caller_binding():
+    """Wave r5 #2: ``global X`` declares the name NON-local — the collector
+    deliberately has no ast.Global branch (the docstring's claim, pinned)."""
+    b = _build(_GLOBAL_DECL)
+    assert "app.py:Foo.own" in _edges_to(b, "f"), _edges_to(b, "f")
+
+
+_M2_GATE_PIN = """
+class Base:
+    @classmethod
+    def inherited(cls): return 1
+
+def maker():
+    class Foo(Base):
+        @classmethod
+        def own(cls): return 2
+    return Foo.inherited()      # the INHERITED classmethod by name — the
+                                # defined_here gate exception, not the own-scan
+"""
+
+
+def test_defined_here_walk_inherited_by_name():
+    """Wave r6 #1: the defined_here M2 exception was unpinned — the r5
+    fixture only exercised the OWN-method scan. The inherited classmethod
+    by name inside the defining function resolves through the gated walk."""
+    b = _build(_M2_GATE_PIN)
+    assert _edges_to(b, "maker") == ["app.py:Base.inherited"], _edges_to(b, "maker")
+
+
+_M1_CTOR_IN_DEFINING = """
+class Base:
+    def __init__(self): self.x = 1
+    def inherited_method(self): return 1
+
+def maker():
+    class Foo(Base):
+        pass
+    s = Foo()                  # the inherited ctor inside the defining caller
+    return s.inherited_method() # M1 inside the defining caller
+"""
+
+
+def test_m1_and_ctor_inside_the_defining_function():
+    """Wave r6 #3: the defined-caller exception was wired into M2 only —
+    the M1/ctor shapes inside the defining function stayed unresolved
+    (master failed too, but the r5 principle holds for both shapes)."""
+    b = _build(_M1_CTOR_IN_DEFINING)
+    edges = _edges_to(b, "maker")
+    assert "app.py:Base.inherited_method" in edges, edges
+    assert "app.py:Base.__init__" in edges, edges
+
+
+_MERGED_LOCAL_NAMESAKES = """
+class BaseA: pass
+class BaseB:
+    @classmethod
+    def load(cls): return 1
+
+def a():
+    class Foo(BaseA): pass
+    return Foo.load()           # walks the MERGED [BaseA, BaseB] — over-seed
+
+def b():
+    class Foo(BaseB): pass
+    return Foo.load()
+"""
+
+
+def test_merged_local_namesakes_disclosed_overseed():
+    """Wave r6 #2: two FUNCTION-LOCAL namesakes merge their bases (the same
+    scope) and the defined_here exception walks the union inside either
+    defining function — a() never touches BaseB but reaches BaseB.load.
+    The OVER-SEED direction (safe per the project's reachability rule),
+    disclosed and pinned as CURRENT semantics."""
+    b = _build(_MERGED_LOCAL_NAMESAKES)
+    assert "app.py:BaseB.load" in _edges_to(b, "a"), _edges_to(b, "a")
+    assert "app.py:BaseB.load" in _edges_to(b, "b"), _edges_to(b, "b")
+
+
+_CALL_PROP_IN_DEFINING = """
+class Base:
+    def __init__(self): self.x = 1
+    def __call__(self): return 1
+    @property
+    def p(self): return 2
+
+def maker():
+    class Foo(Base):
+        pass
+    s = Foo()
+    s()                     # the inherited __call__ inside the defining caller
+    return s.p              # the inherited @property read ditto
+"""
+
+
+def test_dunder_call_and_property_inside_the_defining_function():
+    """Wave r7 #1: the r6 wiring claim was half true — the __call__ fallback
+    and the #309 property-read path never received defined_classes, so both
+    stayed unresolved inside the defining caller. Pinned."""
+    b = _build(_CALL_PROP_IN_DEFINING)
+    edges = _edges_to(b, "maker")
+    assert "app.py:Base.__call__" in edges, edges
+    assert "app.py:Base.p" in edges, edges
+
+
+_MATCH_CAPTURE = """
+class Foo:
+    @classmethod
+    def own(cls): return 1
+
+def f(x):
+    match x:
+        case {"k": Foo}:      # a match-capture at the caller's level
+            pass
+    return Foo.own()
+"""
+
+
+def test_match_capture_binds_the_name():
+    """Wave r7 #2: a MatchAs capture binds like an except-alias — the class
+    reference after it is a variable reference, no edge."""
+    b = _build(_MATCH_CAPTURE)
+    assert "app.py:Foo.own" not in _edges_to(b, "f"), _edges_to(b, "f")
+
+
+_SELF_SUPER_LOCAL_NAMESAKE = """
+class Base:
+    def m(self): return 1
+
+class Foo:                 # the module-level namesake (no bases)
+    pass
+
+def maker():
+    class Foo(Base):       # the function-local namesake (the real base)
+        def go(self):
+            return self.m()
+        def go2(self):
+            return super().m()
+    return Foo
+"""
+
+
+def test_self_and_super_survive_the_local_namesake():
+    """Deep-refute #1 (a correct-to-wrong regression): the r3 merge RESET the
+    file-scope bases to the module side's — severing self.m()/super().m()
+    inside the function-local class's own methods (the parent's union
+    resolved both). The union now survives in all_bases for the self/super
+    walks while the file-scope bases stay module-side."""
+    b = _build(_SELF_SUPER_LOCAL_NAMESAKE)
+    assert "app.py:Base.m" in _edges_to(b, "go"), _edges_to(b, "go")
+    assert "app.py:Base.m" in _edges_to(b, "go2"), _edges_to(b, "go2")
+
+
+_OWN_METHOD_SKIP = """
+class Base:
+    @classmethod
+    def own(cls): return 1
+
+def f(Foo):
+    return Foo.own()       # an untyped param — the OWN method is SKIPPED too
+"""
+
+
+def test_bound_receiver_skips_the_own_method_scan_decision():
+    """Deep-refute #3 (an FN trade, DECIDED + pinned): for a receiver the
+    caller's scope BINDS, the whole class branch is skipped — the own-method
+    scan included (the parent's name-based guess resolved it). A variable is
+    not the class: the name-based edge is a guess the anti-phantom rule
+    rejects; only the TYPED resolution applies."""
+    b = _build(_OWN_METHOD_SKIP)
+    assert _edges_to(b, "f") == [], _edges_to(b, "f")
+
+
+_PARAM_CTOR = """
+class Base:
+    def __init__(self): self.x = 1
+
+def f(Foo):
+    return Foo()          # a parameter shadowing the class — not a ctor call
+"""
+
+
+def test_param_named_like_a_class_is_not_a_ctor_call():
+    """Deep-refute #2: the ctor fallback lacked the bound-name guard — a
+    parameter named like a class fabricated the inherited __init__ edge."""
+    b = _build(_PARAM_CTOR)
+    assert _edges_to(b, "f") == [], _edges_to(b, "f")


### PR DESCRIPTION
## Summary

The call-graph builder resolved an inherited method when the receiver was `self` or `super()`
(two BFS walks over the class bases existed) but dropped the same call when the receiver was a
**locally-constructed instance** (M1: `s = Sub(); s.inherited()`) or the **class name** (M2:
`Sub.inherited_cm()`) — the typed-receiver path never consulted `class_data['bases']`. A method
whose only callers used a typed receiver got an empty caller set and was **pruned while its
caller was kept** — false negatives (~12% of typed-receiver calls lost on the issue's stdlib
census). The project had already decided the required behaviour in C (the dispatch suite's Bug
[30], the sound floor): walk up the base chain to the first ancestor defining the method,
same-file, own-first, no derived-override fan-out, no ancestor => no edge.

## The fix

- **`_same_file_base_walk`** (the `_resolve_self_call`'s own-first FIFO, cycle-guarded order,
  restricted to the caller's file) wired into every typed-receiver path: `_resolve_class_method`
  (M1 — before the cross-file simple-name match), `_resolve_module_call` (M2 — the gate fixed
  per the need-check to key on the class index so method-less subclasses, the most common M2
  shape, reach it), the constructor fallback, the `__call__` dunder, and the property read.
- The wave's guards (7 rounds + the deep-refute, each catching real seams in the prior):
  function-local classes can't hijack imported namesakes (the extractor marks them
  `function_local`; the defining caller's own exception wired into every path); a receiver the
  caller's scope **binds** is a variable, not a class reference — with the scope rules each
  pinned (params, def/class names, walrus, for/with, except-aliases, match-captures,
  comprehensions, class bodies, `global`, imports); subscripted bases (`Sub(Base[int])`)
  no longer sever the chain; the merge reconciles `function_local` and keeps the self/super
  walks' union in `all_bases` while the file-scope bases stay module-side.

## Disclosed limits

- **FIFO, not C3 MRO** (shared with the self walk): a diamond picks a single genuine ancestor,
  not the MRO-correct one — pinned exactly; the C3 unification filed as #440.
- **Imported bases/subclasses stay unresolved** for typed receivers (the caller-file-anchored
  walk can't see them — cross-file inheritance is `PARSER_UPGRADE_PLAN.md:170`): filed as #440.
- The merged-bases over-seed: two same-scope function-local namesakes' bases union (the
  `defined_here` exception walks the union inside either defining function) — the safe
  direction, pinned as CURRENT semantics.
- The try/except-ImportError shim: a module-level fallback class + an import gives M1 the
  fallback and M2 the import (two answers for one name; both-hit-emit-both is the deferred
  refinement).
- For a bound-variable receiver, the own-method scan is skipped too (only the TYPED resolution
  applies) — decided and pinned.

<details>
<summary>Verification evidence (commands + results)</summary>

| check | command | result |
|---|---|---|
| new tests | the issue-318 test file (46 tests) | green; the worktree smokes RED at each round boundary (5 on pristine master, 3 on the pre-r1 commit, 3 on pre-r2, 1 on pre-r5, 1 on pre-r6) # proc-ok |
| full suites | the parser suite; the full suite | the parser side 215 green · the full side 3500 green + the one byte-identical-on-pristine macOS tmp failure # proc-ok |
| the corpus differential | master vs fix on anyio/dateutil/annotated_types | 34 gained / **0 same-file lost / 0 unredirected / 0 newly orphaned**; the PRUNE-DELTA: **11 functions rescued** (their first caller gained — AsyncFile.read/write/seek… no longer prunable) |
| the e2e (the real binary) | the shipped CLI's parse on the issue's five-receiver fixture | M1=True M2=True — both shapes resolve through the real pipeline |
| review | the need-check ("ship the design — strictly dominates the issue's options") + **7 wave rounds + the deep-refute** | each round caught real seams in the prior (the M2 gate, the hijack, the block-wrapped escape, the merged bases, the collector's scope rules, the defining-caller exception, the wiring completeness); the deep-refute caught the merge-reset severing the self/super walks — fixed and pinned |

</details>

Refs #318
