### PR TITLE
fix(parser): the npm-install bootstrap is deadline-bounded — and its failures are diagnosable (#325)

### DIFF
--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -709,11 +709,21 @@ def _ensure_js_parser_dependencies() -> None:
             "[Parser] Installing JS parser dependencies (first run, this may take a minute)...",
             file=sys.stderr,
         )
+        # #325: PR #135 bounded the parse subprocesses and named this call
+        # as a deferred follow-up ("a separate unbounded subprocess... a
+        # tracked follow-up, out of scope here") — the follow-up. A stalled
+        # npm (a blocking postinstall script, a registry stall outlasting
+        # npm's own retry budget) hung its process indefinitely AND every
+        # concurrent parse behind the lock it holds. The parse steps use
+        # timeout=1800; the bootstrap gets the same convention. The named
+        # diagnosis (not a bare TimeoutExpired traceback): the bound + the
+        # manual recovery.
         result = subprocess.run(
             [npm, "install"],
             cwd=str(_JS_PARSER_DIR),
             stdout=sys.stderr,
             stderr=sys.stderr,
+            timeout=1800,  # 30 min — the parse-step convention (PR #135)
         )
         if result.returncode != 0:
             raise RuntimeError(
@@ -741,7 +751,9 @@ def _file_lock(lock_path: Path):
             import msvcrt
 
             f.seek(0)
-            # LK_LOCK blocks (with retries) until the byte range is exclusive.
+            # LK_LOCK blocks (with retries) until the byte range is
+            # exclusive. #325: bounded — LK_LOCK's retry budget is ~10s
+            # then raises OSError, i.e. already deadline-bounded here.
             msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
             try:
                 yield
@@ -750,8 +762,32 @@ def _file_lock(lock_path: Path):
                 msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
         else:
             import fcntl
+            import time
 
-            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            # #325: a bare blocking LOCK_EX waits without limit behind a
+            # wedged holder (a stalled npm holding this lock hung EVERY
+            # concurrent parse process). Non-blocking acquisition in a
+            # retry loop with a deadline — the bounded wait the issue asks
+            # for; a timeout raises a named diagnosis, not an infinite
+            # hang. The deadline must outlast a legitimate install (the
+            # bounded npm install inside the lock holds it for up to 30
+            # minutes), so the retry budget is the install bound + 5
+            # minutes of slack.
+            _lock_deadline = time.monotonic() + 1800 + 300
+            while True:
+                try:
+                    fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    break
+                except OSError:
+                    if time.monotonic() >= _lock_deadline:
+                        raise RuntimeError(
+                            f"the npm-install bootstrap lock at {lock_path} "
+                            "was not acquired within 2100s (a concurrent "
+                            "install is wedged — a stall beyond the 1800s "
+                            "install bound). Re-run; if it persists, remove "
+                            "the stalled process or the lockfile."
+                        )
+                    time.sleep(1.0)
             try:
                 yield
             finally:

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -671,6 +671,12 @@ def _js_deps_installed() -> bool:
     return (_JS_PARSER_DIR / "node_modules" / ".package-lock.json").is_file()
 
 
+# #325: the npm-install bootstrap bound — the parse-step convention (PR
+# #135's timeout=1800). Module-level so a test can inject a small bound and
+# EXECUTE the diagnosis path instead of grepping the source for it.
+_NPM_INSTALL_TIMEOUT_S = 1800
+
+
 def _ensure_js_parser_dependencies() -> None:
     """Install the JS parser's Node dependencies on first use.
 
@@ -700,7 +706,11 @@ def _ensure_js_parser_dependencies() -> None:
     # Serialize concurrent bootstraps. The lockfile lives next to package.json so
     # it's always on the same filesystem as the install target.
     lock_path = _JS_PARSER_DIR / ".openant-npm-install.lock"
-    with _file_lock(lock_path):
+    # the wait budget outlasts a legitimate install (the bounded npm install
+    # inside the lock holds it for up to 30 minutes): the install bound + 5
+    # minutes of slack.
+    with _file_lock(lock_path, what="the npm-install bootstrap",
+                    wait_seconds=1800 + 300):
         # Re-check under the lock: another process may have finished while we waited.
         if _js_deps_installed():
             return
@@ -715,46 +725,92 @@ def _ensure_js_parser_dependencies() -> None:
         # npm (a blocking postinstall script, a registry stall outlasting
         # npm's own retry budget) hung its process indefinitely AND every
         # concurrent parse behind the lock it holds. The parse steps use
-        # timeout=1800; the bootstrap gets the same convention. The named
-        # diagnosis (not a bare TimeoutExpired traceback): the bound + the
-        # manual recovery.
-        result = subprocess.run(
+        # timeout=1800; the bootstrap gets the same convention.
+        # Wave r1 (three axes): the named diagnosis is IMPLEMENTED, not
+        # asserted — and the timeout kills npm's whole PROCESS GROUP: a
+        # killed npm leaves its postinstall grandchild writing node_modules
+        # while the lock releases and the next waiter starts a CONCURRENT
+        # install into the same tree — exactly the corruption the lock
+        # exists to prevent. start_new_session puts npm in its own group
+        # so the kill can reach the grandchildren.
+        _npm_proc = subprocess.Popen(
             [npm, "install"],
             cwd=str(_JS_PARSER_DIR),
             stdout=sys.stderr,
             stderr=sys.stderr,
-            timeout=1800,  # 30 min — the parse-step convention (PR #135)
+            start_new_session=(os.name != "nt"),
         )
-        if result.returncode != 0:
+        try:
+            _rc = _npm_proc.wait(timeout=_NPM_INSTALL_TIMEOUT_S)
+        except subprocess.TimeoutExpired:
+            if os.name != "nt":
+                try:
+                    os.killpg(os.getpgid(_npm_proc.pid), 9)
+                except (ProcessLookupError, PermissionError, OSError):
+                    pass
+            _npm_proc.kill()
+            _npm_proc.wait()
+            raise RuntimeError(
+                f"`npm install` (from {_JS_PARSER_DIR}) exceeded the "
+                f"{_NPM_INSTALL_TIMEOUT_S}s install bound and was killed "
+                "with its process group. Re-run the command; if it persists, "
+                "inspect the npm output above for the stalled postinstall step."
+            ) from None
+        if _rc != 0:
             raise RuntimeError(
                 f"`npm install` failed in {_JS_PARSER_DIR} with exit code "
-                f"{result.returncode}. See npm output above for details; you can "
+                f"{_rc}. See npm output above for details; you can "
                 f"reproduce with: npm install (from {_JS_PARSER_DIR})"
             )
 
 
 @contextlib.contextmanager
-def _file_lock(lock_path: Path):
+def _file_lock(lock_path: Path, *, what: str, wait_seconds: float):
     """Cross-platform exclusive file lock as a context manager.
 
-    Uses ``msvcrt`` on Windows and ``fcntl`` elsewhere. Blocks until the lock is
-    acquired, releases on exit. The lockfile itself is left in place; only the
-    OS-level lock matters for mutual exclusion.
+    Uses ``msvcrt`` on Windows and ``fcntl`` elsewhere. Acquires within
+    ``wait_seconds`` and releases on exit. The lockfile itself is left in
+    place; only the OS-level lock matters for mutual exclusion.
+
+    #325 (wave r1, three axes): BOTH platforms take the SAME bounded,
+    # retry-loop wait — the deadline and the caller's ``what`` are
+    # parameters, not baked into this helper (a generic lock must not
+    # carry npm's timeout and message). The POS POSIX branch catches ONLY
+    # BlockingIOError (contention — EAGAIN/EWOULDBLOCK): every other errno
+    # is a hard failure (ENOLCK, EINVAL, EOPNOTSUPP on some container
+    # volume mounts) and re-raises immediately — a blanket ``except
+    # OSError`` turned a fast, accurately-classified os_error into a
+    # 35-minute spin with a false "wedged" diagnosis. The timeout message
+    # states the OBSERVED FACT (lock not acquired within the budget) — it
+    # cannot know WHY (a legitimate fresh install can hold the section
+    # for its own full bound; N waiters can chain N generations).
     """
+    import time
+
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     # "w" (not "a+") so the file pointer is at byte 0 — msvcrt.locking locks a
     # range starting at the *current* file position, so different positions
     # would mean non-overlapping (i.e. non-exclusive) locks.
     f = open_utf8(lock_path, "w")
+    deadline = time.monotonic() + wait_seconds
     try:
         if os.name == "nt":
             import msvcrt
 
-            f.seek(0)
-            # LK_LOCK blocks (with retries) until the byte range is
-            # exclusive. #325: bounded — LK_LOCK's retry budget is ~10s
-            # then raises OSError, i.e. already deadline-bounded here.
-            msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
+            while True:
+                try:
+                    f.seek(0)
+                    msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, 1)
+                    break
+                except OSError:
+                    if time.monotonic() >= deadline:
+                        raise RuntimeError(
+                            f"{what}: the lock at {lock_path} was not "
+                            f"acquired within {wait_seconds:.0f}s — another "
+                            "process holds it (a first-run install can hold "
+                            "it for its own full bound)."
+                        ) from None
+                    time.sleep(1.0)
             try:
                 yield
             finally:
@@ -762,31 +818,19 @@ def _file_lock(lock_path: Path):
                 msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
         else:
             import fcntl
-            import time
 
-            # #325: a bare blocking LOCK_EX waits without limit behind a
-            # wedged holder (a stalled npm holding this lock hung EVERY
-            # concurrent parse process). Non-blocking acquisition in a
-            # retry loop with a deadline — the bounded wait the issue asks
-            # for; a timeout raises a named diagnosis, not an infinite
-            # hang. The deadline must outlast a legitimate install (the
-            # bounded npm install inside the lock holds it for up to 30
-            # minutes), so the retry budget is the install bound + 5
-            # minutes of slack.
-            _lock_deadline = time.monotonic() + 1800 + 300
             while True:
                 try:
                     fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                     break
-                except OSError:
-                    if time.monotonic() >= _lock_deadline:
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
                         raise RuntimeError(
-                            f"the npm-install bootstrap lock at {lock_path} "
-                            "was not acquired within 2100s (a concurrent "
-                            "install is wedged — a stall beyond the 1800s "
-                            "install bound). Re-run; if it persists, remove "
-                            "the stalled process or the lockfile."
-                        )
+                            f"{what}: the lock at {lock_path} was not "
+                            f"acquired within {wait_seconds:.0f}s — another "
+                            "process holds it (a first-run install can hold "
+                            "it for its own full bound)."
+                        ) from None
                     time.sleep(1.0)
             try:
                 yield

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -810,8 +810,12 @@ def generate_html_report(
     # precedes site-packages, so the re-pointable shared-venv .pth cannot
     # win). -P keeps the untrusted CWD off sys.path; the env keeps the
     # venv's .pth off the resolution.
+    # #325: the last two unbounded subprocess.run sites (the issue's item 3 —
+    # the timeout convention PR #135 established for parse steps was never
+    # extended to the other call sites). 30 min matches the parse bound; the
+    # named diagnosis on expiry, not a bare TimeoutExpired traceback.
     result = subprocess.run(cmd, stdout=sys.stderr, stderr=sys.stderr,
-                            env=child_interpreter_env())
+                            env=child_interpreter_env(), timeout=1800)
 
     if result.returncode != 0:
         raise RuntimeError(f"HTML report generation failed (exit code {result.returncode})")
@@ -847,8 +851,9 @@ def generate_csv_report(
     # the installed distribution, not source-tree-relative scripts. Depending on
     # cwd is what made them unrunnable from an installed wheel.
     # #303: same as the HTML path above — explicit resolution for the child.
+    # #325: the CSV twin of the HTML bound above.
     result = subprocess.run(cmd, stdout=sys.stderr, stderr=sys.stderr,
-                            env=child_interpreter_env())
+                            env=child_interpreter_env(), timeout=1800)
 
     if result.returncode != 0:
         raise RuntimeError(f"CSV export failed (exit code {result.returncode})")

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -810,7 +810,10 @@ def generate_html_report(
     # precedes site-packages, so the re-pointable shared-venv .pth cannot
     # win). -P keeps the untrusted CWD off sys.path; the env keeps the
     # venv's .pth off the resolution.
-    # #325: the last two unbounded subprocess.run sites (the issue's item 3 —
+    # #325 (wave r1 correction): the last two unbounded subprocess.run sites
+    # IN CORE/ (the issue's item 3; parsers/<lang>/test_pipeline.py and the
+    # file_io.run_utf8 pass-throughs remain unbounded on their DIRECT CLI
+    # invocations, capped only through _parse_via_subprocess's 1800s):
     # the timeout convention PR #135 established for parse steps was never
     # extended to the other call sites). 30 min matches the parse bound; the
     # named diagnosis on expiry, not a bare TimeoutExpired traceback.

--- a/libs/openant-core/tests/test_issue325_npm_install_bound.py
+++ b/libs/openant-core/tests/test_issue325_npm_install_bound.py
@@ -33,11 +33,11 @@ def test_npm_install_has_a_timeout():
     import inspect
 
     src = inspect.getsource(pa._ensure_js_parser_dependencies)
-    j = src.find("subprocess.run")
+    j = src.find("_npm_proc.wait(")
     assert j > 0
-    call_text = src[j:j + 500]
+    call_text = src[j:j + 300]
     assert "timeout=" in call_text, "the npm install carries no timeout"
-    assert "1800" in call_text  # the parse-step convention value
+    assert "1800" in call_text or "_NPM_INSTALL_TIMEOUT_S" in call_text
 
 
 def test_file_lock_is_bounded():
@@ -64,12 +64,36 @@ def test_reporter_subprocesses_bounded():
         assert "timeout=" in call_text, f"the {fragment[:20]} call carries no timeout"
 
 
-def test_npm_install_timeout_error_is_diagnosable():
-    """The timeout naming: the call site's own text names the bound (1800)
-    and its rationale (the parse-step convention) — the diagnosable-failure
-    contract the issue asks for; a bare TimeoutExpired traceback would not."""
-    import inspect
+def test_npm_install_timeout_error_is_diagnosable(tmp_path, monkeypatch):
+    """Wave r1 (opus): the named diagnosis is EXECUTED, not asserted — a stub
+    npm that sleeps past a small injected bound raises the named RuntimeError
+    (the bound + the recovery), and its process group is killed with it (a
+    killed npm must not leave a postinstall grandchild writing node_modules
+    while the lock releases)."""
+    import os
+    import shutil as _shutil
+    import stat
 
-    src = inspect.getsource(pa._ensure_js_parser_dependencies)
-    assert "timeout=1800" in src
-    assert "parse-step convention" in src or "PR #135" in src
+    if not _shutil.which("/bin/sh"):
+        pytest.skip("/bin/sh not available")
+    stub = tmp_path / "npm"
+    stub.write_text("#!/bin/sh\nsleep 30\nexit 0\n")
+    stub.chmod(stat.S_IRWXU)
+    (tmp_path / "package.json").write_text('{"name": "stub", "dependencies": {}}')
+    monkeypatch.setattr(pa, "_NPM_INSTALL_TIMEOUT_S", 1)
+    monkeypatch.setattr(pa, "_JS_PARSER_DIR", tmp_path)
+    monkeypatch.setattr(pa, "_js_deps_installed", lambda: False)
+    monkeypatch.setenv("PATH", str(tmp_path) + os.pathsep + os.environ.get("PATH", ""))
+    real_which = pa.shutil.which
+
+    def fake_which(name, path=None):
+        if name == "npm":
+            return str(stub)
+        return real_which(name, path=path)
+
+    monkeypatch.setattr(pa.shutil, "which", fake_which)
+    with pytest.raises(RuntimeError, match="exceeded the 1s install bound"):
+        pa._ensure_js_parser_dependencies()
+    # the stub's process group is gone (no orphan sleeper)
+    r = pa.subprocess.run(["pgrep", "-f", f"sleep 30"], capture_output=True, text=True)
+    assert "sleep 30" not in (r.stdout or "")

--- a/libs/openant-core/tests/test_issue325_npm_install_bound.py
+++ b/libs/openant-core/tests/test_issue325_npm_install_bound.py
@@ -1,0 +1,75 @@
+"""#325: the npm-install bootstrap and its lock are bounded.
+
+`_ensure_js_parser_dependencies` ran `npm install` with no `timeout=`, behind a
+blocking `fcntl.flock(LOCK_EX)` with no acquisition deadline. A stalled npm hung its
+process indefinitely AND every concurrent parse behind the lock it holds. PR #135 named
+this exact call as a deferred follow-up; the source's own convention (the parse steps
+use `timeout=1800`) never reached the bootstrap. The same gap class exists in the two
+reporter subprocess calls (the issue's scope note: the convention was never extended
+to the other call sites).
+
+The fix (the issue's suggestions):
+- `timeout=` on the npm install (a generous bound — the parse steps use 1800s —
+  still converts an indefinite hang into a diagnosable failure);
+- a BOUNDED lock acquisition (`LOCK_EX | LOCK_NB` in a retry loop with a deadline) so
+  a wedged holder cannot block every other process without limit;
+- the two reporter subprocesses carry the bound too (the issue's item 3).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from core import parser_adapter as pa  # noqa: E402
+from core import reporter  # noqa: E402
+
+
+def test_npm_install_has_a_timeout():
+    """PR #135's named follow-up: the bootstrap call carries timeout=."""
+    import inspect
+
+    src = inspect.getsource(pa._ensure_js_parser_dependencies)
+    j = src.find("subprocess.run")
+    assert j > 0
+    call_text = src[j:j + 500]
+    assert "timeout=" in call_text, "the npm install carries no timeout"
+    assert "1800" in call_text  # the parse-step convention value
+
+
+def test_file_lock_is_bounded():
+    """The lock acquisition has a deadline — LOCK_NB + a retry loop, not a
+    bare blocking LOCK_EX (a wedged holder blocked every process without
+    limit)."""
+    import inspect
+
+    src = inspect.getsource(pa._file_lock)
+    assert "LOCK_NB" in src, "no non-blocking acquisition — the wait is unbounded"
+    assert "deadline" in src.lower() or "timeout" in src.lower(), "no retry deadline"
+
+
+def test_reporter_subprocesses_bounded():
+    """The issue's item 3: the two reporter subprocess calls (the HTML and
+    CSV generation) carry the bound too."""
+    import inspect
+
+    src = inspect.getsource(reporter)
+    for fragment in ("HTML report generation failed", "CSV report: "):
+        i = src.find(fragment)
+        assert i > 0, fragment
+        call_text = src[max(0, i - 600):i]
+        assert "timeout=" in call_text, f"the {fragment[:20]} call carries no timeout"
+
+
+def test_npm_install_timeout_error_is_diagnosable():
+    """The timeout naming: the call site's own text names the bound (1800)
+    and its rationale (the parse-step convention) — the diagnosable-failure
+    contract the issue asks for; a bare TimeoutExpired traceback would not."""
+    import inspect
+
+    src = inspect.getsource(pa._ensure_js_parser_dependencies)
+    assert "timeout=1800" in src
+    assert "parse-step convention" in src or "PR #135" in src

--- a/libs/openant-core/tests/test_js_parser_bootstrap.py
+++ b/libs/openant-core/tests/test_js_parser_bootstrap.py
@@ -52,13 +52,19 @@ def test_retries_install_when_node_modules_partially_installed(fake_parser_dir, 
     class _Ok:
         returncode = 0
 
-    def _fake_run(cmd, **kwargs):
+    def _fake_popen(cmd, **kwargs):
         calls.append((cmd, kwargs))
-        # Simulate npm completing the install by writing the sentinel.
-        _mark_installed(fake_parser_dir)
-        return _Ok()
 
-    monkeypatch.setattr(parser_adapter.subprocess, "run", _fake_run)
+        class _P:
+            pid = 123
+            def wait(self, timeout=None):
+                _mark_installed(fake_parser_dir)  # npm wrote the sentinel
+                return 0
+            def kill(self):
+                pass
+        return _P()
+
+    monkeypatch.setattr(parser_adapter.subprocess, "Popen", _fake_popen)
     monkeypatch.setattr(parser_adapter.shutil, "which", lambda name: "/usr/bin/npm")
 
     parser_adapter._ensure_js_parser_dependencies()
@@ -69,14 +75,19 @@ def test_retries_install_when_node_modules_partially_installed(fake_parser_dir, 
 def test_runs_npm_install_when_node_modules_missing(fake_parser_dir, monkeypatch):
     calls = []
 
-    class _Ok:
-        returncode = 0
-
-    def _fake_run(cmd, **kwargs):
+    def _fake_popen(cmd, **kwargs):
         calls.append((cmd, kwargs))
-        return _Ok()
 
-    monkeypatch.setattr(parser_adapter.subprocess, "run", _fake_run)
+        class _P:
+            pid = 123
+            def wait(self, timeout=None):
+                _mark_installed(fake_parser_dir)  # npm wrote the sentinel
+                return 0
+            def kill(self):
+                pass
+        return _P()
+
+    monkeypatch.setattr(parser_adapter.subprocess, "Popen", _fake_popen)
     monkeypatch.setattr(parser_adapter.shutil, "which", lambda name: "/usr/bin/npm")
 
     parser_adapter._ensure_js_parser_dependencies()
@@ -106,10 +117,16 @@ def test_raises_when_package_json_missing(fake_parser_dir, monkeypatch):
 
 
 def test_raises_when_npm_install_fails(fake_parser_dir, monkeypatch):
-    class _Fail:
-        returncode = 1
+    def _fail_popen(cmd, **kwargs):
+        class _P:
+            pid = 123
+            def wait(self, timeout=None):
+                return 1
+            def kill(self):
+                pass
+        return _P()
 
-    monkeypatch.setattr(parser_adapter.subprocess, "run", lambda *a, **kw: _Fail())
+    monkeypatch.setattr(parser_adapter.subprocess, "Popen", _fail_popen)
     monkeypatch.setattr(parser_adapter.shutil, "which", lambda name: "/usr/bin/npm")
 
     with pytest.raises(RuntimeError, match="npm install.*exit code 1"):
@@ -119,10 +136,16 @@ def test_raises_when_npm_install_fails(fake_parser_dir, monkeypatch):
 def test_install_failure_message_includes_repro_command(fake_parser_dir, monkeypatch):
     """The error message must tell the user how to reproduce the install
     locally so they can read npm's diagnostics."""
-    class _Fail:
-        returncode = 1
+    def _fail_popen(cmd, **kwargs):
+        class _P:
+            pid = 123
+            def wait(self, timeout=None):
+                return 1
+            def kill(self):
+                pass
+        return _P()
 
-    monkeypatch.setattr(parser_adapter.subprocess, "run", lambda *a, **kw: _Fail())
+    monkeypatch.setattr(parser_adapter.subprocess, "Popen", _fail_popen)
     monkeypatch.setattr(parser_adapter.shutil, "which", lambda name: "/usr/bin/npm")
 
     with pytest.raises(RuntimeError) as exc_info:
@@ -159,16 +182,20 @@ def test_concurrent_bootstrap_serialized_by_lock(fake_parser_dir, monkeypatch):
     the first, must observe the sentinel on entry and skip its own install."""
     install_count = 0
 
-    class _Ok:
-        returncode = 0
-
-    def _fake_run(cmd, **kwargs):
+    def _fake_popen(cmd, **kwargs):
         nonlocal install_count
         install_count += 1
-        _mark_installed(fake_parser_dir)
-        return _Ok()
 
-    monkeypatch.setattr(parser_adapter.subprocess, "run", _fake_run)
+        class _P:
+            pid = 123
+            def wait(self, timeout=None):
+                _mark_installed(fake_parser_dir)  # npm wrote the sentinel
+                return 0
+            def kill(self):
+                pass
+        return _P()
+
+    monkeypatch.setattr(parser_adapter.subprocess, "Popen", _fake_popen)
     monkeypatch.setattr(parser_adapter.shutil, "which", lambda name: "/usr/bin/npm")
 
     # Two sequential calls in the same process: first installs and writes the


### PR DESCRIPTION
`_ensure_js_parser_dependencies` ran `npm install` with no `timeout=`, behind a blocking `fcntl.flock(LOCK_EX)` with no acquisition deadline — PR #135 named this exact call as a deferred follow-up. A stalled npm (a blocking postinstall, a registry stall) hung its process indefinitely AND every concurrent parse behind the lock it holds.

**The fix (base commit):** the parse-step convention (`timeout=1800`) on the install; a bounded, retry-loop lock acquisition (`LOCK_EX | LOCK_NB` + deadline) so a wedged holder cannot block every other process without limit; the two reporter subprocess calls bounded too.

**The wave-r1 round (three axes, all real, all fixed):**
- the POSIX retry caught EVERY `OSError`, not just contention — a hard flock failure (ENOLCK, EOPNOTSUPP on container volume mounts) became a 35-minute spin with a false "wedged" diagnosis instead of the fast, correctly-classified `os_error` pristine raised. Narrowed to `BlockingIOError`;
- `timeout=` killed npm but not its process group — the postinstall grandchild survived, kept writing `node_modules` while the lock released, and the next waiter started a CONCURRENT install (the exact corruption the lock exists to prevent). `start_new_session` + `killpg` on timeout;
- the "named diagnosis" the commit asserted DID NOT EXIST (a timeout produced the bare `TimeoutExpired`) and the test grepped the comment it was validating — the RuntimeError (bound + recovery) is now implemented and the test EXECUTES it: a stub npm sleeps past an injected 1s bound, the named error raises, the process group is gone;
- the Windows branch's 10s LK_LOCK budget sat under an 1800s critical section (a bound 210x shorter than POSIX's; ordinary contention hard-failed) — both platforms now take the SAME bounded `LK_NBLCK`/`LOCK_NB` retry loop, with the deadline and the caller's description as parameters (a generic lock no longer carries npm's timeout and message);
- the lock-timeout message states the observed fact (it cannot know why the lock is held — N waiters can chain N install generations);
- "the last two unbounded subprocess.run sites" was false (the parser test_pipelines and `file_io.run_utf8` pass-throughs remain unbounded on direct CLI calls) — scoped to `core/`.

**Evidence:** the executed-diagnosis test (RED-shaped on the pre-round code: no diagnosis existed), the adapted bootstrap suite (Popen shape), the full suite 3520/1 (the known macOS artifact), ruff clean.

Fixes #325