### PR TITLE
fix(stage1): a consistency correction writes only a canonical verdict (#425)

### DIFF
--- a/libs/openant-core/tests/test_issue331_finding_shadow.py
+++ b/libs/openant-core/tests/test_issue331_finding_shadow.py
@@ -132,3 +132,57 @@ def test_verdict_only_row_counts_via_verdict_fallback():
     ])
     assert counts["vulnerable"] == 1
     assert counts["errors"] == 1
+
+
+def test_stage2_vocabulary_keeps_the_net():
+    """Wave r1 (three axes, one root cause): DISCLOSURE_ELIGIBLE admitted
+    Stage-2 vocabulary the finding-first readers REJECT — a
+    VULNERABLE -> UNVERIFIED correction wrote finding="unverified" and
+    dropped a disclosed vulnerability from Stage-2 input, confirmed_findings,
+    and disclosure: the net's own failure mode reintroduced through the gate."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "UNVERIFIED",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "UNVERIFIED", "reason": "x"}], "g")
+    out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
+    row = _by_rk(out, VULN_RK)
+    assert row["verdict"] == "UNVERIFIED"
+    assert row["finding"] == "vulnerable", (
+        "the Stage-2 vocabulary must keep the stale-finding net "
+        f"(got {row['finding']!r})"
+    )
+    for token in ("CONFIRMED", "AGREED", "ERROR"):
+        def r2(binding, group, code_by_route, tracker, _tok=token):
+            return s1.Stage1ConsistencyResult(
+                "p", _tok,
+                [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+                  "should_be": _tok, "reason": "x"}], "g")
+        out = _run(r2, [INGESTED_VULN, INGESTED_SAFE])
+        assert _by_rk(out, VULN_RK)["finding"] == "vulnerable", token
+
+
+def test_promoted_errored_row_clears_the_stale_error_key():
+    """Wave r1 (fable): a promoted ERROR row kept its stale `error` key —
+    one row counted as BOTH a confirmed finding (finding-first) and an error
+    (r.get("error")). The gated write clears it."""
+    errored = dict(INGESTED_SAFE)
+    errored["verdict"] = "ERROR"
+    errored["finding"] = "error"
+    errored["error"] = "LLMConnectionError: DNS lookup failed"
+    errored["route_key"] = VULN_RK
+
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "VULNERABLE",
+            [{"route_key": VULN_RK, "original_verdict": "ERROR",
+              "should_be": "VULNERABLE", "reason": "pattern matches sibling"}],
+            "g")
+    out = _run(resolver, [errored, INGESTED_SAFE])
+    row = _by_rk(out, VULN_RK)
+    assert row["verdict"] == "VULNERABLE"
+    assert row["finding"] == "vulnerable"
+    assert "error" not in row, (
+        f"the stale error key makes the promoted row count as both a finding "
+        f"and an error: {row}"
+    )

--- a/libs/openant-core/tests/test_issue331_finding_shadow.py
+++ b/libs/openant-core/tests/test_issue331_finding_shadow.py
@@ -78,10 +78,12 @@ def test_safe_to_vulnerable_correction_lands():
 
 def test_unrecognised_downgrade_keeps_disclosure():
     """The issue's regression (2): VULNERABLE -> INSUFFICIENT_CONTEXT is NOT
-    blocked (INSUFFICIENT_CONTEXT is not in DISCLOSURE_DROPPED) — and the row
-    must REMAIN disclosed: the stale finding is the safety net the naive fix
-    would remove."""
-    assert "insufficient_context" not in {v for v in DISCLOSURE_ELIGIBLE}
+    in F-KB-1a's block-set — the row must REMAIN disclosed. On #331 alone the
+    net was the STALE FINDING (verdict moved, finding kept); stacked with
+    #425's validity gate the proposal is REJECTED WHOLESALE — a stronger
+    preservation with no split-brain row (wave r1 fable+sonnet: the pass is
+    never asked for INSUFFICIENT_CONTEXT — its enum is
+    VULNERABLE | SAFE | INCONCLUSIVE)."""
     def resolver(binding, group, code_by_route, tracker):
         return s1.Stage1ConsistencyResult(
             "p", "INSUFFICIENT_CONTEXT",
@@ -89,14 +91,11 @@ def test_unrecognised_downgrade_keeps_disclosure():
               "should_be": "INSUFFICIENT_CONTEXT", "reason": "x"}], "g")
     out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
     row = _by_rk(out, VULN_RK)
-    assert row["verdict"] == "INSUFFICIENT_CONTEXT"
-    assert "stage1_consistency_update" in row, "the correction is recorded"
-    # The net: the finding is NOT rewritten to an unrecognised value — the row
-    # still reads 'vulnerable' canonically (disclosed).
+    # the row is preserved UNCHANGED — the strongest form of disclosure.
+    assert row["verdict"] in ("INSUFFICIENT_CONTEXT", "VULNERABLE"), row
     assert row["finding"] == "vulnerable"
     assert _canonical(row) == "vulnerable", (
-        "an ungated write would drop this disclosed vulnerability "
-        "(measured: INSUFFICIENT_CONTEXT moves out of confirmed)"
+        "an ungated write would drop this disclosed vulnerability"
     )
     counts = _count_verdicts(out)
     assert counts["vulnerable"] == 1, (
@@ -147,7 +146,11 @@ def test_stage2_vocabulary_keeps_the_net():
               "should_be": "UNVERIFIED", "reason": "x"}], "g")
     out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
     row = _by_rk(out, VULN_RK)
-    assert row["verdict"] == "UNVERIFIED"
+    # (stacked #425: the validity gate REJECTS the Stage-2 vocabulary
+    # outright, so the verdict stays VULNERABLE on this branch; on #331
+    # alone it wrote UNVERIFIED with the finding net. Both keep the row
+    # disclosed — the invariant under test.)
+    assert row["verdict"] in ("UNVERIFIED", "VULNERABLE"), row
     assert row["finding"] == "vulnerable", (
         "the Stage-2 vocabulary must keep the stale-finding net "
         f"(got {row['finding']!r})"

--- a/libs/openant-core/tests/test_issue331_finding_shadow.py
+++ b/libs/openant-core/tests/test_issue331_finding_shadow.py
@@ -1,0 +1,134 @@
+"""#331: a Stage-1 consistency correction writes BOTH keys — gated on eligibility.
+
+When the Stage-1 consistency pass corrects a unit's verdict it wrote `result["verdict"]`
+and never `result["finding"]`. Ingestion (core/analyzer.py:149-152) always sets a
+lowercase `finding`, and every canonical downstream read is finding-first —
+`str(r.get("finding") or r.get("verdict", "")).lower()` (core/verifier.py:118) — so the
+stale `finding` short-circuited the `or` and the correction was invisible: a
+safe -> VULNERABLE correction left {finding: "safe", verdict: "VULNERABLE"}, counted
+safe, filtered out of Stage 2 entirely, absent from the disclosure document.
+
+The second edge points the other way: the stale finding also survives a downgrade to
+a verdict the block-list does not cover — `DISCLOSURE_DROPPED` is
+{inconclusive, protected, rejected, safe}, so `VULNERABLE -> INSUFFICIENT_CONTEXT`
+passes unblocked, and today the stale `finding` is an ACCIDENTAL SAFETY NET keeping the
+row disclosed. An ungated write of `finding` would remove that net and drop a disclosed
+vulnerability (measured in the issue: VULNERABLE -> INSUFFICIENT_CONTEXT /
+NOT_VULNERABLE both move out of `confirmed` under the naive fix).
+
+So the write is GATED: `finding` is updated only when the new verdict is
+disclosure-eligible (DISCLOSURE_ELIGIBLE); unrecognised downgrades keep the stale
+finding (still disclosed via the net) with the correction recorded in
+`stage1_consistency_update`.
+"""
+from core.analyzer import _count_verdicts
+from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
+from utilities import stage1_consistency as s1
+
+VULN_RK = "libs/a/client_utils.py:build_async_httpx_client"
+SAFE_RK = "libs/b/client_utils.py:get_async_httpx_client"
+
+
+def _run(resolver, results):
+    orig = s1._resolve_stage1_inconsistency
+    s1._resolve_stage1_inconsistency = resolver
+    try:
+        return s1.run_stage1_consistency_check(
+            [dict(r) for r in results], {}, binding=object(), tracker=None)
+    finally:
+        s1._resolve_stage1_inconsistency = orig
+
+
+def _by_rk(out, rk):
+    return next(r for r in out if r["route_key"] == rk)
+
+
+def _canonical(r):
+    """The finding-first canonical downstream read (core/verifier.py:118)."""
+    return str(r.get("finding") or r.get("verdict", "")).lower()
+
+
+INGESTED_SAFE = {"route_key": SAFE_RK, "verdict": "SAFE", "finding": "safe"}
+INGESTED_VULN = {"route_key": VULN_RK, "verdict": "VULNERABLE", "finding": "vulnerable"}
+
+
+def test_safe_to_vulnerable_correction_lands():
+    """The issue's regression (1): after safe -> VULNERABLE the unit is in
+    _count_verdicts' vulnerable bucket and reads 'vulnerable' canonically
+    (in confirmed / the Stage-2 input gate)."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "async httpx client builder", "VULNERABLE",
+            [{"route_key": SAFE_RK, "original_verdict": "SAFE",
+              "should_be": "VULNERABLE", "reason": "pattern identical to vulnerable sibling"}],
+            "grouped")
+    out = _run(resolver, [INGESTED_SAFE, INGESTED_VULN])
+    row = _by_rk(out, SAFE_RK)
+    assert row["verdict"] == "VULNERABLE"
+    assert row["finding"] == "vulnerable", (
+        "the correction must write BOTH keys — finding-first reads shadow a "
+        f"verdict-only write: {row}"
+    )
+    counts = _count_verdicts(out)
+    assert counts["vulnerable"] == 2 and counts["safe"] == 0, (
+        f"the corrected unit must count vulnerable (pre-fix: safe=1, vulnerable=0): {counts}"
+    )
+    assert _canonical(row) == "vulnerable"
+
+
+def test_unrecognised_downgrade_keeps_disclosure():
+    """The issue's regression (2): VULNERABLE -> INSUFFICIENT_CONTEXT is NOT
+    blocked (INSUFFICIENT_CONTEXT is not in DISCLOSURE_DROPPED) — and the row
+    must REMAIN disclosed: the stale finding is the safety net the naive fix
+    would remove."""
+    assert "insufficient_context" not in {v for v in DISCLOSURE_ELIGIBLE}
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "INSUFFICIENT_CONTEXT",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "INSUFFICIENT_CONTEXT", "reason": "x"}], "g")
+    out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
+    row = _by_rk(out, VULN_RK)
+    assert row["verdict"] == "INSUFFICIENT_CONTEXT"
+    assert "stage1_consistency_update" in row, "the correction is recorded"
+    # The net: the finding is NOT rewritten to an unrecognised value — the row
+    # still reads 'vulnerable' canonically (disclosed).
+    assert row["finding"] == "vulnerable"
+    assert _canonical(row) == "vulnerable", (
+        "an ungated write would drop this disclosed vulnerability "
+        "(measured: INSUFFICIENT_CONTEXT moves out of confirmed)"
+    )
+    counts = _count_verdicts(out)
+    assert counts["vulnerable"] == 1, (
+        f"the row must still count vulnerable (the net): {counts}"
+    )
+
+
+def test_gate_writes_finding_only_when_eligible():
+    """The gate itself: safe -> INCONCLUSIVE (dropped->dropped, unblocked by
+    F-KB-1a's old-side scope) writes verdict but NOT finding — an ineligible
+    verdict never lands in the canonical read."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "INCONCLUSIVE",
+            [{"route_key": SAFE_RK, "original_verdict": "SAFE",
+              "should_be": "INCONCLUSIVE", "reason": "x"}], "g")
+    out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
+    row = _by_rk(out, SAFE_RK)
+    assert row["verdict"] == "INCONCLUSIVE"
+    assert row["finding"] == "safe", (
+        "ineligible new verdicts must not rewrite finding (the write is gated "
+        "on DISCLOSURE_ELIGIBLE)"
+    )
+
+
+def test_verdict_only_row_counts_via_verdict_fallback():
+    """Prior-art pin (test_verifier_verdictonly_confirmed_drop's domain): a row
+    with NO finding key still counts via the verdict fallback — the fix must
+    not narrow #324's absent-key handling."""
+    counts = _count_verdicts([
+        {"route_key": "a", "verdict": "VULNERABLE", "finding": None},
+        {"route_key": "b", "verdict": None, "finding": None},
+    ])
+    assert counts["vulnerable"] == 1
+    assert counts["errors"] == 1

--- a/libs/openant-core/tests/test_issue425_stage1_verdict_valid.py
+++ b/libs/openant-core/tests/test_issue425_stage1_verdict_valid.py
@@ -1,0 +1,111 @@
+"""#425: a consistency correction writes only a CANONICAL verdict.
+
+apply_stage1_consistency rewrites a Stage-1 result's `verdict` from the consistency
+model's unconstrained `should_be` string — AFTER verdict normalization has run — and
+the only gate before the write was the F-KB-1a downgrade block, which is correct for
+its purpose but is not a VALIDITY gate: anything outside `_DISCLOSURE_DROPPED_UPPER` —
+"MAYBE VULNERABLE", "probably fine" — landed in result["verdict"] verbatim. That is the
+same escape #316/#324 closed at `_normalize_result` / the JSON corrector, surviving at
+the one producer that runs AFTER those gates.
+
+The fix applies the #316/#324 producer discipline to this site: validate `new_verdict`
+against the Stage-1 verdict vocabulary (the `_normalize_result` finding_to_verdict map,
+uppercased: VULNERABLE / SAFE / PROTECTED / BYPASSABLE / INCONCLUSIVE /
+INSUFFICIENT_CONTEXT) — a value outside it is model noise, REJECTED with an audit
+record (the row keeps its valid pre-consistency verdict; the proposal is visible, and
+no information is destroyed by overwriting a valid verdict with garbage or with ERROR).
+
+Stacked on #331 (the finding co-write, gated on disclosure-eligibility): a valid
+correction still updates BOTH keys so finding-first consumers see it — pinned here so
+the validity gate cannot over-block.
+"""
+from utilities import stage1_consistency as s1
+
+VULN_RK = "libs/a/client_utils.py:build_async_httpx_client"
+SAFE_RK = "libs/b/client_utils.py:get_async_httpx_client"
+
+
+def _run(resolver, results):
+    orig = s1._resolve_stage1_inconsistency
+    s1._resolve_stage1_inconsistency = resolver
+    try:
+        return s1.run_stage1_consistency_check(
+            [dict(r) for r in results], {}, binding=object(), tracker=None)
+    finally:
+        s1._resolve_stage1_inconsistency = orig
+
+
+def _by_rk(out, rk):
+    return next(r for r in out if r["route_key"] == rk)
+
+
+INGESTED_SAFE = {"route_key": SAFE_RK, "verdict": "SAFE", "finding": "safe"}
+INGESTED_VULN = {"route_key": VULN_RK, "verdict": "VULNERABLE", "finding": "vulnerable"}
+
+
+def test_unrecognized_should_be_is_rejected_not_written():
+    """The issue's executed shape: `MAYBE VULNERABLE` must NOT land in
+    verdict verbatim — the row keeps its valid pre-consistency verdict, the
+    proposal is audited."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "MAYBE VULNERABLE",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "MAYBE VULNERABLE", "reason": "x"}], "g")
+    out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
+    row = _by_rk(out, VULN_RK)
+    assert row["verdict"] == "VULNERABLE", (
+        f"the unrecognized should_be landed in verdict verbatim: {row['verdict']!r}"
+    )
+    assert row["finding"] == "vulnerable"
+    assert "stage1_consistency_invalid_verdict_blocked" in row, (
+        "the rejected proposal must be audited (visible/countable), not silent"
+    )
+    assert "stage1_consistency_update" not in row
+
+
+def test_lowercase_garbage_is_rejected_not_lowered_into_validity():
+    """"probably fine" — a valid-looking phrase is still not a verdict."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "SAFE",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "probably fine", "reason": "x"}], "g")
+    out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
+    row = _by_rk(out, VULN_RK)
+    assert row["verdict"] == "VULNERABLE"
+    assert "stage1_consistency_invalid_verdict_blocked" in row
+
+
+def test_valid_upgrade_still_lands_both_keys():
+    """Stack pin (#331): the validity gate must not over-block — a canonical
+    safe->VULNERABLE upgrade updates verdict AND finding."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "VULNERABLE",
+            [{"route_key": SAFE_RK, "original_verdict": "SAFE",
+              "should_be": "VULNERABLE", "reason": "pattern matches sibling"}], "g")
+    out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
+    row = _by_rk(out, SAFE_RK)
+    assert row["verdict"] == "VULNERABLE"
+    assert row["finding"] == "vulnerable"
+    assert "stage1_consistency_update" in row
+
+
+def test_canonical_intermediate_recognized_keeps_the_331_net():
+    """INSUFFICIENT_CONTEXT is IN the vocabulary (the _normalize_result map):
+    the correction is written to verdict, and #331's finding-gate keeps the
+    stale finding (the accidental safety net for the unrecognised-downgrade
+    case)."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "INSUFFICIENT_CONTEXT",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "INSUFFICIENT_CONTEXT", "reason": "x"}], "g")
+    out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
+    row = _by_rk(out, VULN_RK)
+    assert row["verdict"] == "INSUFFICIENT_CONTEXT", (
+        "a CANONICAL verdict must not be rejected by the validity gate"
+    )
+    assert row["finding"] == "vulnerable", "the #331 net stays"
+    assert "stage1_consistency_update" in row

--- a/libs/openant-core/tests/test_issue425_stage1_verdict_valid.py
+++ b/libs/openant-core/tests/test_issue425_stage1_verdict_valid.py
@@ -92,11 +92,14 @@ def test_valid_upgrade_still_lands_both_keys():
     assert "stage1_consistency_update" in row
 
 
-def test_canonical_intermediate_recognized_keeps_the_331_net():
-    """INSUFFICIENT_CONTEXT is IN the vocabulary (the _normalize_result map):
-    the correction is written to verdict, and #331's finding-gate keeps the
-    stale finding (the accidental safety net for the unrecognised-downgrade
-    case)."""
+def test_insufficient_context_is_rejected_not_split_brained():
+    """Wave r1 (fable+sonnet): INSUFFICIENT_CONTEXT is EXCLUDED — the
+    consistency prompt's enum is VULNERABLE | SAFE | INCONCLUSIVE, and
+    admitting it whitelisted a no-evidence downgrade AROUND F-KB-1a (it is
+    in neither block-set), producing a split-brain row: verdict moved off
+    VULNERABLE by pattern similarity while finding stayed vulnerable — a
+    disclosed unit mislabeled in every verdict-keyed surface. The rejection
+    preserves the row UNCHANGED (the stronger, coherent form of the net)."""
     def resolver(binding, group, code_by_route, tracker):
         return s1.Stage1ConsistencyResult(
             "p", "INSUFFICIENT_CONTEXT",
@@ -104,8 +107,33 @@ def test_canonical_intermediate_recognized_keeps_the_331_net():
               "should_be": "INSUFFICIENT_CONTEXT", "reason": "x"}], "g")
     out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
     row = _by_rk(out, VULN_RK)
-    assert row["verdict"] == "INSUFFICIENT_CONTEXT", (
-        "a CANONICAL verdict must not be rejected by the validity gate"
+    assert row["verdict"] == "VULNERABLE", (
+        "the proposal is rejected; the row stays as it was"
     )
     assert row["finding"] == "vulnerable", "the #331 net stays"
-    assert "stage1_consistency_update" in row
+    assert "stage1_consistency_invalid_verdict_blocked" in row, (
+        "the rejected proposal is audited"
+    )
+    assert "stage1_consistency_update" not in row
+
+
+def test_rejected_now_lands_at_the_validity_gate():
+    """Wave r1 (fable#2): REJECTED is in F-KB-1a's block-set but NOT in the
+    correctable set — the validity gate fires first, reclassifying the
+    blocked-proposal audit key. Accepted explicitly (the comment at the
+    F-KB-1a branch notes it); pinned so the reclassification is deliberate."""
+    def resolver(binding, group, code_by_route, tracker):
+        return s1.Stage1ConsistencyResult(
+            "p", "REJECTED",
+            [{"route_key": VULN_RK, "original_verdict": "VULNERABLE",
+              "should_be": "REJECTED", "reason": "x"}], "g")
+    out = _run(resolver, [INGESTED_VULN, INGESTED_SAFE])
+    row = _by_rk(out, VULN_RK)
+    assert row["verdict"] == "VULNERABLE", "the row is preserved either way"
+    assert "stage1_consistency_invalid_verdict_blocked" in row, (
+        "REJECTED lands at the validity gate (not in the correctable set)"
+    )
+    assert "stage1_consistency_downgrade_blocked" not in row, (
+        "the F-KB-1a branch no longer fires for REJECTED — the documented "
+        "reclassification"
+    )

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 
 from utilities.llm_client import TokenTracker
 from utilities.llm import PhaseBinding, simple_text
-from core.verdict_taxonomy import DISCLOSURE_DROPPED, DISCLOSURE_ELIGIBLE
+from core.verdict_taxonomy import DISCLOSURE_DROPPED, SEVERITY_FINDING_VERDICTS
 
 # Uppercase mirror of the canonical disclosure-dropped set (this module compares
 # verdicts .upper()'d). Keyed off core.verdict_taxonomy so the guard's block-set
@@ -305,19 +305,35 @@ def run_stage1_consistency_check(
                                 # the correction shadowed by the stale finding
                                 # — a safe->VULNERABLE correction was counted
                                 # safe, filtered out of Stage 2, and absent
-                                # from disclosure. GATE the write on
-                                # disclosure-eligibility: `new_verdict` is
-                                # unvalidated model output (the :281 comment),
-                                # and the :287 block-list covers only
-                                # DISCLOSURE_DROPPED — an unrecognised
-                                # downgrade (VULNERABLE -> INSUFFICIENT_CONTEXT)
-                                # passes unblocked, and the stale finding is
-                                # currently the ACCIDENTAL SAFETY NET keeping
-                                # the row disclosed. An ungated write would
-                                # remove that net and drop a disclosed
-                                # vulnerability (measured in #331).
-                                if str(new_verdict).lower() in DISCLOSURE_ELIGIBLE:
+                                # from disclosure. GATE the write on the
+                                # Stage-1 FINDING verdicts (wave r1, three
+                                # axes): `new_verdict` is unvalidated model
+                                # output (the :281 comment), and
+                                # DISCLOSURE_ELIGIBLE admitted Stage-2
+                                # vocabulary (unverified/confirmed/agreed/
+                                # error) that every finding-first reader
+                                # REJECTS — writing finding="unverified" on a
+                                # VULNERABLE row dropped it from Stage-2
+                                # input, confirmed_findings, and disclosure:
+                                # the net's own failure mode reintroduced
+                                # through the gate. The set that matches the
+                                # readers is {vulnerable, bypassable} —
+                                # SEVERITY_FINDING_VERDICTS. The :287
+                                # block-list covers only DISCLOSURE_DROPPED,
+                                # so an unrecognised downgrade
+                                # (VULNERABLE -> INSUFFICIENT_CONTEXT) passes
+                                # unblocked and the stale finding remains
+                                # the ACCIDENTAL SAFETY NET keeping the row
+                                # disclosed.
+                                if str(new_verdict).lower() in SEVERITY_FINDING_VERDICTS:
                                     result["finding"] = str(new_verdict).lower()
+                                    # wave r1 (fable): a promoted ERRORED row
+                                    # carries a stale `error` key (the adapter
+                                    # raise that errored it) — one row would
+                                    # count as BOTH a confirmed finding and an
+                                    # error. The correction asserts a finding;
+                                    # the error key is cleared with it.
+                                    result.pop("error", None)
                                 result["stage1_consistency_update"] = {
                                     "from": old_verdict,
                                     "to": new_verdict,

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -16,16 +16,24 @@ from dataclasses import dataclass
 
 from utilities.llm_client import TokenTracker
 from utilities.llm import PhaseBinding, simple_text
-from core.verdict_taxonomy import DISCLOSURE_DROPPED, SEVERITY_FINDING_VERDICTS
+from core.verdict_taxonomy import (
+    DISCLOSURE_DROPPED, FINDING_VERDICT_ORDER, SEVERITY_FINDING_VERDICTS,
+)
 
 # #425: the verdict vocabulary a Stage-1 consistency correction may write —
-# the canonical Stage-1 verdicts (analysis_core._normalize_result's
-# finding_to_verdict map, uppercased). Values outside it are rejected at the
-# validity gate below (producer discipline, per #316/#324).
-_CORRECTABLE_STAGE1_VERDICTS = frozenset({
-    "VULNERABLE", "SAFE", "PROTECTED", "BYPASSABLE", "INCONCLUSIVE",
-    "INSUFFICIENT_CONTEXT",
-})
+# DERIVED from the canonical taxonomy (wave r1 fable: a third hand-copied
+# set is the drift this module rejected 250 lines earlier, and it already
+# disagreed — INSUFFICIENT_CONTEXT is in neither DISCLOSURE_ELIGIBLE nor
+# DISCLOSURE_DROPPED). INSUFFICIENT_CONTEXT is deliberately EXCLUDED (wave
+# r1, fable+sonnet): the consistency prompt's enum is
+# VULNERABLE | SAFE | INCONCLUSIVE — the pass is never asked for it — and
+# admitting it whitelisted a no-evidence downgrade AROUND F-KB-1a (it is in
+# neither block-set), leaving a split-brain row: verdict moved off
+# VULNERABLE by pattern similarity while finding stayed vulnerable — a
+# disclosed unit mislabeled in verdict-keyed surfaces. Rejection preserves
+# the row unchanged.
+_CORRECTABLE_STAGE1_VERDICTS = frozenset(
+    v.upper() for v in FINDING_VERDICT_ORDER)
 
 # Uppercase mirror of the canonical disclosure-dropped set (this module compares
 # verdicts .upper()'d). Keyed off core.verdict_taxonomy so the guard's block-set
@@ -312,6 +320,11 @@ def run_stage1_consistency_check(
                             # F-KB-1a: pattern-consistency must not silently downgrade a
                             # surfaced Stage-1 finding to safe. At Stage 1 there is no
                             # per-finding exploit evidence, only pattern similarity (the
+                            # #425 note: REJECTED proposals now land at the validity
+                            # gate FIRST (invalid_verdict_blocked — REJECTED is not in
+                            # the correctable set), so this branch fires for the
+                            # DROPPED values the set admits: INCONCLUSIVE, PROTECTED,
+                            # SAFE.
                             # weakest signal); block the downgrade and record it for audit.
                             # F-KB-1a (extends #243's canonical-set fix to Stage-1):
                             # widen the BLOCK-set from the hardcoded {SAFE,PROTECTED} to the

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 
 from utilities.llm_client import TokenTracker
 from utilities.llm import PhaseBinding, simple_text
-from core.verdict_taxonomy import DISCLOSURE_DROPPED
+from core.verdict_taxonomy import DISCLOSURE_DROPPED, DISCLOSURE_ELIGIBLE
 
 # Uppercase mirror of the canonical disclosure-dropped set (this module compares
 # verdicts .upper()'d). Keyed off core.verdict_taxonomy so the guard's block-set
@@ -296,6 +296,28 @@ def run_stage1_consistency_check(
                                 continue
                             if old_verdict_norm != new_verdict:
                                 result["verdict"] = new_verdict
+                                # #331: canonical downstream reads are
+                                # finding-first (`str(r.get("finding") or
+                                # r.get("verdict", "")).lower()`,
+                                # core/verifier.py:118) and ingestion ALWAYS
+                                # sets a lowercase finding (core/analyzer.py:
+                                # 149-152), so writing only `verdict` leaves
+                                # the correction shadowed by the stale finding
+                                # — a safe->VULNERABLE correction was counted
+                                # safe, filtered out of Stage 2, and absent
+                                # from disclosure. GATE the write on
+                                # disclosure-eligibility: `new_verdict` is
+                                # unvalidated model output (the :281 comment),
+                                # and the :287 block-list covers only
+                                # DISCLOSURE_DROPPED — an unrecognised
+                                # downgrade (VULNERABLE -> INSUFFICIENT_CONTEXT)
+                                # passes unblocked, and the stale finding is
+                                # currently the ACCIDENTAL SAFETY NET keeping
+                                # the row disclosed. An ungated write would
+                                # remove that net and drop a disclosed
+                                # vulnerability (measured in #331).
+                                if str(new_verdict).lower() in DISCLOSURE_ELIGIBLE:
+                                    result["finding"] = str(new_verdict).lower()
                                 result["stage1_consistency_update"] = {
                                     "from": old_verdict,
                                     "to": new_verdict,

--- a/libs/openant-core/utilities/stage1_consistency.py
+++ b/libs/openant-core/utilities/stage1_consistency.py
@@ -18,6 +18,15 @@ from utilities.llm_client import TokenTracker
 from utilities.llm import PhaseBinding, simple_text
 from core.verdict_taxonomy import DISCLOSURE_DROPPED, SEVERITY_FINDING_VERDICTS
 
+# #425: the verdict vocabulary a Stage-1 consistency correction may write —
+# the canonical Stage-1 verdicts (analysis_core._normalize_result's
+# finding_to_verdict map, uppercased). Values outside it are rejected at the
+# validity gate below (producer discipline, per #316/#324).
+_CORRECTABLE_STAGE1_VERDICTS = frozenset({
+    "VULNERABLE", "SAFE", "PROTECTED", "BYPASSABLE", "INCONCLUSIVE",
+    "INSUFFICIENT_CONTEXT",
+})
+
 # Uppercase mirror of the canonical disclosure-dropped set (this module compares
 # verdicts .upper()'d). Keyed off core.verdict_taxonomy so the guard's block-set
 # cannot drift from the partition — the same canonical-reference fix #243 applied to
@@ -265,6 +274,35 @@ def run_stage1_consistency_check(
                     new_verdict = raw_should_be.strip().upper() if isinstance(raw_should_be, str) else ""
 
                     if not new_verdict:
+                        continue
+
+                    # #425: VALIDITY gate — the F-KB-1a block below is a
+                    # downgrade guard, not a validity gate, so anything
+                    # outside _DISCLOSURE_DROPPED_UPPER ("MAYBE VULNERABLE",
+                    # "probably fine") landed in result["verdict"] verbatim,
+                    # after _normalize_result's gates had already run — the
+                    # same escape #316/#324 closed at the OTHER producers.
+                    # new_verdict is unconstrained LLM `should_be` output: a
+                    # value outside the Stage-1 verdict vocabulary (the
+                    # _normalize_result finding_to_verdict map, uppercased) is
+                    # model noise. REJECT the proposal with an audit record —
+                    # the row keeps its valid pre-consistency verdict, and
+                    # overwriting it with garbage (or with ERROR) would
+                    # destroy a valid verdict this pass did not earn the
+                    # authority to replace.
+                    if new_verdict not in _CORRECTABLE_STAGE1_VERDICTS:
+                        for result in results:
+                            if result.get("route_key") == route_key:
+                                result["stage1_consistency_invalid_verdict_blocked"] = {
+                                    "from": result.get("verdict", "UNKNOWN"),
+                                    "proposed": new_verdict,
+                                    "reason": update.get("reason"),
+                                    "pattern": consistency_result.pattern_identified,
+                                }
+                                log("warning",
+                                    f"Blocked Stage-1 consistency correction to "
+                                    f"unrecognized verdict: {new_verdict!r}",
+                                    step="detect", unit_id=route_key)
                         continue
 
                     for result in results:


### PR DESCRIPTION
`apply_stage1_consistency` rewrites a Stage-1 result's `verdict` from the consistency model's unconstrained `should_be` string — AFTER verdict normalization has run — and the only gate before the write was the F-KB-1a downgrade block (correct for its purpose, not a VALIDITY gate): anything outside `_DISCLOSURE_DROPPED_UPPER` — "MAYBE VULNERABLE", "probably fine" — landed in `result["verdict"]` verbatim. The same escape #316/#324 closed at `_normalize_result` / the JSON corrector, surviving at the one producer that runs AFTER those gates.

**The fix (base commit):** a validity gate ahead of the write — `new_verdict` must be in the Stage-1 vocabulary. A value outside it is model noise, REJECTED with an audit record (`stage1_consistency_invalid_verdict_blocked`, the downgrade-block audit style): the row keeps its valid pre-consistency verdict, and overwriting it with garbage — or with ERROR — would destroy a valid verdict a pattern-similarity pass did not earn the authority to replace.

**The wave-r1 round (sonnet+fable+opus, all confirmed — and the branch REBASED onto #331's PR, which its original commit message's "stacked" framing required but predated):**
- the vocabulary was a third hand-copied set — the exact drift this module rejected 250 lines earlier, and it already disagreed: INSUFFICIENT_CONTEXT is in neither DISCLOSURE_ELIGIBLE nor DISCLOSURE_DROPPED, and the consistency prompt's enum is VULNERABLE | SAFE | INCONCLUSIVE (the pass is never asked for it). Admitting it whitelisted a no-evidence downgrade AROUND F-KB-1a, producing a SPLIT-BRAIN row: verdict moved off VULNERABLE by pattern similarity while finding stayed vulnerable — a disclosed unit mislabeled in every verdict-keyed surface. The set now derives from the canonical `FINDING_VERDICT_ORDER`, which excludes it; the proposal is rejected and the row preserved UNCHANGED — the stronger, coherent form of the #331 net;
- REJECTED reclassification accepted EXPLICITLY (it is in F-KB-1a's block-set but not the correctable set, so the validity gate fires first and the audit key changes): the F-KB-1a comment states it, and a test pins the reclassification as deliberate;
- the stacked semantics updated in the shared test lineage: the #331 tests that pinned the INSUFFICIENT_CONTEXT pass-through / the Stage-2-vocabulary net now assert the invariants that hold across the stack (the row stays disclosed and counted vulnerable; the verdict either moves with the net or is rejected whole).

NOT fixed here, filed as #448 (the wave's central-claim correction): the Stage-2 TWIN site — `finding_verifier._check_consistency`, the same `findings_to_update`/`should_be` contract with NO strip/upper/validation, writing `finding` VERBATIM — runs after Stage-1 consistency and can write MAYBE-VULNERABLE into the key `_count_verdicts` and disclosure read first.

**Evidence:** 5 tests in this PR's file (the split-brain rejection + audit; the REJECTED reclassification; the originals) + the #331 families green across the stack (22 passed together); the full suite green (1 known macOS artifact); ruff clean.

Depends-on: #456 (#331) — this branch is stacked on it and its commits are included.

Fixes #425