### PR TITLE
fix(report): a failed dynamic test renders as a failure — never as a verification (#319)

### DIFF
--- a/libs/openant-core/report/README.md
+++ b/libs/openant-core/report/README.md
@@ -95,7 +95,7 @@ The module expects a JSON file with the following structure:
       "stage2_verdict": "vulnerable",
       "severity": "high",
       "severity_source": "model",
-      "dynamic_testing": true,
+      "dynamic_testing": {"status": "CONFIRMED", "tested": "Docker container, <Month Year>"}, // #319: ONLY for a CONFIRMED test; every other status carries "dynamic_testing_attempted" (status/details/evidence/attempted) — never a verification
       "description": "Brief description of the vulnerability.",
       "vulnerable_code": "code snippet here",
       "impact": [

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -142,6 +142,8 @@ def merge_dynamic_results(pipeline_data: dict, pipeline_path: str) -> dict:
     #     (never silently fall back to the positional ID: that is the
     #     defect)
     merged_count = 0
+    attempted_count = 0
+    skipped_count = 0
     refused_count = 0
     abstained_count = 0
     for finding in pipeline_data.get("findings", []):
@@ -157,18 +159,68 @@ def merge_dynamic_results(pipeline_data: dict, pipeline_path: str) -> dict:
         if r_key != f_key:
             refused_count += 1
             continue
-        finding["dynamic_testing"] = {
-            "status": r.get("status"),
-            "details": r.get("details"),
-            "evidence": r.get("evidence", []),
-            "tested": f"Docker container, {date_str}",
-            # the join is auditable after the fact
-            "identity_key": r_key,
-        }
-        merged_count += 1
+        # fa17 hardening (wave r2 + the deep-refute): the results file is
+        # model-supplied — ANY status outside the harness's own VALID set
+        # (exact-case) normalises to UNKNOWN: a non-string, a lowercase
+        # "confirmed" (which would self-contradict the banner), whitespace,
+        # or a newline-bearing string must not leak into the
+        # externally-facing banner. The allowlist is the harness's own.
+        from utilities.dynamic_tester.models import VALID_STATUSES
+        _raw_status = r.get("status")
+        if (not isinstance(_raw_status, str)
+                or _raw_status not in VALID_STATUSES):
+            status = "UNKNOWN"
+        else:
+            status = _raw_status
+        # #319 (wave r1): SKIPPED is "never executed" (models.py: "distinct
+        # from ERROR (a test ran and failed)") — the harness had no Docker
+        # template for the finding's language. Attaching an ATTEMPTED block
+        # (an attempted date, a "test SKIPPED" failure stamp) would be the
+        # mirror of the defect this issue fixes: asserting a container
+        # action that never happened, inverted. SKIPPED attaches nothing;
+        # it is surfaced in the merge's stderr line like the abstain count.
+        if status == "SKIPPED":
+            skipped_count += 1
+            continue
+        # #319: the verification block attaches ONLY for a CONFIRMED test —
+        # an ERRORED or NOT_REPRODUCED test rendered as "Verified via
+        # dynamic testing" in the disclosure (both consumers keyed on the
+        # block's EXISTENCE), and the unconditional `tested` Docker string
+        # asserted a container run that never happened. Every other status
+        # attaches a separate ATTEMPTED block: the transparency (status,
+        # details, evidence, the date-stamped ATTEMPT) without the
+        # verification claim — a template cannot render a failed test as a
+        # verification by omission.
+        if status == "CONFIRMED":
+            finding["dynamic_testing"] = {
+                "status": status,
+                "details": r.get("details"),
+                "evidence": r.get("evidence", []),
+                "tested": f"Docker container, {date_str}",
+                # the join is auditable after the fact
+                "identity_key": r_key,
+            }
+            merged_count += 1
+        else:
+            finding["dynamic_testing_attempted"] = {
+                "status": status,
+                "details": r.get("details"),
+                "evidence": r.get("evidence", []),
+                # NOT `tested`: the container claim is reserved for a test
+                # that ran and confirmed. `attempted` carries the date.
+                "attempted": date_str,
+                "identity_key": r_key,
+            }
+            attempted_count += 1
 
     # #314 suggestion 3: what happened is SURFACED, never silent
     print(f"  Merged {merged_count} dynamic test results from {dynamic_path.name}", file=sys.stderr)
+    if attempted_count:
+        print(f"  [Info] {attempted_count} dynamic test result(s) NOT confirmed "
+              f"(attached as dynamic_testing_attempted — never a verification)", file=sys.stderr)
+    if skipped_count:
+        print(f"  [Info] {skipped_count} dynamic test result(s) SKIPPED — never "
+              f"executed (no harness for the language); nothing attached", file=sys.stderr)
     if refused_count:
         print(f"  [Warning] Refused {refused_count} dynamic test result(s) whose "
               f"identity_key disagrees with the finding — a stale results file "
@@ -205,6 +257,10 @@ def _compact_for_summary(pipeline_data: dict) -> dict:
             "severity": f.get("severity"),
             "severity_source": f.get("severity_source"),
             "dynamic_testing": f.get("dynamic_testing"),
+            # #319 (the e2e-caught gap): the ATTEMPTED block must reach the
+            # summary LLM too — without it a failed test rendered "static"
+            # (safe, but the failure was invisible to the reader).
+            "dynamic_testing_attempted": f.get("dynamic_testing_attempted"),
             "impact": f.get("impact"),
         })
     return compact
@@ -317,6 +373,23 @@ def _disclosure_verdict_header(vulnerability_data: dict) -> str:
     """
     verdict = str(vulnerability_data.get("stage2_verdict") or "").lower()
     stage1 = str(vulnerability_data.get("stage1_verdict") or "").lower()
+    # #319: the dynamic dimension stamps FIRST — a CONFIRMED Docker test is
+    # the strongest verification; an attempted-but-failed one must say NOT
+    # confirmed (never "Verified via dynamic testing" for an ERROR/
+    # NOT_REPRODUCED test).
+    dt = vulnerability_data.get("dynamic_testing")
+    dta = vulnerability_data.get("dynamic_testing_attempted")
+    # #319 (wave r1): the dimensions COMPOSE — the dynamic line ADDS as a
+    # second line, never REPLACES the Stage-2 stamp (the wave's regression:
+    # a Stage-2 CONFIRMED finding whose harness ERRORED read "NOT confirmed
+    # by dynamic testing" with the Stage-2 confirmation DROPPED — the
+    # reader could not distinguish it from a Stage-1-only finding; #283's
+    # ADJUDICATED wording likewise became unreachable).
+    dt_line = ""
+    if isinstance(dt, dict) and dt.get("status") == "CONFIRMED":
+        dt_line = "CONFIRMED by dynamic testing (Docker container)"
+    elif isinstance(dta, dict) and dta.get("status"):
+        dt_line = f"NOT confirmed by dynamic testing (test {dta.get('status')})"
     if verdict in _STAGE2_CONFIRMED:
         status = f"CONFIRMED by Stage-2 attacker simulation ({verdict})"
     elif (verdict in ("vulnerable", "bypassable")
@@ -337,6 +410,8 @@ def _disclosure_verdict_header(vulnerability_data: dict) -> str:
             f"({verdict or 'unknown'})"
         )
     lines = [f"> **Verification:** {status}"]
+    if dt_line:
+        lines.append(f"> **Dynamic testing:** {dt_line}")
     loc = vulnerability_data.get("location")
     if isinstance(loc, dict) and (loc.get("file") or loc.get("function")):
         where = ":".join(str(x) for x in (loc.get("file"), loc.get("function")) if x)

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -117,9 +117,18 @@ def merge_dynamic_results(pipeline_data: dict, pipeline_path: str) -> dict:
     # never calls `.get()` on a bare string/number.
     normalize_results(dynamic_data)
     results_by_id = {}
+    duplicate_ids = 0
     for result in dynamic_data.get("results", []):
         fid = result.get("finding_id")
         if fid:
+            if fid in results_by_id:
+                # verify-wave (sonnet, state-machine axis — F2): a duplicate
+                # finding_id silently last-wins with zero visibility — the
+                # exact anti-pattern this merge's own "what happened is
+                # SURFACED, never silent" rule exists to stop. Counted and
+                # warned below; the last-wins order is unchanged (documented
+                # behavior, not silently chosen).
+                duplicate_ids += 1
             results_by_id[fid] = result
 
     if not results_by_id:
@@ -159,6 +168,21 @@ def merge_dynamic_results(pipeline_data: dict, pipeline_path: str) -> dict:
         if r_key != f_key:
             refused_count += 1
             continue
+        # verify-wave (opus, consumers axis — F1, reproduced): a finding
+        # can enter the merge carrying a PRE-EXISTING dynamic_testing block
+        # (a stale one from an earlier run, or a forged one — pipeline_output
+        # is model-supplied per fa18). The merge previously only ADDED, so a
+        # forged CONFIRMED block coexisted with a fresh ERROR result and
+        # every consumer's dynamic_testing-first preference rendered
+        # "Verified via dynamic testing" — the exact false verification
+        # this fix exists to remove, re-entering through the artifact
+        # channel. The merge is the single authority for a finding's
+        # dynamic-verification state: clear both block keys on every
+        # matched finding BEFORE attaching, so the "cannot render a failed
+        # test as a verification by omission" contract holds
+        # unconditionally for every finding the merge touched.
+        finding.pop("dynamic_testing", None)
+        finding.pop("dynamic_testing_attempted", None)
         # fa17 hardening (wave r2 + the deep-refute): the results file is
         # model-supplied — ANY status outside the harness's own VALID set
         # (exact-case) normalises to UNKNOWN: a non-string, a lowercase
@@ -226,6 +250,9 @@ def merge_dynamic_results(pipeline_data: dict, pipeline_path: str) -> dict:
               f"identity_key disagrees with the finding — a stale results file "
               f"from a previous run; re-run the dynamic tests to regenerate",
               file=sys.stderr)
+    if duplicate_ids:
+        print(f"  [Warning] {duplicate_ids} duplicate finding_id(s) in {dynamic_path.name} "
+              f"— the LAST entry for each id was used", file=sys.stderr)
     if abstained_count:
         print(f"  [Warning] Skipped {abstained_count} dynamic test result(s) with "
               f"no identity_key (a legacy results file); re-run the dynamic "

--- a/libs/openant-core/report/prompts/disclosure.txt
+++ b/libs/openant-core/report/prompts/disclosure.txt
@@ -49,7 +49,7 @@ OUTPUT FORMAT:
 
 ---
 
-Verified via {"dynamic testing" if dynamic_testing else "attacker simulation (Stage 2)" if stage2_verdict in ("confirmed", "agreed") else "static analysis"}.
+Verified via {"dynamic testing" if dynamic_testing else "dynamic test FAILED (status: " + dynamic_testing_attempted.status + ") — NOT verified by it" if dynamic_testing_attempted else "attacker simulation (Stage 2)" if stage2_verdict in ("confirmed", "agreed") else "static analysis"}.
 
 ---
 
@@ -57,7 +57,7 @@ INSTRUCTIONS:
 - Keep summary under 50 words
 - Do NOT include a "## Vulnerable Code" section — it is added automatically after your output is generated. Do NOT emit code fences with the vulnerable source code. If you need to reference the vulnerable code, refer to the function name and describe the issue in prose.
 - Other code snippets (Suggested Fix): show only the minimal change needed, not entire files
-- Steps to Reproduce: if dynamic_testing data exists, use those steps; otherwise write "[REQUIRES DYNAMIC TESTING]" for each step
+- Steps to Reproduce: if dynamic_testing data exists, use those steps; if only dynamic_testing_attempted exists (the test ran but did not confirm), still write "[REQUIRES DYNAMIC TESTING]" — the attempted evidence is diagnostic, not a reproduction; otherwise write "[REQUIRES DYNAMIC TESTING]" for each step
 - Impact: 3-5 bullet points, no sub-bullets
 - Suggested Fix: show minimal code change, use comments to indicate what was added
 - Do not include CVSS scores or severity ratings

--- a/libs/openant-core/report/prompts/summary.txt
+++ b/libs/openant-core/report/prompts/summary.txt
@@ -72,7 +72,7 @@ OUTPUT FORMAT:
 
 | # | Vulnerability | Location | CWE | Severity | Verified |
 |---|--------------|----------|-----|----------|----------|
-| 1 | {short_name} | {file:function} | CWE-{n} | {severity} | {static|verified|dynamic} |
+| 1 | {short_name} | {file:function} | CWE-{n} | {severity} | {static|verified|dynamic|dynamic test failed (<status>)} |
 
 ## False Positives Eliminated
 
@@ -97,7 +97,7 @@ INSTRUCTIONS:
 - Fill in all {placeholders} from the input data
 - If a count is zero, still show "0" in the table
 - Keep "Reason" column under 15 words
-- "Verified" column: "dynamic" if dynamic_testing exists for that finding, "verified" if stage2_verdict is "confirmed" or "agreed" (Stage 2 attacker simulation passed), else "static"
+- "Verified" column, in priority order: "dynamic" if dynamic_testing exists for that finding (a CONFIRMED Docker test); "dynamic test failed (<status>)" if dynamic_testing_attempted exists (the test ran but did not confirm — NEVER render this as verified); "verified" if stage2_verdict is "confirmed" or "agreed" (Stage 2 attacker simulation passed); else "static"
 - "Severity" column: the finding's `severity` field from the input data (critical / high / medium / low); if absent, write the empty cell
 - Language comes from repository.language
 - Commit SHA comes from repository.commit_sha; if null or missing, write "Not available"

--- a/libs/openant-core/report/schema.py
+++ b/libs/openant-core/report/schema.py
@@ -18,6 +18,10 @@ class Finding:
     stage1_verdict: str
     stage2_verdict: str
     dynamic_testing: dict | bool = False
+    # #319: a non-CONFIRMED dynamic test result (ERROR / NOT_REPRODUCED /
+    # ...) — the transparency without the verification claim. Optional and
+    # NOT required: old artifacts validate.
+    dynamic_testing_attempted: Optional[dict] = None
     description: Optional[str] = None
     vulnerable_code: Optional[str] = None
     vulnerable_code_section: Optional[str] = None
@@ -43,6 +47,7 @@ class Finding:
             stage1_verdict=data["stage1_verdict"],
             stage2_verdict=data["stage2_verdict"],
             dynamic_testing=data.get("dynamic_testing", False),
+            dynamic_testing_attempted=data.get("dynamic_testing_attempted"),
             description=data.get("description"),
             vulnerable_code=data.get("vulnerable_code"),
             vulnerable_code_section=data.get("vulnerable_code_section"),

--- a/libs/openant-core/tests/test_issue319_dynamic_status.py
+++ b/libs/openant-core/tests/test_issue319_dynamic_status.py
@@ -1,0 +1,199 @@
+"""#319: a failed dynamic test must not render as a verification.
+
+``merge_dynamic_results`` attached a ``dynamic_testing`` block to a finding whenever a
+dynamic-test result existed for its ID, **with no filter on the result's status** — and both
+consumers of the block (the summary table's "Verified" column and the disclosure document's
+"Verified via" line) key on its **existence**. A finding whose Docker test ERRORED or was
+NOT_REPRODUCED therefore rendered as "Verified via dynamic testing" in the externally-facing
+disclosure; the block's unconditional ``"tested": "Docker container, <Month Year>"`` asserted
+a container run that never happened.
+
+The fix (the issue's own suggestions, composing with #414's identity gate which still runs
+first and unchanged):
+- the full ``dynamic_testing`` block (with the ``tested`` Docker string) attaches ONLY for
+  ``status == "CONFIRMED"``;
+- every other status (ERROR, NOT_REPRODUCED, INCONCLUSIVE, BLOCKED, unknown) attaches a
+  separate ``dynamic_testing_attempted`` block — the transparency without the verification
+  claim, so a template cannot render a failed test as a verification by omission;
+- both templates branch on the two blocks; the disclosure header stamps the dynamic dimension
+  deterministically.
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from report.generator import (  # noqa: E402
+    merge_dynamic_results, _disclosure_verdict_header,
+)
+
+
+def _run_merge(pipeline_findings, results):
+    """The real merge over a real temp scan dir (the results file must be
+    named dynamic_test_results.json beside the pipeline output)."""
+    with tempfile.TemporaryDirectory() as d:
+        pp = Path(d) / "pipeline_output.json"
+        pp.write_text(json.dumps({"findings": pipeline_findings}))
+        (Path(d) / "dynamic_test_results.json").write_text(
+            json.dumps({"results": results}))
+        data = {"findings": [dict(f) for f in pipeline_findings]}
+        merge_dynamic_results(data, str(pp))
+        return data["findings"]
+
+
+_FINDINGS = [
+    {"id": "VULN-001", "identity_key": "a"},
+    {"id": "VULN-002", "identity_key": "b"},
+    {"id": "VULN-003", "identity_key": "c"},
+]
+_RESULTS = [
+    {"finding_id": "VULN-001", "identity_key": "a", "status": "ERROR",
+     "details": "generation failed"},
+    {"finding_id": "VULN-002", "identity_key": "b", "status": "NOT_REPRODUCED",
+     "details": "container ran, no repro"},
+    {"finding_id": "VULN-003", "identity_key": "c", "status": "CONFIRMED",
+     "details": "exploited", "evidence": ["step 1"]},
+]
+
+
+def test_only_confirmed_carries_the_verification_block():
+    """The issue's executed fixture: ERROR / NOT_REPRODUCED / CONFIRMED —
+    the verification block attaches ONLY for CONFIRMED."""
+    out = _run_merge(_FINDINGS, _RESULTS)
+    by_id = {f["id"]: f for f in out}
+    assert "dynamic_testing" in by_id["VULN-003"]
+    assert "dynamic_testing" not in by_id["VULN-001"]
+    assert "dynamic_testing" not in by_id["VULN-002"]
+
+
+def test_attempted_block_carries_the_transparency():
+    """Every non-CONFIRMED status attaches dynamic_testing_attempted (the
+    status visible), never the verification claim."""
+    out = _run_merge(_FINDINGS, _RESULTS)
+    by_id = {f["id"]: f for f in out}
+    for fid, status in (("VULN-001", "ERROR"), ("VULN-002", "NOT_REPRODUCED")):
+        att = by_id[fid].get("dynamic_testing_attempted")
+        assert att, fid
+        assert att["status"] == status
+        assert "tested" not in att, fid          # no container claim
+        assert att.get("attempted"), fid          # the date-stamped attempt
+
+
+def test_tested_only_when_a_container_ran():
+    """The unconditional "Docker container, <Month Year>" asserted a run that
+    never happened — the string appears ONLY in the CONFIRMED block."""
+    out = _run_merge(_FINDINGS, _RESULTS)
+    by_id = {f["id"]: f for f in out}
+    assert "Docker container" in by_id["VULN-003"]["dynamic_testing"]["tested"]
+    for fid in ("VULN-001", "VULN-002"):
+        blk = by_id[fid].get("dynamic_testing_attempted", {})
+        assert "Docker container" not in str(blk), fid
+
+
+def test_identity_gate_unchanged():
+    """#414's gate still runs first: a refused (identity-mismatch) result
+    attaches NOTHING (neither block); the legacy abstain path unchanged."""
+    results = [
+        {"finding_id": "VULN-001", "identity_key": "WRONG", "status": "CONFIRMED"},
+        {"finding_id": "VULN-002", "status": "CONFIRMED"},          # no key: abstain
+    ]
+    out = _run_merge([_FINDINGS[0], _FINDINGS[1]], results)
+    by_id = {f["id"]: f for f in out}
+    assert "dynamic_testing" not in by_id["VULN-001"]
+    assert "dynamic_testing_attempted" not in by_id["VULN-001"]
+    assert "dynamic_testing" not in by_id["VULN-002"]
+
+
+def test_disclosure_header_stamps_the_dynamic_dimension():
+    """The deterministic banner: CONFIRMED-by-dynamic-testing stamps first;
+    an attempted-but-failed stamps NOT-confirmed, before the Stage-2/static
+    logic; a clean static finding keeps the existing wording."""
+    confirmed = {"stage2_verdict": "confirmed",
+                 "dynamic_testing": {"status": "CONFIRMED"},
+                 "stage1_verdict": "vulnerable"}
+    h = _disclosure_verdict_header(confirmed)
+    assert "dynamic testing" in h.lower() and "CONFIRMED" in h
+
+    failed = {"stage2_verdict": "confirmed",
+             "dynamic_testing_attempted": {"status": "ERROR"},
+             "stage1_verdict": "vulnerable"}
+    h2 = _disclosure_verdict_header(failed)
+    assert "NOT confirmed by dynamic testing" in h2, h2
+    assert "ERROR" in h2
+
+    static_only = {"stage2_verdict": "confirmed", "stage1_verdict": "vulnerable"}
+    h3 = _disclosure_verdict_header(static_only)
+    assert "dynamic" not in h3.lower(), h3
+
+
+def test_templates_branch_on_the_two_blocks():
+    """The summary's Verified column and the disclosure's Verified-via line
+    must name the ATTEMPTED block's failed wording — never the verified
+    wording for a failed test."""
+    summary = (Path(__file__).resolve().parents[1] / "report" / "prompts"
+               / "summary.txt").read_text()
+    assert "dynamic_testing_attempted" in summary
+    disclosure = (Path(__file__).resolve().parents[1] / "report" / "prompts"
+                  / "disclosure.txt").read_text()
+    assert "dynamic_testing_attempted" in disclosure
+
+
+def test_schema_accepts_the_attempted_field():
+    """Old artifacts (no attempted field) validate; new ones carry it."""
+    from report.schema import Finding
+
+    base = {"id": "VULN-001", "name": "v", "short_name": "V",
+            "location": {"file": "a.py", "function": "f"},
+            "cwe_id": 79, "cwe_name": "XSS",
+            "stage1_verdict": "vulnerable", "stage2_verdict": "confirmed"}
+    assert Finding.from_dict(base).dynamic_testing_attempted is None
+    new = Finding.from_dict({**base,
+                             "dynamic_testing_attempted": {"status": "ERROR"}})
+    assert new.dynamic_testing_attempted == {"status": "ERROR"}
+
+
+def test_attempted_block_reaches_the_summary_llm():
+    """The e2e-caught gap: _compact_for_summary passed only dynamic_testing —
+    the summary doc rendered the failed tests as "static" (safe, but the
+    failure invisible). The attempted block must reach the LLM."""
+    from report.generator import _compact_for_summary
+
+    data = {"findings": [{
+        "id": "VULN-001",
+        "dynamic_testing_attempted": {"status": "ERROR", "attempted": "August 2026"},
+    }]}
+    compact = _compact_for_summary(data)
+    assert compact["findings"][0]["dynamic_testing_attempted"]["status"] == "ERROR"
+
+
+def test_skipped_attaches_nothing():
+    """Wave r1: SKIPPED is "never executed" (models.py: distinct from ERROR)
+    — attaching an attempted block would be the mirror of the defect this
+    issue fixes (asserting a container action that never happened,
+    inverted). SKIPPED attaches nothing."""
+    results = [{"finding_id": "VULN-001", "identity_key": "a",
+                "status": "SKIPPED", "details": "no harness for the language"}]
+    out = _run_merge([_FINDINGS[0]], results)
+    f = out[0]
+    assert "dynamic_testing" not in f and "dynamic_testing_attempted" not in f
+
+
+def test_null_status_normalised_both_surfaces_agree():
+    """Wave r1: a model-supplied record with NO status must not render
+    "failed (None)" in one surface while the header omits the dimension —
+    normalised to UNKNOWN at the merge."""
+    results = [{"finding_id": "VULN-001", "identity_key": "a",
+                "details": "malformed: no status"}]
+    out = _run_merge([_FINDINGS[0]], results)
+    att = out[0].get("dynamic_testing_attempted")
+    assert att and att["status"] == "UNKNOWN", att
+    h = _disclosure_verdict_header({
+        "stage2_verdict": "confirmed", "stage1_verdict": "vulnerable",
+        "dynamic_testing_attempted": att})
+    assert "UNKNOWN" in h  # the header agrees with the attempted block

--- a/libs/openant-core/tests/test_issue319_dynamic_status.py
+++ b/libs/openant-core/tests/test_issue319_dynamic_status.py
@@ -126,6 +126,13 @@ def test_disclosure_header_stamps_the_dynamic_dimension():
     h2 = _disclosure_verdict_header(failed)
     assert "NOT confirmed by dynamic testing" in h2, h2
     assert "ERROR" in h2
+    # deep-refute (fable, ship-fix stage 7): the Stage-2 stamp must SURVIVE
+    # the dynamic-failure line — the #210/#283 regression (an early-return
+    # dropped the Stage-2 confirmation from a harness-errored finding) must
+    # be pinned by assertion, not just by the compose code being correct.
+    assert "CONFIRMED" in h2 or "ADJUDICATED" in h2, (
+        "the Stage-2 confirmation stamp must be retained alongside the "
+        "NOT-confirmed dynamic line: " + h2)
 
     static_only = {"stage2_verdict": "confirmed", "stage1_verdict": "vulnerable"}
     h3 = _disclosure_verdict_header(static_only)
@@ -197,3 +204,46 @@ def test_null_status_normalised_both_surfaces_agree():
         "stage2_verdict": "confirmed", "stage1_verdict": "vulnerable",
         "dynamic_testing_attempted": att})
     assert "UNKNOWN" in h  # the header agrees with the attempted block
+
+
+def test_preexisting_dynamic_blocks_are_cleared_by_merge(tmp_path):
+    """verify-wave F1 (opus, executed repro): a finding entering the merge
+    with a stale/forged dynamic_testing block + a fresh non-CONFIRMED result
+    must NOT end with both blocks — every consumer prefers dynamic_testing
+    first, so the coexistence rendered a forged verification over a fresh
+    ERROR. The merge clears both keys on every matched finding before
+    attaching."""
+    import json as _json
+    from report.generator import merge_dynamic_results
+
+    d = tmp_path / "scan"
+    d.mkdir()
+    pipeline = {"findings": [{
+        "id": "VULN-001",
+        "identity_key": "k1",
+        "stage1_verdict": "VULNERABLE", "stage2_verdict": "vulnerable",
+        "name": "x", "short_name": "x", "location": {"file": "a.py", "line": 1},
+        "cwe_id": 79, "cwe_name": "x", "description": "d", "vulnerable_code": "c",
+        # the forged block: a CONFIRMED stamp from a previous run (or hand-built)
+        "dynamic_testing": {"status": "CONFIRMED", "tested": "Docker container, January 2020",
+                            "identity_key": "k1"},
+    }]}
+    (d / "pipeline_output.json").write_text(_json.dumps(pipeline))
+    (d / "dynamic_test_results.json").write_text(_json.dumps({
+        "results": [{"finding_id": "VULN-001", "identity_key": "k1",
+                     "status": "ERROR", "details": "the new run errored",
+                     "evidence": []}]}))
+    m = merge_dynamic_results(pipeline, str(d / "pipeline_output.json"))
+    f = m["findings"][0]
+    assert "dynamic_testing" not in f, "the forged CONFIRMED block must not survive a merge that sees the ERROR"
+    assert f.get("dynamic_testing_attempted", {}).get("status") == "ERROR"
+
+    # SKIPPED: a forged block on a never-executed finding is cleared too
+    p2 = {"findings": [dict(forged := pipeline["findings"][0])]}
+    (d / "dynamic_test_results.json").write_text(_json.dumps({
+        "results": [{"finding_id": "VULN-001", "identity_key": "k1",
+                     "status": "SKIPPED", "evidence": []}]}))
+    m2 = merge_dynamic_results(p2, str(d / "pipeline_output.json"))
+    f2 = m2["findings"][0]
+    assert "dynamic_testing" not in f2, "a forged block must not survive a SKIPPED merge"
+    assert "dynamic_testing_attempted" not in f2, "SKIPPED attaches nothing"


### PR DESCRIPTION
## Summary

`merge_dynamic_results` attached a `dynamic_testing` block to a finding whenever a dynamic-test
result existed for its ID — **no status filter** — and both consumers (the summary's "Verified"
column, the disclosure's "Verified via" line) keyed on the block's **existence**. A finding whose
Docker test ERRORED or was NOT_REPRODUCED therefore rendered as "Verified via dynamic testing" in
the externally-facing disclosure, and the unconditional `"tested": "Docker container, <Month Year>"`
asserted a container run that never happened.

## The fix (through 2 wave rounds + a deep-refute, each finding verified and pinned)

- **The verified block attaches ONLY for `CONFIRMED`** (with the `tested` Docker string);
  every other executed status attaches a separate `dynamic_testing_attempted` block — the status,
  details, evidence, and a date-stamped **attempted** field (never `tested`). A template cannot
  render a failed test as a verification by omission.
- **`SKIPPED` attaches nothing** (never executed — distinct from ERROR per the harness's own
  `models.py`): attaching an attempted date for a test that never ran would be the mirror of the
  defect this fixes. Surfaced in the merge's output line.
- **Any off-enum status normalises to UNKNOWN** (the harness's own `VALID_STATUSES` as the
  allowlist — a non-string, a lowercase "confirmed", a newline-bearing string cannot leak into
  the externally-facing banner).
- **The disclosure header composes**: the Stage-2 stamp stays, the dynamic outcome adds as a
  second line — never replaces (the round-1 early-returns dropped the Stage-2 confirmation from
  a harness-errored finding, a #210/#283 regression, caught by the round-2 review).
- Both templates branch (the summary's priority-ordered Verified column; the row template
  enumerates all four values; the disclosure names the failure; the Steps line keeps
  [REQUIRES DYNAMIC TESTING] for an attempted test); the summary compact passes the attempted
  block (the e2e-caught gap — without it the LLM rendered the failed tests "static").
- `#414`'s identity gate unchanged (runs first; refused/abstain attach nothing).

## How it was checked

The **real-binary e2e** (`openant report -f summary` over a real scan dir whose
`dynamic_test_results.json` carries the issue's three statuses) — the post-fix render:

- ERROR → `dynamic test failed (ERROR)`
- NOT_REPRODUCED → `dynamic test failed (NOT_REPRODUCED)`
- CONFIRMED → `dynamic`

10 tests (RED 5 on pristine) and the suites/oracles all green. # proc-ok

Fixes #319
