### PR TITLE
feat: first-class Ollama provider adapter — fully-local SAST, completed per the #346 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ Things on the list, in no particular order:
 
 - **More provider adapters.** vLLM, Cohere, Mistral, Groq, Azure OpenAI — each is a small Python adapter recipe (plus a few Go wizard/probe touch-points if you want it offered by `openant setup llm`) per the contributor guide. Lower the barrier to local / on-prem inference. (Local inference via Ollama shipped in this release — [`OLLAMA.md`](libs/openant-core/utilities/llm/providers/OLLAMA.md).)
 - **Subscription-based auth.** ChatGPT / Codex, Claude Pro / Max, and Gemini Advanced subscriptions don't currently grant API quota — users have to maintain a separate API-tier key per provider. OAuth-based adapters that ride the consumer subscription would close that gap.
-- **Cross-provider tool-call quirks.** All three shipped adapters support tool calling, but the long tail (parallel tool calls, strict-mode schema enforcement, retry semantics on partial JSON) behaves differently per provider. Real-world scans surface these — PRs welcome.
+- **Cross-provider tool-call quirks.** All the shipped adapters support tool calling, but the long tail (parallel tool calls, strict-mode schema enforcement, retry semantics on partial JSON) behaves differently per provider. Real-world scans surface these — PRs welcome.
 - **More languages.** The supported-languages list above is current coverage. Java and C# come up frequently.
 - **Hosted scan service.** Knostic offers free scans for OSS projects today via the form linked above; a self-serve API for trusted partners is a future possibility.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Wizard defaults reflect the project's per-phase recommendations (stronger reason
 | `openrouter` | [openrouter.ai](https://openrouter.ai/settings/keys) | Gateway to many providers with one key and one prepaid balance (also reads `OPENROUTER_API_KEY`). Model IDs are `vendor/model` slugs (`anthropic/claude-sonnet-4.6`, `openai/gpt-4o-mini`, ...) — browse them at [openrouter.ai/models](https://openrouter.ai/models). Offered by `openant setup llm` (leave the base URL blank for the OpenRouter default) — full guide: [`utilities/llm/providers/OPENROUTER.md`](libs/openant-core/utilities/llm/providers/OPENROUTER.md). |
 | `ollama` | — (local server) | Local models via [Ollama](https://ollama.com). No `api_key`: leave it blank (a placeholder is sent automatically); base URL defaults to `http://localhost:11434/v1`. Models must be pulled first (`ollama pull <model>`); model IDs are exactly what `ollama list` shows. Local inference is free — $0 cost reporting. Offered by `openant setup llm` — full guide: [`utilities/llm/providers/OLLAMA.md`](libs/openant-core/utilities/llm/providers/OLLAMA.md). |
 
-All five support tool calling, so any of them can drive the `enhance` and `verify` phases that use the agentic tool-use loop. For Ollama, pick a tools-capable model for those phases — very small local models may not handle tool calls reliably.
+All of them support tool calling, so any of them can drive the `enhance` and `verify` phases that use the agentic tool-use loop. For Ollama, pick a tools-capable model for those phases — very small local models may not handle tool calls reliably.
 
 #### Quick path for Anthropic-only setups
 

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ Wizard defaults reflect the project's per-phase recommendations (stronger reason
 | `google` | [aistudio.google.com](https://aistudio.google.com/apikey) | NOT included in Gemini Advanced — separate billing. |
 | `bedrock` | — (AWS credential chain) | Claude on AWS Bedrock. No `api_key`: credentials come from `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` env vars or a `~/.aws` profile, region from `AWS_REGION`. Model IDs are inference profiles (`us.anthropic.claude-sonnet-4-6`, `global.anthropic.claude-haiku-4-5-20251001-v1:0`, ...) — enable them under "Model access" in the Bedrock console and list them with `aws bedrock list-inference-profiles`. Offered by `openant setup llm` (leave the API key blank — AWS credential chain, probe skipped) — full guide: [`utilities/llm/providers/BEDROCK.md`](libs/openant-core/utilities/llm/providers/BEDROCK.md). |
 | `openrouter` | [openrouter.ai](https://openrouter.ai/settings/keys) | Gateway to many providers with one key and one prepaid balance (also reads `OPENROUTER_API_KEY`). Model IDs are `vendor/model` slugs (`anthropic/claude-sonnet-4.6`, `openai/gpt-4o-mini`, ...) — browse them at [openrouter.ai/models](https://openrouter.ai/models). Offered by `openant setup llm` (leave the base URL blank for the OpenRouter default) — full guide: [`utilities/llm/providers/OPENROUTER.md`](libs/openant-core/utilities/llm/providers/OPENROUTER.md). |
+| `ollama` | — (local server) | Local models via [Ollama](https://ollama.com). No `api_key`: leave it blank (a placeholder is sent automatically); base URL defaults to `http://localhost:11434/v1`. Models must be pulled first (`ollama pull <model>`); model IDs are exactly what `ollama list` shows. Local inference is free — $0 cost reporting. Offered by `openant setup llm` — full guide: [`utilities/llm/providers/OLLAMA.md`](libs/openant-core/utilities/llm/providers/OLLAMA.md). |
 
-All four support tool calling, so any of them can drive the `enhance` and `verify` phases that use the agentic tool-use loop.
+All five support tool calling, so any of them can drive the `enhance` and `verify` phases that use the agentic tool-use loop. For Ollama, pick a tools-capable model for those phases — very small local models may not handle tool calls reliably.
 
 #### Quick path for Anthropic-only setups
 
@@ -286,7 +287,7 @@ openant project switch <org/repo> # switch active project
 
 Things on the list, in no particular order:
 
-- **More provider adapters.** Ollama (local models), vLLM, Cohere, Mistral, Groq, Azure OpenAI — each is a small Python adapter recipe (plus a few Go wizard/probe touch-points if you want it offered by `openant setup llm`) per the contributor guide. Lower the barrier to local / on-prem inference.
+- **More provider adapters.** vLLM, Cohere, Mistral, Groq, Azure OpenAI — each is a small Python adapter recipe (plus a few Go wizard/probe touch-points if you want it offered by `openant setup llm`) per the contributor guide. Lower the barrier to local / on-prem inference. (Local inference via Ollama shipped in this release — [`OLLAMA.md`](libs/openant-core/utilities/llm/providers/OLLAMA.md).)
 - **Subscription-based auth.** ChatGPT / Codex, Claude Pro / Max, and Gemini Advanced subscriptions don't currently grant API quota — users have to maintain a separate API-tier key per provider. OAuth-based adapters that ride the consumer subscription would close that gap.
 - **Cross-provider tool-call quirks.** All three shipped adapters support tool calling, but the long tail (parallel tool calls, strict-mode schema enforcement, retry semantics on partial JSON) behaves differently per provider. Real-world scans surface these — PRs welcome.
 - **More languages.** The supported-languages list above is current coverage. Java and C# come up frequently.

--- a/apps/openant-cli/cmd/llm_probe.go
+++ b/apps/openant-cli/cmd/llm_probe.go
@@ -19,9 +19,14 @@ var anthropicAPIURL = "https://api.anthropic.com/v1/messages"
 // show the user a tailored message ("bad key" vs "model not found" vs
 // "couldn't reach the endpoint") without re-parsing the HTTP body.
 type AnthropicProbeError struct {
-	Kind    string // "auth", "model_not_found", "network", "other"
+	Kind    string // "auth", "model_not_found", "network", "timeout", "other"
 	Status  int    // HTTP status code (0 if no response)
 	Message string // user-facing description
+	// Body is the response body (truncated) — captured so provider-specific
+	// wrappers can discriminate shapes the status code alone cannot (the
+	// Ollama not-pulled 404 vs a base_url-misconfig 404). Empty when the
+	// response had no body.
+	Body string
 }
 
 func (e *AnthropicProbeError) Error() string {

--- a/apps/openant-cli/cmd/llm_probe_openai.go
+++ b/apps/openant-cli/cmd/llm_probe_openai.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 )
@@ -33,13 +36,13 @@ func probeOpenAI(apiKey, baseURL, model string) error {
 }
 
 // openrouterAPIBase is the default OpenRouter base URL — it already includes
-// the ``/v1`` segment (matching the Python adapter's ``_DEFAULT_BASE_URL`` and
+// the “/v1“ segment (matching the Python adapter's “_DEFAULT_BASE_URL“ and
 // the openai SDK's path handling). Package var so tests can point at httptest.
 var openrouterAPIBase = "https://openrouter.ai/api/v1"
 
 // probeOpenRouter verifies an OpenRouter key+model. OpenRouter speaks the
-// OpenAI chat-completions wire API, but its base_url already carries ``/v1``,
-// so we append only ``/chat/completions`` (NOT ``/v1/chat/completions`` like
+// OpenAI chat-completions wire API, but its base_url already carries “/v1“,
+// so we append only “/chat/completions“ (NOT “/v1/chat/completions“ like
 // probeOpenAI) and default a BLANK base_url to OpenRouter — not api.openai.com,
 // which probeOpenAI would hit, failing the probe with an OpenRouter key.
 func probeOpenRouter(apiKey, baseURL, model string) error {
@@ -51,13 +54,17 @@ func probeOpenRouter(apiKey, baseURL, model string) error {
 }
 
 // ollamaAPIBase is the default Ollama base URL — it already includes the
-// ``/v1`` segment (matching the Python adapter's ``_DEFAULT_BASE_URL``).
+// “/v1“ segment (matching the Python adapter's “_DEFAULT_BASE_URL“).
 // Package var so tests can point at httptest.
 var ollamaAPIBase = "http://localhost:11434/v1"
 
+// probeClientTimeout bounds each wizard probe request — package var so the
+// timeout test can shrink it (the established openaiAPIURL pattern).
+var probeClientTimeout = 15 * time.Second
+
 // probeOllama verifies an Ollama model is pulled and serving. Ollama speaks
 // the OpenAI chat-completions wire API on its own base (already carrying
-// ``/v1``, like OpenRouter) and ignores Authorization headers — stock local
+// “/v1“, like OpenRouter) and ignores Authorization headers — stock local
 // Ollama needs no key, so a blank key probes with the same placeholder the
 // Python adapter sends. A key-checking remote gateway still works: any
 // non-blank key is forwarded verbatim.
@@ -73,11 +80,29 @@ func probeOllama(apiKey, baseURL, model string) error {
 	if err == nil {
 		return nil
 	}
-	// Rewrite the generic 404 wording into the fixable `ollama pull` hint.
+	// Rewrite the generic 404 wording into the fixable `ollama pull` hint —
+	// GATED on the captured body (review should-fix #346): only a 404 whose
+	// body actually says the model is unpulled gets the pull advice; a
+	// marker-less 404 is almost always a base_url misconfiguration (the
+	// endpoint path is wrong — e.g. missing /v1) and gets that hint instead.
 	if pe, ok := err.(*AnthropicProbeError); ok && pe.Kind == "model_not_found" {
-		pe.Message = fmt.Sprintf("model %q not pulled into Ollama — run `ollama pull %s` (or `ollama list` to see what's installed)", model, model)
+		lowered := strings.ToLower(pe.Body)
+		if strings.Contains(lowered, "not found") && strings.Contains(lowered, "pull") {
+			pe.Message = fmt.Sprintf("model %q not pulled into Ollama — run `ollama pull %s` (or `ollama list` to see what's installed)", model, model)
+		} else {
+			pe.Message = fmt.Sprintf("HTTP 404 from Ollama (body: %q) but it does not say the model is unpulled — check the base_url: Ollama's OpenAI-compatible API is at http://<host>:11434/v1 (the /v1 segment included)", truncateBody(pe.Body))
+		}
 	}
 	return err
+}
+
+// truncateBody keeps an error message readable — a 4096-byte capture is
+// diagnostic, not a wall.
+func truncateBody(b string) string {
+	if len(b) > 200 {
+		return b[:200] + "..."
+	}
+	return b
 }
 
 // probeChatCompletionsAt POSTs a minimal 1-token request to a full
@@ -104,9 +129,18 @@ func probeChatCompletionsAt(apiKey, endpoint, model string) error {
 	req.Header.Set("authorization", "Bearer "+apiKey)
 	req.Header.Set("content-type", "application/json")
 
-	client := &http.Client{Timeout: 15 * time.Second}
+	client := &http.Client{Timeout: probeClientTimeout}
 	resp, err := client.Do(req)
 	if err != nil {
+		// Review should-fix (#346): a probe TIMEOUT is not an unreachable
+		// server — a cold 15GB+ model's first load takes minutes, and the
+		// wizard said "could not reach" while Ollama was busy loading.
+		if os.IsTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
+			return &AnthropicProbeError{
+				Kind:    "timeout",
+				Message: fmt.Sprintf("probe to %s timed out after %s: if the model was cold, its first load can take minutes — retry the probe (or pre-warm it with a tiny request); if it still times out, check that %s is reachable", endpoint, probeClientTimeout, endpoint),
+			}
+		}
 		return &AnthropicProbeError{
 			Kind:    "network",
 			Message: fmt.Sprintf("could not reach %s: %s", endpoint, err),
@@ -124,9 +158,16 @@ func probeChatCompletionsAt(apiKey, endpoint, model string) error {
 			Message: fmt.Sprintf("authentication rejected (HTTP %d) — double-check the API key", resp.StatusCode),
 		}
 	case http.StatusNotFound:
+		// Review should-fix (#346): the classification stays model_not_found
+		// for the whole OpenAI-wire family (the OpenAI contract test pins it;
+		// OpenAI's own 404 bodies never carry pull markers) — but the BODY is
+		// captured into the error so a provider wrapper (probeOllama) can
+		// discriminate the genuine not-pulled shape from a base_url misconfig.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return &AnthropicProbeError{
 			Kind:    "model_not_found",
 			Status:  resp.StatusCode,
+			Body:    string(body),
 			Message: fmt.Sprintf("model %q not found at %s (HTTP 404) — check the model ID at the provider", model, endpoint),
 		}
 	default:

--- a/apps/openant-cli/cmd/llm_probe_openai.go
+++ b/apps/openant-cli/cmd/llm_probe_openai.go
@@ -92,7 +92,7 @@ func probeOllama(apiKey, baseURL, model string) error {
 	// model load (15GB+ models take minutes on first inference) — layer the
 	// specific advice on the shared neutral timeout.
 	if pe, ok := err.(*AnthropicProbeError); ok && pe.Kind == "timeout" {
-		pe.Message = pe.Message + " — if the model was cold, its first load can take minutes: retry the probe (or pre-warm it with a tiny request)"
+		pe.Message = pe.Message + " — if the model was cold, its first load can take minutes; pre-warm it with a tiny request"
 	}
 	// Rewrite the generic 404 wording into the fixable `ollama pull` hint —
 	// GATED on the captured body (review should-fix #346): only a 404 whose

--- a/apps/openant-cli/cmd/llm_probe_openai.go
+++ b/apps/openant-cli/cmd/llm_probe_openai.go
@@ -58,6 +58,14 @@ func probeOpenRouter(apiKey, baseURL, model string) error {
 // Package var so tests can point at httptest.
 var ollamaAPIBase = "http://localhost:11434/v1"
 
+// The canonical not-pulled body markers — MUST mirror the Python
+// adapter's _NOT_PULLED_MARKERS in utilities/llm/providers/ollama.py
+// (hunt r1: the two halves of the same live-verified gate had drifted).
+const (
+	notPulledMarkerA = "not found"
+	notPulledMarkerB = "try pulling it"
+)
+
 // probeClientTimeout bounds each wizard probe request — package var so the
 // timeout test can shrink it (the established openaiAPIURL pattern).
 var probeClientTimeout = 15 * time.Second
@@ -80,6 +88,12 @@ func probeOllama(apiKey, baseURL, model string) error {
 	if err == nil {
 		return nil
 	}
+	// hunt r1 (sonnet): a timeout on the OLLAMA probe is most often a cold
+	// model load (15GB+ models take minutes on first inference) — layer the
+	// specific advice on the shared neutral timeout.
+	if pe, ok := err.(*AnthropicProbeError); ok && pe.Kind == "timeout" {
+		pe.Message = pe.Message + " — if the model was cold, its first load can take minutes: retry the probe (or pre-warm it with a tiny request)"
+	}
 	// Rewrite the generic 404 wording into the fixable `ollama pull` hint —
 	// GATED on the captured body (review should-fix #346): only a 404 whose
 	// body actually says the model is unpulled gets the pull advice; a
@@ -87,7 +101,10 @@ func probeOllama(apiKey, baseURL, model string) error {
 	// endpoint path is wrong — e.g. missing /v1) and gets that hint instead.
 	if pe, ok := err.(*AnthropicProbeError); ok && pe.Kind == "model_not_found" {
 		lowered := strings.ToLower(pe.Body)
-		if strings.Contains(lowered, "not found") && strings.Contains(lowered, "pull") {
+		// hunt r1 (sonnet): ONE canonical marker set, mirroring the Python
+		// adapter's _NOT_PULLED_MARKERS ("not found", "try pulling it") —
+		// two hand-copied variants of the same live-verified gate drift.
+		if strings.Contains(lowered, notPulledMarkerA) && strings.Contains(lowered, notPulledMarkerB) {
 			pe.Message = fmt.Sprintf("model %q not pulled into Ollama — run `ollama pull %s` (or `ollama list` to see what's installed)", model, model)
 		} else {
 			pe.Message = fmt.Sprintf("HTTP 404 from Ollama (body: %q) but it does not say the model is unpulled — check the base_url: Ollama's OpenAI-compatible API is at http://<host>:11434/v1 (the /v1 segment included)", truncateBody(pe.Body))
@@ -136,9 +153,13 @@ func probeChatCompletionsAt(apiKey, endpoint, model string) error {
 		// server — a cold 15GB+ model's first load takes minutes, and the
 		// wizard said "could not reach" while Ollama was busy loading.
 		if os.IsTimeout(err) || errors.Is(err, context.DeadlineExceeded) {
+			// hunt r1 (sonnet): this probe is SHARED by the OpenAI and
+			// OpenRouter wrappers — the shared message stays provider-
+			// NEUTRAL; the Ollama wrapper layers its cold-load advice on
+			// this kind below.
 			return &AnthropicProbeError{
 				Kind:    "timeout",
-				Message: fmt.Sprintf("probe to %s timed out after %s: if the model was cold, its first load can take minutes — retry the probe (or pre-warm it with a tiny request); if it still times out, check that %s is reachable", endpoint, probeClientTimeout, endpoint),
+				Message: fmt.Sprintf("probe to %s timed out after %s — the provider may be slow to respond; retry, and check that %s is reachable", endpoint, probeClientTimeout, endpoint),
 			}
 		}
 		return &AnthropicProbeError{

--- a/apps/openant-cli/cmd/llm_probe_openai.go
+++ b/apps/openant-cli/cmd/llm_probe_openai.go
@@ -50,6 +50,36 @@ func probeOpenRouter(apiKey, baseURL, model string) error {
 	return probeChatCompletionsAt(apiKey, base+"/chat/completions", model)
 }
 
+// ollamaAPIBase is the default Ollama base URL — it already includes the
+// ``/v1`` segment (matching the Python adapter's ``_DEFAULT_BASE_URL``).
+// Package var so tests can point at httptest.
+var ollamaAPIBase = "http://localhost:11434/v1"
+
+// probeOllama verifies an Ollama model is pulled and serving. Ollama speaks
+// the OpenAI chat-completions wire API on its own base (already carrying
+// ``/v1``, like OpenRouter) and ignores Authorization headers — stock local
+// Ollama needs no key, so a blank key probes with the same placeholder the
+// Python adapter sends. A key-checking remote gateway still works: any
+// non-blank key is forwarded verbatim.
+func probeOllama(apiKey, baseURL, model string) error {
+	base := strings.TrimRight(baseURL, "/")
+	if base == "" {
+		base = ollamaAPIBase
+	}
+	if apiKey == "" {
+		apiKey = "ollama" // placeholder; matches utilities/llm/providers/ollama.py
+	}
+	err := probeChatCompletionsAt(apiKey, base+"/chat/completions", model)
+	if err == nil {
+		return nil
+	}
+	// Rewrite the generic 404 wording into the fixable `ollama pull` hint.
+	if pe, ok := err.(*AnthropicProbeError); ok && pe.Kind == "model_not_found" {
+		pe.Message = fmt.Sprintf("model %q not pulled into Ollama — run `ollama pull %s` (or `ollama list` to see what's installed)", model, model)
+	}
+	return err
+}
+
 // probeChatCompletionsAt POSTs a minimal 1-token request to a full
 // chat-completions endpoint and maps the HTTP status to a probe error. Shared
 // by the OpenAI and OpenRouter probes (both speak the OpenAI wire API).

--- a/apps/openant-cli/cmd/llm_probe_openai.go
+++ b/apps/openant-cli/cmd/llm_probe_openai.go
@@ -88,6 +88,12 @@ func probeOllama(apiKey, baseURL, model string) error {
 	if err == nil {
 		return nil
 	}
+	// hunt r3 (sonnet): parity with the Python adapter — a refused
+	// connection on localhost is almost always a stopped daemon, not a
+	// network fault; layer the same "start it with `ollama serve`" hint.
+	if pe, ok := err.(*AnthropicProbeError); ok && pe.Kind == "network" {
+		pe.Message = pe.Message + " — start the server with `ollama serve` and retry"
+	}
 	// hunt r1 (sonnet): a timeout on the OLLAMA probe is most often a cold
 	// model load (15GB+ models take minutes on first inference) — layer the
 	// specific advice on the shared neutral timeout.

--- a/apps/openant-cli/cmd/llm_probe_test.go
+++ b/apps/openant-cli/cmd/llm_probe_test.go
@@ -403,3 +403,24 @@ func TestProbeChatCompletionsAt_TimeoutIsItsOwnKind(t *testing.T) {
 		t.Errorf("a probe timeout must be its own kind (cold-load hint), got %q", pe.Kind)
 	}
 }
+
+// hunt r4 (sonnet): the round-3 network-kind layering — a refused connection
+// must carry the "ollama serve" hint (parity with the Python adapter).
+func TestProbeOllama_NetworkErrorGetsServeHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		panic("never reached — the connection is refused below")
+	}))
+	url := server.URL
+	server.Close() // refuse connections
+	err := probeOllama("", url, "x")
+	pe, ok := asProbeError(err)
+	if !ok {
+		t.Fatalf("expected AnthropicProbeError, got %T", err)
+	}
+	if pe.Kind != "network" {
+		t.Errorf("expected network kind, got %q", pe.Kind)
+	}
+	if !strings.Contains(pe.Message, "ollama serve") {
+		t.Errorf("a refused connection must carry the serve hint, got: %s", pe.Message)
+	}
+}

--- a/apps/openant-cli/cmd/llm_probe_test.go
+++ b/apps/openant-cli/cmd/llm_probe_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -339,5 +340,66 @@ func TestProbeOllama_UnpulledModel404GetsPullHint(t *testing.T) {
 		t.Fatalf("kind = %v, want model_not_found; err = %v", err, err)
 	} else if !strings.Contains(pe.Message, "ollama pull") {
 		t.Errorf("message = %q, want an `ollama pull` hint", pe.Message)
+	}
+}
+
+// Review fixes (#346): the Ollama 404 gate discriminates the genuine
+// not-pulled body from a base_url misconfiguration, and a probe timeout
+// is a cold-load hint, not "could not reach".
+func TestProbeOllama_GatesPullHintOnBody(t *testing.T) {
+	// genuine not-pulled: Ollama's live body shape
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"model 'x' not found, try pulling it first"}}`))
+	}))
+	defer server.Close()
+	err := probeOllama("", server.URL, "x")
+	pe, ok := asProbeError(err)
+	if !ok {
+		t.Fatalf("expected AnthropicProbeError, got %T", err)
+	}
+	if !strings.Contains(pe.Message, "ollama pull") {
+		t.Errorf("genuine not-pulled 404 must keep the pull hint, got: %s", pe.Message)
+	}
+
+	// marker-less 404 (a base_url misconfig: wrong path, empty/foreign body)
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`404 page not found`))
+	}))
+	defer server2.Close()
+	err2 := probeOllama("", server2.URL, "x")
+	pe2, ok2 := asProbeError(err2)
+	if !ok2 {
+		t.Fatalf("expected AnthropicProbeError, got %T", err2)
+	}
+	if !strings.Contains(pe2.Message, "check the base_url") {
+		t.Errorf("a marker-less 404 is a base_url misconfig, not a pull case, got: %s", pe2.Message)
+	}
+}
+
+func TestProbeChatCompletionsAt_TimeoutIsItsOwnKind(t *testing.T) {
+	// A server that never answers: the probe's 15s client timeout is long,
+	// so bind a shorter one by making the handler sleep past a reduced
+	// client timeout — reuse the package var if the timeout is exported
+	// elsewhere; here we assert the classification on a hanging endpoint
+	// with the client's own deadline overridden via the context path used
+	// by the wizard probe. Simplest: hang the handler longer than the probe
+	// budget is not feasible at 15s in a unit test; assert the KIND mapping
+	// via the http.Client error shape instead.
+	orig := probeClientTimeout
+	defer func() { probeClientTimeout = orig }()
+	probeClientTimeout = 100 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(500 * time.Millisecond)
+	}))
+	defer server.Close()
+	err := probeChatCompletionsAt("k", server.URL, "m")
+	pe, ok := asProbeError(err)
+	if !ok {
+		t.Fatalf("expected AnthropicProbeError, got %T", err)
+	}
+	if pe.Kind != "timeout" {
+		t.Errorf("a probe timeout must be its own kind (cold-load hint), got %q", pe.Kind)
 	}
 }

--- a/apps/openant-cli/cmd/llm_probe_test.go
+++ b/apps/openant-cli/cmd/llm_probe_test.go
@@ -287,3 +287,57 @@ func TestProbeOpenAI_ReasoningModelsUseMaxCompletionTokens(t *testing.T) {
 		})
 	}
 }
+
+func TestProbeOllama_BlankKeyUsesPlaceholderAndDefaultsToLocalhost(t *testing.T) {
+	var gotPath, gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// A blank key must probe with the same placeholder the Python adapter
+	// sends (stock Ollama ignores it); a blank base_url must default to the
+	// local Ollama endpoint (overridden to the test server here), appending
+	// /chat/completions to the /v1 base — no double /v1.
+	orig := ollamaAPIBase
+	defer func() { ollamaAPIBase = orig }()
+	ollamaAPIBase = server.URL + "/v1"
+
+	if err := probeOllama("", "", "qwen3.8:27b"); err != nil {
+		t.Fatalf("expected nil error for 200, got: %v", err)
+	}
+	if gotPath != "/v1/chat/completions" {
+		t.Errorf("path = %q, want '/v1/chat/completions'", gotPath)
+	}
+	if gotAuth != "Bearer ollama" {
+		t.Errorf("authorization = %q, want 'Bearer ollama' (placeholder)", gotAuth)
+	}
+
+	// A non-blank key (key-checking remote gateway) is forwarded verbatim.
+	if err := probeOllama("gateway-secret", server.URL+"/v1", "qwen3.8:27b"); err != nil {
+		t.Fatalf("expected nil error for 200, got: %v", err)
+	}
+	if gotAuth != "Bearer gateway-secret" {
+		t.Errorf("authorization = %q, want 'Bearer gateway-secret'", gotAuth)
+	}
+}
+
+func TestProbeOllama_UnpulledModel404GetsPullHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":{"message":"model 'ghost' not found, try pulling it first"}}`))
+	}))
+	defer server.Close()
+
+	err := probeOllama("ollama", server.URL+"/v1", "ghost")
+	if err == nil {
+		t.Fatal("expected an error for 404, got nil")
+	}
+	if pe, ok := err.(*AnthropicProbeError); !ok || pe.Kind != "model_not_found" {
+		t.Fatalf("kind = %v, want model_not_found; err = %v", err, err)
+	} else if !strings.Contains(pe.Message, "ollama pull") {
+		t.Errorf("message = %q, want an `ollama pull` hint", pe.Message)
+	}
+}

--- a/apps/openant-cli/cmd/setup.go
+++ b/apps/openant-cli/cmd/setup.go
@@ -54,7 +54,7 @@ var setupLLMPhases = []phaseSpec{
 // completed wizard config runs without further changes. The wizard
 // probes each provider+model pair against the real provider API
 // before saving, so a typo'd key or model ID surfaces immediately.
-var supportedProviderTypes = []string{"anthropic", "openai", "google", "bedrock", "openrouter"}
+var supportedProviderTypes = []string{"anthropic", "openai", "google", "bedrock", "openrouter", "ollama"}
 
 // apiKeyHints maps a provider type to a one-line reminder shown right
 // before the wizard asks for the API key. Used to head off the common
@@ -68,6 +68,7 @@ var apiKeyHints = map[string]string{
 	"openai":     "Note: ChatGPT/Codex subscriptions do NOT include API access — get an API key at platform.openai.com (separate billing).",
 	"bedrock":    "Note: Bedrock uses the AWS credential chain, not an API key — leave the key BLANK and export AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY (+ AWS_REGION).",
 	"openrouter": "Note: create an OpenRouter API key at openrouter.ai/keys; the base URL defaults to https://openrouter.ai/api/v1.",
+	"ollama":     "Note: Ollama runs locally and needs NO API key — leave the key BLANK (a placeholder is used automatically). Base URL defaults to http://localhost:11434/v1; models must be pulled first (`ollama pull <model>`).",
 }
 
 type phaseSpec struct {
@@ -508,12 +509,14 @@ func probeAllPhases(
 			return fmt.Errorf("internal: provider %q referenced by phase %q but not collected", ref.Provider, phase)
 		}
 		fmt.Fprintf(os.Stderr, "  %s/%s ... ", ref.Provider, ref.Model)
-		if prov.APIKey == "" {
+		if prov.APIKey == "" && prov.Type != "ollama" {
 			// Blank key means "read from the environment" (the wizard
 			// offers this and WriteLLMConfig persists the env-read shape).
 			// The Go probe can't read the provider's env var, so skip it;
 			// Python's registry.validate() surfaces a missing/blank env
-			// key at scan start instead.
+			// key at scan start instead. Ollama is exempt: it needs no
+			// key at all (the adapter sends a placeholder), so its probe
+			// always runs.
 			fmt.Fprintln(os.Stderr, "SKIPPED (key from environment)")
 			continue
 		}
@@ -537,6 +540,10 @@ func probeAllPhases(
 			// probeOpenRouter defaults a blank base_url to openrouter.ai/api/v1
 			// (NOT api.openai.com) and appends /chat/completions correctly.
 			probeErr = probeOpenRouter(prov.APIKey, prov.BaseURL, ref.Model)
+		case "ollama":
+			// Ollama speaks the OpenAI wire API on localhost:11434/v1 and does
+			// not check keys — probe with the same placeholder the adapter uses.
+			probeErr = probeOllama(prov.APIKey, prov.BaseURL, ref.Model)
 		default:
 			fmt.Fprintln(os.Stderr, "SKIPPED")
 			return fmt.Errorf("provider type %q has no probe implementation yet", prov.Type)

--- a/apps/openant-cli/cmd/setup.go
+++ b/apps/openant-cli/cmd/setup.go
@@ -48,8 +48,9 @@ var setupLLMPhases = []phaseSpec{
 	{name: "report", short: "Disclosure + summary + remediation generation."},
 }
 
-// Provider adapter types the wizard offers in the picker. All three
-// ship with a Python adapter (anthropic, openai, google) — see
+// Provider adapter types the wizard offers in the picker. All of them
+// ship with a Python adapter (anthropic, openai, google, bedrock,
+// openrouter, ollama) — see
 // “libs/openant-core/utilities/llm/providers/__init__.py“ — so a
 // completed wizard config runs without further changes. The wizard
 // probes each provider+model pair against the real provider API

--- a/apps/openant-cli/internal/models/models_test.go
+++ b/apps/openant-cli/internal/models/models_test.go
@@ -7,7 +7,9 @@ import "testing"
 // old hardcoded maps. They never touch a provider API (the interactive wizard's
 // probeAnthropic/etc. issue real billed requests; none of that runs here).
 
-var testProviderTypes = []string{"anthropic", "openai", "google"}
+// Review blocker (#346): ollama was missing — every (provider, phase) the
+// wizard can prefill must resolve, including the local provider.
+var testProviderTypes = []string{"anthropic", "openai", "google", "ollama"}
 
 // Every (provider, phase) the wizard can prefill must resolve to a NON-EMPTY id
 // whose registry record is "current" — never retired/unknown, which is exactly

--- a/apps/openant-cli/internal/models/registry.go
+++ b/apps/openant-cli/internal/models/registry.go
@@ -62,6 +62,10 @@ var tierModel = map[string]map[string]string{
 	"anthropic": {"strong": "claude-opus-4-8", "light": "claude-sonnet-4-6"},
 	"openai":    {"strong": "gpt-4o", "light": "gpt-4o-mini"},
 	"google":    {"strong": "gemini-1.5-pro", "light": "gemini-2.0-flash"},
+	// Local models: free, so tier maps to capability, not cost. Qwen3.8
+	// (27B) is the current-gen local default; qwen3.8 ships 27b only —
+	// modest-hardware users can pick a smaller model per-phase.
+	"ollama": {"strong": "qwen3.8:27b", "light": "qwen3.8:27b"},
 }
 
 // FindConfig locates config/models.json by walking up from the executable path

--- a/apps/openant-cli/internal/models/registry.go
+++ b/apps/openant-cli/internal/models/registry.go
@@ -63,9 +63,11 @@ var tierModel = map[string]map[string]string{
 	"openai":    {"strong": "gpt-4o", "light": "gpt-4o-mini"},
 	"google":    {"strong": "gemini-1.5-pro", "light": "gemini-2.0-flash"},
 	// Local models: free, so tier maps to capability, not cost. Qwen3.8
-	// (27B) is the current-gen local default; qwen3.8 ships 27b only —
-	// modest-hardware users can pick a smaller model per-phase.
-	"ollama": {"strong": "qwen3.8:27b", "light": "qwen3.8:27b"},
+	// (27B) is the current-gen local default; qwen3.5:9b (6.6GB) is the
+	// modest-hardware light tier — the models.json entry ships it for
+	// exactly this (hunt r3: both tiers mapping to the 27B made the
+	// wizard's per-phase tiering a no-op for Ollama).
+	"ollama": {"strong": "qwen3.8:27b", "light": "qwen3.5:9b"},
 }
 
 // FindConfig locates config/models.json by walking up from the executable path

--- a/config/models.json
+++ b/config/models.json
@@ -523,39 +523,6 @@
       },
       "source": "verified against the live OpenRouter catalogue (GET openrouter.ai/api/v1/models, 2026-09-01: google/gemini-3.7-flash $0.75/$3.75 per 1M) and Google's own pricing page, which agrees (#434)",
       "retrieved": "2026-09-01"
-    },
-    {
-      "id": "qwen3.8:27b",
-      "provider": "ollama",
-      "status": "current",
-      "price": {
-        "input": 0.0,
-        "output": 0.0
-      },
-      "source": "verified on ollama.com/library/qwen3.8 (18GB, 256K ctx); local inference is free — $0 by definition, not an unverified vendor price",
-      "retrieved": "2026-08-27"
-    },
-    {
-      "id": "qwen3.5:9b",
-      "provider": "ollama",
-      "status": "current",
-      "price": {
-        "input": 0.0,
-        "output": 0.0
-      },
-      "source": "modest-hardware alternative; verified on ollama.com/library/qwen3.5 (6.6GB); local inference is free — $0 by definition",
-      "retrieved": "2026-08-27"
-    },
-    {
-      "id": "mistral-small3.2:latest",
-      "provider": "ollama",
-      "status": "current",
-      "price": {
-        "input": 0.0,
-        "output": 0.0
-      },
-      "source": "verified live end-to-end: planted-vuln scan, both CWE-89 findings detected (2026-08-25); local inference is free — $0 by definition",
-      "retrieved": "2026-08-27"
     }
   ]
 }

--- a/config/models.json
+++ b/config/models.json
@@ -523,6 +523,39 @@
       },
       "source": "verified against the live OpenRouter catalogue (GET openrouter.ai/api/v1/models, 2026-09-01: google/gemini-3.7-flash $0.75/$3.75 per 1M) and Google's own pricing page, which agrees (#434)",
       "retrieved": "2026-09-01"
+    },
+    {
+      "id": "qwen3.8:27b",
+      "provider": "ollama",
+      "status": "current",
+      "price": {
+        "input": 0.0,
+        "output": 0.0
+      },
+      "source": "verified on ollama.com/library/qwen3.8 (18GB, 256K ctx); local inference is free — $0 by definition, not an unverified vendor price",
+      "retrieved": "2026-08-27"
+    },
+    {
+      "id": "qwen3.5:9b",
+      "provider": "ollama",
+      "status": "current",
+      "price": {
+        "input": 0.0,
+        "output": 0.0
+      },
+      "source": "modest-hardware alternative; verified on ollama.com/library/qwen3.5 (6.6GB); local inference is free — $0 by definition",
+      "retrieved": "2026-08-27"
+    },
+    {
+      "id": "mistral-small3.2:latest",
+      "provider": "ollama",
+      "status": "current",
+      "price": {
+        "input": 0.0,
+        "output": 0.0
+      },
+      "source": "verified live end-to-end: planted-vuln scan, both CWE-89 findings detected (2026-08-25); local inference is free — $0 by definition",
+      "retrieved": "2026-08-27"
     }
   ]
 }

--- a/libs/openant-core/core/model_registry.py
+++ b/libs/openant-core/core/model_registry.py
@@ -9,7 +9,7 @@ Python engine (here) and the Go CLI (``internal/models``), mirroring how
 shipped claim) plus ``source`` + ``retrieved`` (its provenance), so nothing
 asserts a provider fact without a receipt.
 
-Two invariants this module exists to hold:
+Three invariants this module exists to hold:
 
 * **A null price is NEVER a zero price.** ``pricing_map`` OMITS any record whose
   ``price`` is null (retired/unknown models). A null price must fall through to
@@ -22,6 +22,13 @@ Two invariants this module exists to hold:
   to an empty map, because an empty pricing map would price every model at \\$0.
   Unlike ``languages.json`` this file feeds no argparse ``choices``, so there is
   no ``--help`` path to keep alive — pricing is only ever needed for real work.
+* **Local providers price at an explicit, provenanced \\$0.** Providers whose
+  models run on the user's own hardware (``_LOCAL_PROVIDERS``) are exempt from
+  the positive-price rule — their \\$0 is free by definition, not an unverified
+  vendor quote. Their ``current`` models MUST still carry a non-null, explicit
+  ``{"input": 0, "output": 0}`` dict so they are INCLUDED in ``pricing_map``;
+  a null price would drop them onto the unknown-model warn path, which is
+  wrong for a known, deliberately-free provider.
 """
 
 from __future__ import annotations
@@ -40,7 +47,14 @@ from pathlib import Path
 _CONFIG_REL = Path("config") / "models.json"
 _SEARCH_LEVELS = 6
 _VALID_STATUS = frozenset({"current", "retired", "unknown"})
-_VALID_PROVIDERS = frozenset({"anthropic", "openai", "google", "bedrock", "openrouter"})
+_VALID_PROVIDERS = frozenset({"anthropic", "openai", "google", "bedrock", "openrouter", "ollama"})
+
+# Local-inference providers: models run on the user's own hardware, so $0 is a
+# truthful, verified fact — not an unverified vendor quote. The "current =>
+# positive price" invariant exists to stop cloud models silently pricing real
+# token spend at $0; it does not apply here. Local models must still carry an
+# explicit non-null zero dict (see pricing_map) so cost reporting stays defined.
+_LOCAL_PROVIDERS = frozenset({"ollama"})
 
 
 def _search_upward(start: Path) -> Path | None:

--- a/libs/openant-core/generate-context.report.json
+++ b/libs/openant-core/generate-context.report.json
@@ -1,0 +1,25 @@
+{
+  "step": "generate-context",
+  "status": "success",
+  "timestamp": "2026-09-03T13:58:14.192883Z",
+  "duration_seconds": 14.26,
+  "cost_usd": 0.010293,
+  "token_usage": {
+    "input_tokens": 1141,
+    "output_tokens": 458,
+    "total_tokens": 1599
+  },
+  "summary": {
+    "application_type": "web_app",
+    "confidence": 0.62,
+    "source": "llm"
+  },
+  "inputs": {
+    "repo_path": "/private/var/folders/hq/r08v642s63dcx3sd6h87grhr0000gn/T/opencode/openant-prs/fix346-tree/libs/openant-core/tests/fixtures/sample_python_repo",
+    "force": false
+  },
+  "outputs": {
+    "app_context_path": "/private/var/folders/hq/r08v642s63dcx3sd6h87grhr0000gn/T/opencode/openant-prs/fix346-tree/libs/openant-core/application_context.json"
+  },
+  "errors": []
+}

--- a/libs/openant-core/tests/_llm_factories/ollama.py
+++ b/libs/openant-core/tests/_llm_factories/ollama.py
@@ -1,0 +1,43 @@
+"""Scenario factory for the Ollama adapter contract tests.
+
+Ollama speaks OpenAI's Chat Completions wire format through the same
+``openai`` SDK, so the scripted fake-client behaviors are shared with
+the OpenAI factory — this module reuses its scenario handlers verbatim
+and only swaps the adapter under construction. What differs between
+Ollama and the other providers (no real API key, default localhost
+base_url, connection-refused → "ollama serve" hint, unpulled-model 404
+mapping, empty-completion-with-tools guard) is covered by the dedicated
+``tests/test_llm_ollama_adapter.py``.
+
+See ``tests/test_llm_adapter_contract.py`` for the scenario catalogue.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import openai
+
+from utilities.llm import LLMAdapter
+from utilities.llm.providers.ollama import OllamaAdapter
+
+from .openai import _SCENARIO_HANDLERS as SCENARIO_HANDLERS
+
+
+def make_adapter(scenario: str) -> LLMAdapter:
+    """Build an OllamaAdapter whose SDK is scripted for ``scenario``."""
+    if scenario not in SCENARIO_HANDLERS:
+        raise KeyError(f"Unknown scenario: {scenario!r}")
+
+    handler = SCENARIO_HANDLERS[scenario]
+
+    def side_effect(**kwargs: Any) -> Any:
+        return handler(kwargs)
+
+    fake_client = MagicMock(spec=openai.OpenAI)
+    fake_client.chat = MagicMock()
+    fake_client.chat.completions = MagicMock()
+    fake_client.chat.completions.create = MagicMock(side_effect=side_effect)
+
+    return OllamaAdapter(_client=fake_client)

--- a/libs/openant-core/tests/test_llm_adapter_contract.py
+++ b/libs/openant-core/tests/test_llm_adapter_contract.py
@@ -124,6 +124,12 @@ def _openrouter_factory():
     return make_adapter
 
 
+def _ollama_factory():
+    from tests._llm_factories.ollama import make_adapter
+
+    return make_adapter
+
+
 # Each row: (display_name, scenario_factory_callable)
 # Add a row when registering a new adapter.
 ADAPTERS: list[tuple[str, Callable[[str], LLMAdapter]]] = [
@@ -132,6 +138,7 @@ ADAPTERS: list[tuple[str, Callable[[str], LLMAdapter]]] = [
     ("google", _google_factory()),
     ("bedrock", _bedrock_factory()),
     ("openrouter", _openrouter_factory()),
+    ("ollama", _ollama_factory()),
 ]
 
 

--- a/libs/openant-core/tests/test_llm_ollama_adapter.py
+++ b/libs/openant-core/tests/test_llm_ollama_adapter.py
@@ -1,0 +1,306 @@
+"""Ollama-adapter-specific tests.
+
+The shared contract harness (``test_llm_adapter_contract.py``) covers
+behaviors every adapter must satisfy, and the request/response
+translation layer is the OpenAI adapter's (reused, covered by
+``test_llm_openai_adapter.py``). This file covers the bits that are
+specific to Ollama:
+
+* constructor plumbing — default localhost base_url, override,
+  placeholder API key (never a real credential, never an env fallback)
+* unpulled-model 404 mapped to LLMNotFoundError with an
+  ``ollama pull`` hint (live-verified Ollama body)
+* server-down connection error mapped to LLMConnectionError with an
+  ``ollama serve`` hint
+* empty completions (tool-incapable models) raised as LLMResponseError
+  via the shared translator's guard — fail loud, never a clean pass
+* 429 reports to the global rate limiter
+
+These tests stub the SDK boundary so nothing hits the network.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import httpx
+import openai
+import pytest
+
+from utilities.llm import (
+    LLMConnectionError,
+    LLMNotFoundError,
+    LLMRateLimitError,
+    LLMResponseError,
+    Message,
+    TextBlock,
+    ToolDef,
+)
+from utilities.llm.providers.ollama import OllamaAdapter
+from utilities.rate_limiter import get_rate_limiter, reset_rate_limiter
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    reset_rate_limiter()
+    yield
+    reset_rate_limiter()
+
+
+def _ok_response(*, text="hi", finish_reason="stop", tool_calls=None):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(
+            message=SimpleNamespace(content=text, tool_calls=tool_calls),
+            finish_reason=finish_reason,
+        )],
+        usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+    )
+
+
+def _stub_adapter(side_effect):
+    client = MagicMock(spec=openai.OpenAI)
+    client.chat = MagicMock()
+    client.chat.completions = MagicMock()
+    client.chat.completions.create = MagicMock(side_effect=side_effect)
+    return OllamaAdapter(_client=client), client
+
+
+def _fake_http_resp(status):
+    return httpx.Response(
+        status_code=status,
+        headers={},
+        request=httpx.Request("POST", "http://localhost:11434/v1/chat/completions"),
+    )
+
+
+def _complete(adapter, model="qwen3:14b", tools=None):
+    return adapter.complete(
+        model=model,
+        system=None,
+        messages=[Message(role="user", content=[TextBlock("hi")])],
+        max_tokens=8,
+        tools=tools,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestConstructor:
+    def _patched(self, monkeypatch):
+        captured = {}
+
+        class FakeOpenAI:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+                self.chat = MagicMock()
+
+        monkeypatch.setattr(
+            "utilities.llm.providers.ollama.openai.OpenAI", FakeOpenAI
+        )
+        return captured
+
+    def test_defaults_to_localhost_base_url(self, monkeypatch):
+        captured = self._patched(monkeypatch)
+        OllamaAdapter()
+        assert captured["base_url"] == "http://localhost:11434/v1"
+
+    def test_base_url_override_wins(self, monkeypatch):
+        captured = self._patched(monkeypatch)
+        OllamaAdapter(base_url="http://192.168.1.50:11434/v1")
+        assert captured["base_url"] == "http://192.168.1.50:11434/v1"
+
+    def test_placeholder_key_when_none_given(self, monkeypatch):
+        """No key → placeholder bearer, NOT the SDK's OPENAI_API_KEY env
+        default and not a crash."""
+        captured = self._patched(monkeypatch)
+        OllamaAdapter()
+        assert captured["api_key"]  # non-empty (SDK requirement)
+
+    def test_no_env_fallback_for_keys(self, monkeypatch):
+        """A foreign provider key in the env must NEVER be picked up for
+        Ollama — no silent cross-provider credential reuse."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-leak")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-leak")
+        captured = self._patched(monkeypatch)
+        OllamaAdapter()
+        assert captured["api_key"] != "sk-or-leak"
+        assert captured["api_key"] != "sk-openai-leak"
+
+
+# ---------------------------------------------------------------------------
+# Error mapping deltas
+# ---------------------------------------------------------------------------
+
+
+class TestErrors:
+    def test_unpulled_model_404_maps_to_not_found_with_pull_hint(self):
+        """Ollama returns 404 'model ... not found, try pulling it first'
+        for an unpulled model (live-verified body). It must surface as
+        LLMNotFoundError with the `ollama pull` fix in the message."""
+
+        def respond(**kw):
+            raise openai.NotFoundError(
+                message=(
+                    "Error code: 404 - {'error': {'message': "
+                    "\"model 'ghost-model' not found, try pulling it first\", "
+                    "'code': 404}}"
+                ),
+                response=_fake_http_resp(404),
+                body=None,
+            )
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMNotFoundError) as exc_info:
+            _complete(adapter, model="ghost-model")
+        assert "ollama pull" in str(exc_info.value)
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMNotFoundError):
+            adapter.validate(model="ghost-model")
+
+    def test_connection_error_gets_serve_hint(self):
+        import httpx as _httpx
+
+        def respond(**kw):
+            raise openai.APIConnectionError(
+                request=_httpx.Request(
+                    "POST", "http://localhost:11434/v1/chat/completions"
+                )
+            )
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMConnectionError) as exc_info:
+            _complete(adapter)
+        assert "ollama serve" in str(exc_info.value)
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMConnectionError):
+            adapter.validate(model="qwen3:14b")
+
+    def test_other_400_is_a_response_error(self):
+        def respond(**kw):
+            raise openai.BadRequestError(
+                message="max_tokens must be positive",
+                response=_fake_http_resp(400),
+                body=None,
+            )
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMResponseError):
+            _complete(adapter)
+
+
+# ---------------------------------------------------------------------------
+# Empty-completion handling (shared translator guard)
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyCompletionGuard:
+    TOOLS = [
+        ToolDef(
+            name="echo",
+            description="Echo input",
+            input_schema={"type": "object"},
+        )
+    ]
+
+    def test_empty_completion_with_tools_raises(self):
+        """A tool-incapable model that silently ignores `tools` and returns
+        an empty completion must fail loud — via the shared translator's
+        empty-completion guard (same path as every OpenAI-wire adapter).
+        """
+        def respond(**kw):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content="", tool_calls=None),
+                        finish_reason="stop",
+                    )
+                ],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=0),
+            )
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMResponseError) as exc_info:
+            _complete(adapter, tools=self.TOOLS)
+        assert "empty completion" in str(exc_info.value)
+
+    def test_text_completion_with_tools_still_fine(self):
+        """A text-only answer to a tools request is allowed — the
+        pipeline handles plain refusals; only EMPTY completions guard."""
+
+        def respond(**kw):
+            return _ok_response(text="I cannot use tools.")
+
+        adapter, _ = _stub_adapter(respond)
+        result = _complete(adapter, tools=self.TOOLS)
+        assert result.content[0].text == "I cannot use tools."
+
+    def test_empty_choices_raise(self):
+        def respond(**kw):
+            return SimpleNamespace(
+                choices=[],
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=0),
+            )
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMResponseError):
+            _complete(adapter, tools=self.TOOLS)
+
+
+# ---------------------------------------------------------------------------
+# validate() probe
+# ---------------------------------------------------------------------------
+
+
+class TestValidate:
+    def test_validate_probes_one_token(self):
+        client = MagicMock(spec=openai.OpenAI)
+        client.chat = MagicMock()
+        client.chat.completions = MagicMock()
+        client.chat.completions.create = MagicMock(return_value=_ok_response())
+
+        adapter = OllamaAdapter(_client=client)
+        assert adapter.validate(model="qwen3:14b") is None
+
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["model"] == "qwen3:14b"
+        assert kwargs["max_tokens"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter interaction
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiter:
+    def test_429_reports_to_global_limiter(self):
+        def respond(**kw):
+            raise openai.RateLimitError(
+                message="too many requests",
+                response=_fake_http_resp(429),
+                body=None,
+            )
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMRateLimitError):
+            _complete(adapter)
+        # The process-global limiter heard about the 429.
+        assert get_rate_limiter().is_in_backoff()
+
+    def test_validate_429_does_not_back_off_the_fleet(self):
+        def respond(**kw):
+            raise openai.RateLimitError(
+                message="too many requests",
+                response=_fake_http_resp(429),
+                body=None,
+            )
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMRateLimitError):
+            adapter.validate(model="qwen3:14b")
+        assert not get_rate_limiter().is_in_backoff()

--- a/libs/openant-core/tests/test_llm_ollama_adapter.py
+++ b/libs/openant-core/tests/test_llm_ollama_adapter.py
@@ -377,3 +377,25 @@ class TestMarkerless404BaseURLHint:
             response=_fake_http_resp(404), body=None)
         out = _classify_error(not_pulled, report_429=False)
         assert _PULL_HINT in str(out)
+
+
+class TestColdLoadTimeoutOrdering:
+    """hunt r5 (sonnet): the APITimeoutError branch must stay BEFORE its
+    APIConnectionError parent — a swap makes every cold model load read
+    "start it with `ollama serve`" while the server is in fact loading.
+    The hunter proved the order was un-pinned: swapping it left all 18
+    tests green. This test fails on the swap."""
+
+    def test_timeout_gets_the_loading_hint_not_the_serve_hint(self):
+        from utilities.llm.providers.ollama import (
+            _MODEL_LOADING_HINT, _NOT_RUNNING_HINT, _classify_error)
+
+        # httpx.TimeoutException under the SDK's APITimeoutError; construct
+        # via the SDK's own error path (message + response are enough here)
+        err = openai.APITimeoutError(request=_fake_http_resp(404).request)
+        out = _classify_error(err, report_429=False)
+        assert _MODEL_LOADING_HINT in str(out), (
+            "a cold-load timeout must get the loading hint")
+        assert _NOT_RUNNING_HINT not in str(out), (
+            "the serve hint here says 'start ollama serve' to a server that "
+            "IS running and loading — the exact misclassification")

--- a/libs/openant-core/tests/test_llm_ollama_adapter.py
+++ b/libs/openant-core/tests/test_llm_ollama_adapter.py
@@ -333,14 +333,21 @@ class TestCostPath:
                               model="qwen3.8:27b", provider_name="ollama")
         assert lookup_pricing(binding) == {"input": 0.0, "output": 0.0}
 
-    def test_unknown_local_model_takes_the_warn_path(self):
-        """A custom tag absent from the registry is genuinely unknown — the
-        lookup misses (the loud marker fires downstream), it must NOT invent
-        a $0."""
+    def test_unknown_local_model_contrasts_with_the_shipped_entries(self):
+        """hunt r1 (sonnet): a bare `lookup is None` assert was vacuous — it
+        passes whether or not the pricing attribute exists. The DISCRIMINATING
+        pin is the CONTRAST: the same map that resolves the three shipped $0
+        entries must NOT invent a rate for an arbitrary custom tag (the loud
+        unknown-model warn path fires downstream for exactly that tag)."""
         from utilities.llm import PhaseBinding
         from utilities.llm.helpers import lookup_pricing
         from utilities.llm.providers.ollama import OllamaAdapter
 
-        binding = PhaseBinding(phase="analyze", adapter=OllamaAdapter(),
+        adapter = OllamaAdapter()
+        binding = PhaseBinding(phase="analyze", adapter=adapter,
                               model="my-custom-tag", provider_name="ollama")
+        # the contrast, both sides in one test
         assert lookup_pricing(binding) is None
+        for shipped in ("qwen3.8:27b", "qwen3.5:9b", "mistral-small3.2:latest"):
+            assert adapter.pricing.get(shipped) == {"input": 0.0, "output": 0.0}, (
+                f"the map that misses the custom tag must still carry {shipped}")

--- a/libs/openant-core/tests/test_llm_ollama_adapter.py
+++ b/libs/openant-core/tests/test_llm_ollama_adapter.py
@@ -351,3 +351,29 @@ class TestCostPath:
         for shipped in ("qwen3.8:27b", "qwen3.5:9b", "mistral-small3.2:latest"):
             assert adapter.pricing.get(shipped) == {"input": 0.0, "output": 0.0}, (
                 f"the map that misses the custom tag must still carry {shipped}")
+
+
+class TestMarkerless404BaseURLHint:
+    """hunt r3 (sonnet): the Python gate's marker-less arm — a 404 whose body
+    does NOT say not-pulled is a base_url misconfiguration and must get the
+    base_url hint, never the pull advice (the Go mirror tests both arms;
+    this pins the Python half)."""
+
+    def test_markerless_404_gets_base_url_hint_not_pull(self):
+        from utilities.llm.providers.ollama import _BASE_URL_HINT, _PULL_HINT, _classify_error
+
+        markerless = openai.NotFoundError(
+            message="Error code: 404 - {'error': 'page not found'}",
+            response=_fake_http_resp(404), body=None)
+        out = _classify_error(markerless, report_429=False)
+        assert _BASE_URL_HINT in str(out)
+        assert _PULL_HINT not in str(out)
+
+    def test_not_pulled_404_keeps_pull_hint(self):
+        from utilities.llm.providers.ollama import _PULL_HINT, _classify_error
+
+        not_pulled = openai.NotFoundError(
+            message="model 'x' not found, try pulling it first",
+            response=_fake_http_resp(404), body=None)
+        out = _classify_error(not_pulled, report_429=False)
+        assert _PULL_HINT in str(out)

--- a/libs/openant-core/tests/test_llm_ollama_adapter.py
+++ b/libs/openant-core/tests/test_llm_ollama_adapter.py
@@ -118,7 +118,10 @@ class TestConstructor:
         default and not a crash."""
         captured = self._patched(monkeypatch)
         OllamaAdapter()
-        assert captured["api_key"]  # non-empty (SDK requirement)
+        # Review minor (#346): pinned to the exact placeholder — a bare
+        # truthiness assert passed on ANY non-empty key, including a real
+        # credential; the contract is the literal "ollama" placeholder.
+        assert captured["api_key"] == "ollama"
 
     def test_no_env_fallback_for_keys(self, monkeypatch):
         """A foreign provider key in the env must NEVER be picked up for
@@ -304,3 +307,40 @@ class TestRateLimiter:
         with pytest.raises(LLMRateLimitError):
             adapter.validate(model="qwen3:14b")
         assert not get_rate_limiter().is_in_backoff()
+
+
+class TestCostPath:
+    """Review blocker (#346): the PR shipped explicit-$0 models.json entries
+    + the _LOCAL_PROVIDERS exemption, but the adapter never wired `pricing` —
+    every run warned and reported cost_incomplete. These tests pin the wiring
+    so the registry work can never silently go dead again."""
+
+    def test_pricing_attribute_resolves_the_shipped_zero_entries(self):
+        from utilities.llm.providers.ollama import OllamaAdapter
+
+        pricing = OllamaAdapter().pricing
+        # the three shipped local models: explicit $0, present in the map
+        assert pricing.get("qwen3.8:27b") == {"input": 0.0, "output": 0.0}
+        assert pricing.get("qwen3.5:9b") == {"input": 0.0, "output": 0.0}
+        assert pricing.get("mistral-small3.2:latest") == {"input": 0.0, "output": 0.0}
+
+    def test_lookup_pricing_resolves_a_local_binding(self):
+        from utilities.llm import PhaseBinding
+        from utilities.llm.helpers import lookup_pricing
+        from utilities.llm.providers.ollama import OllamaAdapter
+
+        binding = PhaseBinding(phase="analyze", adapter=OllamaAdapter(),
+                              model="qwen3.8:27b", provider_name="ollama")
+        assert lookup_pricing(binding) == {"input": 0.0, "output": 0.0}
+
+    def test_unknown_local_model_takes_the_warn_path(self):
+        """A custom tag absent from the registry is genuinely unknown — the
+        lookup misses (the loud marker fires downstream), it must NOT invent
+        a $0."""
+        from utilities.llm import PhaseBinding
+        from utilities.llm.helpers import lookup_pricing
+        from utilities.llm.providers.ollama import OllamaAdapter
+
+        binding = PhaseBinding(phase="analyze", adapter=OllamaAdapter(),
+                              model="my-custom-tag", provider_name="ollama")
+        assert lookup_pricing(binding) is None

--- a/libs/openant-core/tests/test_model_registry.py
+++ b/libs/openant-core/tests/test_model_registry.py
@@ -58,17 +58,25 @@ def test_model_ids_are_unique():
 
 
 def test_price_nullness_matches_status():
-    """current => real positive price; retired/unknown => null (never $0).
+    """current => real positive price (cloud) or explicit $0 (local); retired/unknown => null.
 
     This is the invariant the cost path depends on: a priced model is dispatchable
     and costs real money; an un-priced model must be omitted from pricing_map so it
-    can never resolve to a silent $0.
+    can never resolve to a silent $0. Local-inference providers
+    (``mr._LOCAL_PROVIDERS``) are the deliberate exception: their $0 is truthful
+    and provenanced ("free by definition"), so a current local model must carry
+    an EXPLICIT zero dict — never null (which would omit it from pricing_map and
+    route it to the unknown-model warn path) and never an unverified vendor quote.
     """
     for rec in mr.load_models():
         price = rec["price"]
         if rec["status"] == "current":
-            assert price and price["input"] > 0 and price["output"] > 0, (
-                f"{rec['id']}: current model must carry a positive price")
+            if rec["provider"] in mr._LOCAL_PROVIDERS:
+                assert price and price["input"] == 0.0 and price["output"] == 0.0, (
+                    f"{rec['id']}: local model must carry an explicit $0 price, not {price}")
+            else:
+                assert price and price["input"] > 0 and price["output"] > 0, (
+                    f"{rec['id']}: current model must carry a positive price")
         else:
             assert price is None, (
                 f"{rec['id']}: {rec['status']} model must have null price, not {price}")

--- a/libs/openant-core/utilities/llm/providers/OLLAMA.md
+++ b/libs/openant-core/utilities/llm/providers/OLLAMA.md
@@ -85,6 +85,19 @@ registry (any custom tag) deliberately still takes the unknown-model warn
 path: an arbitrary tag is genuinely unknown, and the loud marker is honest
 about it.
 
+## Model quality — an honest note (the round-2 adjudication)
+
+A scanner is only as strong as the model behind it. Local models trade
+capability for privacy: a small or base (non-instruct) model can produce
+false-clean scans — a report that says "safe" is the MODEL'S verdict, and
+a 9B local model's verdict is weaker evidence than a frontier model's.
+Use the biggest tool-capable model your hardware fits for the
+tool-calling phases (`enhance`, `verify`), pick chat/instruct models over
+base ones, and treat a clean result from a small local model as "not
+obviously vulnerable" rather than "audited". The confidence fields on
+findings reflect the model's own self-assessment, calibrated for frontier
+models.
+
 ## Troubleshooting
 
 - **Connection refused / could not reach** → the daemon isn't running.

--- a/libs/openant-core/utilities/llm/providers/OLLAMA.md
+++ b/libs/openant-core/utilities/llm/providers/OLLAMA.md
@@ -1,7 +1,10 @@
 # Ollama Provider Guide
 
 Run OpenAnt entirely on local models via [Ollama](https://ollama.com). No API
-key, no per-token cost — source code never leaves the machine.
+key, no per-token cost — with the default `base_url`, source code never
+leaves the machine. (The endpoint is overridable for LAN/remote
+Ollama-compatible gateways — see "Remote / LAN Ollama" below: what leaves
+the machine, and to where, is then exactly your configuration.)
 
 ## Setup
 
@@ -71,9 +74,16 @@ gateway, set `api_key` on the provider entry — it is forwarded verbatim.
 
 ## Cost accounting
 
-Local inference is free; Ollama models report $0 token cost. There is no
-pricing table shipped for this adapter — nothing to keep current, no silent
-cross-provider price guessing (issue #65).
+Local inference is free. The three shipped Ollama models carry explicit
+`{"input": 0, "output": 0}` records in the shared registry
+(`config/models.json`, the `_LOCAL_PROVIDERS` exemption in
+`core/model_registry.py`): their cost reporting is DEFINED — $0 with
+`cost_complete`, never the unknown-model warning. Nothing to keep current
+(no vendor rates to track — free is a fact, not a quote) and no silent
+cross-provider price guessing (issue #65). A local model ABSENT from the
+registry (any custom tag) deliberately still takes the unknown-model warn
+path: an arbitrary tag is genuinely unknown, and the loud marker is honest
+about it.
 
 ## Troubleshooting
 

--- a/libs/openant-core/utilities/llm/providers/OLLAMA.md
+++ b/libs/openant-core/utilities/llm/providers/OLLAMA.md
@@ -4,7 +4,11 @@ Run OpenAnt entirely on local models via [Ollama](https://ollama.com). No API
 key, no per-token cost — with the default `base_url`, source code never
 leaves the machine. (The endpoint is overridable for LAN/remote
 Ollama-compatible gateways — see "Remote / LAN Ollama" below: what leaves
-the machine, and to where, is then exactly your configuration.)
+the machine, and to where, is then exactly your configuration. This
+includes managed remote services like Ollama Cloud — a shipped \$0-local
+model pointed at a billed endpoint is the one shape where the \$0 cost
+report is false; the adapter prints a warning at validation when it sees
+it.)
 
 ## Setup
 

--- a/libs/openant-core/utilities/llm/providers/OLLAMA.md
+++ b/libs/openant-core/utilities/llm/providers/OLLAMA.md
@@ -1,0 +1,87 @@
+# Ollama Provider Guide
+
+Run OpenAnt entirely on local models via [Ollama](https://ollama.com). No API
+key, no per-token cost — source code never leaves the machine.
+
+## Setup
+
+1. Install Ollama and start the server:
+
+   ```bash
+   ollama serve   # often already running as a service
+   ```
+
+2. Pull at least one tools-capable model. The wizard defaults below are a
+   good starting point for a SAST pipeline:
+
+   ```bash
+   ollama pull qwen3.8:27b          # default tier (18GB, 256K ctx — needs ~20GB+ VRAM/RAM)
+   ollama pull qwen3.5:9b           # modest-hardware alternative (6.6GB)
+   ```
+
+3. Configure OpenAnt:
+
+   ```bash
+   openant setup llm
+   ```
+
+   Pick `ollama` as the provider type. **Leave the API key blank** — Ollama
+   doesn't authenticate local requests; the adapter sends a placeholder
+   automatically. Leave the base URL blank to use `http://localhost:11434/v1`.
+
+Or skip the wizard with a hand-authored config:
+
+```json
+{
+  "$schema_version": 2,
+  "default_llm": "local",
+  "llm_providers": {
+    "ollama": {"type": "ollama"}
+  },
+  "llm_configs": {
+    "local": {
+      "app_context": {"provider": "ollama", "model": "qwen3.5:9b"},
+      "llm_reach": {"provider": "ollama", "model": "qwen3.8:27b"},
+      "enhance": {"provider": "ollama", "model": "qwen3.5:9b"},
+      "analyze": {"provider": "ollama", "model": "qwen3.8:27b"},
+      "verify": {"provider": "ollama", "model": "qwen3.8:27b"},
+      "dynamic_test": {"provider": "ollama", "model": "qwen3.5:9b"},
+      "report": {"provider": "ollama", "model": "qwen3.5:9b"}
+    }
+  }
+}
+```
+
+## Model choice
+
+The `enhance` and `verify` phases use an agentic tool-calling loop — pick a
+model that handles tool calls reliably (the Qwen2.5-Coder family works well;
+very small models often don't). If a model can't do tool calls, those phases
+fail loud rather than silently producing empty results.
+
+Model IDs are exactly what `ollama list` shows (`qwen3.8:27b`,
+`llama3.3:70b`, ...). An unpulled model is caught by the wizard probe /
+init-time validation with an `ollama pull <model>` hint.
+
+## Remote / LAN Ollama
+
+Set `base_url` in the provider entry to the remote host, e.g.
+`http://192.168.1.50:11434/v1`. If you front Ollama with a key-checking
+gateway, set `api_key` on the provider entry — it is forwarded verbatim.
+
+## Cost accounting
+
+Local inference is free; Ollama models report $0 token cost. There is no
+pricing table shipped for this adapter — nothing to keep current, no silent
+cross-provider price guessing (issue #65).
+
+## Troubleshooting
+
+- **Connection refused / could not reach** → the daemon isn't running.
+  Start it with `ollama serve`, or check `OLLAMA_HOST`/port and set
+  `base_url` accordingly.
+- **model not found, try pulling it first** → run `ollama pull <model>`.
+- **Slow scans** → full-repo scans make many LLM calls; local hardware is
+  the bottleneck. Use incremental modes (`openant scan --staged`,
+  `--diff-base`, `--pr`) to scan only changed code, and consider a smaller
+  model for the light phases.

--- a/libs/openant-core/utilities/llm/providers/__init__.py
+++ b/libs/openant-core/utilities/llm/providers/__init__.py
@@ -51,11 +51,15 @@ def get_adapter_class(provider_type: str) -> Type[LLMAdapter]:
         from .openrouter import OpenRouterAdapter
 
         return OpenRouterAdapter
+    if provider_type == "ollama":
+        from .ollama import OllamaAdapter
+
+        return OllamaAdapter
 
     raise ValueError(
         f"Unknown provider type: {provider_type!r}. "
         f"Supported in this release: 'anthropic', 'openai', 'google', "
-        f"'bedrock', 'openrouter'. To add a provider, see "
+        f"'bedrock', 'openrouter', 'ollama'. To add a provider, see "
         f"docs/features/llm-providers/HOW_TO_ADD_AN_ADAPTER.md."
     )
 
@@ -66,4 +70,4 @@ def known_provider_types() -> list[str]:
     Used by the Go CLI's ``llm-provider set`` to validate the
     ``type`` field before writing config.json.
     """
-    return ["anthropic", "openai", "google", "bedrock", "openrouter"]
+    return ["anthropic", "openai", "google", "bedrock", "openrouter", "ollama"]

--- a/libs/openant-core/utilities/llm/providers/ollama.py
+++ b/libs/openant-core/utilities/llm/providers/ollama.py
@@ -54,6 +54,8 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
+import sys
+
 import openai
 
 from ..adapter import (
@@ -242,6 +244,22 @@ class OllamaAdapter:
         return _response_to_unified(response, adapter="OllamaAdapter")
 
     def validate(self, model: str) -> None:
+        # reinvest (sol): a SHIPPED $0-local model on a NON-LOCAL base_url
+        # is the one shape where the honest $0 becomes a possible lie — the
+        # registry prices the MODEL (free by definition for local inference),
+        # but a remote gateway (LAN, Ollama Cloud) may bill. Warn once per
+        # combination: the cost report for this run may be false.
+        base = getattr(self, "base_url", _DEFAULT_BASE_URL) or _DEFAULT_BASE_URL
+        if ("localhost" not in base and "127.0.0.1" not in base
+                and base != _DEFAULT_BASE_URL):
+            print(
+                "[OllamaAdapter] note: a shipped $0-local model is running "
+                f"against a non-local endpoint ({base}) — the $0 cost "
+                "accounting is only truthful for local inference; a remote "
+                "gateway may bill. Treat this run's cost_incomplete-free "
+                "$0 with caution.",
+                file=sys.stderr,
+            )
         try:
             response = self._client.chat.completions.create(**{
                 "model": model,

--- a/libs/openant-core/utilities/llm/providers/ollama.py
+++ b/libs/openant-core/utilities/llm/providers/ollama.py
@@ -20,9 +20,14 @@ top is exactly the Ollama-specific surface:
   (still overridable for a LAN/remote Ollama host). Like OpenRouter's,
   this base already carries the ``/v1`` segment.
 
-* **Local = free.** Local inference costs nothing, so no pricing table is
-  shipped: models absent from the shared registry report $0 via the
-  documented "adapter without ``pricing``" path.
+* **Local = free — explicit $0 entries.** Local inference costs nothing,
+  and the three shipped Ollama models carry explicit
+  ``{"input": 0, "output": 0}`` records in the shared registry (the
+  ``_LOCAL_PROVIDERS`` exemption in ``core/model_registry.py``): cost
+  reporting is DEFINED for them ($0, ``cost_complete``), never the
+  unknown-model warn path. A local model ABSENT from the registry still
+  takes that warn path deliberately — an arbitrary tag like ``my-model``
+  is genuinely unknown, and the loud marker is honest there.
 
 * **Error deltas** (verified against Ollama's OpenAI-compat docs and live
   server behavior, 2026-08):
@@ -61,6 +66,7 @@ from ..adapter import (
     Message,
     ToolDef,
 )
+from .._pricing import LazyProviderPricing
 from ._ratelimit import report_rate_limit, wait_for_rate_limit
 from .openai import (
     _messages_to_openai,
@@ -89,6 +95,17 @@ _NOT_RUNNING_HINT = (
     "non-default host/port)"
 )
 
+_MODEL_LOADING_HINT = (
+    " — the request timed out. If the model was cold, its first load can "
+    "take minutes (15GB+ models do); retry, or pre-warm it with a tiny "
+    "1-token request."
+)
+_BASE_URL_HINT = (
+    " — the server answered 404 but the body does not say the model is "
+    "unpulled, so the ENDPOINT is probably wrong: check base_url "
+    "(Ollama's OpenAI-compatible API is http://<host>:11434/v1 — the "
+    "/v1 segment included)."
+)
 _PULL_HINT = (
     " (model not pulled into Ollama — run `ollama pull <model>`, or list "
     "installed models with `ollama list`)"
@@ -105,6 +122,13 @@ def _classify_error(exc: Exception, *, report_429: bool) -> Exception:
     message = redact_secrets(str(exc))
     lowered = message.lower()
 
+    # Review should-fix (#346): APITimeoutError is an APIConnectionError
+    # SUBCLASS (verified against the installed SDK's MRO) — without this
+    # branch first, a cold model's minutes-long first load got the "start
+    # it with `ollama serve`" hint while the server was in fact running
+    # and loading.
+    if isinstance(exc, openai.APITimeoutError):
+        return LLMConnectionError(message + _MODEL_LOADING_HINT)
     if isinstance(exc, openai.APIConnectionError):
         return LLMConnectionError(message + _NOT_RUNNING_HINT)
     if isinstance(exc, openai.RateLimitError):
@@ -112,13 +136,19 @@ def _classify_error(exc: Exception, *, report_429: bool) -> Exception:
         if report_429:
             report_rate_limit(retry_after)
         return LLMRateLimitError(message, retry_after=retry_after)
+    # Review should-fix (#346): the pull hint is GATED on the not-pulled
+    # body markers — a marker-less 404 is usually a base_url misconfig
+    # (the endpoint path is wrong, e.g. missing /v1), and telling the
+    # user to `ollama pull` for a config typo actively misleads. The old
+    # catch-all branch made _is_not_pulled dead: both branches returned
+    # the identical hint.
     if (
         isinstance(exc, openai.NotFoundError)
         or getattr(exc, "status_code", None) == 404
     ) and _is_not_pulled(lowered):
         return LLMNotFoundError(message + _PULL_HINT)
     if isinstance(exc, openai.NotFoundError):
-        return LLMNotFoundError(message + _PULL_HINT)
+        return LLMNotFoundError(message + _BASE_URL_HINT)
     if isinstance(exc, (openai.AuthenticationError, openai.PermissionDeniedError)):
         # Only reachable against key-checking Ollama-compatible gateways;
         # stock Ollama never returns these.
@@ -136,6 +166,11 @@ class OllamaAdapter:
     OpenAI-compatible endpoint via ``openai.OpenAI``."""
 
     name = "ollama"
+
+    # Review blocker (#346): without this attribute, lookup_pricing returns
+    # None and every run warns + reports cost_incomplete — the registry's
+    # explicit-$0 entries stayed dead. Every sibling adapter sets it.
+    pricing = LazyProviderPricing("ollama")
     supports_tools = True
 
     def __init__(

--- a/libs/openant-core/utilities/llm/providers/ollama.py
+++ b/libs/openant-core/utilities/llm/providers/ollama.py
@@ -142,10 +142,10 @@ def _classify_error(exc: Exception, *, report_429: bool) -> Exception:
     # user to `ollama pull` for a config typo actively misleads. The old
     # catch-all branch made _is_not_pulled dead: both branches returned
     # the identical hint.
-    if (
-        isinstance(exc, openai.NotFoundError)
-        or getattr(exc, "status_code", None) == 404
-    ) and _is_not_pulled(lowered):
+    # hunt r2 (sonnet): the status_code==404 disjunct was DEAD — the live
+    # openai SDK always constructs a NotFoundError for a real HTTP 404
+    # (_make_status_error_from_response), and nothing non-SDK reaches here.
+    if isinstance(exc, openai.NotFoundError) and _is_not_pulled(lowered):
         return LLMNotFoundError(message + _PULL_HINT)
     if isinstance(exc, openai.NotFoundError):
         return LLMNotFoundError(message + _BASE_URL_HINT)

--- a/libs/openant-core/utilities/llm/providers/ollama.py
+++ b/libs/openant-core/utilities/llm/providers/ollama.py
@@ -1,0 +1,226 @@
+"""Ollama adapter — implements :class:`LLMAdapter` against a local Ollama server.
+
+Ollama (https://ollama.com) serves open models locally behind an
+OpenAI-compatible Chat Completions endpoint at ``http://localhost:11434/v1``.
+Because the wire format is OpenAI's, this adapter is a thin delegation layer
+over the OpenAI adapter's translation helpers (``_messages_to_openai`` /
+``_tool_to_openai`` / ``_response_to_unified`` / ``_token_param``) — the same
+reuse-not-duplicate approach the OpenRouter adapter takes. What it adds on
+top is exactly the Ollama-specific surface:
+
+* **No API key.** Ollama doesn't authenticate local requests. The adapter
+  sends the literal placeholder ``"ollama"`` as the bearer token (the SDK
+  requires a non-empty key; Ollama ignores it). There is deliberately NO
+  environment-variable fallback: pointing OpenAnt at a *remote* Ollama or
+  an Ollama-compatible gateway that DOES check keys is done via an explicit
+  ``api_key`` in config.json, never by silently borrowing another
+  provider's env credential.
+
+* **Endpoint.** ``base_url`` defaults to ``http://localhost:11434/v1``
+  (still overridable for a LAN/remote Ollama host). Like OpenRouter's,
+  this base already carries the ``/v1`` segment.
+
+* **Local = free.** Local inference costs nothing, so no pricing table is
+  shipped: models absent from the shared registry report $0 via the
+  documented "adapter without ``pricing``" path.
+
+* **Error deltas** (verified against Ollama's OpenAI-compat docs and live
+  server behavior, 2026-08):
+
+  - Server not running / wrong port surfaces as ``APIConnectionError`` —
+    mapped to :class:`LLMConnectionError` with a "start it with
+    ``ollama serve``" hint, because "connection refused" on localhost is
+    almost always a stopped daemon, not a network fault.
+  - A model that isn't pulled is a **404** whose body says
+    ``"model '<id>' not found, try pulling it first"`` — mapped to
+    :class:`LLMNotFoundError` with an ``ollama pull`` hint so init-time
+    validation reads as the fixable typo it is.
+
+Tool-incapable models that ignore ``tools`` and return empty completions
+are handled by the SHARED translator's empty-completion guard (raises
+:class:`LLMResponseError`) — same path as every other OpenAI-wire
+adapter; nothing Ollama-specific to add here.
+
+Rate limiting matches the other adapters (local servers can still 429
+under load); connection errors never touch the global limiter.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import openai
+
+from ..adapter import (
+    CompletionResult,
+    LLMAuthError,
+    LLMConnectionError,
+    LLMNotFoundError,
+    LLMRateLimitError,
+    LLMResponseError,
+    Message,
+    ToolDef,
+)
+from ._ratelimit import report_rate_limit, wait_for_rate_limit
+from .openai import (
+    _messages_to_openai,
+    _response_to_unified,
+    _retry_after_from,
+    _token_param,
+    _tool_to_openai,
+)
+from .._redact import redact_secrets, redacted_cause_from
+
+
+_DEFAULT_BASE_URL = "http://localhost:11434/v1"
+
+# Ollama doesn't check Authorization headers on local requests, but the
+# openai SDK requires a non-empty api_key. This placeholder is never a
+# real credential.
+_PLACEHOLDER_API_KEY = "ollama"
+
+# Live-verified fragments of Ollama's 404 body for an unpulled model:
+#   {"error":{"message":"model 'x' not found, try pulling it first","code":404}}
+_NOT_PULLED_MARKERS = ("not found", "try pulling it")
+
+_NOT_RUNNING_HINT = (
+    " (could not reach the Ollama server — is it running? "
+    "Start it with `ollama serve`, or set base_url in config.json for a "
+    "non-default host/port)"
+)
+
+_PULL_HINT = (
+    " (model not pulled into Ollama — run `ollama pull <model>`, or list "
+    "installed models with `ollama list`)"
+)
+
+
+def _classify_error(exc: Exception, *, report_429: bool) -> Exception:
+    """Map an ``openai`` SDK exception to the adapter taxonomy.
+
+    Shared by ``complete()`` and ``validate()``; only ``complete()``
+    reports 429s to the global limiter (``report_429``), matching the
+    reference adapters.
+    """
+    message = redact_secrets(str(exc))
+    lowered = message.lower()
+
+    if isinstance(exc, openai.APIConnectionError):
+        return LLMConnectionError(message + _NOT_RUNNING_HINT)
+    if isinstance(exc, openai.RateLimitError):
+        retry_after = _retry_after_from(exc)
+        if report_429:
+            report_rate_limit(retry_after)
+        return LLMRateLimitError(message, retry_after=retry_after)
+    if (
+        isinstance(exc, openai.NotFoundError)
+        or getattr(exc, "status_code", None) == 404
+    ) and _is_not_pulled(lowered):
+        return LLMNotFoundError(message + _PULL_HINT)
+    if isinstance(exc, openai.NotFoundError):
+        return LLMNotFoundError(message + _PULL_HINT)
+    if isinstance(exc, (openai.AuthenticationError, openai.PermissionDeniedError)):
+        # Only reachable against key-checking Ollama-compatible gateways;
+        # stock Ollama never returns these.
+        return LLMAuthError(message)
+    # BadRequestError (other 400s), APIStatusError (5xx, anything else).
+    return LLMResponseError(message)
+
+
+def _is_not_pulled(lowered_message: str) -> bool:
+    return all(marker in lowered_message for marker in _NOT_PULLED_MARKERS)
+
+
+class OllamaAdapter:
+    """:class:`LLMAdapter` implementation backed by a local Ollama server's
+    OpenAI-compatible endpoint via ``openai.OpenAI``."""
+
+    name = "ollama"
+    supports_tools = True
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        base_url: Optional[str] = None,
+        max_retries: int = 2,
+        _client: Optional[openai.OpenAI] = None,
+    ):
+        """Construct the adapter.
+
+        Args:
+            api_key: Ignored by stock Ollama. Only needed when targeting a
+                key-checking Ollama-compatible gateway; defaults to a
+                placeholder. Deliberately does NOT read any environment
+                variable — no silent cross-provider credential reuse.
+            base_url: Override the endpoint. ``None`` means
+                ``http://localhost:11434/v1``.
+            max_retries: Forwarded to the SDK (kept low — a down local
+                server should fail fast, not retry-stall a scan).
+            _client: Injected SDK instance for testing.
+        """
+        if _client is not None:
+            self._client = _client
+            return
+
+        self._client = openai.OpenAI(
+            api_key=api_key if api_key else _PLACEHOLDER_API_KEY,
+            base_url=base_url if base_url is not None else _DEFAULT_BASE_URL,
+            max_retries=max_retries,
+        )
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def complete(
+        self,
+        *,
+        model: str,
+        system: Optional[str],
+        messages: list[Message],
+        max_tokens: int,
+        tools: Optional[list[ToolDef]] = None,
+    ) -> CompletionResult:
+        request: dict[str, Any] = {
+            "model": model,
+            _token_param(model): max_tokens,
+            "messages": _messages_to_openai(messages, system, model),
+        }
+        if tools:
+            request["tools"] = [_tool_to_openai(t) for t in tools]
+
+        # Cooperate with cross-worker backoff before issuing the call.
+        wait_for_rate_limit()
+
+        try:
+            response = self._client.chat.completions.create(**request)
+        except openai.APIError as exc:
+            raise _classify_error(exc, report_429=True) from redacted_cause_from(exc)
+
+        # NOTE: no adapter-level empty-completion guard here. The shared
+        # ``_response_to_unified`` translator already raises
+        # :class:`LLMResponseError` when a completion carries neither text
+        # nor tool calls, so a tool-incapable small model that silently
+        # ignores ``tools`` fails loud through the same path every other
+        # OpenAI-wire adapter uses.
+        return _response_to_unified(response, adapter="OllamaAdapter")
+
+    def validate(self, model: str) -> None:
+        try:
+            response = self._client.chat.completions.create(**{
+                "model": model,
+                _token_param(model): 1,
+                "messages": [{"role": "user", "content": "hi"}],
+            })
+        except openai.APIError as exc:
+            raise _classify_error(exc, report_429=False) from redacted_cause_from(exc)
+
+        choices = getattr(response, "choices", None) or []
+        if not choices:
+            raise LLMResponseError(
+                f"OllamaAdapter: probe against {model!r} returned no choices"
+            )
+        # Touch the text so linters/type-checkers see the shape used; the
+        # contract only requires success/failure signaling here.
+        _ = getattr(choices[0].message, "content", None) or ""


### PR DESCRIPTION
Supersedes #346 (carries @Roughn3ck's work verbatim — the two commits cherry-picked with authorship preserved — plus the review-driven completion).

## Why this branch

#346 shipped a strong, recipe-conforming adapter whose review (two independent adversarial passes + a re-run adjudicating the design fork) found one blocker cluster and several should-fixes — most importantly that the PR was **internally split**: commit 1 said "no pricing table", commit 2 built an explicit-$0 registry + a `_LOCAL_PROVIDERS` exemption, but the adapter never wired `pricing` — so the registry work was dead code and every Ollama run would emit the unknown-model warning and report `cost_incomplete: true`, the exact outcome the PR's own invariant text calls wrong.

## What this branch adds (all findings fixed, each verified from source)

1. **(blocker)** `pricing = LazyProviderPricing("ollama")` wired — the explicit-$0 entries go live ($0, `cost_complete`, no false warning); docs aligned to that design; cost-path tests added (the shipped entries resolve; a lookup resolves a local binding; an unknown custom tag still takes the loud warn path — deliberately).
2. **(blocker)** `testProviderTypes` extended with ollama (bedrock/openrouter tried and reverted — they lack per-phase wizard defaults; the failing test was the evidence).
3. **(should-fix)** 404 gating: the pull hint fires only on the genuine not-pulled body markers (Python's `_is_not_pulled` was dead — a catch-all returned the identical hint); a marker-less 404 (base_url misconfig) gets a base_url hint. Go: the shared probe keeps 404→model_not_found for the OpenAI-wire family (the contract test pins it) but captures the body into a new `AnthropicProbeError.Body`; `probeOllama` gates its rewrite on it.
4. **(should-fix)** Cold loads: Python maps `APITimeoutError` ahead of its `APIConnectionError` parent (MRO-verified) to a loading hint, not "start ollama serve"; Go classifies probe timeouts as their own kind (provider-neutral message; `probeOllama` layers the cold-load advice); `probeClientTimeout` is a shrinkable package var. Both arms test-pinned (the branch order swap fails its test).
5. Parity + polish: `probeOllama`'s network kind layers the "ollama serve" hint (tested); the wizard's light tier maps to qwen3.5:9b (both tiers had mapped to the 27B — a tiering no-op); the canonical not-pulled markers are one set across Go and Python (each suite pins both arms); README's two stale adapter counts reworded; the mistral entry's provenance re-attributed ("contributor-reported", not "verified" — the registry keeps no receipt for the contributor's e2e); OLLAMA.md gains the round-2-adjudicated model-quality disclosure (a small local model's false-clean risk) and its egress line is qualified (default-local-only).

## Gates (both skills, in full, twice — the verify pass confirmed executed evidence for every stage)

T3 manifest · need-check NEEDED · RED re-derived (the cost-path tests fail 3/3 on the contributor's un-wired code; the Go probe arms fail to build there; the branch-order pin fails on the swap) · a 6-round sonnet bug-hunt to a **DRY** round (14 findings: shared-surface regressions, marker drift, vacuous/missing tests ×5, dead code, stale comments ×3, a provenance overclaim, the tier no-op — every fix test-pinned) · fable deep-refute (4 findings: 2 fixed, 2 pre-existing rendering gates dismissed to named follow-ups — the per-step $0-as-'-' glyph and the Go formatter's cost>0 suppression, both pre-existing, both now surfaced) · ruff + go vet clean · Python suite 3549 passed / 0 failed · Go suites green under -race · collision vs current master clean (merge-tree exit 0) · CI below.

## Named follow-ups (not this branch)

- The two $0-rendering epistemic gaps (html_report's '-' glyph; the Go formatter's cost>0 suppression) — pre-existing gates, first user-visible on an all-local scan.
- Base issues observed while working here: `docs/features/llm-providers/HOW_TO_ADD_AN_ADAPTER.md` is cited from three sites but exists nowhere in the tree; the wizard probe failure path `os.Exit(1)`s discarding the entered API key.

Closes #346 (with the review thread carrying the full review + the fix list; the contributor keeps authorship on the cherry-picked commits).

Co-authored-by: Roughn3ck <Roughn3ck@users.noreply.github.com>