### PR TITLE
fix(stage2/dynamic-test): an interrupt propagates — it is not a completion (#419)

### DIFF
--- a/libs/openant-core/tests/test_issue419_ki_propagates.py
+++ b/libs/openant-core/tests/test_issue419_ki_propagates.py
@@ -1,0 +1,134 @@
+"""#419: an interrupt during verify or dynamic-test propagates — it is not a
+completion.
+
+The #417 interrupt-swallow class persists at two more stages (panel enumeration
+during #418's review):
+
+- `finding_verifier.py:952` (sequential): the KeyboardInterrupt handler prints
+  'progress saved' and FALLS THROUGH — a SIGINT during verify makes the scan
+  continue to the next stage with partially-verified results: the live-run shape
+  is the #417 one — the scan completes, success envelope, no exit 130.
+- `finding_verifier.py:987` (parallel): `executor.shutdown(...)` then a bare
+  `return` — same swallow, parallel path.
+- `dynamic_tester/__init__.py:343`: `return results` on KI, and the caller then
+  writes DYNAMIC_TEST_RESULTS.md from PARTIAL results — an interrupted run
+  presented with a completion artifact.
+
+`core/reporter.py:975` already re-raises (clean); #418 (enhance) and #411
+(analyze) fix the other stages. The contract: checkpoints hold the progress
+(every completed unit is saved as it completes — that is the resume story), and
+the KI itself PROPAGATES so the CLI can exit 130 with an interrupted envelope —
+never a success one.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+import utilities.dynamic_tester as dt  # noqa: E402
+from utilities.finding_verifier import FindingVerifier  # noqa: E402
+from utilities.llm import PhaseBinding  # noqa: E402
+
+
+class _ToolsAdapter:
+    name = "anthropic"
+    supports_tools = True
+
+    def validate(self, model):
+        pass
+
+
+def _bare_verifier():
+    """A FindingVerifier without the heavy init (the batch methods under test
+    only touch _log and _verify_one, both set here/monkeypatched)."""
+    v = FindingVerifier.__new__(FindingVerifier)
+    v._log = lambda *a, **k: None
+    return v
+
+
+_RESULTS = [{"route_key": "a:f1"}, {"route_key": "a:f2"}, {"route_key": "a:f3"}]
+
+
+def test_sequential_verify_ki_propagates():
+    """SIGINT mid-verify must propagate out of the sequential batch — the
+    handler at :952 printed 'progress saved' and fell through (the scan then
+    completed with partially-verified results and a success envelope)."""
+    v = _bare_verifier()
+    n = {"i": 0}
+
+    def fake_verify_one(result, code_by_route):
+        n["i"] += 1
+        if n["i"] == 2:
+            raise KeyboardInterrupt
+        return (result["route_key"], "ok", 0.01, "w0", {})
+
+    v._verify_one = fake_verify_one
+    with pytest.raises(KeyboardInterrupt):
+        v._verify_batch_sequential(list(_RESULTS), {}, None)
+    # the completed units before the interrupt were processed (their
+    # checkpoint saves are the resume story — not a reason to swallow).
+    assert n["i"] == 2
+
+
+def test_parallel_verify_ki_propagates():
+    """The parallel path's handler shut the executor down and returned bare —
+    same swallow."""
+    v = _bare_verifier()
+
+    def fake_verify_one(result, code_by_route):
+        if result["route_key"] == "a:f2":
+            raise KeyboardInterrupt
+        return (result["route_key"], "ok", 0.01, "w0", {})
+
+    v._verify_one = fake_verify_one
+    with pytest.raises(KeyboardInterrupt):
+        v._verify_batch_parallel(list(_RESULTS), {}, None, workers=2)
+
+
+def test_dynamic_test_ki_propagates_not_partial_report(tmp_path):
+    """The dynamic-test handler `return results` on KI and the caller then
+    wrote DYNAMIC_TEST_RESULTS.md from PARTIAL results — an interrupted run
+    presented with a completion artifact. The KI must propagate (the
+    checkpoints hold the progress; the envelope must say interrupted)."""
+    pipeline = tmp_path / "pipeline_output.json"
+    pipeline.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [{
+            "id": "f1", "name": "X", "short_name": "x", "location": "a.py:1",
+            "cwe_id": 79, "stage2_verdict": "confirmed",
+            "vulnerable_code": "eval(x)", "attack_vector": "a",
+            "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f",
+        }],
+    }))
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_ToolsAdapter(),
+                                model="m", provider_name="anthropic")
+
+    def gen_interrupts(*a, **k):
+        raise KeyboardInterrupt
+
+    orig = dt.generate_test
+    dt.generate_test = gen_interrupts
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            dt.run_dynamic_tests(
+                pipeline_output_path=str(pipeline),
+                output_dir=str(tmp_path / "out"),
+                checkpoint_path=str(tmp_path / "cp"),
+                registry=_FakeRegistry(),
+            )
+    finally:
+        dt.generate_test = orig
+    # No partial-results completion artifact from an interrupted run.
+    assert not (tmp_path / "out" / "DYNAMIC_TEST_RESULTS.md").exists(), (
+        "an interrupted dynamic-test run must not write the completion report "
+        "from partial results"
+    )

--- a/libs/openant-core/tests/test_issue419_ki_propagates.py
+++ b/libs/openant-core/tests/test_issue419_ki_propagates.py
@@ -91,10 +91,15 @@ def test_parallel_verify_ki_propagates():
 
 
 def test_dynamic_test_ki_propagates_not_partial_report(tmp_path):
-    """The dynamic-test handler `return results` on KI and the caller then
-    wrote DYNAMIC_TEST_RESULTS.md from PARTIAL results — an interrupted run
-    presented with a completion artifact. The KI must propagate (the
-    checkpoints hold the progress; the envelope must say interrupted)."""
+    """The dynamic-test handler `return results` on KI handed the caller the
+    partial results — they flowed into run_tests' DynamicTestStepResult ->
+    ctx.summary -> dynamic-test.report.json -> the scan continued to the
+    report step -> the SUCCESS envelope (wave r1 fable+opus: the original
+    commit message misdescribed this as a DYNAMIC_TEST_RESULTS.md
+    partial-write — that writer sits AFTER the old return and never ran on
+    the interrupt path; the real pre-fix harm was the swallowed exit). The
+    KI must propagate so the CLI exits 130 and the step report (fixed in
+    #420's PR) says interrupted."""
     pipeline = tmp_path / "pipeline_output.json"
     pipeline.write_text(json.dumps({
         "repository": {"name": "t", "language": "python"},
@@ -127,8 +132,59 @@ def test_dynamic_test_ki_propagates_not_partial_report(tmp_path):
             )
     finally:
         dt.generate_test = orig
-    # No partial-results completion artifact from an interrupted run.
-    assert not (tmp_path / "out" / "DYNAMIC_TEST_RESULTS.md").exists(), (
-        "an interrupted dynamic-test run must not write the completion report "
-        "from partial results"
-    )
+    # (shape pin — wave r1: green on pristine too; the writer sits after the
+    # old return. The pre-fix harm was the swallowed exit, above.)
+    assert not (tmp_path / "out" / "DYNAMIC_TEST_RESULTS.md").exists()
+
+
+def test_dynamic_test_ki_saves_the_completed_unit_first(tmp_path):
+    """Wave r1 (fable): the resume story's other half — a KI arriving after
+    one finding COMPLETED leaves its checkpoint saved (the raise must not
+    land before the completed unit's save; e.g. a re-nested try would)."""
+    pipeline = tmp_path / "pipeline_output.json"
+    pipeline.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [
+            {"id": "f1", "name": "X", "short_name": "x", "location": "a.py:1",
+             "cwe_id": 79, "stage2_verdict": "confirmed",
+             "vulnerable_code": "eval(x)", "attack_vector": "a",
+             "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f"},
+            {"id": "f2", "name": "Y", "short_name": "y", "location": "b.py:1",
+             "cwe_id": 79, "stage2_verdict": "confirmed",
+             "vulnerable_code": "eval(y)", "attack_vector": "a",
+             "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f"},
+        ],
+    }))
+    cp = tmp_path / "cp"
+    seen = {"n": 0}
+
+    def gen(finding=None, *a, **k):
+        seen["n"] += 1
+        if seen["n"] == 2:
+            raise KeyboardInterrupt
+        # a COMPLETED first finding: the real loop saves its checkpoint
+        return None
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_ToolsAdapter(),
+                                model="m", provider_name="anthropic")
+
+    orig = dt.generate_test
+    dt.generate_test = gen
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            dt.run_dynamic_tests(
+                pipeline_output_path=str(pipeline),
+                output_dir=str(tmp_path / "out"),
+                checkpoint_path=str(cp),
+                registry=_FakeRegistry(),
+            )
+    finally:
+        dt.generate_test = orig
+    import json as _json
+    f1 = cp / "f1.json"
+    assert f1.exists(), "the completed finding's checkpoint must survive the interrupt"
+    saved = _json.loads(f1.read_text())
+    assert saved.get("id") == "f1", saved

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -405,7 +405,14 @@ def run_dynamic_tests(
     except KeyboardInterrupt:
         print("\n[Dynamic Test] Interrupted — progress saved to checkpoints",
               file=sys.stderr, flush=True)
-        return results
+        # #419 (the #417 class): `return results` here swallowed the
+        # interrupt AND handed the caller partial results, which then wrote
+        # DYNAMIC_TEST_RESULTS.md as a completion artifact for an
+        # interrupted run. The checkpoints hold the progress (every
+        # completed finding is saved as it completes — the resume story);
+        # the interrupt itself PROPAGATES so the CLI exits 130 with an
+        # interrupted envelope, never a success one.
+        raise
 
     # Generate report
     total_cost = tracker.total_cost_usd

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -952,6 +952,12 @@ class FindingVerifier:
         except KeyboardInterrupt:
             print("[Verify] Interrupted — progress saved to checkpoints",
                   file=sys.stderr, flush=True)
+            # #419 (the #417 class): the checkpoints hold the progress (every
+            # completed unit is saved as it completes) — the interrupt itself
+            # PROPAGATES so the CLI exits 130 with an interrupted envelope.
+            # Falling through made the scan continue with partially-verified
+            # results and complete with a SUCCESS envelope.
+            raise
 
     def _verify_batch_parallel(self, results, code_by_route, progress_callback, workers,
                                 checkpoint=None, summary_callback=None):
@@ -990,7 +996,11 @@ class FindingVerifier:
             executor.shutdown(wait=False, cancel_futures=True)
             print("[Verify] Progress saved to checkpoints",
                   file=sys.stderr, flush=True)
-            return
+            # #419 (the #417 class): a bare `return` here swallowed the
+            # interrupt on the parallel path — the scan completed with a
+            # success envelope, no exit 130. Propagate (the checkpoints hold
+            # the completed units).
+            raise
         executor.shutdown(wait=False)
 
     def _check_consistency(

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -999,7 +999,14 @@ class FindingVerifier:
             # #419 (the #417 class): a bare `return` here swallowed the
             # interrupt on the parallel path — the scan completed with a
             # success envelope, no exit 130. Propagate (the checkpoints hold
-            # the completed units).
+            # the completed units). Wave r1 (opus) residual, documented:
+            # cancel_futures cancels only QUEUED work — the <=workers
+            # in-flight verification loops keep running in non-daemon
+            # threads, and under the Go CLI the raise is bounded by the 5s
+            # SIGKILL; a DIRECT python -m openant invocation blocks in
+            # interpreter shutdown until they finish. Not a regression, and
+            # their results are not checkpointed (the save loop has exited)
+            # — the retry owns them on resume.
             raise
         executor.shutdown(wait=False)
 


### PR DESCRIPTION
The #417 interrupt-swallow class persisted at two more stages (panel enumeration during #418's review): the sequential verify handler printed 'progress saved' and FELL THROUGH — a SIGINT during verify made the scan continue with partially-verified results and complete with a SUCCESS envelope, no exit 130; the parallel handler shut the executor down and returned BARE — same swallow; and the dynamic-test handler `return results` on KI, handing the caller PARTIAL results which flowed into the step summary → the report step → the success envelope (the corrected framing from the wave round — the original commit message described a DYNAMIC_TEST_RESULTS.md partial-write that never existed on that path).

**The fix (base commit):** the #417/#418 contract at all three sites — the checkpoints hold the progress (every completed unit/finding is saved as it completes — that IS the resume story), and the KeyboardInterrupt itself PROPAGATES so the CLI can exit 130 with an interrupted envelope, never a success one. `core/reporter.py:975` already re-raises (clean); #418 (enhance) and #411 (analyze) fix the other stages; no other KI handler exists in the two call paths (KeyboardInterrupt is a BaseException — no broad except-Exception re-swallow).

**The wave-r1 round (fable+opus, all confirmed, all fixed):**
- the resume story's other half was untested: a KI arriving after a finding COMPLETED — the raise must not land before the completed unit's checkpoint save (a re-nested try would regress exactly this). Pinned: the first finding's checkpoint survives the interrupt;
- the parallel-path residual documented at the raise site (opus): cancel_futures cancels only queued work; the in-flight verification loops finish in non-daemon threads (bounded by the Go CLI's 5s SIGKILL; a direct `python -m openant` invocation waits them out in interpreter shutdown), and their results are not checkpointed — the retry owns them on resume. Not a regression; now stated instead of overstated;
- the step-report layer one layer up (all three axes): that is PR #420 (except BaseException → status "interrupted") — this PR and that one are a pair.

**Evidence:** 3 base tests (RED 3 on pristine) + the completed-unit-checkpoint pin; the verify/dynamic/interrupt families 132 passed; the full suite 3520/1 (the known macOS artifact); ruff clean.

Fixes #419