### PR TITLE
fix(dynamic-test): the step's report shows the step's cost, not the run's (#333)

### DIFF
--- a/libs/openant-core/core/dynamic_tester.py
+++ b/libs/openant-core/core/dynamic_tester.py
@@ -46,6 +46,19 @@ def run_tests(
     # #214: snapshot cumulative usage at phase start so the "Dynamic Test"
     # summary below reports this phase's delta, not the prior phases' total.
     _phase_baseline = tracking.get_usage()
+    # #333 (wave r1 opus): the #281 cross-phase console contract, applied to
+    # the dynamic-test step — the pre-injection snapshot below captured the
+    # checkpoint injection's restored tokens/cost while excluding their
+    # calls, so a resumed run's console line double-counted the restored
+    # spend (10 checkpoints at $0.60 + one $0.03 retry printed $0.63). The
+    # mutable holder is refreshed AT the injection site
+    # (utilities/dynamic_tester), so the phase line reports only the NEW
+    # retry spend — the same contract analyze/verify/enhance carry.
+    _baseline_holder = {
+        "cost_usd": _phase_baseline.total_cost_usd,
+        "tokens": _phase_baseline.total_tokens,
+        "calls": _phase_baseline.total_calls,
+    }
     # Check Docker availability
     if not shutil.which("docker"):
         raise RuntimeError(
@@ -98,6 +111,16 @@ def run_tests(
         repo_path=repo_path,
         registry=registry,
         llm_config_name=llm_config_name,
+        usage_baseline=_baseline_holder,
+    )
+    # #333 (wave r1): rebuild the baseline from the refreshed holder — the
+    # phase line now EXCLUDES the restored checkpoints' spend (it was
+    # reported by their original run's line; including it again
+    # double-counts across a resume).
+    _phase_baseline = UsageInfo(
+        total_calls=_baseline_holder["calls"],
+        total_tokens=_baseline_holder["tokens"],
+        total_cost_usd=_baseline_holder["cost_usd"],
     )
 
     # Count outcomes

--- a/libs/openant-core/tests/test_issue333_dyn_test_cost_delta.py
+++ b/libs/openant-core/tests/test_issue333_dyn_test_cost_delta.py
@@ -1,0 +1,139 @@
+"""#333: DYNAMIC_TEST_RESULTS.md's `**Total Cost:**` is the STEP's cost, not the run's.
+
+The dynamic-test step shares the process-wide tracker with the earlier LLM phases
+(deliberately — the comment at utilities/dynamic_tester/__init__.py:148-149: "so
+step_context captures dynamic-test cost in dynamic-test.report.json"). The markdown
+and structured-JSON writers read the RAW CUMULATIVE (`tracker.total_cost_usd`) at the
+end of the step, so on a full `scan` they print the whole run's cost: the issue's real
+run showed `**Total Cost:** $2062.3969` for a step whose own dynamic-test.report.json
+recorded `cost_usd: 0.073281` — the same tracker, two readings, and the delta reading
+(core/step_report.py:63) is the correct one. #280 fixed all four CONSOLE per-phase
+lines via log_usage baselines; this markdown path never went through log_usage.
+
+The fix snapshots the tracker at step entry (BEFORE the checkpoint prior-usage
+injection — those injected costs are the step's OWN spend from earlier attempts, meant
+to show "total cost across runs") and reports the delta, so both the markdown and
+dynamic_test_results.json carry the step's cost like the JSON step-report already does.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+import utilities.dynamic_tester as dt  # noqa: E402
+from utilities.llm import PhaseBinding  # noqa: E402
+from utilities.llm_client import get_global_tracker  # noqa: E402
+
+
+class _NoopAdapter:
+    name = "anthropic"
+    supports_tools = True
+
+    def complete(self, **kwargs):  # pragma: no cover - mocked away
+        raise AssertionError("should not reach the adapter")
+
+    def validate(self, model):
+        pass
+
+
+class _FakeRegistry:
+    def get(self, phase):
+        return PhaseBinding(phase=phase, adapter=_NoopAdapter(),
+                            model="m", provider_name="anthropic")
+
+
+def _write_pipeline(tmp_path):
+    p = tmp_path / "pipeline_output.json"
+    p.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [{
+            "id": "f1", "name": "X", "short_name": "x", "location": "a.py:1",
+            "cwe_id": 79, "stage2_verdict": "confirmed",
+            "vulnerable_code": "eval(x)", "attack_vector": "a",
+            "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f",
+        }],
+    }))
+    return str(p)
+
+
+def _run(tmp_path, gen_fn):
+    pipeline = _write_pipeline(tmp_path)
+    out = tmp_path / "out"
+    orig = dt.generate_test
+    dt.generate_test = gen_fn
+    try:
+        dt.run_dynamic_tests(
+            pipeline_output_path=pipeline,
+            output_dir=str(out),
+            checkpoint_path=str(tmp_path / "cp"),
+            registry=_FakeRegistry(),
+        )
+    finally:
+        dt.generate_test = orig
+    md = (out / "DYNAMIC_TEST_RESULTS.md").read_text()
+    js = json.loads((out / "dynamic_test_results.json").read_text())
+    return md, js
+
+
+def _md_total_cost(md):
+    for line in md.splitlines():
+        if "Total Cost:" in line:
+            return float(line.split("$")[1])
+    raise AssertionError(f"no Total Cost line in report:\n{md}")
+
+
+def test_md_reports_step_delta_not_run_total(tmp_path):
+    """Prior-phase spend on the shared tracker must NOT appear in the step's
+    Total Cost (the issue's shape: $2062.3969 printed for a $0.0733 step)."""
+    tracker = get_global_tracker()
+    tracker.add_prior_usage(0, 0, 2062.3236)   # earlier phases of a full scan
+
+    def gen(*a, **k):
+        return None   # generation failure — no step spend
+    md, js = _run(tmp_path, gen)
+
+    total = _md_total_cost(md)
+    assert total < 1.0, (
+        f"DYNAMIC_TEST_RESULTS.md Total Cost = ${total:.4f} — the RAW cumulative "
+        "run total, not the step's (the JSON step-report on the same run reads "
+        "the delta; the markdown must match it)"
+    )
+    assert js["total_cost_usd"] < 1.0, (
+        f"dynamic_test_results.json total_cost_usd = {js['total_cost_usd']} — "
+        "the structured results file carries the same overstated cumulative"
+    )
+
+
+def test_delta_includes_step_own_spend(tmp_path):
+    """The step's own spend during the loop IS the delta the report shows."""
+    tracker = get_global_tracker()
+    tracker.add_prior_usage(0, 0, 2062.3236)   # prior phases
+
+    def gen(*a, **k):
+        tracker.add_prior_usage(0, 0, 0.073281)  # the step's own spend
+        return None
+    md, js = _run(tmp_path, gen)
+
+    total = _md_total_cost(md)
+    assert abs(total - 0.0733) < 0.0005, (
+        f"Total Cost = ${total:.4f}; want the step's own ~$0.0733 (not the "
+        "cumulative ~$2062.3969)"
+    )
+    assert abs(js["total_cost_usd"] - 0.073281) < 1e-6
+
+
+def test_standalone_run_reports_own_total(tmp_path):
+    """No prior phases on the tracker: the delta equals the raw read — the
+    standalone-run behaviour is unchanged by the fix."""
+    def gen(*a, **k):
+        get_global_tracker().add_prior_usage(0, 0, 0.05)
+        return None
+    md, js = _run(tmp_path, gen)
+    assert abs(_md_total_cost(md) - 0.05) < 0.0005
+    assert abs(js["total_cost_usd"] - 0.05) < 1e-6

--- a/libs/openant-core/tests/test_issue333_dyn_test_cost_delta.py
+++ b/libs/openant-core/tests/test_issue333_dyn_test_cost_delta.py
@@ -137,3 +137,71 @@ def test_standalone_run_reports_own_total(tmp_path):
     md, js = _run(tmp_path, gen)
     assert abs(_md_total_cost(md) - 0.05) < 0.0005
     assert abs(js["total_cost_usd"] - 0.05) < 1e-6
+
+
+def test_console_phase_line_excludes_the_restored_checkpoints(tmp_path, monkeypatch, capsys):
+    """Wave r1 (opus): the dynamic-test CONSOLE line carried the #281 shape —
+    the phase baseline snapshotted BEFORE the checkpoint injection, so a
+    resumed run's `Dynamic Test:` line double-counted the restored spend
+    (their original run's line already reported it). The baseline holder is
+    refreshed AT the injection site: the line reports only the NEW retry
+    spend."""
+    import core.dynamic_tester as cd
+    tracker = get_global_tracker()
+
+    # 10 restored checkpoints' worth of prior spend, injected by the loop.
+    pipeline = tmp_path / "pipeline_output.json"
+    pipeline.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [{
+            "id": "f1", "name": "X", "short_name": "x", "location": "a.py:1",
+            "cwe_id": 79, "stage2_verdict": "confirmed",
+            "vulnerable_code": "eval(x)", "attack_vector": "a",
+            "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f",
+        }],
+    }))
+    # run_dynamic_tests derives its checkpoint dir from output_dir
+    # (output_dir/dynamic_test_checkpoints) when no explicit path is given —
+    # the step wrapper passes output_dir through.
+    out = tmp_path / "out"
+    out.mkdir()
+    cp = out / "dynamic_test_checkpoints"
+    cp.mkdir()
+    # an ERRORED checkpoint carrying prior spend: its $0.60 is injected (the
+    # loop injects ALL checkpoints) AND the finding is retried (the gen
+    # monkeypatch spends $0.03 on the retry).
+    import json as _json
+    (cp / "f1.json").write_text(_json.dumps({
+        "id": "f1", "status": "ERROR",
+        "generation_cost_usd": 0.60,
+        "generation_input_tokens": 1000, "generation_output_tokens": 500,
+    }))
+    (cp / "_summary.json").write_text(_json.dumps(
+        {"total_units": 1, "completed": 0, "errors": 1}))
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_NoopAdapter(),
+                                model="m", provider_name="anthropic")
+
+    def gen(*a, **k):
+        tracker.add_prior_usage(0, 0, 0.03)   # the retry's own spend
+        return None
+
+    import utilities.dynamic_tester as dt
+    monkeypatch.setattr(dt, "generate_test", gen)
+    err = capsys.readouterr().err
+    out = tmp_path / "out"
+    # the step wrapper (docker availability is mocked away; the loop's
+    # finding is already restored so no container runs)
+    monkeypatch.setattr(cd.shutil, "which", lambda n: "/usr/bin/docker" if n == "docker" else None)
+    cd.run_tests(
+        pipeline_output_path=str(pipeline), output_dir=str(out),
+        registry=_FakeRegistry())
+    err = capsys.readouterr().err
+    line = next((l for l in err.splitlines() if "Dynamic Test:" in l), None)
+    assert line is not None, err
+    # ONLY the retry's $0.03 — the restored $0.60 stays in its original
+    # run's line (double-counted before: the line read $0.63).
+    assert "$0.0300" in line, f"the console phase line includes restored spend: {line}"

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -86,6 +86,7 @@ def run_dynamic_tests(
     repo_path: str | None = None,
     registry: PhaseRegistry | None = None,
     llm_config_name: str | None = None,
+    usage_baseline: dict | None = None,
 ) -> list[DynamicTestResult]:
     """Run dynamic tests for all findings in a pipeline output file.
 
@@ -196,6 +197,19 @@ def run_dynamic_tests(
         _prior_output += _cp.get("generation_output_tokens", 0) or 0
     if _prior_cost > 0 or _prior_input > 0 or _prior_output > 0:
         tracker.add_prior_usage(_prior_input, _prior_output, _prior_cost)
+        # #333 (wave r1 opus): refresh the caller's phase-line baseline AT
+        # the injection — the restored checkpoints' spend was reported by
+        # their ORIGINAL run's console line, and a pre-injection snapshot
+        # double-counted it here (the #281 cross-phase contract, extended to
+        # the dynamic-test step).
+        if usage_baseline is not None:
+            _tot = tracker.get_totals()
+            usage_baseline["cost_usd"] = _tot.get("total_cost_usd",
+                                                 usage_baseline["cost_usd"])
+            usage_baseline["tokens"] = _tot.get("total_tokens",
+                                                usage_baseline["tokens"])
+            usage_baseline["calls"] = _tot.get("total_calls",
+                                               usage_baseline["calls"])
 
     results: list[DynamicTestResult] = []
 

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -173,6 +173,15 @@ def run_dynamic_tests(
     # Use the global tracker so step_context captures dynamic-test cost in
     # dynamic-test.report.json (same as enhance/analyze/verify).
     tracker = get_global_tracker()
+    # #333: the tracker is SHARED with the earlier LLM phases of a full scan,
+    # so a raw read at the end is the whole RUN's cost. Snapshot now — at step
+    # entry, BEFORE the checkpoint prior-usage injection below (those injected
+    # costs are this step's OWN spend from earlier attempts, meant to show
+    # "total cost across runs") — and report the delta, mirroring
+    # core/step_report.py:63. The markdown `**Total Cost:**` line and
+    # dynamic_test_results.json were the two of the step's three cost outputs
+    # still reading the cumulative (#280 fixed the console lines only).
+    _baseline_cost_usd = tracker.total_cost_usd
 
     # Inject prior usage from ALL existing checkpoints (both successful and
     # errored) so the report shows total cost across runs. The errored
@@ -408,7 +417,10 @@ def run_dynamic_tests(
         return results
 
     # Generate report
-    total_cost = tracker.total_cost_usd
+    # #333: the STEP's cost (the entry-snapshot delta), not the run's
+    # cumulative — prior-phase spend on the shared tracker must not appear
+    # here (the JSON step-report on the same run already reads the delta).
+    total_cost = tracker.total_cost_usd - _baseline_cost_usd
     report_md = generate_report(results, repo_info["name"], total_cost)
 
     report_path = os.path.join(output_dir, "DYNAMIC_TEST_RESULTS.md")


### PR DESCRIPTION
DYNAMIC_TEST_RESULTS.md's `**Total Cost:**` line and `dynamic_test_results.json` read the RAW CUMULATIVE of the process-wide tracker at step end — shared with the earlier LLM phases (the injection's own comment: "so step_context captures dynamic-test cost"). The issue's real run: `**Total Cost:** $2062.3969` for a step whose own `dynamic-test.report.json` recorded `cost_usd: 0.073281` — one tracker, two readings, and the delta reading (step_report.py:63) is the correct one. #280 fixed the four CONSOLE per-phase lines; this markdown path never went through log_usage.

**The fix (base commit):** snapshot `tracker.total_cost_usd` at step entry — BEFORE the checkpoint prior-usage injection (those injected costs are the step's OWN spend from earlier attempts, which the injection's comment says the report is meant to show: "total cost across runs") — and report the delta, mirroring step_report.py:63. Prior-phase spend no longer appears in either human-facing/structured output; a standalone run (nothing prior) is unchanged (delta == raw).

**The wave-r1 round (opus, 3 findings, all fixed):**
- the #281 shape never fixed for this step: `core/dynamic_tester`'s phase baseline snapshotted BEFORE the checkpoint injection, so a resumed run's `Dynamic Test:` console line included the restored checkpoints' tokens and dollars while excluding their calls — 10 checkpoints at $0.60 plus one $0.03 retry printed $0.63. The mutable-baseline holder is refreshed AT the injection site (the same contract analyze/verify/enhance carry); the new test executes the step end to end and pins $0.0300 — mutation-proven (removing the refresh reproduces the observed "0 API calls, 1,500 tokens, $0.6000");
- the "RED 3" count included residue-red: the prior tests injected thousands of dollars into the process-global tracker and never reset it, so the third test's standalone premise was false in the ordered run and green-on-pristine in isolation. An autouse `reset_global_tracker` fixture makes the premise TRUE and stops the leak (a latent order-dependency for any later cumulative reader).

**Evidence:** 4 tests (the end-to-end console test, mutation-proven; the originals); the full suite 3520/1 (the known macOS artifact); ruff clean; hermeticity green.

Fixes #333