### PR TITLE
fix(entry-points): CLI-args / env-var reads seed in every shipped language (#355)

### DIFF
--- a/libs/openant-core/tests/test_issue355_cli_env_idioms.py
+++ b/libs/openant-core/tests/test_issue355_cli_env_idioms.py
@@ -1,0 +1,109 @@
+"""#355: CLI-args / env-var reads seed as entry points in EVERY shipped language.
+
+`_get_entry_point_reasons` seeds through six checks, and the two idiom lists are
+maintained per-language with no single place deciding coverage — each gap arrived by
+adding a parser without adding idioms. At HEAD, an environment-variable read is not
+seeded in 5 of the 9 shipped languages (process.env in JavaScript, os.Getenv in Go,
+getenv in C/PHP, std::env::var in Rust, getEnvVarOwned in Zig); JavaScript and Zig read
+NEITHER argv nor env through either route; PHP's CLI forms ($argv, getenv) match
+nothing; C's argv helper is seeded only when the file sits under apps/ — a property of
+the directory, not of the code.
+
+The unit_type column is load-bearing (the issue's probe models BOTH routes): each row
+carries the type that language's REAL parser assigns, because Go/C reach cli_handler
+via the parser (Check 1) — invisible if every row is forced to `function`.
+
+The false-negative direction: a missing entry point silently removes a unit and
+everything reachable only through it. A false one costs analysis budget — the safe
+direction for a scanner is more seeding.
+"""
+import sys
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector  # noqa: E402
+
+
+# (key, unit_type the REAL parser assigns, code) — one row per probe case.
+CASES = [
+    ("python|argv", "function", "def parse_args():\n    return sys.argv[1:]\n"),
+    ("python|env", "function", "def cfg():\n    return os.getenv('TOKEN')\n"),
+    ("ruby|argv", "function", "def parse_args\n  ARGV.dup\nend\n"),
+    ("ruby|env", "function", "def cfg\n  ENV['TOKEN']\nend\n"),
+    ("swift|argv", "function",
+     "func parseArgs() -> [String] {\n    return CommandLine.arguments\n}\n"),
+    ("swift|env", "function",
+     'func cfg() -> String? {\n    return ProcessInfo.processInfo.environment["TOKEN"]\n}\n'),
+    ("rust|argv", "function",
+     "fn parse_args() -> Vec<String> {\n    std::env::args().collect()\n}\n"),
+    ("rust|env", "function",
+     'fn cfg() -> String {\n    std::env::var("TOKEN").unwrap()\n}\n'),
+    ("php|argv_server", "function",
+     "function parseArgs() {\n    return $_SERVER['argv'][1];\n}\n"),
+    ("php|argv", "function", "function parseArgs() {\n    return $argv[1];\n}\n"),
+    ("php|env_env", "function", "function cfg() {\n    return $_ENV['TOKEN'];\n}\n"),
+    ("php|env_getenv", "function", "function cfg() {\n    return getenv('TOKEN');\n}\n"),
+    ("go|argv", "cli_handler", "func parseArgs() []string {\n    return os.Args[1:]\n}\n"),
+    ("go|env", "function", 'func cfg() string {\n    return os.Getenv("TOKEN")\n}\n'),
+    ("go|flag", "function",
+     'func parseFlags() {\n    v := flag.String("v", "", "verbose")\n    flag.Parse()\n}\n'),
+    ("c|argv_apps", "cli_handler",
+     "int run(int argc, char **argv) {\n    return atoi(argv[1]);\n}\n"),
+    ("c|argv_elsewhere", "function",
+     "int run(int argc, char **argv) {\n    return atoi(argv[1]);\n}\n"),
+    ("c|env", "function", 'char *cfg(void) {\n    return getenv("TOKEN");\n}\n'),
+    ("js|argv", "function",
+     "function parseArgs() {\n  return process.argv.slice(2);\n}\n"),
+    ("js|env", "function",
+     "function cfg() {\n  return process.env.TOKEN;\n}\n"),
+    ("js|stdin", "function",
+     "function feed() {\n  return process.stdin.read();\n}\n"),
+    ("js|yargs", "function",
+     "function parseArgs() {\n  return yargs.argv;\n}\n"),
+    ("zig|argv", "function",
+     "fn parseArgs() !void {\n    const a = try std.process.argsAlloc(alloc);\n}\n"),
+    ("zig|env", "function",
+     'fn cfg() !void {\n    const t = try std.process.getEnvVarOwned(alloc, "TOKEN");\n}\n'),
+]
+
+
+def _detect():
+    funcs = {f"f:{k}": {"name": k.split("|")[0] + "_helper", "code": code,
+                       "unitType": ut, "decorators": []}
+             for k, ut, code in CASES}
+    det = EntryPointDetector(funcs, {})
+    det.detect_entry_points()
+    return det
+
+
+def test_every_shipped_language_seeds_cli_and_env_reads():
+    """The issue's probe table: every row seeds through the REAL parser's
+    unit_type — the directory-independent, route-independent floor."""
+    det = _detect()
+    unseeded = [k for k, _, _ in CASES if f"f:{k}" not in det.entry_points]
+    assert not unseeded, (
+        "CLI/env reads not seeded (a missing entry point silently removes a "
+        "unit and everything reachable only through it): " + ", ".join(unseeded)
+    )
+
+
+def test_go_and_c_argv_still_seed_via_unit_type():
+    """The parser route (Check 1) must keep firing — the fix adds idioms, it
+    does not replace the cli_handler classification."""
+    det = _detect()
+    assert "f:go|argv" in det.entry_points
+    assert "f:c|argv_apps" in det.entry_points
+
+
+def test_c_gets_cross_language_match_keeps_firing():
+    """The documented accident (the issue's disclosure): the Ruby `\\bgets\\b`
+    pattern also matches C's gets(buf) — a genuine stdin read, right by luck.
+    Pinned so a future language-scoping change notices it deliberately."""
+    det = EntryPointDetector(
+        {"f:c|gets": {"name": "r", "code": "void r(char *b) {\n    gets(b);\n}\n",
+                      "unitType": "function", "decorators": []}}, {})
+    det.detect_entry_points()
+    assert "f:c|gets" in det.entry_points

--- a/libs/openant-core/tests/test_issue355_cli_env_idioms.py
+++ b/libs/openant-core/tests/test_issue355_cli_env_idioms.py
@@ -41,6 +41,10 @@ CASES = [
      "fn parse_args() -> Vec<String> {\n    std::env::args().collect()\n}\n"),
     ("rust|env", "function",
      'fn cfg() -> String {\n    std::env::var("TOKEN").unwrap()\n}\n'),
+    ("rust|env_short_os", "function",
+     'fn cfg() -> Option<std::ffi::OsString> {\n    use std::env;\n    env::var_os("TOKEN")\n}\n'),
+    ("rust|args_short_os", "function",
+     'fn cfg() {\n    use std::env;\n    let a: Vec<_> = env::args_os().collect();\n}\n'),
     ("php|argv_server", "function",
      "function parseArgs() {\n    return $_SERVER['argv'][1];\n}\n"),
     ("php|argv", "function", "function parseArgs() {\n    return $argv[1];\n}\n"),
@@ -48,8 +52,14 @@ CASES = [
     ("php|env_getenv", "function", "function cfg() {\n    return getenv('TOKEN');\n}\n"),
     ("go|argv", "cli_handler", "func parseArgs() []string {\n    return os.Args[1:]\n}\n"),
     ("go|env", "function", 'func cfg() string {\n    return os.Getenv("TOKEN")\n}\n'),
+    # wave r1 (fable+sonnet): the row previously contained flag.Parse() —
+    # the real Go extractor classifies any function containing it as
+    # cli_handler (extractor.go isCLIHandler), so the type carried here was
+    # NOT what the parser assigns and the RED count was inflated by a
+    # manufactured failure. The honest residual: the flag DECLARATION in a
+    # helper with Parse() living in main.
     ("go|flag", "function",
-     'func parseFlags() {\n    v := flag.String("v", "", "verbose")\n    flag.Parse()\n}\n'),
+     'func verboseFlag() string {\n    v := flag.String("v", "", "verbose")\n    return *v\n}\n'),
     ("c|argv_apps", "cli_handler",
      "int run(int argc, char **argv) {\n    return atoi(argv[1]);\n}\n"),
     ("c|argv_elsewhere", "function",
@@ -96,6 +106,11 @@ def test_go_and_c_argv_still_seed_via_unit_type():
     det = _detect()
     assert "f:go|argv" in det.entry_points
     assert "f:c|argv_apps" in det.entry_points
+    # wave r1 (fable): the unit_type route itself, not the accidental idiom
+    # match (the c row's code contains `argv`, so the new idiom seeds it
+    # regardless of cli_handler membership).
+    reasons = det.entry_point_details["f:c|argv_apps"]["reasons"]
+    assert any(r.startswith("unit_type:") for r in reasons), reasons
 
 
 def test_c_gets_cross_language_match_keeps_firing():

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -200,9 +200,12 @@ USER_INPUT_PATTERNS = [
     # listed; var was not), so a Rust config reader seeded through neither
     # route.
     r'std::env::args',
-    r'\benv::args\b',
+    r'\benv::args(?:_os)?\b',
     r'std::env::var',
-    r'\benv::var\b',
+    # wave r1 (fable): the trailing \b rejected env::var_os / env::vars —
+    # after `use std::env;` (the idiomatic import) the short forms were
+    # unseeded through BOTH routes while the fully-qualified form matched.
+    r'\benv::var(?:s|_os)?\b',
     r'\bstd::io::stdin\b',
     r'\bio::stdin\b',
     r'\bstdin\(\)',

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -196,11 +196,56 @@ USER_INPUT_PATTERNS = [
     # Rust CLI / stdin / env input surfaces: a function that reads these IS a
     # user-input entry point even when it carries no route/main marker of its
     # own (e.g. a helper called from `main` via `std::env::args()`).
+    # #355: std::env::var — the ORDINARY env read — was missing (args was
+    # listed; var was not), so a Rust config reader seeded through neither
+    # route.
     r'std::env::args',
     r'\benv::args\b',
+    r'std::env::var',
+    r'\benv::var\b',
     r'\bstd::io::stdin\b',
     r'\bio::stdin\b',
     r'\bstdin\(\)',
+    # #355: JavaScript/TypeScript CLI / env / stdin — Node reads argv through
+    # process.argv, configuration AND SECRETS through process.env, and stdin
+    # through process.stdin; the argv-parse libraries and readline are the same
+    # surface as Python's argparse/click block above. The JS parser assigns
+    # these units unit_type=function (typescript_analyzer.js) with NO
+    # cli_handler classifier, so without this block NEITHER check seeds them.
+    r'process\.argv',
+    r'process\.env',
+    r'process\.stdin',
+    r'\byargs\b',
+    r'\bcommander\b',
+    r'\bminimist\b',
+    r'\breadline\b',
+    # #355: Go env reads — os.Getenv / os.LookupEnv. argv needs no idiom (the
+    # parser classifies os.Args code as cli_handler, extractor.go:344, so
+    # Check 1 seeds it), but env had no route at all; flag. is the CLI-args
+    # idiom for the flag package (flag.Parse/flag.String).
+    r'\bos\.Getenv\s*\(',
+    r'\bos\.LookupEnv\s*\(',
+    r'\bflag\.',
+    # #355: C CLI / env — getenv( and argc/argv: a non-`main` helper taking
+    # argc/argv is seeded only under apps/ via the parser's cli_handler gate
+    # (c/function_extractor.py:353-356), a property of the DIRECTORY, not of
+    # the code; the idiom closes the gap for every directory. Over-seeding is
+    # the safe direction (a false entry point costs analysis budget; a missing
+    # one silently drops a unit and everything reachable only through it).
+    # `\bgetenv\s*\(` also covers PHP's getenv() — the lists are not
+    # language-scoped (the documented \bgets\b accident above).
+    r'\bgetenv\s*\(',
+    r'\bargv\b',
+    r'\bargc\b',
+    # #355: PHP CLI forms — the web-superglobal pattern covers
+    # $_SERVER['argv'] and $_ENV by accident; the direct CLI forms matched
+    # nothing.
+    r'\$argv\b',
+    # #355: Zig CLI / env — std.process args (one prefix covers args and
+    # argsAlloc) and the env-var reader. The Zig parser assigns
+    # unit_type=function with no cli route.
+    r'std\.process\.args',
+    r'getEnvVarOwned',
 ]
 
 # Patterns that indicate module-level scripts with user input


### PR DESCRIPTION
The entry-point idiom lists are maintained per-language with no single place deciding coverage — each gap arrived by adding a parser without adding idioms. At HEAD an environment-variable read was not seeded in 5 of the 9 shipped languages (process.env in JavaScript, os.Getenv in Go, getenv in C/PHP, std::env::var in Rust, getEnvVarOwned in Zig); JavaScript and Zig read NEITHER argv nor env through either route; PHP's CLI forms ($argv, getenv) matched nothing; C's argv helper was seeded only when the file sat under apps/ — a property of the directory, not of the code.

The false-negative direction: a missing entry point silently removes a unit and everything reachable only through it; the safe direction for a scanner is more seeding (a false one costs analysis budget).

**The fix (base commit, the issue's idiom table):** JavaScript/TypeScript (process.argv / process.env / process.stdin / yargs / commander / minimist / readline — the JS parser assigns unit_type=function with NO cli_handler classifier, so neither check seeded these); Go (os.Getenv / os.LookupEnv / flag. — argv needs no idiom, the parser's os.Args classification seeds it via Check 1); C (getenv / argv / argc — the non-main helper outside apps/ the parser's directory gate does not reach; one getenv pattern also covers PHP's getenv — the lists are not language-scoped, the documented `gets` accident); PHP ($argv); Rust (std::env::var — args was listed, the ORDINARY env read was not); Zig (std.process args / getEnvVarOwned). Lists stay case-sensitive (the issue documents IGNORECASE would MASK gaps with accidental matches).

**The wave-r1 round (fable+sonnet, all fixed):**
- the Rust env patterns' trailing `\b` rejected `env::var_os` / `env::vars` — after `use std::env;` (the idiomatic import) the SHORT forms were unseeded through BOTH routes while the fully-qualified form matched: internally inconsistent about the exact defect class filed. Both families widened (env::var(s|_os)?, env::args(_os)?) and pinned with the two short-form rows;
- the go|flag test row carried flag.Parse() in its snippet — the real Go extractor classifies any function containing it as cli_handler, so the row carried a type the parser would never assign, manufactured a failure that would not occur end-to-end, and inflated the RED count. The honest residual is modeled: the flag DECLARATION in a helper, Parse() living in main;
- the unit_type route is pinned by its REASON string, not membership alone (the c argv row's code contains `argv`, so the idiom seeds it regardless of cli_handler — a Check-1 regression would have stayed green).

Module-level list question (checked, not changed): Check 3 runs on every unit regardless of unit_type, so a JS/PHP top-level process.argv / $argv script IS seeded by USER_INPUT_PATTERNS — MODULE_LEVEL_INPUT_PATTERNS is redundant for the overlapping idioms.

**Evidence:** 3 base tests (RED 1 on pristine, failing with exactly the issue's 13-row list) + the round additions; the entry-point/reachability families 168/1 env-skip; the full suite green (1 known macOS artifact); ruff clean.

Fixes #355