### PR TITLE
fix(parsers/ruby): inline-visibility definitions are extracted, not dropped (#329)

### DIFF
--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -498,6 +498,24 @@ class FunctionExtractor:
                     # a definition; the arg-form keeps its no-descent behaviour
                     # (descending would emit phantom units from the symbols).
                     handled = not self._call_wraps_a_definition(node)
+                    if not handled:
+                        # Wave r1 (three axes, one root cause): descend into
+                        # the call's children EXCEPT its own visibility-keyword
+                        # identifier — the generic descend re-visited `private`
+                        # as a standalone node, tripped the bare-marker toggle
+                        # below, and leaked the visibility onto EVERY
+                        # subsequent sibling `def` in the class body (a
+                        # genuinely public method following an inline-visibility
+                        # def was misclassified and dropped as a route-handler
+                        # — the entry-point false-negative direction this fix
+                        # set out to close, reintroduced through a side channel).
+                        kw = method_name
+                        for child in node.children:
+                            if child.type == 'identifier' and \
+                                    self._node_text(child, source) == kw:
+                                continue
+                            stack.append((child, class_name, module_name, vis_state))
+                        handled = True
                 if not handled:
                     for child in reversed(node.children):
                         stack.append((child, class_name, module_name, vis_state))

--- a/libs/openant-core/parsers/ruby/function_extractor.py
+++ b/libs/openant-core/parsers/ruby/function_extractor.py
@@ -255,6 +255,27 @@ class FunctionExtractor:
                     return None  # first real arg is not a constant
         return None
 
+    @staticmethod
+    def _definitions_wrapped_by(call_node):
+        """Method/singleton_method nodes passed as arguments to a call (#329).
+
+        Covers `private def x`, `private(def x)` and `private def self.x` — the
+        inline-visibility forms tree-sitter parses as a call whose argument
+        (direct child or inside an argument_list) is the definition itself.
+        """
+        out = []
+        for c in call_node.children:
+            if c.type in ('method', 'singleton_method'):
+                out.append(c)
+            elif c.type == 'argument_list':
+                out.extend(gc for gc in c.children
+                           if gc.type in ('method', 'singleton_method'))
+        return out
+
+    def _call_wraps_a_definition(self, node) -> bool:
+        """True when this call's arguments contain a method definition (#329)."""
+        return bool(self._definitions_wrapped_by(node))
+
     def _call_receiver_and_method(self, node, source: bytes):
         """For a 'call' node, return (method_name, [literal positional args]).
 
@@ -469,7 +490,14 @@ class FunctionExtractor:
                     # the named symbol(s), NOT subsequent defs. Consume it here
                     # (without descending) so its inner `private` identifier does
                     # not leak into the bare-marker toggle below.
-                    handled = True
+                    # #329: the inline-def form `private def foo` is ALSO a call
+                    # named `private`, but its argument is a method node —
+                    # consuming that without descending drops the definition
+                    # (a missing call-graph node: a tainted path THROUGH the
+                    # method disappears). Descend exactly when the call wraps
+                    # a definition; the arg-form keeps its no-descent behaviour
+                    # (descending would emit phantom units from the symbols).
+                    handled = not self._call_wraps_a_definition(node)
                 if not handled:
                     for child in reversed(node.children):
                         stack.append((child, class_name, module_name, vis_state))
@@ -607,6 +635,17 @@ class FunctionExtractor:
                 method_name, args = self._call_receiver_and_method(child, source)
                 if method_name in ('define_method', 'alias_method') and args:
                     methods.append(args[0])
+                # #329: `private def x` / `private def self.x` — the roster must
+                # not disagree with `functions` (both are part of the emitted
+                # artifact); the singleton carries the `self.` prefix like the
+                # singleton_method case above.
+                for defn in self._definitions_wrapped_by(child):
+                    mname = self._get_method_name(defn, source)
+                    if mname:
+                        if defn.type == 'singleton_method':
+                            methods.append(f"self.{mname}")
+                        else:
+                            methods.append(mname)
         return methods
 
     @staticmethod

--- a/libs/openant-core/tests/parsers/ruby/test_issue329_inline_visibility.py
+++ b/libs/openant-core/tests/parsers/ruby/test_issue329_inline_visibility.py
@@ -122,3 +122,45 @@ def test_arg_form_visibility_keeps_no_descent(tmp_path):
     )
     roster = result["classes"]["n.rb:D"]["methods"]
     assert "g" in roster and "h" in roster
+
+
+def test_inline_visibility_does_not_leak_onto_siblings(tmp_path):
+    """Wave r1 (three axes, one root cause): the descend re-visited the call's
+    own `private` identifier, tripping the bare-marker toggle and leaking the
+    visibility onto every subsequent sibling def — a genuinely public method
+    after an inline-visibility def was misclassified and dropped as a
+    route-handler (the entry-point false-negative direction)."""
+    result = _extract(
+        tmp_path,
+        "leak.rb",
+        "class C\n"
+        "  private def a; end\n"
+        "  def plain; end\n"
+        "end\n",
+    )
+    names = _names(result)
+    assert "a" in names and "plain" in names, names
+    plain = next(fd for fd in result["functions"].values() if fd["name"] == "plain")
+    leaked = plain.get("visibility")
+    assert leaked in (None, "public"), (
+        f"the inline `private def` leaked onto the sibling: plain.visibility={leaked!r}"
+    )
+
+
+def test_arg_form_still_does_not_toggle(tmp_path):
+    """The arg form `private :g` must not toggle the class-body visibility
+    either (the no-descent path never re-visits the identifier — pinned)."""
+    result = _extract(
+        tmp_path,
+        "noleak.rb",
+        "class D\n"
+        "  def g; end\n"
+        "  private :g\n"
+        "  def h; end\n"
+        "end\n",
+    )
+    h = next(fd for fd in result["functions"].values() if fd["name"] == "h")
+    leaked = h.get("visibility")
+    assert leaked in (None, "public"), (
+        f"the arg-form toggled a sibling: h.visibility={leaked!r}"
+    )

--- a/libs/openant-core/tests/parsers/ruby/test_issue329_inline_visibility.py
+++ b/libs/openant-core/tests/parsers/ruby/test_issue329_inline_visibility.py
@@ -1,0 +1,124 @@
+"""#329: the Ruby extractor drops inline-visibility method definitions.
+
+`private def foo` / `protected def foo` / `public def foo` (and the parenthesised /
+singleton forms) are parsed by tree-sitter as a `call` named `private` whose argument
+is a `method` node. The extractor's arg-form branch (merged PR #86 — `private :foo`
+privatizes only the NAMED symbol, so consuming without descending is correct there)
+matches on method name only, sets `handled = True`, and the nested def never reaches
+the `method` handler: the unit is absent from `functions` and from the class roster.
+A dropped method is a missing call-graph node — a tainted path THROUGH an
+inline-visibility method disappears (the false-negative direction).
+
+`module_function def x` and `private_class_method def x` survive (different call
+names, not in the tuple), block-style `private` + `def x` survives (the bare-marker
+toggle path) — same syntactic shape, different call name, opposite outcome: the
+mechanism, per the issue's executed matrix.
+
+The fix descends only when the visibility call actually WRAPS a definition — the
+arg-form negative control (no phantom units, roster unchanged) must keep its
+no-descent behaviour.
+"""
+import sys
+from pathlib import Path
+
+_CORE_ROOT = Path(__file__).resolve().parents[3]
+if str(_CORE_ROOT) not in sys.path:
+    sys.path.insert(0, str(_CORE_ROOT))
+
+from parsers.ruby.function_extractor import FunctionExtractor
+
+
+def _extract(tmp_path: Path, filename: str, source: str) -> dict:
+    rb = tmp_path / filename
+    rb.write_text(source)
+    extractor = FunctionExtractor(str(tmp_path))
+    return extractor.extract_all([filename])
+
+
+def _names(result: dict) -> set:
+    return {fd["name"] for fd in result["functions"].values()}
+
+
+def test_inline_visibility_methods_are_extracted(tmp_path):
+    """`private/protected/public def` units are extracted; the plain `def`
+    control in the same class body proves the absences are not a harness artifact."""
+    result = _extract(
+        tmp_path,
+        "inline.rb",
+        "class C\n"
+        "  private def a; end\n"
+        "  protected def b; end\n"
+        "  public def c; end\n"
+        "  def plain; end\n"
+        "end\n",
+    )
+    names = _names(result)
+    assert "plain" in names, f"control missing — fixture failed to parse: {names}"
+    for m in ("a", "b", "c"):
+        assert m in names, (
+            f"inline-visibility method {m!r} dropped (control 'plain' present): {names}"
+        )
+    # Units are class-qualified like plain defs.
+    assert "inline.rb:C.a" in result["functions"]
+    assert "inline.rb:C.b" in result["functions"]
+    assert "inline.rb:C.c" in result["functions"]
+
+
+def test_inline_visibility_singleton_is_extracted(tmp_path):
+    """`private def self.x` — the inline singleton form; `def self.y` is the control."""
+    result = _extract(
+        tmp_path,
+        "sing.rb",
+        "class C\n"
+        "  private def self.x; end\n"
+        "  def self.y; end\n"
+        "end\n",
+    )
+    names = _names(result)
+    assert "y" in names, f"control missing — fixture failed to parse: {names}"
+    assert "x" in names, f"inline singleton dropped (control 'y' present): {names}"
+    assert "sing.rb:C.x" in result["functions"]
+
+
+def test_inline_visibility_methods_reach_the_class_roster(tmp_path):
+    """classes[...]['methods'] must not disagree with functions: the roster
+    carries the inline methods too, with the `self.` prefix for singletons."""
+    result = _extract(
+        tmp_path,
+        "roster.rb",
+        "class C\n"
+        "  private def a; end\n"
+        "  def plain; end\n"
+        "end\n"
+        "class D\n"
+        "  private def self.sing; end\n"
+        "end\n",
+    )
+    roster_c = result["classes"]["roster.rb:C"]["methods"]
+    assert "plain" in roster_c, f"control missing from roster: {roster_c}"
+    assert "a" in roster_c, f"inline method missing from roster: {roster_c}"
+    roster_d = result["classes"]["roster.rb:D"]["methods"]
+    assert "self.sing" in roster_d, (
+        f"inline singleton missing from roster (want 'self.sing'): {roster_d}"
+    )
+
+
+def test_arg_form_visibility_keeps_no_descent(tmp_path):
+    """The negative control: `private :g` privatizes only the NAMED symbol —
+    descending would emit phantom units from the symbols. Exactly the two defs."""
+    result = _extract(
+        tmp_path,
+        "n.rb",
+        "class D\n"
+        "  def g; end\n"
+        "  def h; end\n"
+        "  private :g\n"
+        "  protected :h\n"
+        "end\n",
+    )
+    names = _names(result)
+    assert names == {"g", "h"}, (
+        f"arg-form visibility must not invent units (want exactly g, h): {names}"
+    )
+    roster = result["classes"]["n.rb:D"]["methods"]
+    assert "g" in roster and "h" in roster


### PR DESCRIPTION
The Ruby `FunctionExtractor` drops methods defined with the inline-visibility form `private def foo` / `protected def foo` / `public def foo` (the issue's fifteen-form matrix: all four inline forms dropped; `module_function def`, block-style, plain `def` survive — same syntactic shape, different call name, opposite outcome). A dropped method is a missing call-graph node: a tainted path THROUGH an inline-visibility method disappears (the false-negative direction).

**Root cause:** the arg-form branch (merged PR #86 — `private :foo` privatizes only the NAMED symbol, so no-descent is correct there) matches on method name only; `private def foo` is ALSO a call named `private`, but its argument is a `method` node — `handled = True` skipped the descent, so the nested def never reached the `method` handler. The second site: the roster (`_collect_class_method_names`) mined only `define_method`/`alias_method`, so `classes[...]['methods']` disagreed with `functions` too (output consistency only — the issue's correction: the roster's only non-test consumers are the class-reopen dedup; fixing the extractor alone recovers units AND edges).

**The fix (base commit):** descend exactly when the visibility call wraps a definition (`_call_wraps_a_definition` via `_definitions_wrapped_by` — direct, parenthesised, and singleton forms); the arg-form keeps its no-descent behaviour (descending would emit phantom units from the symbols); the roster mines the same nodes with the `self.` prefix for singletons. 4 tests, RED 3 on pristine (each failing on the defect assertion with the control present); the Ruby suite 80/0; the full suite 3520/1 (the known macOS artifact).

**The wave-r1 round (three axes, one root cause, all fixed):**
- descending the wrapped call's children re-visited the call's OWN `private` identifier as a standalone node, tripped the bare-marker toggle, and leaked the visibility onto EVERY subsequent sibling `def` in the class body — a genuinely public method after an inline-visibility def was misclassified and dropped as a route-handler (the entry-point false-negative direction, reintroduced through a side channel none of the round-1 tests asserted on — no test checked the visibility field). The descend skips the keyword identifier now; the leak is pinned (mutation-proven: removing the keyword-skip fails the new test) and the arg-form no-toggle pin added.

**Evidence:** 6 tests in the file (the leak pin; the arg-form no-toggle; the four originals); the ruby suite 82/0; the full suite 3522/1 (the known macOS artifact); ruff clean.

Fixes #329