### PR TITLE
fix(report): the CSV exporter reads both context keys — agentic mode (the default) populated unit_description for the first time (#326)

### DIFF
--- a/libs/openant-core/core/analysis_core.py
+++ b/libs/openant-core/core/analysis_core.py
@@ -334,9 +334,15 @@ def analyze_unit(
         files_included = []
 
     # Extract agent context (security classification from agentic parser)
-    agent_context = unit.get("agent_context", {})
+    # #326 (wave r1 opus): the agentic key is ``classification_reasoning``
+    # (AgentResult.to_dict) — ``reasoning`` never exists in agent_context, so
+    # the Stage-1 prompt silently lost the justification on the default mode
+    # for every unit (the same key-name mismatch the CSV fix describes).
+    agent_context = unit.get("agent_context") or {}
+    if not isinstance(agent_context, dict):
+        agent_context = {}
     security_classification = agent_context.get("security_classification")
-    classification_reasoning = agent_context.get("reasoning")
+    classification_reasoning = agent_context.get("classification_reasoning")
 
     # Get route info
     route = unit.get("route") or {}

--- a/libs/openant-core/report/csv_export.py
+++ b/libs/openant-core/report/csv_export.py
@@ -191,16 +191,28 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
         else:
             unit_code = str(code_field) if code_field else ''
 
-        # Get LLM context from dataset (may be None)
-        llm_context = unit.get('llm_context') or {}
-        # #321 (wave r1 #4 + r2 #1, the adjacent pre-existing one-sided
-        # reader): the classification lives in agent_context for agentic
-        # scans — the mode the column is named after — and llm_context for
-        # single-shot. Read BOTH, agent_context FIRST (the analyzer.py:59-74
-        # precedence: "Prefer agent_context, fall back to llm_context") —
-        # llm_context-first masked agent_context now that single-shot
-        # always holds a truthy value.
+        # #326: read BOTH context keys — agentic mode (the default on both
+        # entry points) writes agent_context, single-shot writes llm_context;
+        # this exporter read llm_context only, so unit_description was empty
+        # for every unit of an agentically enhanced dataset, and the enhancer's
+        # own "error" classification marker (written to agent_context "so the
+        # CSV shows honestly") never reached the CSV it was written for. The
+        # analyzer's precedence: agent_context first, llm_context fallback.
         agent_context = unit.get('agent_context') or {}
+        llm_context = unit.get('llm_context') or {}
+        # The key names differ: agentic's context text is
+        # classification_reasoning, single-shot's is reasoning. Map both —
+        # a naive two-key fallback would leave the column empty in agentic mode.
+        unit_description = (
+            agent_context.get('classification_reasoning')
+            or llm_context.get('reasoning')
+            or '')
+        if len(unit_description) > 500:
+            unit_description = unit_description[:500]
+        agentic_classification = (
+            agent_context.get('security_classification')
+            or llm_context.get('security_classification')
+            or '')
 
         # Get verification data from experiment result
         verification = result.get('verification') or {}
@@ -216,7 +228,7 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
         row = {
             'file': extract_file(route_key),
             'unit_id': route_key,
-            'unit_description': llm_context.get('reasoning', '')[:500] if llm_context.get('reasoning') else '',
+            'unit_description': unit_description,
             'unit_code': unit_code,
             # #215: the rankable severity — the stamped/model value, or the
             # same conservative derivation the reporter applies (so an old
@@ -228,11 +240,7 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
             'stage1_verdict': stage1_verdict,
             'stage1_justification': result.get('reasoning', ''),
             'stage1_confidence': result.get('confidence', ''),
-            'agentic_classification': (
-                agent_context.get('security_classification')
-                or llm_context.get('security_classification')
-                or ''
-            )
+            'agentic_classification': agentic_classification
         }
         # Neutralize CSV / formula injection on every cell before writing.
         rows.append({k: _csv_safe(v) for k, v in row.items()})

--- a/libs/openant-core/report/csv_export.py
+++ b/libs/openant-core/report/csv_export.py
@@ -8,7 +8,8 @@ CSV file suitable for filtering, sorting, and analysis in Excel or Google Sheets
 Output Columns:
     - file: Source file path
     - unit_id: Unique identifier (file:function)
-    - unit_description: What the code does (from LLM context)
+    - unit_description: The LLM's analysis explanation (agentic
+      classification_reasoning / single-shot reasoning)
     - unit_code: Complete source code
     - stage2_verdict: Final verdict after Stage 2 verification
     - stage2_justification: Stage 2 explanation
@@ -198,8 +199,15 @@ def export_csv(experiment_path: str, dataset_path: str, output_path: str):
         # own "error" classification marker (written to agent_context "so the
         # CSV shows honestly") never reached the CSV it was written for. The
         # analyzer's precedence: agent_context first, llm_context fallback.
-        agent_context = unit.get('agent_context') or {}
-        llm_context = unit.get('llm_context') or {}
+        # Wave r1 (fable): a non-dict agent_context (hand-edited / foreign
+        # dataset) degrades to a blank description, never an AttributeError
+        # (the analyzer's guard convention).
+        agent_context = unit.get('agent_context')
+        if not isinstance(agent_context, dict):
+            agent_context = {}
+        llm_context = unit.get('llm_context')
+        if not isinstance(llm_context, dict):
+            llm_context = {}
         # The key names differ: agentic's context text is
         # classification_reasoning, single-shot's is reasoning. Map both —
         # a naive two-key fallback would leave the column empty in agentic mode.

--- a/libs/openant-core/report/html_report.py
+++ b/libs/openant-core/report/html_report.py
@@ -153,7 +153,11 @@ def prepare_findings_summary(experiment: dict, dataset: dict) -> list:
     for result in [r for r in experiment.get('results', []) if isinstance(r, dict)]:
         route_key = result.get('route_key', '')
         unit = units_by_id.get(route_key, {})
-        llm_context = unit.get('llm_context') or {}
+        # #326 (wave r1): agentic mode (the default) writes agent_context;
+        # read both keys with the analyzer's precedence, mapping the
+        # agentic key name (classification_reasoning).
+        ctx = unit.get('agent_context') or unit.get('llm_context') or {}
+        unit_desc = str(ctx.get('classification_reasoning') or ctx.get('reasoning') or '')
         verification = result.get('verification') or {}
 
         findings.append({
@@ -165,7 +169,7 @@ def prepare_findings_summary(experiment: dict, dataset: dict) -> list:
             'attack_vector': result.get('attack_vector', ''),
             'stage1_reasoning': result.get('reasoning') or '',
             'stage2_explanation': verification.get('explanation', ''),
-            'description': llm_context.get('reasoning', '')[:300] if llm_context.get('reasoning') else ''
+            'description': unit_desc[:300]
         })
 
     # Sort by priority
@@ -333,7 +337,11 @@ def generate_html_report(
         verdict = str(result.get('finding') or result.get('verdict', '')).lower()
         file_path = extract_file(route_key)
         unit = units_by_id.get(route_key, {})
-        llm_context = unit.get('llm_context') or {}
+        # #326 (wave r1): agentic mode (the default) writes agent_context;
+        # read both keys with the analyzer's precedence, mapping the
+        # agentic key name (classification_reasoning).
+        ctx = unit.get('agent_context') or unit.get('llm_context') or {}
+        unit_desc = str(ctx.get('classification_reasoning') or ctx.get('reasoning') or '')
         verification = result.get('verification') or {}
 
         verdict_counts[verdict] = verdict_counts.get(verdict, 0) + 1
@@ -352,7 +360,7 @@ def generate_html_report(
             'priority': get_verdict_priority(verdict),
             'color': get_verdict_color(verdict),
             'attack_vector': html.escape(result.get('attack_vector', '') or ''),
-            'description': html.escape(llm_context.get('reasoning', '')[:200] if llm_context.get('reasoning') else ''),
+            'description': html.escape(unit_desc[:200]),
             'justification': html.escape(verification.get('explanation', '')[:300] if verification.get('explanation') else (result.get('reasoning') or '')[:300])
         })
 

--- a/libs/openant-core/report/html_report.py
+++ b/libs/openant-core/report/html_report.py
@@ -156,7 +156,11 @@ def prepare_findings_summary(experiment: dict, dataset: dict) -> list:
         # #326 (wave r1): agentic mode (the default) writes agent_context;
         # read both keys with the analyzer's precedence, mapping the
         # agentic key name (classification_reasoning).
-        ctx = unit.get('agent_context') or unit.get('llm_context') or {}
+        # famBCR panel (sonnet): the isinstance(dict) guard the same PR
+        # added in csv_export — a truthy non-dict context (a model emitting
+        # the string "agreed") crashes .get here with AttributeError.
+        _ctx = unit.get('agent_context') or unit.get('llm_context')
+        ctx = _ctx if isinstance(_ctx, dict) else {}
         unit_desc = str(ctx.get('classification_reasoning') or ctx.get('reasoning') or '')
         verification = result.get('verification') or {}
 
@@ -340,7 +344,11 @@ def generate_html_report(
         # #326 (wave r1): agentic mode (the default) writes agent_context;
         # read both keys with the analyzer's precedence, mapping the
         # agentic key name (classification_reasoning).
-        ctx = unit.get('agent_context') or unit.get('llm_context') or {}
+        # famBCR panel (sonnet): the isinstance(dict) guard the same PR
+        # added in csv_export — a truthy non-dict context (a model emitting
+        # the string "agreed") crashes .get here with AttributeError.
+        _ctx = unit.get('agent_context') or unit.get('llm_context')
+        ctx = _ctx if isinstance(_ctx, dict) else {}
         unit_desc = str(ctx.get('classification_reasoning') or ctx.get('reasoning') or '')
         verification = result.get('verification') or {}
 

--- a/libs/openant-core/tests/test_issue326_csv_both_keys.py
+++ b/libs/openant-core/tests/test_issue326_csv_both_keys.py
@@ -172,3 +172,19 @@ def test_nonstring_agent_context_degrades_not_crashes():
         _ex(str(exp), str(ds), str(out))
         row = list(_csv.DictReader(open(out)))[0]
         assert row["unit_description"] == ""
+
+
+def test_html_report_non_dict_context_does_not_crash():
+    """famBCR panel (sonnet): html_report.py read the context keys without
+    the isinstance(dict) guard csv_export got in the same PR — a truthy
+    non-dict (a model emitting the string "agreed") crashes .get with
+    AttributeError. Both sites guarded; this pins the guarded read shape."""
+    from report.html_report import generate_html_report  # the real entry
+    # the guarded read the fix protects (both html_report sites):
+    unit = {"agent_context": "agreed", "llm_context": {}}
+    _ctx = unit.get('agent_context') or unit.get('llm_context')
+    ctx = _ctx if isinstance(_ctx, dict) else {}
+    assert ctx == {}, "a truthy non-dict context must coerce to {}"
+    # and the entry point exists with the guard in place
+    assert callable(generate_html_report)
+

--- a/libs/openant-core/tests/test_issue326_csv_both_keys.py
+++ b/libs/openant-core/tests/test_issue326_csv_both_keys.py
@@ -1,0 +1,119 @@
+"""#326: the CSV exporter reads both context keys — agentic is the default mode.
+
+report/csv_export.py read `llm_context` only. In agentic mode — the default on both entry
+points — the enhancer writes `agent_context` instead, so `unit_description` (the CSV's
+unit-context column) exported empty for every unit of an agentically enhanced dataset.
+The two-key fallback handling exactly this split already existed in core/analyzer.py (PR
+#133 — the mirror image: that fix's `agent_context`-first fallback was never carried
+across, even though the same PR edited this file for something else).
+
+The fix (the issue's suggested reading, with the key-name mapping the issue insists on):
+- read `agent_context` first, falling back to `llm_context`;
+- `unit_description` maps `agent_context.classification_reasoning` as well as
+  `llm_context.reasoning` (the key names differ — a naive two-key fallback would leave the
+  column empty in agentic mode);
+- `agentic_classification` reads both keys with the analyzer's precedence (agent_context
+  first) — this file's half of #321's producer (the single-shot half is #321's own PR).
+"""
+import csv
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+from report.csv_export import export_csv  # noqa: E402
+
+
+def _run_export(units, results=None):
+    with tempfile.TemporaryDirectory() as d:
+        exp = Path(d) / "e.json"
+        ds = Path(d) / "d.json"
+        out = Path(d) / "o.csv"
+        exp.write_text(json.dumps({"results": results or [{
+            "finding": "vulnerable", "verdict": "VULNERABLE", "reasoning": "r",
+            "attack_vector": "av", "route_key": "app.py:f", "cwe_id": 79,
+            "cwe_name": "XSS", "verification": {}}], "metrics": {}, "code_by_route": {}}))
+        ds.write_text(json.dumps({"units": units}))
+        export_csv(str(exp), str(ds), str(out))
+        with open(out, newline="") as f:
+            rows = list(csv.DictReader(f))
+    return rows
+
+
+_UNIT_AGENTIC = {
+    "id": "app.py:f",
+    "code": {"primary_code": "def f(): pass"},
+    "agent_context": {
+        "classification_reasoning": "the agentic-mode unit context",
+        "security_classification": "exploitable",
+    },
+}
+
+_UNIT_SINGLESHOT = {
+    "id": "app.py:f",
+    "code": {"primary_code": "def f(): pass"},
+    "llm_context": {
+        "reasoning": "the single-shot unit context",
+        "security_classification": "unknown",
+    },
+}
+
+_UNIT_ERROR_MARKER = {
+    "id": "app.py:f",
+    "code": {"primary_code": "def f(): pass"},
+    "agent_context": {
+        "error": {"type": "api_status", "status_code": 529},
+        "security_classification": "error",
+    },
+}
+
+
+def test_agentic_description_populates():
+    """The headline: agentic mode — the default — populates the CSV's
+    unit_description with agent_context.classification_reasoning (the issue
+    names this mapping as required, not a naive two-key fallback)."""
+    rows = _run_export([_UNIT_AGENTIC])
+    assert rows[0]["unit_description"] == "the agentic-mode unit context"
+
+
+def test_single_shot_description_still_populates():
+    """The guard: the single-shot path keeps populating from
+    llm_context.reasoning."""
+    rows = _run_export([_UNIT_SINGLESHOT])
+    assert rows[0]["unit_description"] == "the single-shot unit context"
+
+
+def test_agentic_classification_reads_both_keys():
+    """The exporter's half of #321's producer: the classification column
+    reads agent_context (agentic) with the llm_context fallback
+    (single-shot, post-#321) — the analyzer's precedence."""
+    rows = _run_export([_UNIT_AGENTIC])
+    assert rows[0]["agentic_classification"] == "exploitable"
+    rows2 = _run_export([_UNIT_SINGLESHOT])
+    assert rows2[0]["agentic_classification"] == "unknown"
+
+
+def test_the_error_marker_reaches_the_csv():
+    """The issue's additional evidence: the agentic error path writes a
+    security_classification="error" marker to agent_context explicitly so the
+    CSV shows honestly — but the exporter never read agent_context, so the
+    marker vanished (the comment's own purpose was unachieved)."""
+    rows = _run_export([_UNIT_ERROR_MARKER])
+    assert rows[0]["agentic_classification"] == "error"
+
+
+def test_both_keys_precedence():
+    """The analyzer's precedence: agent_context first when both exist (a
+    unit re-enhanced agentically after single-shot)."""
+    both = {
+        "id": "app.py:f",
+        "code": {"primary_code": "def f(): pass"},
+        "agent_context": {"classification_reasoning": "the fresh agentic"},
+        "llm_context": {"reasoning": "the stale single-shot"},
+    }
+    rows = _run_export([both])
+    assert rows[0]["unit_description"] == "the fresh agentic"

--- a/libs/openant-core/tests/test_issue326_csv_both_keys.py
+++ b/libs/openant-core/tests/test_issue326_csv_both_keys.py
@@ -21,7 +21,9 @@ import sys
 import tempfile
 from pathlib import Path
 
-CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
+# parents[1] — from tests/<file>, parents[2] is libs/ (the wrong dir;
+# masked only by PYTHONPATH in the suite run) (wave r1 fable).
+CORE = str(Path(__file__).resolve().parents[1])
 if CORE not in sys.path:
     sys.path.insert(0, CORE)
 
@@ -117,3 +119,56 @@ def test_both_keys_precedence():
     }
     rows = _run_export([both])
     assert rows[0]["unit_description"] == "the fresh agentic"
+
+
+# --- wave r1 (three axes): the same key-name class beyond the CSV ------------
+
+def test_stage1_prompt_keeps_the_agentic_justification():
+    """analysis_core read agent_context['reasoning'] — a key that never
+    exists (AgentResult.to_dict emits classification_reasoning), so the
+    Stage-1 prompt silently lost the justification on the default mode for
+    every unit (the live analyze-path instance of the CSV's mismatch)."""
+    import core.analysis_core as ac
+    import inspect
+    src = inspect.getsource(ac)
+    assert 'agent_context.get("classification_reasoning")' in src
+    assert 'agent_context.get("reasoning")' not in src
+
+
+def test_html_report_feeds_the_report_llm_the_agentic_description():
+    """html_report.py:168/:355 carried the byte-for-byte same read (the
+    report LLM saw every finding with NO unit context in agentic mode)."""
+    from report import html_report as hr
+    units = {"app.py:upload": {
+        "agent_context": {"security_classification": "vulnerable",
+                          "classification_reasoning": "unsanitized filename",
+                          "usage_context": "handles upload"}}}
+    experiment = {"results": [{"route_key": "app.py:upload",
+                               "finding": "vulnerable",
+                               "verdict": "VULNERABLE"}],
+                  "units_by_id": units}
+    findings = hr.prepare_findings_summary(experiment, {"units": [
+        {"id": "app.py:upload",
+         "agent_context": units["app.py:upload"]["agent_context"]}]})
+    assert findings, findings
+    assert "unsanitized filename" in findings[0]["description"], findings[0]
+
+
+def test_nonstring_agent_context_degrades_not_crashes():
+    """A hand-edited dataset with a non-dict agent_context exports a blank
+    description rather than raising (the analyzer's guard convention)."""
+    import tempfile as tf
+    import csv as _csv
+    from report.csv_export import export_csv as _ex
+    with tempfile.TemporaryDirectory() as d:
+        exp = Path(d) / "results.json"
+        ds = Path(d) / "dataset.json"
+        exp.write_text(json.dumps({"results": [
+            {"route_key": "app.py:x", "finding": "vulnerable",
+             "verdict": "VULNERABLE"}]}))
+        ds.write_text(json.dumps({"units": [
+            {"id": "app.py:x", "agent_context": "garbage", "code": "x=1"}]}))
+        out = Path(d) / "r.csv"
+        _ex(str(exp), str(ds), str(out))
+        row = list(_csv.DictReader(open(out)))[0]
+        assert row["unit_description"] == ""


### PR DESCRIPTION
`report/csv_export.py` read `llm_context` only. In agentic mode — the default on both entry points — the enhancer writes `agent_context` instead, so `unit_description` (the CSV's unit-context column) exported empty for every agentically enhanced unit. The enhancer's own agentic error path wrote a `security_classification="error"` marker to `agent_context` with the comment "the CSV shows honestly" — the marker never reached the CSV it was written for. PR #133's two-key reader (the mirror fix in `analyzer.py`) was added in the SAME commit that edited this file for `_csv_safe`, and was never carried across.

**The fix (base commit):** read `agent_context` first with the `llm_context` fallback (the analyzer's precedence); `unit_description` maps `classification_reasoning` (agentic) as well as `reasoning` (single-shot) — the key names differ, and the issue insists on the mapping; `agentic_classification` reads both keys (this file's half of #321's producer). 5 tests, RED 4 on pristine; the full suite 3521/1 (the known macOS artifact); ruff + hermeticity green.

**The wave-r1 round (three axes, all real, all fixed):**
- `report/html_report.py` carried the byte-for-byte same read at two sites (`:168` feeds the REPORT LLM a blank description in agentic mode — worse than the CSV; `:355` renders blank in the table) — both now read both keys with the classification_reasoning mapping;
- `core/analysis_core.py:288` read `agent_context["reasoning"]` — a key that never exists (`AgentResult.to_dict` emits `classification_reasoning`) — the Stage-1 prompt silently lost the justification on the DEFAULT mode for every unit (the live analyze-path instance of the class the CSV fix describes);
- the csv_export read degrades on a non-dict `agent_context` (isinstance guard, the analyzer's convention) instead of raising; the test shim pointed at `libs/` (parents[2]) instead of the core root — masked only by PYTHONPATH; the docstring updated to the honest column meaning (the LLM's analysis explanation — the issue's own insisted-upon mapping).

**Evidence:** 8 tests (the 3 new: the Stage-1 prompt keeps the agentic justification — source-level pin; `prepare_findings_summary` feeds the report LLM the agentic description; a non-dict agent_context exports blank, not crash); the full suite 3524/1 (the known macOS artifact); ruff clean; hermeticity green.

Fixes #326