### PR TITLE
fix(core): an interrupted step's report says "interrupted", not "success" (#420)

### DIFF
--- a/apps/openant-cli/internal/report/sarif.go
+++ b/apps/openant-cli/internal/report/sarif.go
@@ -115,8 +115,7 @@ func BuildSARIF(data ReportData, opts SARIFOptions) map[string]any {
 		if sr.Step == "scan" {
 			continue
 		}
-		if sr.ErrorCount > 0 || len(sr.Errors) > 0 ||
-			sr.Status == "error" || sr.Status == "partial" {
+		if stepReportIsFailure(sr) {
 			execOK = false
 			if sr.ErrorCount > 0 || len(sr.Errors) > 0 {
 				detail := fmt.Sprintf("step %s: %d unit error(s)", sr.Step, sr.ErrorCount)
@@ -160,6 +159,18 @@ func BuildSARIF(data ReportData, opts SARIFOptions) map[string]any {
 // verdict (vulnerable, bypassable, …) since OpenAnt findings are not yet
 // keyed by a stable per-rule taxonomy. Categories from ReportData supply
 // the rule descriptions.
+// stepReportIsFailure is the SARIF gate's failure-class predicate (#420
+// wave r1, fable+opus): a step row fails the run when it carries unit
+// errors OR a failure-class status — error, partial, AND interrupted (the
+// #420 status carries empty errors/summary, so before the gate knew the
+// word it matched no disjunct and read executionSuccessful: true — the
+// exact false-green shape #285/#305 exist to close).
+func stepReportIsFailure(sr StepReport) bool {
+	return sr.ErrorCount > 0 || len(sr.Errors) > 0 ||
+		sr.Status == "error" || sr.Status == "partial" ||
+		sr.Status == "interrupted"
+}
+
 func sarifRulesFor(data ReportData) ([]map[string]any, map[string]int) {
 	descByVerdict := make(map[string]string, len(data.Categories))
 	for _, c := range data.Categories {

--- a/apps/openant-cli/internal/report/sarif_interrupted_test.go
+++ b/apps/openant-cli/internal/report/sarif_interrupted_test.go
@@ -1,0 +1,27 @@
+package report
+
+import (
+	"testing"
+)
+
+// #420 (wave r1, fable+opus): an INTERRUPTED step must gate the SARIF run as
+// NOT executionSuccessful — the status carries empty errors/summary, so before
+// the gate knew the word it matched no disjunct and produced the exact
+// false-green #285/#305 exist to close. Consumer-level pin (the producer
+// tests alone could not see the vocabulary split).
+func TestSarifInterruptedStepIsFailure(t *testing.T) {
+	for _, status := range []string{"interrupted", "error", "partial"} {
+		sr := StepReport{Step: "verify", Status: status}
+		if !stepReportIsFailure(sr) {
+			t.Fatalf("status %q must be failure-class in the SARIF gate", status)
+		}
+	}
+	sr := StepReport{Step: "parse", Status: "success"}
+	if stepReportIsFailure(sr) {
+		t.Fatalf("a successful step must not be failure-class")
+	}
+	sr2 := StepReport{Step: "parse", Status: "success", ErrorCount: 3}
+	if !stepReportIsFailure(sr2) {
+		t.Fatalf("unit errors must be failure-class regardless of status")
+	}
+}

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -1453,7 +1453,11 @@ def _write_scan_report(
     total_duration = sum(sr.get("duration_seconds", 0) for sr in step_reports)
     # #285: aggregate the per-step status and errors — the scan report must
     # be at least as informative as the per-step files it summarises.
-    _STATUS_RANK = {"success": 0, "skipped": 1, "partial": 2, "error": 3}
+    # #420 (wave r1, fable+opus): "interrupted" ranks with the failure
+    # class — the .get(..., 0) default silently ranked it as success, and
+    # the aggregate scan status fed to the envelope stayed green.
+    _STATUS_RANK = {"success": 0, "skipped": 1, "partial": 2, "error": 3,
+                    "interrupted": 4}
     _worst_status = "success"
     for sr in step_reports:
         _st = str(sr.get("status", "success") or "success").lower()

--- a/libs/openant-core/core/step_report.py
+++ b/libs/openant-core/core/step_report.py
@@ -59,16 +59,36 @@ def step_context(step: str, output_dir: str, inputs: dict | None = None):
         print(f"[{step}] ERROR: {exc}", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         raise
-    except BaseException:
+    except KeyboardInterrupt:
         # #420 (the #417/#418/#419 contract): an interrupt propagating through
         # a step must not leave an on-disk artifact claiming success — the
         # finally below would write the DEFAULT status="success" with an
-        # empty summary. `except Exception` above cannot catch these
-        # (KeyboardInterrupt / SystemExit / GeneratorExit), so a propagating
-        # BaseException marks the step "interrupted": the resume path and
-        # any artifact reader can see the run was cut short. stdout envelope
+        # empty summary. `except Exception` above cannot catch it, so a
+        # propagating KI marks the step "interrupted": the resume path and
+        # the artifact readers can see the run was cut short. stdout envelope
         # unaffected — no envelope is emitted on the KI path; the Go
         # exit-130 contract still works. This is the stderr/file channel.
+        report.status = "interrupted"
+        raise
+    except SystemExit as exc:
+        # wave r1 (opus): SystemExit is NOT an interrupt — it is how
+        # deterministic error exits are signalled (report/generator.py's
+        # validation sys.exit(1), generate_context's unsupported-type
+        # sys.exit(2)). Mapping it to "interrupted" erased the cause and
+        # contradicted the exit code (the Go contract reads "interrupted"
+        # as 130). Non-zero codes are ERROR with the cause recorded;
+        # a zero code is a deliberate early exit (interrupted, no error).
+        code = exc.code if isinstance(exc.code, int) else (1 if exc.code else 0)
+        if code != 0:
+            report.status = "error"
+            report.errors.append(f"SystemExit: {code}")
+            print(f"[{step}] ERROR: SystemExit({code})", file=sys.stderr)
+        else:
+            report.status = "interrupted"
+        raise
+    except BaseException:
+        # GeneratorExit / anything else non-Exception: the run was cut
+        # short, not failed — same artifact contract as the KI branch.
         report.status = "interrupted"
         raise
     finally:

--- a/libs/openant-core/core/step_report.py
+++ b/libs/openant-core/core/step_report.py
@@ -59,6 +59,18 @@ def step_context(step: str, output_dir: str, inputs: dict | None = None):
         print(f"[{step}] ERROR: {exc}", file=sys.stderr)
         traceback.print_exc(file=sys.stderr)
         raise
+    except BaseException:
+        # #420 (the #417/#418/#419 contract): an interrupt propagating through
+        # a step must not leave an on-disk artifact claiming success — the
+        # finally below would write the DEFAULT status="success" with an
+        # empty summary. `except Exception` above cannot catch these
+        # (KeyboardInterrupt / SystemExit / GeneratorExit), so a propagating
+        # BaseException marks the step "interrupted": the resume path and
+        # any artifact reader can see the run was cut short. stdout envelope
+        # unaffected — no envelope is emitted on the KI path; the Go
+        # exit-130 contract still works. This is the stderr/file channel.
+        report.status = "interrupted"
+        raise
     finally:
         # Issue #209/#285: a step that records errors via
         # ``ctx.errors.append(...)`` or that counts per-item failures in
@@ -69,7 +81,7 @@ def step_context(step: str, output_dir: str, inputs: dict | None = None):
         # stays reserved for the propagating-exception path). The scanner's
         # degrade idiom (status="skipped", reason in summary, no errors) is
         # unaffected.
-        if report.status != "error":
+        if report.status not in ("error", "interrupted"):
             _summary = report.summary if isinstance(report.summary, dict) else {}
             _counted = _summary.get("error_count")
             _error_count = _counted if isinstance(_counted, int) and _counted > 0 else 0

--- a/libs/openant-core/tests/test_issue419_ki_propagates.py
+++ b/libs/openant-core/tests/test_issue419_ki_propagates.py
@@ -1,0 +1,134 @@
+"""#419: an interrupt during verify or dynamic-test propagates — it is not a
+completion.
+
+The #417 interrupt-swallow class persists at two more stages (panel enumeration
+during #418's review):
+
+- `finding_verifier.py:952` (sequential): the KeyboardInterrupt handler prints
+  'progress saved' and FALLS THROUGH — a SIGINT during verify makes the scan
+  continue to the next stage with partially-verified results: the live-run shape
+  is the #417 one — the scan completes, success envelope, no exit 130.
+- `finding_verifier.py:987` (parallel): `executor.shutdown(...)` then a bare
+  `return` — same swallow, parallel path.
+- `dynamic_tester/__init__.py:343`: `return results` on KI, and the caller then
+  writes DYNAMIC_TEST_RESULTS.md from PARTIAL results — an interrupted run
+  presented with a completion artifact.
+
+`core/reporter.py:975` already re-raises (clean); #418 (enhance) and #411
+(analyze) fix the other stages. The contract: checkpoints hold the progress
+(every completed unit is saved as it completes — that is the resume story), and
+the KI itself PROPAGATES so the CLI can exit 130 with an interrupted envelope —
+never a success one.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+import utilities.dynamic_tester as dt  # noqa: E402
+from utilities.finding_verifier import FindingVerifier  # noqa: E402
+from utilities.llm import PhaseBinding  # noqa: E402
+
+
+class _ToolsAdapter:
+    name = "anthropic"
+    supports_tools = True
+
+    def validate(self, model):
+        pass
+
+
+def _bare_verifier():
+    """A FindingVerifier without the heavy init (the batch methods under test
+    only touch _log and _verify_one, both set here/monkeypatched)."""
+    v = FindingVerifier.__new__(FindingVerifier)
+    v._log = lambda *a, **k: None
+    return v
+
+
+_RESULTS = [{"route_key": "a:f1"}, {"route_key": "a:f2"}, {"route_key": "a:f3"}]
+
+
+def test_sequential_verify_ki_propagates():
+    """SIGINT mid-verify must propagate out of the sequential batch — the
+    handler at :952 printed 'progress saved' and fell through (the scan then
+    completed with partially-verified results and a success envelope)."""
+    v = _bare_verifier()
+    n = {"i": 0}
+
+    def fake_verify_one(result, code_by_route):
+        n["i"] += 1
+        if n["i"] == 2:
+            raise KeyboardInterrupt
+        return (result["route_key"], "ok", 0.01, "w0", {})
+
+    v._verify_one = fake_verify_one
+    with pytest.raises(KeyboardInterrupt):
+        v._verify_batch_sequential(list(_RESULTS), {}, None)
+    # the completed units before the interrupt were processed (their
+    # checkpoint saves are the resume story — not a reason to swallow).
+    assert n["i"] == 2
+
+
+def test_parallel_verify_ki_propagates():
+    """The parallel path's handler shut the executor down and returned bare —
+    same swallow."""
+    v = _bare_verifier()
+
+    def fake_verify_one(result, code_by_route):
+        if result["route_key"] == "a:f2":
+            raise KeyboardInterrupt
+        return (result["route_key"], "ok", 0.01, "w0", {})
+
+    v._verify_one = fake_verify_one
+    with pytest.raises(KeyboardInterrupt):
+        v._verify_batch_parallel(list(_RESULTS), {}, None, workers=2)
+
+
+def test_dynamic_test_ki_propagates_not_partial_report(tmp_path):
+    """The dynamic-test handler `return results` on KI and the caller then
+    wrote DYNAMIC_TEST_RESULTS.md from PARTIAL results — an interrupted run
+    presented with a completion artifact. The KI must propagate (the
+    checkpoints hold the progress; the envelope must say interrupted)."""
+    pipeline = tmp_path / "pipeline_output.json"
+    pipeline.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [{
+            "id": "f1", "name": "X", "short_name": "x", "location": "a.py:1",
+            "cwe_id": 79, "stage2_verdict": "confirmed",
+            "vulnerable_code": "eval(x)", "attack_vector": "a",
+            "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f",
+        }],
+    }))
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_ToolsAdapter(),
+                                model="m", provider_name="anthropic")
+
+    def gen_interrupts(*a, **k):
+        raise KeyboardInterrupt
+
+    orig = dt.generate_test
+    dt.generate_test = gen_interrupts
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            dt.run_dynamic_tests(
+                pipeline_output_path=str(pipeline),
+                output_dir=str(tmp_path / "out"),
+                checkpoint_path=str(tmp_path / "cp"),
+                registry=_FakeRegistry(),
+            )
+    finally:
+        dt.generate_test = orig
+    # No partial-results completion artifact from an interrupted run.
+    assert not (tmp_path / "out" / "DYNAMIC_TEST_RESULTS.md").exists(), (
+        "an interrupted dynamic-test run must not write the completion report "
+        "from partial results"
+    )

--- a/libs/openant-core/tests/test_issue419_ki_propagates.py
+++ b/libs/openant-core/tests/test_issue419_ki_propagates.py
@@ -91,10 +91,15 @@ def test_parallel_verify_ki_propagates():
 
 
 def test_dynamic_test_ki_propagates_not_partial_report(tmp_path):
-    """The dynamic-test handler `return results` on KI and the caller then
-    wrote DYNAMIC_TEST_RESULTS.md from PARTIAL results — an interrupted run
-    presented with a completion artifact. The KI must propagate (the
-    checkpoints hold the progress; the envelope must say interrupted)."""
+    """The dynamic-test handler `return results` on KI handed the caller the
+    partial results — they flowed into run_tests' DynamicTestStepResult ->
+    ctx.summary -> dynamic-test.report.json -> the scan continued to the
+    report step -> the SUCCESS envelope (wave r1 fable+opus: the original
+    commit message misdescribed this as a DYNAMIC_TEST_RESULTS.md
+    partial-write — that writer sits AFTER the old return and never ran on
+    the interrupt path; the real pre-fix harm was the swallowed exit). The
+    KI must propagate so the CLI exits 130 and the step report (fixed in
+    #420's PR) says interrupted."""
     pipeline = tmp_path / "pipeline_output.json"
     pipeline.write_text(json.dumps({
         "repository": {"name": "t", "language": "python"},
@@ -127,8 +132,59 @@ def test_dynamic_test_ki_propagates_not_partial_report(tmp_path):
             )
     finally:
         dt.generate_test = orig
-    # No partial-results completion artifact from an interrupted run.
-    assert not (tmp_path / "out" / "DYNAMIC_TEST_RESULTS.md").exists(), (
-        "an interrupted dynamic-test run must not write the completion report "
-        "from partial results"
-    )
+    # (shape pin — wave r1: green on pristine too; the writer sits after the
+    # old return. The pre-fix harm was the swallowed exit, above.)
+    assert not (tmp_path / "out" / "DYNAMIC_TEST_RESULTS.md").exists()
+
+
+def test_dynamic_test_ki_saves_the_completed_unit_first(tmp_path):
+    """Wave r1 (fable): the resume story's other half — a KI arriving after
+    one finding COMPLETED leaves its checkpoint saved (the raise must not
+    land before the completed unit's save; e.g. a re-nested try would)."""
+    pipeline = tmp_path / "pipeline_output.json"
+    pipeline.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [
+            {"id": "f1", "name": "X", "short_name": "x", "location": "a.py:1",
+             "cwe_id": 79, "stage2_verdict": "confirmed",
+             "vulnerable_code": "eval(x)", "attack_vector": "a",
+             "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f"},
+            {"id": "f2", "name": "Y", "short_name": "y", "location": "b.py:1",
+             "cwe_id": 79, "stage2_verdict": "confirmed",
+             "vulnerable_code": "eval(y)", "attack_vector": "a",
+             "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f"},
+        ],
+    }))
+    cp = tmp_path / "cp"
+    seen = {"n": 0}
+
+    def gen(finding=None, *a, **k):
+        seen["n"] += 1
+        if seen["n"] == 2:
+            raise KeyboardInterrupt
+        # a COMPLETED first finding: the real loop saves its checkpoint
+        return None
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_ToolsAdapter(),
+                                model="m", provider_name="anthropic")
+
+    orig = dt.generate_test
+    dt.generate_test = gen
+    try:
+        with pytest.raises(KeyboardInterrupt):
+            dt.run_dynamic_tests(
+                pipeline_output_path=str(pipeline),
+                output_dir=str(tmp_path / "out"),
+                checkpoint_path=str(cp),
+                registry=_FakeRegistry(),
+            )
+    finally:
+        dt.generate_test = orig
+    import json as _json
+    f1 = cp / "f1.json"
+    assert f1.exists(), "the completed finding's checkpoint must survive the interrupt"
+    saved = _json.loads(f1.read_text())
+    assert saved.get("id") == "f1", saved

--- a/libs/openant-core/tests/test_issue420_step_interrupted_status.py
+++ b/libs/openant-core/tests/test_issue420_step_interrupted_status.py
@@ -43,11 +43,25 @@ def test_propagating_ki_writes_interrupted_status(tmp_path):
     )
 
 
-def test_propagating_system_exit_writes_interrupted_status(tmp_path):
+def test_propagating_system_exit_writes_error_with_the_code(tmp_path):
+    """Wave r1 (opus): SystemExit is not an interrupt — it is how
+    deterministic error exits are signalled. A non-zero code is ERROR with
+    the cause recorded (mapping it to "interrupted" erased the validation
+    error and contradicted the exit code: the Go contract reads
+    "interrupted" as 130); a ZERO code is a deliberate early exit."""
     with pytest.raises(SystemExit):
         with step_context("t_step", str(tmp_path)):
             raise SystemExit(2)
-    assert _read(tmp_path)["status"] == "interrupted"
+    rep = _read(tmp_path)
+    assert rep["status"] == "error", (
+        "SystemExit(2) is an error exit, not an interrupt"
+    )
+    assert any("SystemExit: 2" in e for e in rep["errors"]), rep
+
+    with pytest.raises(SystemExit):
+        with step_context("t_step2", str(tmp_path)):
+            raise SystemExit(0)
+    assert _read(tmp_path, "t_step2")["status"] == "interrupted"
 
 
 def test_propagating_exception_stays_error(tmp_path):
@@ -70,6 +84,41 @@ def test_interrupted_with_errors_is_not_downgraded_to_partial(tmp_path):
             ctx.errors.append("unit 7 failed before the interrupt")
             raise KeyboardInterrupt
     assert _read(tmp_path)["status"] == "interrupted"
+    # wave r1 (opus): the pre-interrupt errors SURVIVE into the artifact —
+    # what distinguishes an interrupted-after-failures step from a bare one.
+    assert any("unit 7 failed" in e for e in _read(tmp_path)["errors"])
+
+
+def test_generator_exit_writes_interrupted_status(tmp_path):
+    """The GeneratorExit case named in the comment, pinned (wave r1 opus)."""
+    def _gen():
+        with step_context("t_step", str(tmp_path)):
+            yield
+            raise AssertionError("unreachable")
+    g = _gen()
+    next(g)
+    g.close()   # GeneratorExit fires INSIDE the body at the yield; close()
+                # itself does not raise when the generator cooperates
+    assert _read(tmp_path)["status"] == "interrupted"
+
+
+def test_sarif_gate_treats_interrupted_as_failure_class():
+    """Wave r1 (fable+opus): the SARIF executionSuccessful gate — the
+    consumer-level pin lives in the Go suite
+    (sarif_interrupted_test.go: TestSarifInterruptedStepIsFailure); this
+    Python-side companion asserts the Go suite carries it and passes."""
+    import shutil as _sh
+    import subprocess
+    from pathlib import Path as _P
+    if not _sh.which("go"):
+        pytest.skip("Go toolchain not available")
+    out = subprocess.run(
+        ["go", "test", "./internal/report/", "-run",
+         "TestSarifInterruptedStepIsFailure", "-count=1", "-v"],
+        capture_output=True, text=True,
+        cwd=str(_P(__file__).resolve().parents[3] / "apps" / "openant-cli"),
+        timeout=300)
+    assert "PASS" in out.stdout, out.stdout + out.stderr
 
 
 def test_normal_and_partial_derivations_unchanged(tmp_path):

--- a/libs/openant-core/tests/test_issue420_step_interrupted_status.py
+++ b/libs/openant-core/tests/test_issue420_step_interrupted_status.py
@@ -1,0 +1,89 @@
+"""#420: an interrupted step's on-disk report says "interrupted", not "success".
+
+When an interrupt propagates through a step (the #417/#418/#419 contract — the
+handlers re-raise), `step_context`'s finally still writes the step report with the
+DEFAULT status="success" and an empty summary — the on-disk artifact of an
+interrupted run lies (stdout envelope unaffected: no envelope is emitted on the KI
+path, so the Go exit-130 contract still works; this is the stderr/file channel only).
+
+The fix: a propagating BaseException that is NOT an Exception (KeyboardInterrupt,
+SystemExit, GeneratorExit — the ones `except Exception` cannot catch) maps the step's
+status to "interrupted" before re-raising, and the partial-derivation in the finally
+never downgrades it. The propagating-Exception path stays "error"; a normal step stays
+"success"; the errors/error_count derivation stays "partial".
+"""
+import json
+import sys
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+import pytest  # noqa: E402
+
+from core.step_report import step_context  # noqa: E402
+
+
+def _read(tmp_path, step="t_step"):
+    return json.loads((tmp_path / f"{step}.report.json").read_text())
+
+
+def test_propagating_ki_writes_interrupted_status(tmp_path):
+    """The KI propagates (the #419 contract) AND the artifact says
+    interrupted — on pristine the file was written status="success" with an
+    empty summary: the on-disk artifact of an interrupted run lied."""
+    with pytest.raises(KeyboardInterrupt):
+        with step_context("t_step", str(tmp_path), inputs={"a": 1}):
+            raise KeyboardInterrupt
+    rep = _read(tmp_path)
+    assert rep["status"] == "interrupted", (
+        f"the interrupted step's report says {rep['status']!r} — the resume path "
+        "and any artifact reader must see the run was cut short"
+    )
+
+
+def test_propagating_system_exit_writes_interrupted_status(tmp_path):
+    with pytest.raises(SystemExit):
+        with step_context("t_step", str(tmp_path)):
+            raise SystemExit(2)
+    assert _read(tmp_path)["status"] == "interrupted"
+
+
+def test_propagating_exception_stays_error(tmp_path):
+    """The Exception path is unchanged: status "error", the message recorded,
+    the exception re-raised."""
+    with pytest.raises(ValueError, match="boom"):
+        with step_context("t_step", str(tmp_path)):
+            raise ValueError("boom")
+    rep = _read(tmp_path)
+    assert rep["status"] == "error"
+    assert any("boom" in e for e in rep["errors"])
+
+
+def test_interrupted_with_errors_is_not_downgraded_to_partial(tmp_path):
+    """A step that recorded errors AND was then interrupted: "interrupted" is
+    the more specific, final answer — the partial-derivation must not
+    overwrite it."""
+    with pytest.raises(KeyboardInterrupt):
+        with step_context("t_step", str(tmp_path)) as ctx:
+            ctx.errors.append("unit 7 failed before the interrupt")
+            raise KeyboardInterrupt
+    assert _read(tmp_path)["status"] == "interrupted"
+
+
+def test_normal_and_partial_derivations_unchanged(tmp_path):
+    """The #209/#285 derivation is untouched: success stays success, an
+    error_count in the summary derives partial, an explicit skipped stays."""
+    with step_context("ok_step", str(tmp_path)) as ctx:
+        ctx.summary = {"total_units": 3}
+    assert _read(tmp_path, "ok_step")["status"] == "success"
+
+    with step_context("p_step", str(tmp_path)) as ctx:
+        ctx.summary = {"error_count": 2}
+    assert _read(tmp_path, "p_step")["status"] == "partial"
+
+    with step_context("s_step", str(tmp_path)) as ctx:
+        ctx.status = "skipped"
+        ctx.summary = {"reason": "no toolchain"}
+    assert _read(tmp_path, "s_step")["status"] == "skipped"

--- a/libs/openant-core/tests/test_issue420_step_interrupted_status.py
+++ b/libs/openant-core/tests/test_issue420_step_interrupted_status.py
@@ -107,11 +107,25 @@ def test_sarif_gate_treats_interrupted_as_failure_class():
     consumer-level pin lives in the Go suite
     (sarif_interrupted_test.go: TestSarifInterruptedStepIsFailure); this
     Python-side companion asserts the Go suite carries it and passes."""
+    import re as _re
     import shutil as _sh
     import subprocess
     from pathlib import Path as _P
     if not _sh.which("go"):
         pytest.skip("Go toolchain not available")
+    # the python-test CI runners carry a PATH `go` OLDER than the module's
+    # directive (ubuntu: 1.21 vs go.mod's 1.25.8, GOTOOLCHAIN=local) — skip:
+    # the Go CI jobs exercise the gate with a proper toolchain.
+    _src = _P(__file__).resolve().parents[3] / "apps" / "openant-cli"
+    _ver = subprocess.run(["go", "version"], capture_output=True,
+                          text=True).stdout
+    _vm = _re.search(r"go(\d+(?:\.\d+)+)", _ver)
+    _want = _re.search(r"^go\s+(\d+(?:\.\d+)*)",
+                       (_src / "go.mod").read_text(), _re.M)
+    if _vm and _want:
+        _vt = lambda v: tuple(int(x) for x in v.split("."))
+        if _vt(_vm.group(1)) < _vt(_want.group(1)):
+            pytest.skip(f"go {_vm.group(1)} older than the module's go {_want.group(1)}")
     out = subprocess.run(
         ["go", "test", "./internal/report/", "-run",
          "TestSarifInterruptedStepIsFailure", "-count=1", "-v"],

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -405,7 +405,14 @@ def run_dynamic_tests(
     except KeyboardInterrupt:
         print("\n[Dynamic Test] Interrupted — progress saved to checkpoints",
               file=sys.stderr, flush=True)
-        return results
+        # #419 (the #417 class): `return results` here swallowed the
+        # interrupt AND handed the caller partial results, which then wrote
+        # DYNAMIC_TEST_RESULTS.md as a completion artifact for an
+        # interrupted run. The checkpoints hold the progress (every
+        # completed finding is saved as it completes — the resume story);
+        # the interrupt itself PROPAGATES so the CLI exits 130 with an
+        # interrupted envelope, never a success one.
+        raise
 
     # Generate report
     total_cost = tracker.total_cost_usd

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -952,6 +952,12 @@ class FindingVerifier:
         except KeyboardInterrupt:
             print("[Verify] Interrupted — progress saved to checkpoints",
                   file=sys.stderr, flush=True)
+            # #419 (the #417 class): the checkpoints hold the progress (every
+            # completed unit is saved as it completes) — the interrupt itself
+            # PROPAGATES so the CLI exits 130 with an interrupted envelope.
+            # Falling through made the scan continue with partially-verified
+            # results and complete with a SUCCESS envelope.
+            raise
 
     def _verify_batch_parallel(self, results, code_by_route, progress_callback, workers,
                                 checkpoint=None, summary_callback=None):
@@ -990,7 +996,11 @@ class FindingVerifier:
             executor.shutdown(wait=False, cancel_futures=True)
             print("[Verify] Progress saved to checkpoints",
                   file=sys.stderr, flush=True)
-            return
+            # #419 (the #417 class): a bare `return` here swallowed the
+            # interrupt on the parallel path — the scan completed with a
+            # success envelope, no exit 130. Propagate (the checkpoints hold
+            # the completed units).
+            raise
         executor.shutdown(wait=False)
 
     def _check_consistency(

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -999,7 +999,14 @@ class FindingVerifier:
             # #419 (the #417 class): a bare `return` here swallowed the
             # interrupt on the parallel path — the scan completed with a
             # success envelope, no exit 130. Propagate (the checkpoints hold
-            # the completed units).
+            # the completed units). Wave r1 (opus) residual, documented:
+            # cancel_futures cancels only QUEUED work — the <=workers
+            # in-flight verification loops keep running in non-daemon
+            # threads, and under the Go CLI the raise is bounded by the 5s
+            # SIGKILL; a DIRECT python -m openant invocation blocks in
+            # interpreter shutdown until they finish. Not a regression, and
+            # their results are not checkpointed (the save loop has exited)
+            # — the retry owns them on resume.
             raise
         executor.shutdown(wait=False)
 


### PR DESCRIPTION
When an interrupt propagates through a step (the #417/#418/#419 contract — the handlers re-raise), `step_context`'s finally still wrote the step report with the DEFAULT `status="success"` and an empty summary — the on-disk artifact of an interrupted run lied (stdout envelope unaffected: no envelope is emitted on the KI path, so the Go exit-130 contract still works; this is the stderr/file channel only). Panel-found during #418's review.

**The fix (base commit):** a propagating BaseException that `except Exception` cannot catch marks the step `"interrupted"` before re-raising; the #209/#285 partial-derivation never downgrades it (interrupted-with-errors stays interrupted — the more specific, final answer). The Exception path stays "error"; success/skipped untouched. No consumer gates on step-report status for resume (the per-unit StepCheckpoint system is separate) — the value is additive and readable by the resume path and any artifact reader.

**The wave-r1 round (three axes, all confirmed, all fixed — and the branch REBASED onto #419's PR, which the original commit's "applies to verify" claim required):**
- `"interrupted"` was INVISIBLE to both consumers that rank status: the SARIF `executionSuccessful` gate matched a closed status set — an interrupted step carries empty errors/summary, so it matched NO disjunct and read `executionSuccessful: true`, the exact false-green shape #285/#305 exist to close (on the channel that becomes a merge gate); and `scanner.py`'s `_STATUS_RANK` defaulted it to the SUCCESS rank, keeping the aggregate scan status green. The gate (extracted into `stepReportIsFailure`) and the rank table (interrupted: 4) know the word; both pinned at the consumer level;
- SystemExit is NOT an interrupt (opus): it is how deterministic error exits are signalled (report/generator's validation `sys.exit(1)`, generate_context's unsupported-type `sys.exit(2)`). Mapping it to "interrupted" erased the cause and contradicted the exit code (the Go contract reads "interrupted" as 130). A non-zero code is now ERROR with `"SystemExit: <code>"` recorded; a zero code (a deliberate early exit) stays interrupted;
- the GeneratorExit case named in the comment had no test; the pre-interrupt `ctx.errors` SURVIVAL is pinned (what distinguishes an interrupted-after-failures step from a bare one).

**Evidence:** 7 Python tests (RED 3 on pristine — the KI status, the SystemExit status, the no-downgrade guard; the round additions: SystemExit(2)→error+cause, SystemExit(0)→interrupted, GeneratorExit, the errors-survival pin, the Go-suite companion) + the Go-side consumer pin (`TestSarifInterruptedStepIsFailure`); the full suite 3528/1 (the known macOS artifact); the Go suite 10/10; gofmt/vet/ruff clean.

Depends-on: #463 (#419) — this branch is stacked on it and its commits are included.

Fixes #420