### PR TITLE
fix(config): claude-opus-4-8 priced at its live rate — the 3x cross-provider divergence resolved (#344)

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment \u2014 see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests.",
+  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment — see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
   "schema_version": 1,
   "models": [
     {
@@ -7,11 +7,11 @@
       "provider": "anthropic",
       "status": "current",
       "price": {
-        "input": 15.0,
-        "output": 75.0
+        "input": 5.0,
+        "output": 25.0
       },
-      "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Anthropic pricing",
-      "retrieved": "2026-07-23"
+      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) — both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
+      "retrieved": "2026-09-01"
     },
     {
       "id": "claude-sonnet-4-6",
@@ -64,22 +64,22 @@
       "provider": "bedrock",
       "status": "current",
       "price": {
-        "input": 15.0,
-        "output": 75.0
+        "input": 5.0,
+        "output": 25.0
       },
-      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record (Bedrock Claude token rates match the direct Anthropic API)",
-      "retrieved": "2026-07-31"
+      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record, corrected to $5/$25 per #344's live re-verification (Bedrock Claude token rates match the direct Anthropic API)",
+      "retrieved": "2026-09-01"
     },
     {
       "id": "global.anthropic.claude-opus-4-8",
       "provider": "bedrock",
       "status": "current",
       "price": {
-        "input": 15.0,
-        "output": 75.0
+        "input": 5.0,
+        "output": 25.0
       },
-      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record (Bedrock Claude token rates match the direct Anthropic API)",
-      "retrieved": "2026-07-31"
+      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record, corrected to $5/$25 per #344's live re-verification (Bedrock Claude token rates match the direct Anthropic API)",
+      "retrieved": "2026-09-01"
     },
     {
       "id": "us.anthropic.claude-sonnet-4-6",

--- a/config/models.json
+++ b/config/models.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment — see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
+  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment \u2014 see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
   "schema_version": 1,
   "models": [
     {
@@ -10,7 +10,7 @@
         "input": 5.0,
         "output": 25.0
       },
-      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) — both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
+      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) \u2014 both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
       "retrieved": "2026-09-01"
     },
     {
@@ -64,11 +64,12 @@
       "provider": "bedrock",
       "status": "current",
       "price": {
-        "input": 5.0,
-        "output": 25.0
+        "input": 5.5,
+        "output": 27.5
       },
-      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record, corrected to $5/$25 per #344's live re-verification (Bedrock Claude token rates match the direct Anthropic API)",
-      "retrieved": "2026-09-01"
+      "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
+      "retrieved": "2026-07-31",
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-opus-4-8",
@@ -78,19 +79,20 @@
         "input": 5.0,
         "output": 25.0
       },
-      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record, corrected to $5/$25 per #344's live re-verification (Bedrock Claude token rates match the direct Anthropic API)",
-      "retrieved": "2026-09-01"
+      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-opus-4-8 record, corrected to $5/$25 per #344's live re-verification (Bedrock Claude token rates match the direct Anthropic API); the mirrored direct rate re-verified 2026-09-01 via Anthropic's pricing page (global endpoints: standard pricing)",
+      "retrieved": "2026-07-31"
     },
     {
       "id": "us.anthropic.claude-sonnet-4-6",
       "provider": "bedrock",
       "status": "current",
       "price": {
-        "input": 3.0,
-        "output": 15.0
+        "input": 3.3,
+        "output": 16.5
       },
-      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-sonnet-4-6 record (Bedrock Claude token rates match the direct Anthropic API)",
-      "retrieved": "2026-07-31"
+      "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
+      "retrieved": "2026-07-31",
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-sonnet-4-6",
@@ -100,7 +102,7 @@
         "input": 3.0,
         "output": 15.0
       },
-      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-sonnet-4-6 record (Bedrock Claude token rates match the direct Anthropic API)",
+      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-sonnet-4-6 record (Bedrock Claude token rates match the direct Anthropic API); the mirrored direct rate re-verified 2026-09-01 via Anthropic's pricing page (global endpoints: standard pricing)",
       "retrieved": "2026-07-31"
     },
     {
@@ -108,11 +110,12 @@
       "provider": "bedrock",
       "status": "current",
       "price": {
-        "input": 1.0,
-        "output": 5.0
+        "input": 1.1,
+        "output": 5.5
       },
-      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-haiku-4-5-20251001 record (Bedrock Claude token rates match the direct Anthropic API)",
-      "retrieved": "2026-07-31"
+      "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
+      "retrieved": "2026-07-31",
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -122,7 +125,7 @@
         "input": 1.0,
         "output": 5.0
       },
-      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-haiku-4-5-20251001 record (Bedrock Claude token rates match the direct Anthropic API)",
+      "source": "verified against a live Bedrock account via list-inference-profiles (us-east-1, status ACTIVE); price mirrors the anthropic claude-haiku-4-5-20251001 record (Bedrock Claude token rates match the direct Anthropic API); the mirrored direct rate re-verified 2026-09-01 via Anthropic's pricing page (global endpoints: standard pricing)",
       "retrieved": "2026-07-31"
     },
     {

--- a/libs/openant-core/tests/test_model_config_centralize.py
+++ b/libs/openant-core/tests/test_model_config_centralize.py
@@ -144,7 +144,10 @@ def test_b_consumers_import_without_cycle():
 # CURRENT models. The retired ids were priced in the old dict but must never
 # price now (they resolve to warn + $0).
 _EXPECTED_ANTHROPIC_CURRENT = {
-    "claude-opus-4-8": {"input": 15.00, "output": 75.00},
+    # #344: corrected to the live rate — Anthropic's pricing page and the live
+    # OpenRouter catalogue both say $5/$25 per MTok for Opus 4.8; the prior
+    # 15/75 was the retired Opus 4.1-era shipped-table rate.
+    "claude-opus-4-8": {"input": 5.00, "output": 25.00},
     "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
     "claude-haiku-4-5-20251001": {"input": 1.00, "output": 5.00},
 }

--- a/libs/openant-core/tests/test_model_config_centralize.py
+++ b/libs/openant-core/tests/test_model_config_centralize.py
@@ -137,8 +137,11 @@ def test_b_consumers_import_without_cycle():
         importlib.import_module(mod)
 
 
-# --- (c) values are behavior-preserving ------------------------------
-# Snapshot of the exact literals present BEFORE the refactor.
+# --- (c) values mirror config/models.json ---------------------------
+# A hand-maintained mirror of the registry's CURRENT rates (NOT a frozen
+# pre-refactor snapshot: #344 corrected claude-opus-4-8 to the live rate —
+# every deliberate price change is a three-place edit: models.json, this
+# mirror, and any record_call-math pin).
 # Post-cutover, pricing_map("anthropic") OMITS retired/unknown ids (null-priced
 # in config/models.json), so the adapter table and MODEL_PRICING expose only the
 # CURRENT models. The retired ids were priced in the old dict but must never

--- a/libs/openant-core/tests/test_models_price_cross_check.py
+++ b/libs/openant-core/tests/test_models_price_cross_check.py
@@ -30,9 +30,10 @@ from core.model_registry import find_models_config
 
 def _family(model_id: str) -> str:
     """Normalise an id to its model family across every id convention in the file."""
-    s = re.sub(r"^[a-z]+/", "", model_id)              # vendor/ slug (OpenRouter)
-    s = re.sub(r"^(us|global|eu|apac)\.[a-z]+\.", "", s)  # region.vendor. (Bedrock)
+    s = re.sub(r"^[a-z0-9][a-z0-9-]*/", "", model_id)    # vendor/ slug (OpenRouter, hyphens/digits incl.)
+    s = re.sub(r"^(us|global|eu|apac|jp|au|ca|sa)\.[a-z0-9-]+\.", "", s)  # region.vendor. (Bedrock)
     s = re.sub(r"-v\d+:\d+$", "", s)                   # Bedrock version suffix
+    s = re.sub(r":[a-z0-9-]+$", "", s)                   # OpenRouter variant (:free, :thinking, :batch)
     s = re.sub(r"-\d{8}$", "", s)                     # Anthropic date stamp
     return s.replace(".", "-")                        # 4.5 vs 4-5 conventions
 
@@ -47,36 +48,45 @@ def _priced_records(data):
 def test_same_family_prices_agree_across_providers():
     conf = find_models_config()
     assert conf is not None, "config/models.json not locatable (find_models_config)"
-    data = json.loads(conf.read_text())
+    # wave r1 (opus): pin the encoding — the registry loader does, and a
+    # non-UTF-8-default runner would raise UnicodeDecodeError instead of
+    # reporting the invariant.
+    data = json.loads(conf.read_text(encoding="utf-8"))
     fam = defaultdict(list)
     for r in _priced_records(data):
         fam[_family(r["id"])].append(r)
 
     disagreements = []
     for family, recs in sorted(fam.items()):
-        # The escape hatch: an EXPLICIT price_diverges annotation (a reason string)
-        # exempts the family — a gateway may legitimately reprice, but it must say so.
-        if any(isinstance(r.get("price_diverges"), str) and r["price_diverges"].strip()
-               for r in recs):
+        # wave r1 (three axes): compare EVERY record in the family — the
+        # per-provider setdefault kept only the FIRST bedrock record and the
+        # second mirror (us./global. share provider "bedrock") escaped every
+        # comparison: correcting one mirror while the other stayed 15/75 was
+        # GREEN. And the price_diverges hatch exempts only the ANNOTATED
+        # record's own comparisons, not the whole family (an annotated
+        # OpenRouter reprice must not blind the check to the
+        # anthropic-vs-bedrock pairs of the same family).
+        comparable = [r for r in recs
+                      if not (isinstance(r.get("price_diverges"), str)
+                              and r["price_diverges"].strip())]
+        annotated = [r for r in recs
+                     if isinstance(r.get("price_diverges"), str)
+                     and r["price_diverges"].strip()]
+        if len(comparable) + len(annotated) < 2 or not comparable:
             continue
-        providers = {}
-        for r in recs:
-            providers.setdefault(r.get("provider"), r)
-        if len(providers) < 2:
-            continue
-        first = next(iter(providers.values()))
-        base = (first["price"]["input"], first["price"]["output"])
-        for prov, r in sorted(providers.items()):
-            if (r["price"]["input"], r["price"]["output"]) != base:
+        base = comparable[0]
+        b = (base["price"]["input"], base["price"]["output"])
+        for r in comparable[1:]:
+            if (r["price"]["input"], r["price"]["output"]) != b:
                 disagreements.append(
-                    f"{family}: {prov} says {r['price']} but "
-                    f"{first.get('provider')} says {first['price']}"
+                    f"{family}: {r['id']} says {r['price']} but "
+                    f"{base['id']} says {base['price']}"
                 )
     assert not disagreements, (
         "cross-provider price disagreement without a `price_diverges` annotation "
         "(the run's reported cost is off by the ratio depending on routing; "
-        "annotate a legitimate gateway reprice or correct the stale record):\n  "
-        + "\n  ".join(disagreements)
+        "annotate a legitimate gateway/endpoint reprice or correct the stale "
+        "record):\n  " + "\n  ".join(disagreements)
     )
 
 

--- a/libs/openant-core/tests/test_models_price_cross_check.py
+++ b/libs/openant-core/tests/test_models_price_cross_check.py
@@ -1,0 +1,100 @@
+"""#344: records for the same model family must agree on price unless annotated.
+
+config/models.json is the single source of truth for pricing, read by BOTH the Python
+engine and the Go CLI. A model can be reachable through several providers (direct
+anthropic, bedrock, openrouter), and the issue's census found 15 comparable families —
+14 agree to the cent across providers, and the one that diverged (claude-opus-4-8:
+15/75 on anthropic+bedrock vs 5/25 on openrouter, a clean 3x on BOTH numbers) was the
+stale shipped-table rate: live Anthropic pricing and the live OpenRouter catalogue BOTH
+say $5/$25 per MTok — 15/75 is the retired Opus 4.1-era rate. A run's reported cost was
+off by 3x depending on routing.
+
+This test holds the invariant the file already keeps in 14 of 15 cases: same-family
+records agree unless the divergence is EXPLICITLY annotated. The escape hatch is the
+optional `price_diverges` field (a non-empty reason string) on the diverging record — a
+gateway may legitimately reprice, but it must say so.
+
+The family map is a real normalization, not a bare regex — ids appear as `vendor/slug`
+(OpenRouter), `region.vendor.id` plus `-vN:N` (Bedrock), and `id-YYYYMMDD` (Anthropic
+date stamps), and `4.5` vs `4-5` dot/dash conventions differ across providers. Missing
+any convention silently SPLITS a family and hides a comparable pair (the issue's
+script originally stripped only `anthropic/` and reported 2 comparable families where
+there are 15).
+"""
+import json
+import re
+from collections import defaultdict
+
+from core.model_registry import find_models_config
+
+
+def _family(model_id: str) -> str:
+    """Normalise an id to its model family across every id convention in the file."""
+    s = re.sub(r"^[a-z]+/", "", model_id)              # vendor/ slug (OpenRouter)
+    s = re.sub(r"^(us|global|eu|apac)\.[a-z]+\.", "", s)  # region.vendor. (Bedrock)
+    s = re.sub(r"-v\d+:\d+$", "", s)                   # Bedrock version suffix
+    s = re.sub(r"-\d{8}$", "", s)                     # Anthropic date stamp
+    return s.replace(".", "-")                        # 4.5 vs 4-5 conventions
+
+
+def _priced_records(data):
+    for m in data.get("models", []):
+        price = m.get("price")
+        if isinstance(price, dict) and "id" in m:
+            yield m
+
+
+def test_same_family_prices_agree_across_providers():
+    conf = find_models_config()
+    assert conf is not None, "config/models.json not locatable (find_models_config)"
+    data = json.loads(conf.read_text())
+    fam = defaultdict(list)
+    for r in _priced_records(data):
+        fam[_family(r["id"])].append(r)
+
+    disagreements = []
+    for family, recs in sorted(fam.items()):
+        # The escape hatch: an EXPLICIT price_diverges annotation (a reason string)
+        # exempts the family — a gateway may legitimately reprice, but it must say so.
+        if any(isinstance(r.get("price_diverges"), str) and r["price_diverges"].strip()
+               for r in recs):
+            continue
+        providers = {}
+        for r in recs:
+            providers.setdefault(r.get("provider"), r)
+        if len(providers) < 2:
+            continue
+        first = next(iter(providers.values()))
+        base = (first["price"]["input"], first["price"]["output"])
+        for prov, r in sorted(providers.items()):
+            if (r["price"]["input"], r["price"]["output"]) != base:
+                disagreements.append(
+                    f"{family}: {prov} says {r['price']} but "
+                    f"{first.get('provider')} says {first['price']}"
+                )
+    assert not disagreements, (
+        "cross-provider price disagreement without a `price_diverges` annotation "
+        "(the run's reported cost is off by the ratio depending on routing; "
+        "annotate a legitimate gateway reprice or correct the stale record):\n  "
+        + "\n  ".join(disagreements)
+    )
+
+
+def test_family_map_distinguishes_every_convention():
+    """The normalizer must not SPLIT or MERGE families wrongly — the guard the
+    issue's own script needed (a missed convention hides comparable pairs)."""
+    f = _family
+    # split: different families stay different
+    assert f("claude-opus-4-8") != f("claude-sonnet-4-6")
+    assert f("claude-opus-4-8") != f("claude-opus-4-1")
+    # merge: one family across all four conventions
+    ids = {
+        "claude-opus-4-8",                             # direct anthropic
+        "us.anthropic.claude-opus-4-8",                 # bedrock regional
+        "global.anthropic.claude-opus-4-8",             # bedrock global
+        "anthropic/claude-opus-4.8",                    # openrouter
+    }
+    assert len({f(i) for i in ids}) == 1, {f(i) for i in ids}
+    # the date-stamp and version-suffix forms too
+    assert f("claude-haiku-4-5-20251001") == f("us.anthropic.claude-haiku-4-5-20251001-v1:0")
+    assert f("claude-haiku-4-5-20251001") == f("anthropic/claude-haiku-4.5")

--- a/libs/openant-core/tests/test_token_tracker.py
+++ b/libs/openant-core/tests/test_token_tracker.py
@@ -72,5 +72,7 @@ class TestTokenTracker:
     def test_opus_pricing(self):
         tracker = TokenTracker()
         result = tracker.record_call("claude-opus-4-8", 1_000_000, 1_000_000)
-        # Opus: $15/M input, $75/M output
-        assert result["cost_usd"] == 90.0
+        # #344: Opus 4.8's live rate — $5/M input, $25/M output (both Anthropic's
+        # pricing page and the OpenRouter catalogue; the prior 15/75 was the
+        # retired Opus 4.1-era shipped-table rate).
+        assert result["cost_usd"] == 30.0

--- a/libs/openant-core/utilities/llm/providers/OPENROUTER.md
+++ b/libs/openant-core/utilities/llm/providers/OPENROUTER.md
@@ -128,7 +128,13 @@ A model outside that set still works — it just reports `$0` in cost
 accounting with a one-time warning. To price it, add a record to
 `config/models.json` with `"provider": "openrouter"` and the rate shown
 in the catalogue (OpenRouter lists per-token prices; the registry wants
-per-million).
+per-million). **If the gateway rate genuinely differs from the direct
+provider's** (the same model family carries a differently-priced
+direct-provider record), the record must ALSO carry a `price_diverges`
+reason string — the cross-provider invariant
+(`tests/test_models_price_cross_check.py`) requires same-family records
+to agree unless the divergence is annotated on the record that carries
+it (#344).
 
 ## Errors and troubleshooting
 


### PR DESCRIPTION
`config/models.json` carried two prices for Claude Opus 4.8 differing by exactly 3x: 15.00/75.00 under the direct-Anthropic id and its two declared Bedrock mirrors, 5.00/25.00 under the OpenRouter id — a run's reported cost off by 3x depending on routing, on a number used to decide whether a scan configuration is affordable. Of the fifteen families carrying both a direct-vendor and an OpenRouter record, fourteen agreed to the cent; the divergent one's Anthropic record self-declared "not re-verified against live Anthropic pricing" (15/75 is the retired Opus 4.1-era shipped-table rate).

**Re-verified against BOTH live sources:** Anthropic's pricing page (Claude Opus 4.8 = $5/$25 per MTok) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M) agree — the direct record was the stale one. All three 15/75 records corrected to 5/25 with refreshed provenance naming both live checks.

**Plus the CI invariant the issue asked for:** same-family records must agree on price unless the divergence is EXPLICITLY annotated (the optional `price_diverges` reason string — a gateway may legitimately reprice, but it must say so). The cross-check test uses the production locator (`find_models_config`) and a family map covering every id convention in the file, pinned by a split/merge guard test.

**The wave-r1 round (three axes, all confirmed, all fixed):**
- THE GUARD SAW ONE RECORD PER PROVIDER: the cross-check deduped by provider name (setdefault), so us./global. Bedrock mirrors (both `provider: bedrock`) escaped every comparison — correcting one mirror while the other stayed 15/75 was GREEN, the exact partial-fix shape of #344 itself. The guard now compares EVERY record; mutation-proven (a single-mirror flip fires it). The `price_diverges` hatch exempts only the ANNOTATED record, not the family;
- THE REGIONAL PREMIUM (from Anthropic's own pricing page: "Starting with Claude Sonnet 4.5, Haiku 4.5, and Opus 4.5: Regional and multi-region endpoints include a 10% premium over global endpoints"): the us.anthropic.* records were flat copies of the direct rate. All three regional records (opus-4-8, sonnet-4-6, haiku-4-5) now carry the direct rate x1.1 with a `price_diverges` annotation stating the rule and its source; the global.anthropic.* records keep the standard rate;
- PROVENANCE HONESTY: `retrieved` is the record's only staleness signal, and it was bumped to the price-fix date on records whose liveness receipt (list-inference-profiles) was five weeks old — the price re-derivation now lives in `source` with its own date; `retrieved` returns to the liveness date. The file stays pure ASCII; the reader pins `encoding="utf-8"`;
- the normalizer covers hyphenated OpenRouter vendors, the jp/au/ca/sa region prefixes, and `:free`/`:thinking`/`:batch` variants; OPENROUTER.md's contributor instruction documents the `price_diverges` step; the centralize snapshot's header states the honest contract.

**Evidence:** the cross-check (RED on the pre-fix file — the opus-4-8 disagreement named across providers — and GREEN after); the mutation proof; the models/registry/token families 23 passed; the Go consumers green; ruff clean.

Fixes #344