### PR TITLE
fix(parsers/javascript): module-top-level code becomes a line-masked module unit (#330)

### DIFF
--- a/libs/openant-core/parsers/javascript/typescript_analyzer.js
+++ b/libs/openant-core/parsers/javascript/typescript_analyzer.js
@@ -1033,51 +1033,91 @@ class TypeScriptAnalyzer {
   }
 
   /**
-   * Emit a synthetic unit when a file's top-level statements are dominated by
-   * a bare side-effect call (e.g. an Electron preload script that only calls
-   * contextBridge.exposeInMainWorld({...})). Without this, such files yield
-   * zero units even though they carry analysable behaviour.
+   * #330: emit ONE synthetic `<file>:module` unit per file holding the module
+   * top-level code — IIFEs, callbacks passed to top-level calls, bare driver
+   * calls, initialiser calls — which belongs to no emitted unit. The call
+   * graph scans only emitted units' code, so in any file with >=1 real unit
+   * those calls (including calls to sinks) never became edges: a sink
+   * reachable through bootstrap code alone got no incoming edge from it
+   * (the false-negative direction). The previous capture fired only on
+   * files with ZERO units.
+   *
+   * The residual is masked by EMITTED UNIT LINE RANGES — the Python
+   * extractor's :__module__ precedent, which wrote down why: exclusion by
+   * whole-STATEMENT containment drops the class/object-literal boundary and
+   * leaks member bodies in, attributing their calls to module load, which is
+   * not when they run (with module_level entry-point seeding, fabricated
+   * reachability). Emitted only when the residual contains a call. This
+   * subsumes the old empty-file fallback, whose receiver-naming also
+   * fabricated callee labels (`x.js:[1].forEach`).
    */
   _extractTopLevelSideEffects(sourceFile, relativePath) {
-    // Only synthesise when the regular extractors produced nothing for this
-    // file — otherwise we'd duplicate real functions/methods.
+    const functionId = `${relativePath}:module`;
+    // A real unit named `module` wins — never clobber it.
+    if (this.functions[functionId]) return;
+
     const filePrefix = `${relativePath}:`;
-    const hasAny = Object.keys(this.functions).some((id) =>
-      id.startsWith(filePrefix),
-    );
-    if (hasAny) return;
-
-    for (const statement of sourceFile.getStatements()) {
-      if (statement.getKindName() !== "ExpressionStatement") continue;
-      const expr = statement.getExpression();
-      if (!expr || expr.getKindName() !== "CallExpression") continue;
-
-      const callee = expr.getExpression();
-      let label = "module";
-      if (callee && callee.getKindName() === "PropertyAccessExpression") {
-        const obj = callee.getExpression
-          ? callee.getExpression().getText()
-          : "";
-        const member = callee.getName ? callee.getName() : "";
-        label = member ? `${obj}.${member}` : obj || "module";
-      } else if (callee && callee.getKindName() === "Identifier") {
-        label = callee.getText();
+    const covered = new Set();
+    for (const [id, fd] of Object.entries(this.functions)) {
+      if (!id.startsWith(filePrefix)) continue;
+      const s = fd.startLine;
+      const e = fd.endLine;
+      if (Number.isInteger(s) && Number.isInteger(e)) {
+        for (let ln = s; ln <= e; ln++) covered.add(ln);
       }
-
-      const functionId = `${relativePath}:${label}`;
-      if (this.functions[functionId]) continue;
-      const code = statement.getFullText();
-      this.functions[functionId] = {
-        name: label,
-        code: code,
-        isExported: false,
-        unitType: "module_level",
-        startLine: statement.getStartLineNumber(),
-        endLine: statement.getEndLineNumber(),
-      };
-      // One synthetic unit per file is enough to make the file analysable.
-      return;
     }
+
+    const lines = sourceFile.getFullText().split("\n");
+    const residual = [];
+    let first = null;
+    let last = null;
+    for (let i = 0; i < lines.length; i++) {
+      const ln = i + 1;
+      if (covered.has(ln)) continue;
+      const stripped = lines[i].trim();
+      if (
+        !stripped ||
+        stripped.startsWith("//") ||
+        stripped.startsWith("/*") ||
+        stripped.startsWith("*")
+      ) {
+        continue;
+      }
+      residual.push(lines[i]);
+      if (first === null) first = ln;
+      last = ln;
+    }
+    if (first === null || !residual.length) return;
+
+    const code = residual.join("\n");
+    if (!this._residualContainsCall(code)) return;
+
+    this.functions[functionId] = {
+      name: "module",
+      code: code,
+      isExported: false,
+      unitType: "module_level",
+      startLine: first,
+      endLine: last,
+    };
+  }
+
+  /**
+   * True when text contains a function call — `foo(..)`, `obj.method(..)`,
+   * `new C(..)` — excluding keyword openers (if/for/while/switch/catch/
+   * function), which are not calls. #330's emit gate: a file whose residual is
+   * imports and assignments only yields no module unit.
+   */
+  _residualContainsCall(text) {
+    const KEYWORDS = new Set([
+      "if", "for", "while", "switch", "catch", "function",
+    ]);
+    const re = /([A-Za-z_$][\w$]*)\s*\(/g;
+    let m;
+    while ((m = re.exec(text)) !== null) {
+      if (!KEYWORDS.has(m[1])) return true;
+    }
+    return false;
   }
 
   /**

--- a/libs/openant-core/parsers/javascript/typescript_analyzer.js
+++ b/libs/openant-core/parsers/javascript/typescript_analyzer.js
@@ -1066,19 +1066,44 @@ class TypeScriptAnalyzer {
         for (let ln = s; ln <= e; ln++) covered.add(ln);
       }
     }
+    // #330 (wave r1 opus): CLASS DECLARATION RANGES are masked whole — the
+    // Python :__module__ precedent covers ast.ClassDef bodies, and class
+    // field initializers (`private repo = new Repo();`, `cache =
+    // buildCache();`) are on NO unit's line range, so they leaked into the
+    // residual and their calls were attributed to module load — fabricated
+    // reachability from a synthetic root, the exact defect the b.js guard
+    // asserts against, one class field away.
+    for (const cls of sourceFile.getDescendantsOfKind(
+        ts.SyntaxKind.ClassDeclaration)) {
+      for (let ln = cls.getStartLineNumber(); ln <= cls.getEndLineNumber(); ln++) {
+        covered.add(ln);
+      }
+    }
 
     const lines = sourceFile.getFullText().split("\n");
     const residual = [];
     let first = null;
     let last = null;
+    // #330 (wave r1 sonnet): track multi-line /* ... */ blocks — an interior
+    // line without a leading * is still comment content, and commented-out
+    // code must not fabricate module-load edges (the resolver extracts the
+    // module unit's edges from this text with plain regexes).
+    let inBlockComment = false;
     for (let i = 0; i < lines.length; i++) {
       const ln = i + 1;
       if (covered.has(ln)) continue;
       const stripped = lines[i].trim();
+      if (inBlockComment) {
+        if (stripped.endsWith("*/")) inBlockComment = false;
+        continue;
+      }
+      if (stripped.startsWith("/*")) {
+        if (!stripped.endsWith("*/")) inBlockComment = true;
+        continue;
+      }
       if (
         !stripped ||
         stripped.startsWith("//") ||
-        stripped.startsWith("/*") ||
         stripped.startsWith("*")
       ) {
         continue;
@@ -1100,6 +1125,61 @@ class TypeScriptAnalyzer {
       startLine: first,
       endLine: last,
     };
+
+    // #330 (wave r1 opus, the headline): the Pattern-A companion — every
+    // other synthetic emit pairs the unit with real callGraph edges, and the
+    // analyzer's callGraph is what call_graph.json (and therefore the
+    // reachability pipeline) consumes. Without this, the module unit existed
+    // with [] edges in the graph that gates reachability: the issue's false
+    // negative survived behind the resolver's second graph (which only
+    // bundles the dataset).
+    this.callGraph[functionId] = this._moduleUnitEdges(
+      sourceFile, covered, relativePath);
+  }
+
+  /**
+   * The module unit's outgoing edges: the CallExpression/NewExpression
+   * descendants that start on UNCOVERED lines (the residual's own calls —
+   * the same shape extractCallsFromFunction derives from a function node,
+   * filtered to the lines the unit actually carries).
+   */
+  _moduleUnitEdges(sourceFile, covered, relativePath) {
+    const calls = [];
+    const seen = new Set();
+    const pushName = (name, dynamic, member = false) => {
+      const key = `${name} ${dynamic ? 1 : 0}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      calls.push({ resolved: false, name: name, dynamic: dynamic, member: member });
+    };
+    const callExprs = sourceFile.getDescendantsOfKind(
+      ts.SyntaxKind.CallExpression,
+    );
+    for (const callExpr of callExprs) {
+      if (covered.has(callExpr.getStartLineNumber())) continue;
+      const callee = callExpr.getExpression();
+      const normalized = this._normalizeCallName(callee);
+      if (normalized) {
+        pushName(normalized, false,
+                 !!callee && callee.getKindName() === "PropertyAccessExpression");
+      } else {
+        const raw = callee ? callee.getText().replace(/\s+/g, " ").trim() : "";
+        pushName(raw, true);
+      }
+      for (const arg of callExpr.getArguments()) {
+        if (arg.getKindName() === "Identifier") {
+          pushName(arg.getText(), false);
+        }
+      }
+    }
+    const newExprs = sourceFile.getDescendantsOfKind(
+      ts.SyntaxKind.NewExpression,
+    );
+    for (const newExpr of newExprs) {
+      if (covered.has(newExpr.getStartLineNumber())) continue;
+      pushName(newExpr.getExpression().getText(), false);
+    }
+    return calls;
   }
 
   /**
@@ -1109,8 +1189,13 @@ class TypeScriptAnalyzer {
    * imports and assignments only yields no module unit.
    */
   _residualContainsCall(text) {
+    // #330 (wave r1 opus): `require(...)`/`import(...)` are module-system
+    // plumbing, not bootstrap behaviour — the Python precedent skips
+    // import lines before deciding to emit, and a plain CJS header
+    // (`const fs = require('fs');`) otherwise emitted a zero-edge module
+    // unit for nearly every file in a corpus.
     const KEYWORDS = new Set([
-      "if", "for", "while", "switch", "catch", "function",
+      "if", "for", "while", "switch", "catch", "function", "require", "import",
     ]);
     const re = /([A-Za-z_$][\w$]*)\s*\(/g;
     let m;

--- a/libs/openant-core/tests/parsers/javascript/test_issue330_module_scope_unit.py
+++ b/libs/openant-core/tests/parsers/javascript/test_issue330_module_scope_unit.py
@@ -154,3 +154,85 @@ def test_no_module_unit_without_a_residual_call(tmp_path):
     assert "x.js:module" not in out["functions"], (
         f"no residual call — module unit must not be emitted: {list(out['functions'])}"
     )
+
+
+def _analyze_only(repo_path, file_path):
+    cmd = ["node", str(ANALYZER_JS), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def test_module_unit_edges_reach_the_reachability_graph(tmp_path):
+    """Wave r1 (opus, the headline): the analyzer's own callGraph gates
+    call_graph.json — the reachability pipeline never reads the resolver's
+    second graph. Without the Pattern-A companion the unit existed with []
+    edges: the issue's false negative survived behind the unit's presence."""
+    repo = tmp_path / "m330g"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "x.js").write_text(X_JS)
+    out = _analyze_only(repo, repo / "x.js")
+    mod = out.get("callGraph", {}).get("x.js:module", [])
+    names = {e.get("name") for e in mod}
+    assert "sink" in names, f"the module unit's edges are missing from the graph that gates reachability: {mod}"
+    assert "main" in names, mod
+
+
+def test_class_field_initializers_do_not_leak(tmp_path):
+    """Wave r1 (opus): class field initializers are on NO unit's line range
+    (the Python precedent covers whole ClassDef bodies) — buildCache() ran at
+    instantiation but was attributed to module load: fabricated reachability
+    from a synthetic root, one class field away from the b.js guard."""
+    src = """function buildCache() { return 1; }
+function bootstrapCall() { return 3; }
+class Svc {
+  cache = buildCache();
+}
+bootstrapCall();
+"""
+    repo = tmp_path / "m330f"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "f.js").write_text(src)
+    out = _analyze_only(repo, repo / "f.js")
+    mod = out.get("callGraph", {}).get("f.js:module", [])
+    names = {e.get("name") for e in mod}
+    assert "bootstrapCall" in names, mod
+    assert "buildCache" not in names, f"class-field initializer attributed to module load: {mod}"
+
+
+def test_require_only_header_does_not_emit(tmp_path):
+    """Wave r1 (opus): `const fs = require('fs')` is module-system plumbing,
+    not bootstrap behaviour (the Python precedent skips import lines before
+    deciding) — a CJS header alone must not emit a zero-edge module unit."""
+    src = "const fs = require('fs');\nconst path = require('path');\n"
+    repo = tmp_path / "m330c"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "c.js").write_text(src)
+    out = _analyze_only(repo, repo / "c.js")
+    assert "c.js:module" not in out["functions"], list(out["functions"])
+
+
+def test_commented_out_code_fabricates_no_edges(tmp_path):
+    """Wave r1 (sonnet): interior lines of a /* ... */ block without a
+    leading * leaked into the residual — commented-out calls must not
+    fabricate module-load edges."""
+    src = """function realHelper() { return 1; }
+function legacyMigrate() { return 2; }
+/*
+realHelper();
+legacyMigrate();
+*/
+"""
+    repo = tmp_path / "m330k"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / "k.js").write_text(src)
+    out = _analyze_only(repo, repo / "k.js")
+    mod = out.get("callGraph", {}).get("k.js:module")
+    if mod is not None:
+        names = {e.get("name") for e in mod}
+        assert "realHelper" not in names and "legacyMigrate" not in names, mod
+    # and the residual gate: a file whose only "call" is commented out
+    # emits no module unit at all (no uncovered call).
+    assert "k.js:module" not in out["functions"], list(out["functions"])

--- a/libs/openant-core/tests/parsers/javascript/test_issue330_module_scope_unit.py
+++ b/libs/openant-core/tests/parsers/javascript/test_issue330_module_scope_unit.py
@@ -1,0 +1,156 @@
+"""#330: module-top-level code becomes a unit — line-masked, never containment.
+
+In a JS/TS file with at least one real function, code at module top level — IIFEs,
+callbacks passed to top-level calls, bare driver calls, initialiser calls — belonged
+to no emitted unit, and the call graph scans only emitted units' code, so calls made
+at module load (including calls to sinks) never became edges. A sink reachable through
+top-level bootstrap code alone got no incoming edge from it (the false-negative
+direction). The old capture (`_extractTopLevelSideEffects`) fired only on files with
+ZERO units.
+
+The exclusion strategy is the point: the synthetic module unit must mask by EMITTED
+UNIT LINE RANGES (the Python extractor's :__module__ precedent, which wrote down why),
+NOT by whole-statement containment — containment drops the class/object-literal
+boundary and leaks member bodies in, attributing their calls to module load, which is
+not when they run (and with module_level entry-point seeding, fabricated reachability).
+The b.js fixture below separates the two strategies: only the bootstrap call runs at
+module load.
+"""
+import json
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+PARSERS_JS_DIR = Path(__file__).parent.parent.parent.parent / "parsers" / "javascript"
+ANALYZER_JS = PARSERS_JS_DIR / "typescript_analyzer.js"
+RESOLVER_JS = PARSERS_JS_DIR / "dependency_resolver.js"
+NODE_MODULES = PARSERS_JS_DIR / "node_modules"
+
+pytestmark = pytest.mark.skipif(
+    not shutil.which("node") or not NODE_MODULES.exists(),
+    reason="Node.js or JS parser npm dependencies not available",
+)
+
+
+def _analyze(repo_path, file_path):
+    cmd = ["node", str(ANALYZER_JS), str(repo_path), str(file_path)]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, (
+        f"analyzer failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return json.loads(result.stdout)
+
+
+def _build_call_graph(analyzer_output: dict) -> dict:
+    harness = textwrap.dedent(
+        f"""
+        const {{ DependencyResolver }} = require({json.dumps(str(RESOLVER_JS))});
+        const out = JSON.parse(process.argv[1]);
+        const r = new DependencyResolver(out, {{}});
+        r.buildCallGraph();
+        process.stdout.write(JSON.stringify(r.callGraph));
+        """
+    )
+    result = subprocess.run(
+        ["node", "-e", harness, "--", json.dumps(analyzer_output)],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, f"resolver failed:\n{result.stderr}"
+    return json.loads(result.stdout)
+
+
+def _pipeline(tmp_path, name, source, filename="x.js"):
+    repo = tmp_path / name
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / filename
+    fp.write_text(source)
+    return _analyze(repo, fp), _build_call_graph(_analyze(repo, fp))
+
+
+X_JS = """function sink() { return 1; }
+function realFn() { sink(); }
+(function boot() { sink(); })();
+[1].forEach(function () { sink(); });
+main();
+function main() { return 2; }
+const initv = sink();
+"""
+
+B_JS = """class K {
+  constructor() { this.v = 1; }
+  method() { classOnlyHelper(); }
+}
+const handlers = {
+  handle() { objLitHelper(); }
+};
+function classOnlyHelper() { return 1; }
+function objLitHelper() { return 2; }
+bootstrapCall();
+function bootstrapCall() { return 3; }
+"""
+
+
+def test_toplevel_calls_reach_the_graph_in_multi_unit_file(tmp_path):
+    """The issue's x.js: IIFE, callback, bare driver call and initialiser all
+    call sink in a file with real units — the control edge realFn -> sink is
+    present, so a missing module edge is the defect, not a broken harness."""
+    out, cg = _pipeline(tmp_path, "m330x", X_JS)
+    assert "x.js:realFn" in out["functions"], "control missing — fixture failed"
+    assert cg.get("x.js:realFn") == ["x.js:sink"], "control edge missing"
+    mod = cg.get("x.js:module")
+    assert mod is not None, (
+        "no module-scope unit: top-level bootstrap calls made no edges "
+        f"(functions={list(out['functions'])})"
+    )
+    assert "x.js:sink" in mod, f"module unit must reach sink (IIFE/callback/init): {mod}"
+    assert "x.js:main" in mod, f"module unit must reach main (bare driver call): {mod}"
+
+
+def test_module_unit_emitted_with_type_and_range(tmp_path):
+    out, _ = _pipeline(tmp_path, "m330t", X_JS)
+    mod = out["functions"].get("x.js:module")
+    assert mod is not None, f"no x.js:module unit: {list(out['functions'])}"
+    assert mod["unitType"] == "module_level"
+    assert mod["code"].strip(), "module unit must carry the residual text"
+
+
+def test_no_phantom_member_edges_line_masked(tmp_path):
+    """The fabrication guard: only bootstrapCall runs at module load. A
+    containment-based exclusion yields the three phantom member edges; the
+    line-masked residual must contain exactly the bootstrap call."""
+    out, cg = _pipeline(tmp_path, "m330b", B_JS, filename="b.js")
+    assert "b.js:bootstrapCall" in out["functions"], "control missing — fixture failed"
+    mod = cg.get("b.js:module")
+    assert mod is not None, f"no module unit for b.js: {list(out['functions'])}"
+    assert "b.js:bootstrapCall" in mod, f"the genuine bootstrap edge is missing: {mod}"
+    for phantom in ("b.js:classOnlyHelper", "b.js:handlers.handle", "b.js:objLitHelper"):
+        assert phantom not in mod, (
+            f"phantom edge {phantom} — member calls attributed to module load, "
+            "which is not when they run (containment-style leak)"
+        )
+
+
+def test_single_side_effect_file_still_emits_sanitised(tmp_path):
+    """The old fallback's domain (preload scripts): still >=1 unit, now under
+    the sanitised `module` label — not the fabricated callee label
+    `x.js:[1].forEach` (the issue's secondary note)."""
+    repo = tmp_path / "m330p"
+    repo.mkdir(parents=True, exist_ok=True)
+    fp = repo / "file.js"
+    fp.write_text("contextBridge.exposeInMainWorld('api', { ping: () => 1 });\n")
+    out = _analyze(repo, fp)
+    assert len(out["functions"]) >= 1, f"side-effect-only file must emit a unit: {out}"
+    assert "file.js:module" in out["functions"]
+
+
+def test_no_module_unit_without_a_residual_call(tmp_path):
+    """Imports and covered units only — the residual has no call, so no
+    module unit is emitted (the emit-when-contains-call gate)."""
+    src = "import fs from 'fs';\nfunction a() { return 1; }\nfunction b() { return a(); }\n"
+    out, _ = _pipeline(tmp_path, "m330n", src)
+    assert "x.js:module" not in out["functions"], (
+        f"no residual call — module unit must not be emitted: {list(out['functions'])}"
+    )


### PR DESCRIPTION
In a JS/TS file with at least one real function or class, code at module top level — IIFEs, callbacks passed to top-level calls, bare driver calls, initialiser calls — belongs to no extracted unit, and the call graph scans only emitted units' code, so calls made at module load (including calls to sinks) never became edges. A sink reachable through top-level bootstrap code alone got no incoming edge from it (the false-negative direction; the issue's matrix, executed at b5019628). The only capture fired on files with ZERO units; `process.env` — the ordinary way a Node service reads configuration, including secrets — was invisible to entry-point seeding entirely.

**The fix (base commit):** one synthetic `<file>:module` unit per file (unit_type `module_level`) holding the lines NOT covered by any emitted unit's line-range — the line-masked exclusion the Python `:__module__` precedent set and wrote down why (whole-STATEMENT containment drops the class/object-literal boundary and leaks member bodies in — the issue's b.js separates the two strategies). Emitted only when the residual contains a call. 5 tests, RED 4 on pristine incl. the b.js fabrication guard; the JS suite 109/0; the full suite 3521/1 (the known macOS artifact).

**The wave-r1 round (three axes, all real, all fixed):**
- THE HEADLINE: the module unit existed with `[]` edges in the ANALYZER'S callGraph — the graph `call_graph.json` (and therefore the reachability pipeline) actually consumes. The 5-test evidence measured the RESOLVER'S second graph (dataset bundling only), so a sink reachable only through module-load bootstrap STILL had no incoming edge under `--level reachable` — the issue's false negative survived behind the unit's presence. The Pattern-A companion is now emitted: `_moduleUnitEdges` collects the CallExpression/NewExpression descendants that start on UNCOVERED lines;
- class field initializers (`private repo = new Repo();`) are on NO unit's line range, leaked into the residual, and were attributed to module load — fabricated reachability from a synthetic root. CLASS DECLARATION RANGES are now masked whole (the Python ClassDef precedent);
- `require(...)`/`import(...)` are module-system plumbing, not bootstrap behaviour (the Python precedent skips import lines) — a plain CJS header otherwise emitted a zero-edge module unit for nearly every file in a corpus; the emit gate excludes them;
- interior lines of a `/* ... */` block without a leading `*` leaked into the residual — commented-out calls fabricated module-load edges; the block-comment state is tracked.

Known residual, documented: nested object-literal handler tables (depth > 1) are emitted as units only at depth 1.

**Evidence:** 9 tests (the 4 round-1 additions incl. the analyzer-graph companion — the graph that gates reachability — and the class-field mask); the JS suite 113/0; the full suite 3525/1 (the known macOS artifact); node --check clean; ruff clean.

Fixes #330