### PR TITLE
fix(parsers/swift): an arithmetic callee still emits its call site — only the rightmost operand (#327)

### DIFF
--- a/libs/openant-core/parsers/swift/call_graph_builder.py
+++ b/libs/openant-core/parsers/swift/call_graph_builder.py
@@ -841,12 +841,46 @@ class CallGraphBuilder:
                         # here; a rightmost arithmetic node is descended, not
                         # attributed. Labels come from the OUTER node (the hoisted
                         # argument list is the rightmost operand's).
+                        #
+                        # Wave r1 (probed with tree-sitter, documented so the
+                        # next reader does not re-derive):
+                        # - bitwise (`x | f()`), custom-infix (`a <> f()`) and
+                        #   range (`0..<f()`) do NOT hoist — the call is an
+                        #   ordinary inner node the walk already resolves; the
+                        #   arithmetic-only scope of #327 HOLDS.
+                        # - a trailing COMMENT child (`a + b /* x */ (...)`)
+                        #   is stepped back past, not mistaken for the operand.
+                        # - `a + -f()` (a prefix_expression rightmost): the
+                        #   hoisted suffix applies to the whole `-f()`, so the
+                        #   prefix's OPERAND is the postfix-callable callee —
+                        #   descend into it (f is genuinely called).
+                        # - KNOWN RESIDUAL: a subscript rightmost (`a +
+                        #   tbl[i]()`) abstains — attributing `tbl` would
+                        #   fabricate a call on a possibly-array base; the #299
+                        #   alias-gated container path owns that dispatch.
+                        # - The navigation sub-branch below is defensive: the
+                        #   reachable `a + obj.m()` shapes reduce EARLY (the
+                        #   outer callee is already the navigation_expression
+                        #   the pre-existing branch handles); kept for grammar
+                        #   variance at no cost (the issue's item 3).
                         last = callee.children[-1] if callee.children else None
                         while (last is not None
                                and last.type in ("additive_expression",
-                                                 "multiplicative_expression")
+                                                 "multiplicative_expression",
+                                                 "prefix_expression")
                                and last.children):
-                            last = last.children[-1]
+                            if last.type == "prefix_expression":
+                                # the operand follows the operator: the LAST
+                                # non-operator child is the postfix-callable one
+                                last = last.children[-1]
+                            else:
+                                last = last.children[-1]
+                        if last is not None and last.type == "comment" and callee.children:
+                            # `a + b /* cached */ (x)`: step back past a
+                            # trailing comment to the real operand
+                            real = [c for c in callee.children
+                                    if c.type != "comment"]
+                            last = real[-1] if real else None
                         if last is not None and last.type == "simple_identifier":
                             labels, arity, trailing, unlabeled_trailing = self._call_labels(node, source)
                             sites.append({"text": self._text(last, source),

--- a/libs/openant-core/parsers/swift/call_graph_builder.py
+++ b/libs/openant-core/parsers/swift/call_graph_builder.py
@@ -825,6 +825,42 @@ class CallGraphBuilder:
                             sites.append({"text": dotted, "labels": labels,
                                           "arity": arity, "trailing": trailing,
                                           "unlabeled_trailing": unlabeled_trailing, "member": True})
+                    elif callee.type in ("additive_expression", "multiplicative_expression"):
+                        # #327: `f() + g()` — tree-sitter makes the `+`-expression
+                        # the callee of the OUTER call_expression and hoists g's
+                        # parens into the outer call_suffix, so neither existing
+                        # branch matched and g's site was never emitted (the
+                        # `+ - * / %` matrix in the issue). Attribute ONLY the
+                        # rightmost postfix-callable operand — the one the hoisted
+                        # suffix belongs to. The left operand is a VALUE: emitting
+                        # it fabricates an edge (`scale + t()` where `scale` is a
+                        # local Int would phantom-edge the real `scale` function).
+                        # Deeper chains (`c + tA() * lA()`) NEST — the inner
+                        # call_expression is re-walked below and fires this same
+                        # branch — so only the outermost rightmost is attributed
+                        # here; a rightmost arithmetic node is descended, not
+                        # attributed. Labels come from the OUTER node (the hoisted
+                        # argument list is the rightmost operand's).
+                        last = callee.children[-1] if callee.children else None
+                        while (last is not None
+                               and last.type in ("additive_expression",
+                                                 "multiplicative_expression")
+                               and last.children):
+                            last = last.children[-1]
+                        if last is not None and last.type == "simple_identifier":
+                            labels, arity, trailing, unlabeled_trailing = self._call_labels(node, source)
+                            sites.append({"text": self._text(last, source),
+                                          "labels": labels, "arity": arity,
+                                          "trailing": trailing,
+                                          "unlabeled_trailing": unlabeled_trailing})
+                        elif last is not None and last.type == "navigation_expression":
+                            dotted = self._navigation_text(last, source)
+                            if dotted:
+                                labels, arity, trailing, unlabeled_trailing = self._call_labels(node, source)
+                                sites.append({"text": dotted, "labels": labels,
+                                              "arity": arity, "trailing": trailing,
+                                              "unlabeled_trailing": unlabeled_trailing,
+                                              "member": True})
                 self._collect_arg_refs(node, source, arg_refs)
             elif node.type == "constructor_expression":
                 # `Box<Int>(value: 1)` — callee is a `user_type`; the base nominal is

--- a/libs/openant-core/tests/parsers/swift/test_issue327_arith_callee.py
+++ b/libs/openant-core/tests/parsers/swift/test_issue327_arith_callee.py
@@ -1,0 +1,96 @@
+"""#327: the Swift call-graph builder emits the arithmetic-callee call site.
+
+`_extract_calls` recorded a call only when the callee was a `simple_identifier` or a
+`navigation_expression`. Tree-sitter parses `f() + g()` with an ARITHMETIC expression as the
+callee of the outer call — neither branch matches, so g's site is not emitted and the edge is
+lost. Executed at b501968: `tAdd()` called plainly resolves; the same `tAdd()` as the right
+operand of `+` does not. The lost set: `+ - * / %` (additive/multiplicative shapes). `&&`, `??`,
+`<`, ternary, compound assign, and parenthesised right operands all resolve — arithmetic
+specifically, not binary expressions generally.
+
+The fabrication guard: a fix that attributes the LEFT operand invents calls — `scale + t()`
+would emit a phantom `scale` (a local Int, colliding with a real function name). Only the
+RIGHTMOST postfix-callable operand is attributed, with the outer node's labels.
+"""
+import sys
+from pathlib import Path
+
+CORE = str(Path(__file__).resolve().parents[3])  # libs/openant-core
+if CORE not in sys.path:
+    sys.path.insert(0, CORE)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _helpers import build  # noqa: E402
+
+
+FIXTURE = """
+func tAdd() -> Int { return 5 }
+func lhsA() -> Int { return 3 }
+func lhsB() -> Bool { return true }
+func lhsC() -> Int? { return nil }
+func lhsD() -> Int { return 3 }
+func lhsE() -> Int { return 3 }
+func mk() -> Helper { return Helper() }
+struct Helper { func m() -> Int { return 1 } }
+func f() -> Int { return 1 }
+func scale() -> Int { return 7 }
+
+func ctlAdd() -> Int { return tAdd() }
+func binAdd() -> Int { return lhsA() + tAdd() }
+func binSub() -> Int { return lhsA() - tAdd() }
+func binMul() -> Int { return lhsA() * tAdd() }
+func binDiv() -> Int { return lhsA() / tAdd() }
+func binMod() -> Int { return lhsA() % tAdd() }
+func twoCalls() -> Int { let c = 9; return c + tAdd() * lhsA() }
+func binNav() -> Int { return lhsA() + mk().m() }
+func noFabrication() -> Int { let scale = 3; return scale + tAdd() }
+"""
+
+
+def _callers_of(fn):
+    return fn
+
+
+def _run(src):
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        _, out = build(Path(d), {"A.swift": src})
+    return out["call_graph"]
+
+
+
+def test_arith_right_operand_resolves():
+    """The issue's matrix: tAdd() lost as the right operand of + - * / %."""
+    b = _run(FIXTURE)
+    for fn in ("binAdd", "binSub", "binMul", "binDiv", "binMod"):
+        edges = b.get(f"A.swift:{fn}", [])
+        assert "A.swift:tAdd" in edges, (fn, edges)
+
+
+def test_control_still_resolves():
+    b = _run(FIXTURE)
+    assert "A.swift:tAdd" in b.get("A.swift:ctlAdd", [])
+
+
+def test_left_side_call_also_survives():
+    """binNav's mk() — the LEFT operand's inner call — must not be lost."""
+    b = _run(FIXTURE)
+    edges = b.get("A.swift:binNav", [])
+    assert "A.swift:Helper.m" in edges, edges
+
+
+def test_no_phantom_left_operand():
+    """The fabrication guard: `scale + tAdd()` where scale is a LOCAL Int — no
+    edge to the scale FUNCTION; the rightmost postfix-callable operand only."""
+    b = _run(FIXTURE)
+    edges = b.get("A.swift:noFabrication", [])
+    assert "A.swift:tAdd" in edges, edges
+    assert "A.swift:scale" not in edges, edges
+
+
+def test_two_calls_both_resolve():
+    """`c + tAdd() * lhsA()` — both right-operand calls surface."""
+    b = _run(FIXTURE)
+    edges = b.get("A.swift:twoCalls", [])
+    assert "A.swift:tAdd" in edges, edges
+    assert "A.swift:lhsA" in edges, edges

--- a/libs/openant-core/tests/parsers/swift/test_issue327_arith_callee.py
+++ b/libs/openant-core/tests/parsers/swift/test_issue327_arith_callee.py
@@ -15,9 +15,6 @@ RIGHTMOST postfix-callable operand is attributed, with the outer node's labels.
 import sys
 from pathlib import Path
 
-CORE = str(Path(__file__).resolve().parents[3])  # libs/openant-core
-if CORE not in sys.path:
-    sys.path.insert(0, CORE)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _helpers import build  # noqa: E402
@@ -47,10 +44,6 @@ func noFabrication() -> Int { let scale = 3; return scale + tAdd() }
 """
 
 
-def _callers_of(fn):
-    return fn
-
-
 def _run(src):
     import tempfile
     with tempfile.TemporaryDirectory() as d:
@@ -65,6 +58,10 @@ def test_arith_right_operand_resolves():
     for fn in ("binAdd", "binSub", "binMul", "binDiv", "binMod"):
         edges = b.get(f"A.swift:{fn}", [])
         assert "A.swift:tAdd" in edges, (fn, edges)
+        # wave r1 (three axes): the LEFT operand's own call was asserted
+        # nowhere — a change that stopped pushing the additive's children
+        # would keep every matrix test green.
+        assert "A.swift:lhsA" in edges, (fn, edges)
 
 
 def test_control_still_resolves():
@@ -77,6 +74,11 @@ def test_left_side_call_also_survives():
     b = _run(FIXTURE)
     edges = b.get("A.swift:binNav", [])
     assert "A.swift:Helper.m" in edges, edges
+    # wave r1 (all axes): mk — the call nested in the right operand's
+    # navigation chain — was asserted NOWHERE (the test only checked the
+    # already-green Helper.m, pristine-safe; the docstring claimed this).
+    assert "A.swift:mk" in edges, edges
+    assert "A.swift:lhsA" in edges, edges
 
 
 def test_no_phantom_left_operand():
@@ -94,3 +96,48 @@ def test_two_calls_both_resolve():
     edges = b.get("A.swift:twoCalls", [])
     assert "A.swift:tAdd" in edges, edges
     assert "A.swift:lhsA" in edges, edges
+
+
+def test_navigation_right_operand_self_receiver():
+    """Wave r1 (fable): `1 + self.m()` — the reachable navigation shape (the
+    early reduction makes the outer callee the navigation_expression the
+    pre-existing branch handles; pins that the fix did not break it)."""
+    src = """
+struct S {
+    func m() -> Int { return 1 }
+    func n() -> Int { return 1 + self.m() }
+}
+"""
+    b = _run(src)
+    edges = b.get("A.swift:S.n", [])
+    assert "A.swift:S.m" in edges, edges
+
+
+def test_prefix_rightmost_operand_is_called():
+    """Wave r1 (probed + confirmed): `a + -f()` — the hoisted suffix applies
+    to the whole `-f()`, so the prefix's operand IS the callee (f is genuinely
+    called). RED before this round (the site was silently lost)."""
+    src = """
+func f() -> Int { return 1 }
+func pre() -> Int { return a + -f() }
+"""
+    b = _run(src)
+    edges = b.get("A.swift:pre", [])
+    assert "A.swift:f" in edges, edges
+
+
+def test_labels_come_from_the_outer_node():
+    """Wave r1 (opus): the commit's central design claim — labels/arity come
+    from the OUTER node (the hoisted argument list) — was untested (every
+    fixture was zero-arity). Pinned at the SITE level: the arithmetic-callee
+    site carries the x label and arity 1 (reading the callee instead would
+    yield labels=[] / arity=0 — the additive has no call_suffix)."""
+    from _helpers import CallGraphBuilder
+    src = "func pick() -> Int { return 2 + over(x: 1) }"
+    bld = CallGraphBuilder({"functions": {}, "classes": {}, "files": {}})
+    sites, _refs = bld._find_calls_in_code(src)
+    arith = [s for s in sites if s["text"] == "over"]
+    assert arith, sites
+    s = arith[0]
+    assert s["labels"] == ["x"], s
+    assert s["arity"] == 1, s

--- a/libs/openant-core/tests/parsers/swift/test_issue327_arith_callee.py
+++ b/libs/openant-core/tests/parsers/swift/test_issue327_arith_callee.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _helpers import build  # noqa: E402
+from _helpers import build, edges  # noqa: E402
 
 
 FIXTURE = """
@@ -141,3 +141,22 @@ def test_labels_come_from_the_outer_node():
     s = arith[0]
     assert s["labels"] == ["x"], s
     assert s["arity"] == 1, s
+
+
+def test_trailing_comment_operand_skipped(tmp_path):
+    """famBCR panel (sonnet): the trailing-comment skip branch
+    (`b /* cached */ + t /* hoisted */ (x)` — step back past the comment
+    to the real operand) had zero coverage. Pinned with the file's own
+    build helper: the callee t must still resolve through the comment."""
+    src = """
+func t() -> Int { return 1 }
+func run() -> Int {
+    let b = 2
+    return b /* cached */ + t /* hoisted */ (x)
+}
+"""
+    _, cg = build(tmp_path, {"app.swift": src})
+    all_edges = edges(cg)
+    assert ("run", "t") in all_edges, (
+        f"the trailing comment must not hide the callee: {all_edges}")
+


### PR DESCRIPTION
`_extract_calls` recorded a call only when the callee was a `simple_identifier` or a `navigation_expression`. Tree-sitter parses `f() + g()` with an ARITHMETIC expression as the callee of the OUTER call and hoists g's parens into the outer call_suffix — neither branch matched, g's site was never emitted (the `+ - * / %` matrix in the issue; `&&`, `??`, `<`, ternary, compound assign all resolve — arithmetic specifically, not binary expressions generally). The issue's census: 89/52187 arithmetic-callee sites, 32 genuinely lost per-caller.

**The fix (base commit):** a third branch for additive/multiplicative callees attributing ONLY the rightmost postfix-callable operand (the hoisted suffix's owner); the left operand is a VALUE — emitting it fabricates an edge (`scale + t()` where scale is a local Int would phantom-edge the real `scale` function, the issue's executed fabrication case); labels from the OUTER node; nested chains re-walked; rightmost arithmetic descended. 5 tests, RED 3 on pristine; the Swift suite 80/0 (issue-HEAD + later additions); the JS-unrelated full suite 3521/1 (the known macOS artifact).

**The wave-r1 round (three axes + local tree-sitter probes — the wave's sandbox denied execution):**
- the PREFIX rightmost (`a + -f()`): the hoisted suffix applies to the whole `-f()`, so the prefix's operand IS the callee — f is genuinely called, and the site was silently lost (probed: no call_graph entry on the prior code). The descent handles prefix_expression; a trailing comment child is stepped back past;
- `test_left_side_call_also_survives` asserted only the pristine-green Helper.m edge — mk (the docstring's own claim) and lhsA (the left operand's call) were asserted NOWHERE; now asserted, along with lhsA across the whole matrix;
- the labels-from-the-OUTER-node claim was untestable by edge identity (the graph collapses overloads to the bare name); pinned at the SITE level (labels=['x'], arity=1);
- the operator scope PROBED, not assumed: bitwise (`x | f()`), custom-infix (`a <> f()`) and range (`0..<f()`) do NOT hoist — the arithmetic-only scope holds, documented with the probe evidence; the navigation sub-branch is documented as defensive (the reachable shapes reduce early); the subscript rightmost is the known residual (#299's alias-gated path owns that dispatch); hygiene: the dead helper and unused path insert removed.

**Evidence:** 8 tests (the prefix test is RED on the pre-round code; the labels test fails under the mutation it exists to catch); the file green alone; the swift directory batch carries the pre-existing order pollution (identical on the branch base — fixed separately in the #415 PR); the full suite 3524/1 (the known macOS artifact); ruff clean.

Fixes #327