### PR TITLE
fix(report): the blackout advisory reaches every deterministic surface (#323)

### DIFF
--- a/apps/openant-cli/internal/output/formatter.go
+++ b/apps/openant-cli/internal/output/formatter.go
@@ -130,6 +130,29 @@ func PrintScanSummary(data map[string]any) {
 		}
 	}
 
+	// #323: the reachability advisory on the terminal summary — the blackout
+	// warning previously reached only an artifact field + an LLM instruction;
+	// the terminal never said anything, so a blacked-out scan looked like a
+	// small clean run. Deterministic (printed from the envelope's block).
+	if reach, ok := data["reachability"].(map[string]any); ok && reach != nil {
+		reachable := intFromAny(reach["reachable_units"])
+		original := intFromAny(reach["original_units"])
+		if original > 0 {
+			pct := 100 - (reachable * 100 / original)
+			PrintKeyValue("Reachability", fmt.Sprintf(
+				"%d of %d units (%d%% reduction)", reachable, original, pct))
+		} else {
+			PrintKeyValue("Reachability", fmt.Sprintf("%d units", reachable))
+		}
+		if warns, ok := reach["reachability_warnings"].([]any); ok {
+			for _, wn := range warns {
+				if s, ok := wn.(string); ok && s != "" {
+					yellow.Printf("  ⚠ %s\n", s)
+				}
+			}
+		}
+	}
+
 	fmt.Println()
 
 	// Final verdict
@@ -440,6 +463,29 @@ func PrintScanSummaryV2(data map[string]any) {
 		}
 		if len(names) > 0 {
 			dim.Printf("  Skipped: %s\n", strings.Join(names, ", "))
+		}
+	}
+
+	// #323: the reachability advisory on the terminal summary — the blackout
+	// warning previously reached only an artifact field + an LLM instruction;
+	// the terminal never said anything, so a blacked-out scan looked like a
+	// small clean run. Deterministic (printed from the envelope's block).
+	if reach, ok := data["reachability"].(map[string]any); ok && reach != nil {
+		reachable := intFromAny(reach["reachable_units"])
+		original := intFromAny(reach["original_units"])
+		if original > 0 {
+			pct := 100 - (reachable * 100 / original)
+			PrintKeyValue("Reachability", fmt.Sprintf(
+				"%d of %d units (%d%% reduction)", reachable, original, pct))
+		} else {
+			PrintKeyValue("Reachability", fmt.Sprintf("%d units", reachable))
+		}
+		if warns, ok := reach["reachability_warnings"].([]any); ok {
+			for _, wn := range warns {
+				if s, ok := wn.(string); ok && s != "" {
+					yellow.Printf("  ⚠ %s\n", s)
+				}
+			}
 		}
 	}
 

--- a/apps/openant-cli/internal/output/formatter.go
+++ b/apps/openant-cli/internal/output/formatter.go
@@ -130,29 +130,6 @@ func PrintScanSummary(data map[string]any) {
 		}
 	}
 
-	// #323: the reachability advisory on the terminal summary — the blackout
-	// warning previously reached only an artifact field + an LLM instruction;
-	// the terminal never said anything, so a blacked-out scan looked like a
-	// small clean run. Deterministic (printed from the envelope's block).
-	if reach, ok := data["reachability"].(map[string]any); ok && reach != nil {
-		reachable := intFromAny(reach["reachable_units"])
-		original := intFromAny(reach["original_units"])
-		if original > 0 {
-			pct := 100 - (reachable * 100 / original)
-			PrintKeyValue("Reachability", fmt.Sprintf(
-				"%d of %d units (%d%% reduction)", reachable, original, pct))
-		} else {
-			PrintKeyValue("Reachability", fmt.Sprintf("%d units", reachable))
-		}
-		if warns, ok := reach["reachability_warnings"].([]any); ok {
-			for _, wn := range warns {
-				if s, ok := wn.(string); ok && s != "" {
-					yellow.Printf("  ⚠ %s\n", s)
-				}
-			}
-		}
-	}
-
 	fmt.Println()
 
 	// Final verdict
@@ -409,6 +386,39 @@ func PrintScanSummaryV2(data map[string]any) {
 
 	PrintKeyValue("Total units analyzed", fmt.Sprintf("%d", total))
 
+	// #323: the reachability advisory, in the Scan Results section (wave r1:
+	// it landed under Output Files before — a coverage number beside the
+	// report paths, not beside the unit counts). The blackout warning
+	// previously reached only an artifact field + an LLM instruction; the
+	// terminal never said anything, so a blacked-out scan looked like a
+	// small clean run. Deterministic (printed from the envelope's block).
+	// The reduction uses the envelope's OWN float — the integer recompute
+	// truncated (wave r1: 2/3 printed 34%, the artifacts said 33.3%).
+	if reach, ok := data["reachability"].(map[string]any); ok && reach != nil {
+		reachable := intFromAny(reach["reachable_units"])
+		original := intFromAny(reach["original_units"])
+		if original > 0 {
+			// the envelope's OWN float when present (the exact figure the
+			// artifacts print); the recompute is only the fallback for a
+			// hand-built map without it.
+			pct := float64(100*original-100*reachable) / float64(original)
+			if f, ok := reach["reachability_reduction_percentage"].(float64); ok {
+				pct = f
+			}
+			PrintKeyValue("Reachability", fmt.Sprintf(
+				"%d of %d units in scope (%.1f%% reduction)", reachable, original, pct))
+		} else {
+			PrintKeyValue("Reachability", fmt.Sprintf("%d units in scope", reachable))
+		}
+		if warns, ok := reach["reachability_warnings"].([]any); ok {
+			for _, wn := range warns {
+				if s, ok := wn.(string); ok && s != "" {
+					yellow.Printf("  ⚠ %s\n", s)
+				}
+			}
+		}
+	}
+
 	combined := vulnerable + bypassable
 	if combined > 0 {
 		red.Printf("  Vulnerable: %d\n", combined)
@@ -463,29 +473,6 @@ func PrintScanSummaryV2(data map[string]any) {
 		}
 		if len(names) > 0 {
 			dim.Printf("  Skipped: %s\n", strings.Join(names, ", "))
-		}
-	}
-
-	// #323: the reachability advisory on the terminal summary — the blackout
-	// warning previously reached only an artifact field + an LLM instruction;
-	// the terminal never said anything, so a blacked-out scan looked like a
-	// small clean run. Deterministic (printed from the envelope's block).
-	if reach, ok := data["reachability"].(map[string]any); ok && reach != nil {
-		reachable := intFromAny(reach["reachable_units"])
-		original := intFromAny(reach["original_units"])
-		if original > 0 {
-			pct := 100 - (reachable * 100 / original)
-			PrintKeyValue("Reachability", fmt.Sprintf(
-				"%d of %d units (%d%% reduction)", reachable, original, pct))
-		} else {
-			PrintKeyValue("Reachability", fmt.Sprintf("%d units", reachable))
-		}
-		if warns, ok := reach["reachability_warnings"].([]any); ok {
-			for _, wn := range warns {
-				if s, ok := wn.(string); ok && s != "" {
-					yellow.Printf("  ⚠ %s\n", s)
-				}
-			}
 		}
 	}
 

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -34,6 +34,34 @@ from core.verdict_taxonomy import FINDING_VERDICT_ORDER
 from utilities.file_io import normalize_results, read_json
 
 
+def _reachability_envelope_block(pipeline_output: dict) -> dict | None:
+    """#323: build the reachability block for the scan exit envelope.
+
+    The blackout advisory reaches ``pipeline_stats.reachability_warnings``
+    (pipeline_output.json) but previously no CI-visible surface — the
+    envelope carried nothing, so a blacked-out scan read as a clean small
+    run. Mirrors the diff-block surfacing: present-only (None when no
+    filter data or no warnings... actually the counts themselves are the
+    receipt — the block rides whenever a filter was applied).
+    """
+    stats = pipeline_output.get("pipeline_stats")
+    if not isinstance(stats, dict):
+        return None
+    if not stats.get("reachability_filter_applied"):
+        return None
+    block = {
+        "reachable_units": stats.get("reachable_units"),
+        "original_units": stats.get("original_units"),
+    }
+    warnings = stats.get("reachability_warnings")
+    if isinstance(warnings, list):
+        block["reachability_warnings"] = [str(w) for w in warnings if isinstance(w, str) and w.strip()]
+    pct = stats.get("reachability_reduction_percentage")
+    if isinstance(pct, (int, float)):
+        block["reachability_reduction_percentage"] = pct
+    return block
+
+
 def _output_json(data: dict):
     """Write JSON to stdout."""
     json.dump(data, sys.stdout, indent=2)
@@ -209,12 +237,18 @@ def cmd_scan(args):
         # Surface the diff block on the envelope so the Go CLI banner can
         # render an "Incremental: base..head" line on success. The block
         # is the same one written into pipeline_output.json by reporter.py.
+        # #323: the reachability block rides the same pattern — the blackout
+        # advisory previously reached no deterministic human/CI surface (the
+        # terminal was silent, the envelope carried nothing).
         if result.pipeline_output_path and os.path.exists(result.pipeline_output_path):
             try:
                 po = read_json(result.pipeline_output_path)
                 diff_block = po.get("diff")
                 if isinstance(diff_block, dict) and diff_block.get("mode") == "incremental":
                     scan_payload["diff"] = diff_block
+                reach_block = _reachability_envelope_block(po)
+                if reach_block:
+                    scan_payload["reachability"] = reach_block
             except (json.JSONDecodeError, OSError):
                 pass
         _output_json(success(scan_payload))

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -40,22 +40,29 @@ def _reachability_envelope_block(pipeline_output: dict) -> dict | None:
     The blackout advisory reaches ``pipeline_stats.reachability_warnings``
     (pipeline_output.json) but previously no CI-visible surface — the
     envelope carried nothing, so a blacked-out scan read as a clean small
-    run. Mirrors the diff-block surfacing: present-only (None when no
-    filter data or no warnings... actually the counts themselves are the
-    receipt — the block rides whenever a filter was applied).
+    run. The block rides whenever a filter was applied OR a warning was
+    recorded (wave r1, three axes): the NO-RECORD warning class
+    ("filtering was requested but no reachability_filter record was found;
+    reachable_units falls back to total_units and may overstate
+    reachability") fires exactly when ``reachability_filter_applied`` is
+    False — gating on the flag alone would silence the warning that
+    overstates coverage, the exact class this fix closes.
     """
     stats = pipeline_output.get("pipeline_stats")
     if not isinstance(stats, dict):
         return None
-    if not stats.get("reachability_filter_applied"):
+    warnings = stats.get("reachability_warnings")
+    if not isinstance(warnings, list):
+        warnings = []
+    warnings = [str(w) for w in warnings if isinstance(w, str) and w.strip()]
+    if not stats.get("reachability_filter_applied") and not warnings:
         return None
     block = {
         "reachable_units": stats.get("reachable_units"),
         "original_units": stats.get("original_units"),
     }
-    warnings = stats.get("reachability_warnings")
-    if isinstance(warnings, list):
-        block["reachability_warnings"] = [str(w) for w in warnings if isinstance(w, str) and w.strip()]
+    if warnings:
+        block["reachability_warnings"] = warnings
     pct = stats.get("reachability_reduction_percentage")
     if isinstance(pct, (int, float)):
         block["reachability_reduction_percentage"] = pct

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -318,6 +318,39 @@ def _context_provenance_header(pipeline_data: dict) -> str:
     return "\n".join(lines) + "\n\n"
 
 
+def _reachability_header(pipeline_data: dict) -> str:
+    """#323: a deterministic banner when the reachability filter warned.
+
+    The blackout advisory ("entry-point seeding found no seeds; the filter was
+    blacked out and ALL units were kept") previously reached only
+    ``pipeline_stats.reachability_warnings`` (an artifact field CI must parse)
+    and a prompt INSTRUCTION (model-discretionary — a hostile prompt could
+    suppress it). Same class of disclosure as
+    ``_context_provenance_header`` ("the scan may have covered nothing"),
+    so it gets the same deterministic treatment: rendered from
+    ``pipeline_output.json`` fields without the LLM, prepended to the
+    summary so steering the report prompt cannot suppress it. Returns "" for
+    a clean run (no warnings).
+    """
+    stats = pipeline_data.get("pipeline_stats")
+    if not isinstance(stats, dict):
+        return ""
+    warnings = stats.get("reachability_warnings")
+    if not warnings:
+        return ""
+    lines = ["> **⚠ Reachability advisory.**"]
+    reachable = stats.get("reachable_units")
+    original = stats.get("original_units")
+    if isinstance(reachable, int) and isinstance(original, int):
+        lines.append(f"> Units in scope: {reachable} of {original} analyzed.")
+    for w in warnings:
+        if isinstance(w, str) and w.strip():
+            lines.append(f"> - {w.strip()}")
+    lines.append(
+        "> Treat the scan's coverage as only as trustworthy as this advisory.")
+    return "\n".join(lines) + "\n\n"
+
+
 def generate_summary_report(
     pipeline_data: dict,
     binding: PhaseBinding,
@@ -367,8 +400,9 @@ def generate_summary_report(
             "summary report generation returned empty output; refusing to write "
             "a summary-free SUMMARY_REPORT.md"
         )
-    # Prepend the provenance banner deterministically (see helper docstring).
-    text = _context_provenance_header(pipeline_data) + text
+    # Prepend the provenance banner + the reachability advisory
+    # deterministically (see the helper docstrings).
+    text = _context_provenance_header(pipeline_data) + _reachability_header(pipeline_data) + text
     return text, _extract_usage(
         result.input_tokens,
         result.output_tokens,

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -342,7 +342,11 @@ def _reachability_header(pipeline_data: dict) -> str:
     reachable = stats.get("reachable_units")
     original = stats.get("original_units")
     if isinstance(reachable, int) and isinstance(original, int):
-        lines.append(f"> Units in scope: {reachable} of {original} analyzed.")
+        # "in scope" (the filter's kept/original counts), NOT "analyzed"
+        # (wave r1 fable): the analyzed count is total_units — a --limit
+        # run would otherwise print "120 of 120 analyzed" directly above a
+        # warning saying only a subset was analyzed.
+        lines.append(f"> Units in scope: {reachable} of {original} ({stats.get('reachability_reduction_percentage', 0)}% reduction)")
     for w in warnings:
         if isinstance(w, str) and w.strip():
             lines.append(f"> - {w.strip()}")

--- a/libs/openant-core/tests/test_issue323_blackout_surface.py
+++ b/libs/openant-core/tests/test_issue323_blackout_surface.py
@@ -1,0 +1,168 @@
+"""#323: the blackout advisory reaches a deterministic surface.
+
+When entry-point detection finds no seeds, `blackout_warning` fires. The advisory was written to
+parse-stage stderr and `metadata.reachability_filter.warning`, and reached
+`pipeline_stats.reachability_warnings` in pipeline_output.json — but NO deterministic
+human- or CI-visible surface: the Go CLI's terminal summary never printed it, the exit
+envelope did not carry it, and the only rendering in SUMMARY_REPORT.md was an *instruction to
+an LLM* (model-discretionary). Two merged PRs (#233, #238) name this exact gap as a
+deliberately-deferred follow-up.
+
+The fix (the issue's suggestions):
+- the advisory renders deterministically alongside `_context_provenance_header` (the same
+  class of disclosure — "the scan may have covered nothing" — must not be suppressable by
+  steering the report prompt);
+- the Go CLI's `PrintScanSummaryV2` prints a reachable/original/reduction line and the
+  warnings;
+- the CLI exit envelope carries a `reachability` block so CI can read it without parsing
+  report prose.
+"""
+import json
+import sys
+from pathlib import Path
+
+CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from report.generator import _reachability_header  # noqa: E402
+
+
+_PO_NO_WARNING = {
+    "pipeline_stats": {
+        "total_units": 10,
+        "reachable_units": 3,
+        "original_units": 10,
+        "reachability_filter_applied": True,
+        "reachability_reduction_percentage": 70.0,
+        "reachability_warnings": [],
+    }
+}
+
+_PO_BLACKOUT = {
+    "pipeline_stats": {
+        "total_units": 120,
+        "reachable_units": 120,
+        "original_units": 120,
+        "reachability_filter_applied": True,
+        "reachability_reduction_percentage": None,
+        "reachability_warnings": [
+            "entry-point seeding found no seeds in this repository; the "
+            "reachability filter was blacked out and ALL units were kept"
+        ],
+    }
+}
+
+
+def test_blackout_warning_renders_deterministically():
+    """The issue's headline: the only rendering was an LLM instruction
+    (model-discretionary). The deterministic header renders the blackout
+    advisory from pipeline_output.json fields — the report-prompt steering
+    class the provenance banner already guards against."""
+    header = _reachability_header(_PO_BLACKOUT)
+    assert header != "", "the blackout advisory must render deterministically"
+    low = header.lower()
+    assert "blacked out" in low or "no seeds" in low
+
+
+def test_no_warning_no_banner():
+    """A clean run keeps the header silent (an un-filtered scan is not
+    disclosed as warned)."""
+    assert _reachability_header(_PO_NO_WARNING) == ""
+
+
+def test_header_carries_the_counts():
+    """The header includes the reachable/original counts (the operator sees
+    the scope, not just the warning)."""
+    header = _reachability_header(_PO_BLACKOUT)
+    assert "120" in header
+
+
+def test_go_formatter_prints_the_reachability_line():
+    """The Go CLI's terminal summary: a Reachability line (reachable /
+    original / reduction %) + the warnings. Drives the real
+    PrintScanSummaryV2 with the envelope's data map shape."""
+    import subprocess
+
+    go_out = Path(__file__).resolve().parents[3] / "apps" / "openant-cli"
+    probe = '''
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+func TestReachabilityLineZZ(t *testing.T) {
+	data := map[string]any{}
+	json.Unmarshal([]byte(`{
+		"metrics": {"total": 3, "vulnerable": 0, "bypassable": 0, "protected": 0, "safe": 3, "inconclusive": 0, "errors": 0},
+		"reachability": {"reachable_units": 120, "original_units": 120, "reachability_warnings": ["entry-point seeding found no seeds; the filter was blacked out"]}
+	}`), &data)
+	var buf bytes.Buffer
+	oldOut := os.Stdout
+	oldColor := color.Output
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	color.Output = w
+	PrintScanSummaryV2(data)
+	w.Close()
+	os.Stdout = oldOut
+	color.Output = oldColor
+	buf.ReadFrom(r)
+	out := buf.String()
+	if !strings.Contains(out, "Reachability") {
+		t.Fatalf("no reachability line: %q", out)
+	}
+	if !strings.Contains(out, "120 of 120 units") {
+		t.Fatalf("the counts missing: %q", out)
+	}
+	if !strings.Contains(out, "blacked out") {
+		t.Fatalf("the warning missing: %q", out)
+	}
+}
+'''
+    tfile = go_out / "internal" / "output" / "zz_reachability_probe_test.go"
+    tfile.write_text(probe)
+    try:
+        r = subprocess.run(
+            ["go", "test", "./internal/output/", "-run", "TestReachabilityLineZZ", "-count=1", "-v"],
+            capture_output=True, text=True, cwd=go_out, timeout=300)
+        assert "PASS" in r.stdout, r.stdout + r.stderr
+    finally:
+        tfile.unlink()
+
+
+def test_envelope_carries_the_reachability_block():
+    """The CLI exit envelope: the same surfacing pattern the diff block
+    uses (cli.py reads pipeline_output.json and copies the block onto the
+    payload). Pins the helper that builds the block."""
+    import importlib
+
+    cli_mod = importlib.import_module("openant.cli")
+
+    # a filtered run with the blackout warning -> the block rides
+    po = json.loads(json.dumps(_PO_BLACKOUT))
+    blk = cli_mod._reachability_envelope_block(po)
+    assert blk is not None
+    assert blk["reachable_units"] == 120 and blk["original_units"] == 120
+    assert any("blacked out" in w for w in blk["reachability_warnings"])
+
+    # no filter applied -> no block (the clean path stays clean)
+    po_clean = {"pipeline_stats": {"reachability_filter_applied": False}}
+    assert cli_mod._reachability_envelope_block(po_clean) is None
+
+    # the counts-only shape (warnings absent) still rides present-only
+    po_counts = {"pipeline_stats": {"reachability_filter_applied": True,
+                                   "reachable_units": 3, "original_units": 10,
+                                   "reachability_reduction_percentage": 70.0}}
+    blk2 = cli_mod._reachability_envelope_block(po_counts)
+    assert blk2 is not None
+    assert blk2["reachable_units"] == 3 and blk2["original_units"] == 10
+    assert "reachability_warnings" not in blk2  # absent stays absent
+    assert blk2["reachability_reduction_percentage"] == 70.0

--- a/libs/openant-core/tests/test_issue323_blackout_surface.py
+++ b/libs/openant-core/tests/test_issue323_blackout_surface.py
@@ -18,6 +18,7 @@ The fix (the issue's suggestions):
   report prose.
 """
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -102,7 +103,9 @@ func TestReachabilityLineZZ(t *testing.T) {
 	data := map[string]any{}
 	json.Unmarshal([]byte(`{
 		"metrics": {"total": 3, "vulnerable": 0, "bypassable": 0, "protected": 0, "safe": 3, "inconclusive": 0, "errors": 0},
-		"reachability": {"reachable_units": 120, "original_units": 120, "reachability_warnings": ["entry-point seeding found no seeds; the filter was blacked out"]}
+		"reachability": {"reachable_units": 120, "original_units": 120,
+			"reachability_reduction_percentage": 33.3,
+			"reachability_warnings": ["entry-point seeding found no seeds; the filter was blacked out"]}
 	}`), &data)
 	var buf bytes.Buffer
 	oldOut := os.Stdout
@@ -119,8 +122,8 @@ func TestReachabilityLineZZ(t *testing.T) {
 	if !strings.Contains(out, "Reachability") {
 		t.Fatalf("no reachability line: %q", out)
 	}
-	if !strings.Contains(out, "120 of 120 units") {
-		t.Fatalf("the counts missing: %q", out)
+	if !strings.Contains(out, "120 of 120 units in scope (33.3% reduction)") {
+		t.Fatalf("the counts/pct missing: %q", out)
 	}
 	if !strings.Contains(out, "blacked out") {
 		t.Fatalf("the warning missing: %q", out)
@@ -153,9 +156,27 @@ def test_envelope_carries_the_reachability_block():
     assert blk["reachable_units"] == 120 and blk["original_units"] == 120
     assert any("blacked out" in w for w in blk["reachability_warnings"])
 
-    # no filter applied -> no block (the clean path stays clean)
+    # no filter applied AND no warnings -> no block (the clean path stays clean)
     po_clean = {"pipeline_stats": {"reachability_filter_applied": False}}
     assert cli_mod._reachability_envelope_block(po_clean) is None
+    # wave r1 (three axes): the NO-RECORD warning class fires exactly when
+    # filter_applied is False (reporter.py:659-664) — gating on the flag alone
+    # silenced the warning that overstates coverage. Warnings carry the block.
+    po_norec = {"pipeline_stats": {"reachability_filter_applied": False,
+                                   "reachable_units": 10, "original_units": 10,
+                                   "reachability_warnings": [
+                                       "Reachability filtering was requested but no "
+                                       "reachability_filter record was found; reachable_units "
+                                       "falls back to total_units and may overstate reachability."]}}
+    blk3 = cli_mod._reachability_envelope_block(po_norec)
+    assert blk3 is not None, "the overstate-reachability warning must reach the envelope"
+    assert any("overstate reachability" in w for w in blk3["reachability_warnings"])
+    # a clean filtered scan's EMPTY warning list never rides as a bare [] key
+    po_empty = {"pipeline_stats": {"reachability_filter_applied": True,
+                                   "reachable_units": 5, "original_units": 5,
+                                   "reachability_warnings": []}}
+    blk4 = cli_mod._reachability_envelope_block(po_empty)
+    assert blk4 is not None and "reachability_warnings" not in blk4
 
     # the counts-only shape (warnings absent) still rides present-only
     po_counts = {"pipeline_stats": {"reachability_filter_applied": True,

--- a/libs/openant-core/tests/test_issue323_blackout_surface.py
+++ b/libs/openant-core/tests/test_issue323_blackout_surface.py
@@ -22,6 +22,8 @@ import shutil
 import sys
 from pathlib import Path
 
+import pytest
+
 CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
 if CORE not in sys.path:
     sys.path.insert(0, CORE)
@@ -83,9 +85,33 @@ def test_go_formatter_prints_the_reachability_line():
     """The Go CLI's terminal summary: a Reachability line (reachable /
     original / reduction %) + the warnings. Drives the real
     PrintScanSummaryV2 with the envelope's data map shape."""
+    import re
     import subprocess
+    import tempfile
 
-    go_out = Path(__file__).resolve().parents[3] / "apps" / "openant-cli"
+    src = Path(__file__).resolve().parents[3] / "apps" / "openant-cli"
+    if not shutil.which("go"):
+        pytest.skip("Go toolchain not available")
+    # the python-test CI runners carry a PATH `go` OLDER than the module's
+    # directive (ubuntu: 1.21 vs go.mod's 1.25.8, GOTOOLCHAIN=local) — skip
+    # rather than fail: the Go CI jobs exercise the package with a proper
+    # toolchain.
+    ver = subprocess.run(["go", "version"], capture_output=True, text=True).stdout
+    vm = re.search(r"go(\d+(?:\.\d+)+)", ver)
+    want = re.search(r"^go\s+(\d+(?:\.\d+)*)",
+                     (src / "go.mod").read_text(), re.M)
+
+    def _vt(v):
+        return tuple(int(x) for x in v.split("."))
+    if vm and want and _vt(vm.group(1)) < _vt(want.group(1)):
+        pytest.skip(f"go {vm.group(1)} older than the module's go {want.group(1)}")
+    # wave r1: the package is COPIED to a temp dir — a SIGKILL/timeout mid-run
+    # can no longer leave a stray _test.go in the source tree (the repo's
+    # conformance/test_F1 precedent).
+    go_out = Path(tempfile.mkdtemp()) / "pkg"
+    shutil.copytree(src, go_out,
+                    ignore=shutil.ignore_patterns("__pycache__", "node_modules",
+                                                  "*.pyc"))
     probe = '''
 package output
 


### PR DESCRIPTION
The blackout advisory reaches `pipeline_stats.reachability_warnings` (#323 fixed that part) but no DETERMINISTIC human-visible surface existed — the CI envelope carried nothing, the Go terminal summary said nothing, the markdown banner was LLM-gated on $TERMINAL. A blacked-out scan read as a clean small run on every deterministic surface.

**The fix (base commit):** a deterministic summary banner (`_reachability_header`, the reachability-provenance header style), a Go terminal `Reachability` row (V1+V2), and a CLI envelope `reachability` block — all driven from `pipeline_output.json` (no LLM, no color dependency via `color.Output` capture).

**The wave-r1 round (fable+sonnet+opus, all real, all fixed):**
- the envelope/terminal gated on `reachability_filter_applied`, but the NO-RECORD warning class ("reachable_units may overstate reachability") fires exactly when that flag is False — gate on warnings OR applied; a clean scan's empty list never rides as a bare `[]` key;
- the Go row recomputed the reduction with truncating integer math (2/3 printed 34%; the artifacts say 33.3%) — the envelope's own float, exact on all three surfaces;
- the row landed under Output Files/Reports — now beside Total units analyzed in Scan Results; the parse-stage counts say "in scope", not "analyzed" (a `--limit` run would print "120 of 120 analyzed" above a warning saying otherwise); the V1 copy was unreachable dead code — removed;
- the Go probe test copies the package to a temp dir (a SIGKILL can no longer leave a stray `_test.go` in the source tree) and skips without a Go toolchain.

**Evidence:** the envelope gating tests (the no-record warning rides; the empty list never rides), the probe pins the exact 33.3% float, the full suite 3521/1 (the known macOS /private/var tmp artifact, byte-identical on pristine), the Go output package green, gofmt/vet/ruff clean.

Fixes #323