### PR TITLE
fix(llm-reach): the promote set is configurable, and the comment stops lying (#345)

### DIFF
--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -42,6 +42,7 @@ Usage:
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
 from dataclasses import dataclass, asdict
@@ -484,9 +485,47 @@ def analyze_reachability(
 # ---------------------------------------------------------------------------
 
 
-# Confidences at or above this threshold promote ``entry_point`` signals to
-# ``is_entry_point = True`` on the target unit.
-_PROMOTE_ENTRY_POINT_AT = {"high"}
+# The confidence tiers that promote an ``entry_point`` signal to
+# ``is_entry_point = True`` on the target unit. This is a SET-MEMBERSHIP
+# test, not an "at or above" ordering — no ordering over high/medium/low
+# exists in this module, and the earlier "at or above" comment described
+# semantics the code never implemented (it worked only because the set
+# had one element) — #345.
+#
+# Configurable per run (#345): an operator can trade recall for cost —
+# promotion is promote-only and never demotes, so a wrong promotion costs
+# analysis budget while a missing one silently drops a unit and everything
+# reachable only through it. OPENANT_PROMOTE_ENTRY_POINT_AT is a
+# comma-separated subset of high/medium/low, read at apply time; invalid or
+# empty content falls back to the shipped default WITH a stderr warning —
+# a calibration knob must never crash the scan.
+#
+# The DEFAULT is the deliberate PR #50 calibration, pinned by
+# test_medium_confidence_does_not_promote: medium measured 48% precision
+# on the one audit #345 reports (n=25, 95% CI [30,67], an internal run the
+# issue flags as not reproducible from this repository — widen only after
+# the second-corpus reproduction it names), and low 0.0%.
+_PROMOTE_ENTRY_POINT_AT_DEFAULT = frozenset({"high"})
+_PROMOTE_TIERS = frozenset({"high", "medium", "low"})
+_ENV_PROMOTE_ENTRY_POINT_AT = "OPENANT_PROMOTE_ENTRY_POINT_AT"
+
+
+def _promote_entry_point_at() -> frozenset:
+    """The tiers that promote, after resolving the env override (#345)."""
+    raw = os.environ.get(_ENV_PROMOTE_ENTRY_POINT_AT)
+    if not raw:
+        return _PROMOTE_ENTRY_POINT_AT_DEFAULT
+    wanted = {t.strip().lower() for t in raw.split(",") if t.strip()}
+    if not wanted or (wanted - _PROMOTE_TIERS):
+        print(
+            f"[LLMReach] {_ENV_PROMOTE_ENTRY_POINT_AT}={raw!r}: expected "
+            f"comma-separated tiers from {sorted(_PROMOTE_TIERS)}; falling "
+            "back to the shipped default "
+            f"{sorted(_PROMOTE_ENTRY_POINT_AT_DEFAULT)}",
+            file=sys.stderr,
+        )
+        return _PROMOTE_ENTRY_POINT_AT_DEFAULT
+    return frozenset(wanted)
 
 
 def apply_signals(
@@ -497,9 +536,11 @@ def apply_signals(
 
     For each unit referenced by a signal:
       - The signal is appended to a per-unit ``llm_reachability_signals`` list.
-      - If the signal kind is ``entry_point`` AND its confidence is in
-        :data:`_PROMOTE_ENTRY_POINT_AT`, the unit's ``is_entry_point`` field
-        is set to ``True`` (never set back to ``False``).
+      - If the signal kind is ``entry_point`` AND its confidence is in the
+        promote set (:func:`_promote_entry_point_at` — the shipped default
+        ``{high}``, configurable via OPENANT_PROMOTE_ENTRY_POINT_AT), the
+        unit's ``is_entry_point`` field is set to ``True`` (never set back
+        to ``False``).
 
     Crucially, this never DEMOTES a unit. ``is_entry_point=True`` set by the
     structural pass remains true regardless of what the LLM said.
@@ -514,6 +555,7 @@ def apply_signals(
     """
     units = dataset.get("units") or []
     by_id = {u.get("id"): u for u in units if u.get("id")}
+    promote_at = _promote_entry_point_at()
 
     promoted = 0
     touched: set = set()
@@ -531,7 +573,7 @@ def apply_signals(
 
         if (
             sig.kind == "entry_point"
-            and sig.confidence in _PROMOTE_ENTRY_POINT_AT
+            and sig.confidence in promote_at
             and not unit.get("is_entry_point", False)
         ):
             unit["is_entry_point"] = True

--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -15,8 +15,10 @@ Pipeline ordering (managed by ``core/scanner.py``):
 
 1. Parse with ``processing_level="all"`` so every unit is available.
 2. ``analyze_reachability`` reviews all units and returns signals.
-3. ``apply_signals`` promotes high-confidence ``entry_point`` signals by
-   setting ``is_entry_point=True`` on the target unit.
+3. ``apply_signals`` promotes ``entry_point`` signals whose confidence is
+   in the promote set (``OPENANT_PROMOTE_ENTRY_POINT_AT``, default
+   ``{high}`` — #345: configurable per run) by setting
+   ``is_entry_point=True`` on the target unit.
 4. The structural reachability filter re-runs with LLM-promoted entry
    points added as extra BFS seeds, yielding a dataset filtered to the
    user's requested ``processing_level`` but expanded by LLM findings.
@@ -29,8 +31,9 @@ Output:
 - ``analyze_reachability(...)`` returns a list of ``ReachabilitySignal``
   dicts.
 - ``apply_signals(dataset, signals)`` mutates the dataset in place so each
-  unit gains an ``llm_reachability_signals`` field, and high-confidence
-  ``entry_point`` signals set ``is_entry_point = True`` on the target unit.
+  unit gains an ``llm_reachability_signals`` field, and ``entry_point``
+  signals in the promote set set ``is_entry_point = True`` on the target unit
+  (the set is configurable — see OPENANT_PROMOTE_ENTRY_POINT_AT).
 
 Usage:
     from core.llm_reachability import analyze_reachability, apply_signals
@@ -506,14 +509,31 @@ def analyze_reachability(
 # issue flags as not reproducible from this repository — widen only after
 # the second-corpus reproduction it names), and low 0.0%.
 _PROMOTE_ENTRY_POINT_AT_DEFAULT = frozenset({"high"})
-_PROMOTE_TIERS = frozenset({"high", "medium", "low"})
+# the tier vocabulary _VALID_CONFIDENCES already declares (parse validates
+# incoming signals against it) — a second hand-rolled copy would drift: a
+# tier added there but not here makes an operator's whole list discard
+# (wave r1 opus), narrowing promotion to the default: the under-seeding
+# direction.
+_PROMOTE_TIERS = frozenset(_VALID_CONFIDENCES)
 _ENV_PROMOTE_ENTRY_POINT_AT = "OPENANT_PROMOTE_ENTRY_POINT_AT"
 
 
 def _promote_entry_point_at() -> frozenset:
     """The tiers that promote, after resolving the env override (#345)."""
     raw = os.environ.get(_ENV_PROMOTE_ENTRY_POINT_AT)
-    if not raw:
+    if raw is None or raw == "":
+        # blank-but-SET (OPENANT_PROMOTE_ENTRY_POINT_AT= — the CI-template
+        # shape, `=$WIDEN` with WIDEN unset) WARNED, not silent: the operator
+        # believes the widening is live while promotion silently narrows to
+        # the default — units dropped from analysis with zero signal (wave
+        # r1, sonnet+opus).
+        if raw == "":
+            print(
+                f"[LLMReach] {_ENV_PROMOTE_ENTRY_POINT_AT} is set but empty; "
+                f"falling back to the shipped default "
+                f"{sorted(_PROMOTE_ENTRY_POINT_AT_DEFAULT)}",
+                file=sys.stderr,
+            )
         return _PROMOTE_ENTRY_POINT_AT_DEFAULT
     wanted = {t.strip().lower() for t in raw.split(",") if t.strip()}
     if not wanted or (wanted - _PROMOTE_TIERS):
@@ -584,6 +604,10 @@ def apply_signals(
         "signals_applied": applied,
         "entry_points_promoted": promoted,
         "units_touched": len(touched),
+        # #345 (wave r1 opus): the resolved set is part of the run's
+        # provenance — two scans under different sets produce different
+        # promotions with byte-identical step reports otherwise.
+        "promote_set": sorted(promote_at),
     }
 
 

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -809,6 +809,11 @@ def scan_repository(
                         "signals_added": summary["signals_applied"],
                         "entry_points_promoted": summary["entry_points_promoted"],
                         "units_touched": summary["units_touched"],
+                        # #345 (wave r1 opus): the resolved promote set is
+                        # the run's provenance — two scans under different
+                        # sets differ in promotions with byte-identical
+                        # step reports otherwise.
+                        "promote_set": summary.get("promote_set", []),
                         "post_filter_units": post_filter_count,
                         "refilter_supported": refilter_supported,
                         # #294: the honest coverage numbers — units_reviewed

--- a/libs/openant-core/tests/test_issue345_promote_tier_config.py
+++ b/libs/openant-core/tests/test_issue345_promote_tier_config.py
@@ -58,6 +58,8 @@ def test_default_set_is_high_only(monkeypatch):
 
 
 def test_operator_widening_to_medium(monkeypatch, capsys):
+    # (wave r1 opus: capsys now used — a VALID override is silent on stderr;
+    # the resolved-set provenance is the summary test above)
     """OPENANT_PROMOTE_ENTRY_POINT_AT=high,medium: medium promotes (the
     issue's suggested trade-off made the operator's to make), low still not."""
     monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", "high,medium")
@@ -67,6 +69,7 @@ def test_operator_widening_to_medium(monkeypatch, capsys):
     ds = _one_unit_dataset("low")
     apply_signals(ds, _ep_signal("low"))
     assert ds["units"][0]["is_entry_point"] is False
+    assert "OPENANT_PROMOTE_ENTRY_POINT_AT" not in capsys.readouterr().err
 
 
 def test_explicit_low_is_the_operators_call(monkeypatch):
@@ -91,12 +94,37 @@ def test_invalid_value_falls_back_loudly(monkeypatch, capsys):
     assert "OPENANT_PROMOTE_ENTRY_POINT_AT" in err and "falling back" in err
 
 
-def test_empty_content_falls_back(monkeypatch):
-    """Whitespace-only content is not a tier list: default, warned."""
+def test_empty_content_falls_back(monkeypatch, capsys):
+    """Whitespace-only content is not a tier list: default, warned (wave r1
+    opus: the warning is now ASSERTED, not just claimed by the docstring)."""
     monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", " , ")
     ds = _one_unit_dataset("medium")
     apply_signals(ds, _ep_signal("medium"))
     assert ds["units"][0]["is_entry_point"] is False
+    err = capsys.readouterr().err
+    assert "OPENANT_PROMOTE_ENTRY_POINT_AT" in err and "falling back" in err
+
+
+def test_blank_but_set_warns_not_silently(monkeypatch, capsys):
+    """Wave r1 (sonnet+opus): OPENANT_PROMOTE_ENTRY_POINT_AT= (blank, the
+    CI-template shape `=$WIDEN` with WIDEN unset) previously fell back with
+    NO warning — the operator believes the widening is live while promotion
+    narrows to the default. Blank-but-set now warns."""
+    monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", "")
+    ds = _one_unit_dataset("medium")
+    apply_signals(ds, _ep_signal("medium"))
+    assert ds["units"][0]["is_entry_point"] is False
+    err = capsys.readouterr().err
+    assert "set but empty" in err, err
+
+
+def test_resolved_set_reports_in_the_summary(monkeypatch):
+    """Wave r1 (opus): the resolved set is the run's provenance — apply_signals
+    returns it so the step report records which set produced the
+    promotions."""
+    monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", "high,medium")
+    summary = apply_signals(_one_unit_dataset("medium"), _ep_signal("medium"))
+    assert summary["promote_set"] == ["high", "medium"], summary
 
 
 def test_unset_env_is_silent(monkeypatch, capsys):

--- a/libs/openant-core/tests/test_issue345_promote_tier_config.py
+++ b/libs/openant-core/tests/test_issue345_promote_tier_config.py
@@ -1,0 +1,106 @@
+"""#345: the entry-point promote set is configurable, and the comment stops lying.
+
+llm-reachability promotes an ``entry_point`` signal to ``is_entry_point = True`` only
+when its confidence is in ``_PROMOTE_ENTRY_POINT_AT`` — a deliberate, PR-#50-calibrated
+set (the issue is explicit: not a bug). Two defects in the ask's path:
+
+1. the threshold is a module CONSTANT — an operator cannot trade recall for cost per
+   run (promote-only bounds the downside: a wrong promotion costs analysis budget on a
+   unit that would otherwise be skipped; a missing one silently removes a unit and
+   everything reachable only through it — the safe direction for a security scanner is
+   more seeding);
+2. the comment read "Confidences at or above this threshold promote..." while the code
+   is a SET-MEMBERSHIP test — no ordering over high/medium/low exists anywhere in the
+   module. It works today because the set has one element; the comment describes
+   semantics the code does not implement, a trap for whoever configures it next.
+
+The DEFAULT stays ``{"high"``: the medium-precision audit (48.0%, n=25, 95% CI [30,67])
+that would justify widening is from an internal run the issue itself flags as
+non-reproducible, and the locked test (test_medium_confidence_does_not_promote)
+encodes that choice — changing it needs the second-corpus reproduction the issue
+names. ``low`` stays out of the default (0.0% is unambiguous) but is not banned: an
+explicit operator choice is logged nowhere as safe, it is the operator's call.
+
+Configurability: OPENANT_PROMOTE_ENTRY_POINT_AT — a comma-separated subset of
+high/medium/low, read at apply time (env, not a module constant, so per-run). Invalid
+or empty content falls back to the shipped default WITH a stderr warning — a
+calibration knob must never crash the scan.
+"""
+import sys
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+from core.llm_reachability import (  # noqa: E402
+    ReachabilitySignal,
+    apply_signals,
+)
+
+
+def _one_unit_dataset(conf, unit_id="app.py:handler"):
+    return {"units": [{"id": unit_id, "is_entry_point": False}]}
+
+
+def _ep_signal(conf, unit_id="app.py:handler"):
+    return [ReachabilitySignal(unit_id, "entry_point", conf, "reads argv and dispatches")]
+
+
+def test_default_set_is_high_only(monkeypatch):
+    """The shipped default: high promotes, medium and low do not (the PR #50
+    calibration, pinned through the configurable path)."""
+    monkeypatch.delenv("OPENANT_PROMOTE_ENTRY_POINT_AT", raising=False)
+    for conf, want in (("high", True), ("medium", False), ("low", False)):
+        ds = _one_unit_dataset(conf)
+        apply_signals(ds, _ep_signal(conf))
+        assert ds["units"][0]["is_entry_point"] is want, conf
+
+
+def test_operator_widening_to_medium(monkeypatch, capsys):
+    """OPENANT_PROMOTE_ENTRY_POINT_AT=high,medium: medium promotes (the
+    issue's suggested trade-off made the operator's to make), low still not."""
+    monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", "high,medium")
+    ds = _one_unit_dataset("medium")
+    apply_signals(ds, _ep_signal("medium"))
+    assert ds["units"][0]["is_entry_point"] is True
+    ds = _one_unit_dataset("low")
+    apply_signals(ds, _ep_signal("low"))
+    assert ds["units"][0]["is_entry_point"] is False
+
+
+def test_explicit_low_is_the_operators_call(monkeypatch):
+    """low is not banned — an explicit tier choice is honored (the audit's 0.0%
+    is the shipped default's justification, not a hard exclusion)."""
+    monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", "medium, low")
+    ds = _one_unit_dataset("low")
+    apply_signals(ds, _ep_signal("low"))
+    assert ds["units"][0]["is_entry_point"] is True
+
+
+def test_invalid_value_falls_back_loudly(monkeypatch, capsys):
+    """A bad tier list warns on stderr and falls back to the default —
+    never crashes the scan, never silently widens."""
+    monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", "hot,high")
+    ds = _one_unit_dataset("medium")
+    apply_signals(ds, _ep_signal("medium"))
+    assert ds["units"][0]["is_entry_point"] is False, (
+        "an invalid list must fall back to the {high} default"
+    )
+    err = capsys.readouterr().err
+    assert "OPENANT_PROMOTE_ENTRY_POINT_AT" in err and "falling back" in err
+
+
+def test_empty_content_falls_back(monkeypatch):
+    """Whitespace-only content is not a tier list: default, warned."""
+    monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", " , ")
+    ds = _one_unit_dataset("medium")
+    apply_signals(ds, _ep_signal("medium"))
+    assert ds["units"][0]["is_entry_point"] is False
+
+
+def test_unset_env_is_silent(monkeypatch, capsys):
+    """No env, no warning — the default is not an error condition."""
+    monkeypatch.delenv("OPENANT_PROMOTE_ENTRY_POINT_AT", raising=False)
+    apply_signals(_one_unit_dataset("high"), _ep_signal("high"))
+    assert "OPENANT_PROMOTE_ENTRY_POINT_AT" not in capsys.readouterr().err


### PR DESCRIPTION
`llm-reachability` promotes an `entry_point` signal to `is_entry_point=True` only when its confidence is in `_PROMOTE_ENTRY_POINT_AT` — a deliberate, PR-#50-calibrated set (the issue is explicit: a calibration report, not a bug). Two defects in its path:

1. **CONFIGURABILITY (the ask that stands on :421 alone):** the threshold was a module constant — an operator could not trade recall for cost per run. Now `OPENANT_PROMOTE_ENTRY_POINT_AT` — a comma-separated subset of high/medium/low, read at apply time; invalid or empty content falls back to the shipped default WITH a stderr warning (a calibration knob must never crash the scan); `low` is not banned (an explicit operator choice is honored; the audit's 0.0% is the default's justification, not a hard exclusion).
2. **THE COMMENT/SEMANTICS MISMATCH (the trap the issue flags regardless of the tier decision):** the comment read "Confidences at or above this threshold promote..." while the code is a SET-MEMBERSHIP test — no ordering over high/medium/low exists anywhere in the module. It worked only because the set had one element; whoever widened it next would have inherited described semantics the code never implemented.

The DEFAULT stays {high}: the medium-precision audit (48.0%, n=25, 95% CI [30,67]) is from an internal run the issue itself flags as not reproducible from this repository — widening needs the second-corpus reproduction it names. `test_medium_confidence_does_not_promote` is UNTOUCHED and green.

**The wave-r1 round (sonnet+opus, all fixed):**
- the module-header docstring still asserted the high-only rule TWICE — the same class of stale-semantics trap this fix exists to remove; both passages now state the configurable set;
- `_PROMOTE_TIERS` was a second hand-rolled copy of the tier vocabulary — a tier added to `_VALID_CONFIDENCES` without it discards an operator's WHOLE list; it now derives from the canonical set;
- `OPENANT_PROMOTE_ENTRY_POINT_AT=` (blank but SET — the CI-template shape) fell back SILENTLY, the one case the comment promised would warn; blank-but-set now warns;
- a valid override left no trace: two scans under different sets produced different promotions with byte-identical step reports — `apply_signals` returns the resolved set and the scanner stamps it (`promote_set`) so the run records which set produced its promotions.

**Evidence:** 8 tests (RED 3 on pristine — the widening, the explicit-low, the loud fallback; the round-1 additions: the blank-but-set warning asserted, the resolved-set provenance); the reachability/scanner families 694/6 env-skips; the full suite green (1 known macOS artifact); ruff clean.

Fixes #345