### PR TITLE
fix(tests): parser test batches behave like individual runs (#415)

### DIFF
--- a/libs/openant-core/tests/parsers/conftest.py
+++ b/libs/openant-core/tests/parsers/conftest.py
@@ -45,7 +45,14 @@ def _is_shadow(name, mod):
         paths.extend(Path(str(entry)) for entry in p)
     if not paths:
         return False
-    return all(_TESTS_TREE == t or _TESTS_TREE in t.parents for t in paths)
+    # wave r1 (sonnet): RESOLVE both sides — a literal `..` never collapses
+    # in Path/Path.parents, so an unresolved `.../<lang>/../../parsers`
+    # carries the tests tree as a lexical ancestor of the REAL module's
+    # file and the check misread the genuine package as a shadow.
+    return all(
+        (lambda rp: _TESTS_TREE == rp or _TESTS_TREE in rp.parents)(t.resolve())
+        for t in paths
+    )
 
 
 def _is_stale_bare_stage_module(name, mod):
@@ -67,12 +74,53 @@ def _is_stale_bare_stage_module(name, mod):
     return False
 
 
+# A sys.path entry under which the REGULAR tests/parsers/ package would
+# shadow the source namespace: ONLY the tests tree itself (wave r1 lesson,
+# measured: the core root and the campaign root contain NO parsers/
+# package — stripping them broke 69 tests whose legitimate imports live
+# there — while tests/parsers/__init__.py makes the tests tree a genuine
+# shadow source). The tests/parsers/<lang>/ inserts the language helpers
+# rely on (runtime `from _helpers import ...`) contain no parsers/ package
+# and stay.
+_SHADOW_PATH_ENTRIES = [_TESTS_TREE]
+
+
+def _strip_shadow_path_entries():
+    """Remove sys.path entries that make tests/parsers shadow the source
+    package (wave r1, fable+sonnet: unbinding the sys.modules shadow alone
+    cannot neutralize the class — the very next parsers.* import re-resolves
+    against the same poisoned path and re-binds it; the shipped repro's
+    self-removing insert was the only shape the old fixture cured). No
+    parser test needs these entries (their headers insert the core root or
+    their own language dir), and the root-level polluters run after the
+    parsers subtree in every collection order (directories first), so the
+    removal cannot break a later test's imports."""
+    removed = []
+    for e in list(sys.path):
+        try:
+            p = Path(e)
+        except (TypeError, ValueError):
+            continue
+        # resolve BOTH sides: `..`-segments never collapse in Path.parents,
+        # and the corrected headers' literal `../../..` entries carried the
+        # tests tree as a LEXICAL ancestor of the real module's __file__
+        # (sonnet) — the shadow check misfired on the genuine package.
+        rp = p.resolve()
+        for shadow_root in _SHADOW_PATH_ENTRIES:
+            if rp == shadow_root:
+                sys.path.remove(e)
+                removed.append(e)
+                break
+    return removed
+
+
 @pytest.fixture(autouse=True)
 def _clean_import_state():
-    """Unbind a stale test-directory `parsers` shadow before and after each
-    test (the shadow is what a directory batch's ModuleNotFoundErrors come
-    from; the real source package stays warm — the full-suite ordering
-    shares it across root-level tests)."""
+    """Unbind a stale test-directory `parsers` shadow and strip the
+    shadow-path sys.path entries before each test (both halves are needed:
+    an unbound shadow re-binds on the next import if the path still
+    carries the poison entry); the real source package stays warm — the
+    full-suite ordering shares it across root-level tests."""
 
     def _unbind_stale():
         for name in [n for n, m in list(sys.modules.items())
@@ -80,5 +128,6 @@ def _clean_import_state():
             del sys.modules[name]
 
     _unbind_stale()
+    _strip_shadow_path_entries()
     yield
     _unbind_stale()

--- a/libs/openant-core/tests/parsers/conftest.py
+++ b/libs/openant-core/tests/parsers/conftest.py
@@ -1,0 +1,84 @@
+"""#415: a directory-only pytest run behaves like individual runs.
+
+Running pytest on a single test-DIRECTORY (not the full suite) hits cross-test import
+pollution: a test module's header can leave ``sys.modules['parsers']`` bound to the
+TEST-DIR shadow (``tests/parsers/`` is a REGULAR package that outranks the source
+``parsers/`` namespace whenever ``tests/`` lands on sys.path), so every later
+in-process import of ``parsers.<lang>.<module>`` in the same batch resolves into the
+test directory and fails (``ModuleNotFoundError: No module named
+'parsers.swift.repository_scanner'``). Each file passes alone; the batch self-pollinates;
+the full-suite ordering never hits it — a LOCAL developer-experience defect, not a CI
+one. Named instances: the swift / rust / python directory batches (PRs #394 / #398 / #407).
+
+This conftest is the SAFETY NET of the fix, not its whole: headers that insert the wrong
+directory are corrected at their source (the #299/#309 headers inserted ``tests/`` where
+they needed the core root), and tests that mutate import state at RUNTIME are expected
+to restore it themselves. Between tests, the SHADOW is surgically unbound: if
+``sys.modules['parsers']`` (or a ``parsers.*`` submodule) resolves under the TESTS tree
+instead of the source tree, it is a stale test-directory binding and is deleted so the
+next import re-resolves against the source. The REAL package is deliberately left warm —
+the full-suite ordering shares it across root-level tests, and re-importing modules
+mid-suite (unbinding the real package between every test) breaks 113 of them by mixing
+old and new module objects. sys.path is deliberately NOT reset: test headers legitimately
+install their own directory (the runtime ``from _helpers import ...`` pattern), and a
+global baseline restore would break exactly those. No production code changes.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_TESTS_TREE = Path(__file__).resolve().parents[1]          # .../tests
+_SRC_TREE = Path(__file__).resolve().parents[2] / "parsers"  # .../parsers
+
+
+def _is_shadow(name, mod):
+    """True when a `parsers`-flavored module resolves under the TESTS tree."""
+    if name != "parsers" and not name.startswith("parsers."):
+        return False
+    paths = []
+    f = getattr(mod, "__file__", None)
+    if isinstance(f, str):
+        paths.append(Path(f))
+    p = getattr(mod, "__path__", None)
+    if p:
+        paths.extend(Path(str(entry)) for entry in p)
+    if not paths:
+        return False
+    return all(_TESTS_TREE == t or _TESTS_TREE in t.parents for t in paths)
+
+
+def _is_stale_bare_stage_module(name, mod):
+    """RETIRED (kept documented, not wired): a bare parser-stage name
+    (repository_scanner, function_extractor, ...) bound from the SOURCE
+    tree is the cross-language sibling-basename collision — in an
+    all-languages-one-process batch, a bare name bound from
+    parsers/<lang-A> serves a parsers/<lang-B> import (the observed
+    failure: the python parse reusing C's repository_scanner scanned 0
+    Python files). Unbinding it between tests does NOT fix that batch — the
+    re-import resolves against ACCUMULATED header-inserted parser dirs in
+    sys.path order, so the wrong language's module comes right back — and
+    it broke 15 full-order tests by re-importing parser stage modules that
+    root-level tests hold warm references into. The real fix is migrating
+    the per-language pipelines' sibling imports to unique names —
+    PRODUCTION code, explicitly out of this issue's scope ("no production
+    code changes"). Documented here so the next person does not re-derive
+    the dead end."""
+    return False
+
+
+@pytest.fixture(autouse=True)
+def _clean_import_state():
+    """Unbind a stale test-directory `parsers` shadow before and after each
+    test (the shadow is what a directory batch's ModuleNotFoundErrors come
+    from; the real source package stays warm — the full-suite ordering
+    shares it across root-level tests)."""
+
+    def _unbind_stale():
+        for name in [n for n, m in list(sys.modules.items())
+                     if _is_shadow(n, m)]:
+            del sys.modules[name]
+
+    _unbind_stale()
+    yield
+    _unbind_stale()

--- a/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
@@ -26,7 +26,12 @@ import os
 import sys
 import tempfile
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+# #415: two ".." from tests/parsers/<lang> inserted `tests/` — and tests/parsers/
+# is a REGULAR package that outranks the source parsers/ namespace, so every
+# later in-process parsers.* import in the same pytest batch resolved into the
+# TEST directory (the rust collection errors, the zig/php shadow binds). The
+# insert only exists so the file runs standalone; it needs the core root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from core.parser_adapter import parse_repository  # noqa: E402
 

--- a/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
+++ b/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
@@ -26,7 +26,11 @@ import sys
 import tempfile
 from pathlib import Path
 
-PROJECT_ROOT = Path(__file__).resolve().parents[2]
+# #415: parents[2] from tests/parsers/python/<file> is `tests/` — and tests/parsers
+# is a REGULAR package that outranks the source parsers/ namespace, so every
+# later in-process parsers.* import in the same pytest batch resolved into the
+# TEST directory. The insert needs the CORE root, parents[3].
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 

--- a/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
@@ -23,7 +23,12 @@ import os
 import sys
 import tempfile
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+# #415: this header previously inserted `tests/` (two ".." from
+# tests/parsers/ruby) — and tests/parsers/ is a REGULAR package, so with it
+# on sys.path every later in-process `parsers.*` import in the same pytest
+# batch resolved into the TEST directory. The insert only exists so the
+# file runs standalone; it needs the CORE root, three ".." up.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from core.parser_adapter import parse_repository  # noqa: E402
 

--- a/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
@@ -24,7 +24,12 @@ import os
 import sys
 import tempfile
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+# #415: two ".." from tests/parsers/<lang> inserted `tests/` — and tests/parsers/
+# is a REGULAR package that outranks the source parsers/ namespace, so every
+# later in-process parsers.* import in the same pytest batch resolved into the
+# TEST directory (the rust collection errors, the zig/php shadow binds). The
+# insert only exists so the file runs standalone; it needs the core root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from core.parser_adapter import parse_repository  # noqa: E402
 

--- a/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
@@ -28,7 +28,13 @@ import os
 import sys
 import tempfile
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+# #415: this header previously inserted `tests/` (two ".." from
+# tests/parsers/swift) — and tests/parsers/ is a REGULAR package, so with it
+# on sys.path every later in-process `parsers.*` import in the same pytest
+# batch resolved into the TEST directory (ModuleNotFoundError: No module
+# named 'parsers.swift.repository_scanner'). The insert only exists so the
+# file runs standalone; it needs the CORE root, three ".." up.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from core.parser_adapter import parse_repository  # noqa: E402
 

--- a/libs/openant-core/tests/parsers/test_issue415_pollution_isolation.py
+++ b/libs/openant-core/tests/parsers/test_issue415_pollution_isolation.py
@@ -1,0 +1,58 @@
+"""#415: a directory-only pytest run behaves like individual runs.
+
+Running pytest on a single test-DIRECTORY (not the full suite) hits cross-test import
+pollution: a test module's IMPORT-TIME `sys.path.insert` (e.g. #299's header inserts
+`tests/` — and `tests/parsers/` is a regular package, which SHADOWS the source
+`parsers/` namespace package) makes every later in-process import of
+`parsers.<lang>.<module>` resolve into the TEST directory and fail
+(`ModuleNotFoundError: No module named 'parsers.swift.repository_scanner'`). The
+named instances (swift/rust/python batches, PRs #394/#398/#407) share the shape: each
+file passes alone, the batch self-pollinates, and the full-suite ordering never hits
+it — a LOCAL developer-experience defect, not a CI one.
+
+The two tests below mirror the real pair in one file, in the poisoner-then-victim
+order a directory batch produces: the first does exactly what
+`test_issue299_swift_container_dispatch.py`'s import block does, the second exactly
+what `test_swift_prune_telemetry.py::_load_pipeline` does. The conftest's
+between-test import-state fixture (baseline sys.path captured at conftest import —
+BEFORE any test module mutates it — plus a parsers-flavored sys.modules purge) is
+what makes the second pass.
+"""
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[2]
+
+
+def test_poisoner_inserts_tests_dir_like_the_299_header():
+    """The pre-#415 batch state, reproduced minimally and SELF-CLEANED (the
+    convention this fix asks of runtime import-state mutation): tests/ on
+    sys.path binds sys.modules['parsers'] to tests/parsers/ — the regular
+    package that outranks the source namespace — which is exactly what the
+    un-fixed #299 header left behind for the next test in the batch."""
+    entry = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    sys.path.insert(0, entry)
+    try:
+        import parsers  # noqa: F401, E402 — binds the test-dir shadow
+        assert "parsers" in sys.modules
+    finally:
+        sys.path.remove(entry)
+
+
+def test_victim_loads_the_swift_pipeline_after_the_poisoner():
+    """Exactly test_swift_prune_telemetry's _load_pipeline: an importlib exec of
+    parsers/swift/test_pipeline.py, whose package imports must resolve against
+    the SOURCE parsers/ — not the test-dir shadow the previous test installed."""
+    spec = importlib.util.spec_from_file_location(
+        "swift_pipeline_iso_415red", _CORE / "parsers" / "swift" / "test_pipeline.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)   # ModuleNotFoundError on a polluted batch
+    assert hasattr(mod, "main"), "the swift pipeline module did not load"
+    # And the package import resolved against the SOURCE tree.
+    from parsers.swift import repository_scanner as rs
+    assert str(_CORE / "parsers") in str(rs.__file__), (
+        "parsers.swift.repository_scanner resolved against the TEST shadow, "
+        f"not the source tree: {rs.__file__}"
+    )

--- a/libs/openant-core/tests/parsers/test_issue415_pollution_isolation.py
+++ b/libs/openant-core/tests/parsers/test_issue415_pollution_isolation.py
@@ -44,15 +44,90 @@ def test_poisoner_inserts_tests_dir_like_the_299_header():
 def test_victim_loads_the_swift_pipeline_after_the_poisoner():
     """Exactly test_swift_prune_telemetry's _load_pipeline: an importlib exec of
     parsers/swift/test_pipeline.py, whose package imports must resolve against
-    the SOURCE parsers/ — not the test-dir shadow the previous test installed."""
+    the SOURCE parsers/. Runs against the FORCED post-poison state (this
+    test's own setup re-installs both halves the way a real off-by-one
+    header would leave them), so the victim exercises the CONFTEST's cleanup
+    in the order the fixture actually fires — order-independent."""
+    # re-install the poison the way a header leaves it (both halves) —
+    # and purge the parsers.* family FIRST: an in-batch run has earlier
+    # tests' REAL modules cached, and the sys.modules cache would serve
+    # them past the shadow (the historical failing state was a process
+    # where no parsers import had run yet — the purge reproduces exactly
+    # that, deterministically, in any batch order).
+    import types
+    for _n in [n for n in list(sys.modules)
+               if n == "parsers" or n.startswith("parsers.")]:
+        del sys.modules[_n]
+    entry = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    shadow = types.ModuleType("parsers")
+    shadow.__file__ = str(Path(entry) / "parsers" / "__init__.py")
+    shadow.__path__ = [str(Path(entry) / "parsers")]
+    sys.path.insert(0, entry)
+    sys.modules["parsers"] = shadow
+    # the poison persists INTO this test (no cleanup) — the fixture at the
+    # NEXT setup clears it; here we verify the victim itself would fail:
     spec = importlib.util.spec_from_file_location(
-        "swift_pipeline_iso_415red", _CORE / "parsers" / "swift" / "test_pipeline.py")
+        "swift_pipeline_iso_415chk", _CORE / "parsers" / "swift" / "test_pipeline.py")
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)   # ModuleNotFoundError on a polluted batch
+    try:
+        spec.loader.exec_module(mod)
+        raise AssertionError("the poisoned state did NOT break the load — the repro is vacuous")
+    except ModuleNotFoundError:
+        pass
+    finally:
+        sys.path.remove(entry)
+        for _n in [n for n in list(sys.modules)
+                   if n == "parsers" or n.startswith("parsers.")]:
+            del sys.modules[_n]   # the failed import bound parsers.swift to the shadow too
+    # cleaned state: the load succeeds and resolves against the SOURCE tree
+    spec = importlib.util.spec_from_file_location(
+        "swift_pipeline_iso_415ok", _CORE / "parsers" / "swift" / "test_pipeline.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
     assert hasattr(mod, "main"), "the swift pipeline module did not load"
-    # And the package import resolved against the SOURCE tree.
     from parsers.swift import repository_scanner as rs
     assert str(_CORE / "parsers") in str(rs.__file__), (
         "parsers.swift.repository_scanner resolved against the TEST shadow, "
         f"not the source tree: {rs.__file__}"
     )
+
+
+def test_the_fixture_neutralizes_a_real_header_insert():
+    """Wave r1 (fable, the HIGH finding): the old fixture only cured the
+    SELF-REMOVING poisoner — a real header's tests/ insert persists for the
+    process lifetime, and the very next parsers.* import re-bound the
+    shadow despite the unbind. The fixture now strips the shadow-path ENTRY
+    too: simulate a real header (insert, NO cleanup) and verify the next
+    test's setup state."""
+    import importlib.util as _ilu
+    _spec = _ilu.spec_from_file_location(
+        "parsers_conftest_iso_415", Path(__file__).parent / "conftest.py")
+    _cmod = _ilu.module_from_spec(_spec)
+    _spec.loader.exec_module(_cmod)
+    _strip = _cmod._strip_shadow_path_entries
+    import types
+
+    entry = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    sys.path.insert(0, entry)          # a real header leaves this behind
+    shadow = types.ModuleType("parsers")
+    shadow.__file__ = str(Path(entry) / "parsers" / "__init__.py")
+    shadow.__path__ = [str(Path(entry) / "parsers")]
+    sys.modules["parsers"] = shadow    # ...and this
+    try:
+        # the fixture's strip (what the NEXT test's setup runs):
+        removed = _strip()
+        assert entry in [str(r) for r in removed] or entry not in sys.path
+        assert entry not in sys.path, "the poison entry survived the strip"
+        for _n in [n for n in list(sys.modules)
+                   if n == "parsers" or n.startswith("parsers.")]:
+            del sys.modules[_n]
+        import parsers
+        assert "tests" not in str(getattr(parsers, "__file__", "")), (
+            f"the shadow re-bound after the strip: {getattr(parsers, '__file__', None)}"
+        )
+    finally:
+        if entry in sys.path:
+            sys.path.remove(entry)
+        for _n in [n for n in list(sys.modules)
+                   if n == "parsers" or n.startswith("parsers.")]:
+            del sys.modules[_n]

--- a/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
+++ b/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
@@ -25,7 +25,12 @@ import os
 import sys
 import tempfile
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+# #415: two ".." from tests/parsers/<lang> inserted `tests/` — and tests/parsers/
+# is a REGULAR package that outranks the source parsers/ namespace, so every
+# later in-process parsers.* import in the same pytest batch resolved into the
+# TEST directory (the rust collection errors, the zig/php shadow binds). The
+# insert only exists so the file runs standalone; it needs the core root.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 
 from core.parser_adapter import parse_repository  # noqa: E402
 


### PR DESCRIPTION
Running pytest on a single test-DIRECTORY (not the full suite) hits cross-test import pollution: each file passes alone, the batch self-pollinates, and the full-suite ordering never sees it — a LOCAL developer-experience defect (swift/rust/python batches; PRs #394/#398/#407's local-env notes; re-met and diagnosed empirically here: swift 12 failed, rust 16 collection errors, python 6 failed, zig 4 failed on pristine master).

**THE MECHANISM (re-derived, not theorized):** `tests/parsers/` is a REGULAR package, and a later regular package on sys.path outranks the source `parsers/` namespace, so whenever `tests/` lands on sys.path, the next fresh in-process `parsers.*` import binds the TEST shadow (dumped: `sys.modules['parsers'] -> tests/parsers/__init__.py`) and every later `parsers.<lang>.<module>` import resolves into the test directory — ModuleNotFoundError. The poison arrived via seven test headers with an off-by-one path insert (both #299 container-dispatch files, the rust/php/zig #299 siblings, and #309's parents[2]).

**The fix (base commit):** the seven headers corrected at their source to insert the CORE root; `tests/parsers/conftest.py` — a surgical autouse fixture unbinding a `parsers` shadow that resolves under the TESTS tree, before and after every test (the real source package stays warm — unbinding it broke 113 full-order tests, measured then narrowed; sys.path deliberately not reset globally — headers legitimately install their own dir for the runtime `from _helpers import ...` pattern); a poisoner-then-victim repro pair, RED on pristine, GREEN under the fixture.

**The wave-r1 round (fable+sonnet, all confirmed, all fixed):**
- THE SAFETY NET COULD NOT NEUTRALIZE THE CLASS (fable, HIGH): unbinding the sys.modules shadow alone cures nothing when the header-inserted `tests/` entry persists — the very next parsers.* import re-resolves against the same poisoned path and re-binds it. The fixture now ALSO strips the shadow-path sys.path entry at every setup — ONLY the tests tree itself (measured: stripping the core root or campaign root broke 69 tests whose legitimate imports live there). The mechanism test pins the real-header shape (insert, no cleanup → entry removed, shadow unbound, fresh import resolves to source);
- the repro was VACUOUS in every batch containing it (pytest collects the language dirs first, the real package was always pre-bound, `import parsers` was a no-op — it only ever failed when the file ran alone). The repro now FORCES the historical post-poison state directly (shadow bound + entry inserted + the parsers.* family purged so earlier tests' cached real modules cannot serve the import), demonstrates the load failing under it, and succeeds after the cleanup — order-independent in any batch;
- `Path.parents` never collapses `..` (sonnet): the five non-python corrected headers insert literal `../../..` entries, and an unresolved path carried the tests tree as a LEXICAL ANCESTOR of the real module's file — the shadow check misread the genuine package. Both sides of the check (and the strip) `resolve()` now.

Remaining class, documented: the maximal all-languages-one-process batch's bare-sibling-name collisions (the python parse reusing C's `repository_scanner`) need production import migration — the conftest comment records the dead end (unbinding breaks full-order tests; the wrong-language module comes right back through the accumulated header dirs).

**Evidence:** 3 tests in the isolation file (the forced-state repro; the mechanism test); the maximal parsers batch 879 passed / 4 pre-existing (the #309 cross-language class, identical on the branch base — note: PR #427's round routes those to `errors`, another reason these compose); the full suite 3519/1 (the known macOS artifact); ruff clean.

Fixes #415