### PR TITLE
fix(core): an unrecognized non-empty verdict routes to the error accounting (#427)

### DIFF
--- a/libs/openant-core/core/analysis_core.py
+++ b/libs/openant-core/core/analysis_core.py
@@ -74,7 +74,14 @@ def _normalize_result(result: dict) -> dict:
         if isinstance(_finding, str) and _finding.strip().lower() in _CANONICAL_FINDINGS:
             # keep the canonical finding; the row's accounting is unchanged
             # (the raw verdict is preserved above for manual review).
-            pass
+            # famBCR panel (sonnet): the KEPT verdict must be normalized to
+            # MATCH the finding — the downstream severity stamping keys on
+            # `verdict`, and leaving the garbage "SAY WHAT" there silently
+            # dropped severity for exactly these rows (the #436 stamp gates
+            # on VULNERABLE/BYPASSABLE). The row now carries the finding's
+            # canonical verdict uppercase, so every verdict-keyed consumer
+            # agrees with every finding-keyed one.
+            result["verdict"] = _finding.strip().upper()
         else:
             if _finding is not None and (
                     not isinstance(_finding, str) or _finding.strip()):

--- a/libs/openant-core/core/analysis_core.py
+++ b/libs/openant-core/core/analysis_core.py
@@ -20,7 +20,7 @@ import json
 from typing import TYPE_CHECKING
 from datetime import datetime
 
-from core.verdict_taxonomy import SEVERITIES, _SEVERITIES
+from core.verdict_taxonomy import SEVERITIES, _SEVERITIES, STAGE1_VERDICTS
 
 from prompts.prompt_selector import get_analysis_prompt
 from prompts.vulnerability_analysis import get_system_prompt as get_stage1_system_prompt
@@ -43,6 +43,24 @@ def _normalize_result(result: dict) -> dict:
     # with the key present (a null verdict crashed _count_verdicts' fallback).
     verdict = result.get("verdict")
     has_verdict = isinstance(verdict, str) and verdict.strip() != ""
+    # #427: an unrecognized NON-EMPTY verdict string ({"verdict": "SAY WHAT"},
+    # {"verdict": "weird"} — the same untrusted model-JSON class #316's
+    # garbage findings came from) previously passed through unchanged and
+    # failed OPEN at every accounting sink: dropped from all _count_verdicts
+    # buckets (sum < total), analyze_result_is_error -> False (adopted as
+    # complete on resume, never retried), counted as completed by the
+    # summary seeding, never in the disclosure set. The same garbage class
+    # failed CLOSED for the FINDING key (#426) and OPEN for the verdict key —
+    # close the asymmetry with the matching whitelist: known verdicts pass;
+    # anything else routes to the error accounting with the raw preserved.
+    if has_verdict and verdict.strip().upper() not in STAGE1_VERDICTS:
+        result["raw_verdict"] = verdict
+        if isinstance(result.get("finding"), str) and result["finding"].strip():
+            # The finding beside the garbage verdict is preserved raw too
+            # (it may itself be valid — the row is what routes to error).
+            result["raw_finding"] = result["finding"]
+        result["verdict"] = "ERROR"
+        result["finding"] = "error"
     if not has_verdict and "finding" in result:
         finding = result["finding"]
         if not isinstance(finding, str):

--- a/libs/openant-core/core/analysis_core.py
+++ b/libs/openant-core/core/analysis_core.py
@@ -20,7 +20,13 @@ import json
 from typing import TYPE_CHECKING
 from datetime import datetime
 
-from core.verdict_taxonomy import SEVERITIES, _SEVERITIES, STAGE1_VERDICTS
+from core.verdict_taxonomy import (
+    FINDING_VERDICT_ORDER, SEVERITIES, _SEVERITIES, STAGE1_VERDICTS,
+)
+
+# the canonical lowercase finding strings a garbage-verdict row may keep
+# (wave r1 opus: the finding-first sinks key on exactly these).
+_CANONICAL_FINDINGS = frozenset(FINDING_VERDICT_ORDER) | {"error"}
 
 from prompts.prompt_selector import get_analysis_prompt
 from prompts.vulnerability_analysis import get_system_prompt as get_stage1_system_prompt
@@ -53,14 +59,31 @@ def _normalize_result(result: dict) -> dict:
     # failed CLOSED for the FINDING key (#426) and OPEN for the verdict key —
     # close the asymmetry with the matching whitelist: known verdicts pass;
     # anything else routes to the error accounting with the raw preserved.
+    # Wave r1 (opus) — the finding-kept redesign: routing the WHOLE row to
+    # error even when the model's `finding` was a usable canonical string
+    # ("vulnerable") EXCLUDED it from Stage-2 selection and disclosure —
+    # the finding-first sinks were already counting it correctly, so the
+    # erasure was a false negative for a row whose model reply asserted
+    # vulnerable. The garbage VERDICT is discarded (raw preserved); a
+    # USABLE finding is KEPT (the row keeps its finding-driven accounting
+    # and disclosure); only when the finding is absent or itself unusable
+    # does the row route to the error shape.
     if has_verdict and verdict.strip().upper() not in STAGE1_VERDICTS:
         result["raw_verdict"] = verdict
-        if isinstance(result.get("finding"), str) and result["finding"].strip():
-            # The finding beside the garbage verdict is preserved raw too
-            # (it may itself be valid — the row is what routes to error).
-            result["raw_finding"] = result["finding"]
-        result["verdict"] = "ERROR"
-        result["finding"] = "error"
+        _finding = result.get("finding")
+        if isinstance(_finding, str) and _finding.strip().lower() in _CANONICAL_FINDINGS:
+            # keep the canonical finding; the row's accounting is unchanged
+            # (the raw verdict is preserved above for manual review).
+            pass
+        else:
+            if _finding is not None and (
+                    not isinstance(_finding, str) or _finding.strip()):
+                # a non-string or non-empty finding beside the garbage
+                # verdict is preserved raw (wave r1 fable: the #316 branch
+                # preserves non-string raws; erasing them destroyed data).
+                result["raw_finding"] = _finding
+            result["verdict"] = "ERROR"
+            result["finding"] = "error"
     if not has_verdict and "finding" in result:
         finding = result["finding"]
         if not isinstance(finding, str):
@@ -103,9 +126,12 @@ def _normalize_result(result: dict) -> dict:
         result["verdict"] = "ERROR"
         result["finding"] = "error"
 
-    # Ensure verdict is uppercase
+    # Ensure verdict is uppercase (wave r1 fable: STRIPPED too — a "safe "
+    # passed the whitelist's .strip().upper() check and was then stored
+    # unstripped, which the sinks dropped: the exact fail-open the fix
+    # closes, for an input the check had just classified canonical).
     if "verdict" in result and isinstance(result["verdict"], str):
-        result["verdict"] = result["verdict"].upper()
+        result["verdict"] = result["verdict"].strip().upper()
 
     # #215: a rankable severity, FINDING-ONLY — stamped AFTER the verdict
     # decision, and only for the finding verdicts (VULNERABLE/BYPASSABLE).

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -418,7 +418,11 @@ def _count_verdicts(results):
             # half-stamped row): agree with analyze_result_is_error, which
             # classifies it as an error.
             counts["errors"] += 1
-        # else: an unrecognized verdict — the documented F13 gap (dropped).
+        # #427: an unrecognized verdict is a malformed model reply — the
+        # error bucket (the F13 partition closes; the sink-side
+        # analyze_result_is_error agrees, so resume retries the row too).
+        else:
+            counts["errors"] += 1
     return counts
 
 

--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -212,9 +212,12 @@ def analyze_result_is_error(res) -> bool:
     finding-first — a legacy ``{"verdict": "ERROR", "finding": "vulnerable"}``
     row is an error here (retried) but counted vulnerable there; the retried
     outcome replaces it, so the disagreement is transient. An
-    unrecognized-but-effective verdict (``"SAY WHAT"``) is NOT an error here
-    — that drop is the documented F13 partition gap, deliberately out of
-    scope (#316/#324).
+    unrecognized-but-effective verdict (``"SAY WHAT"``) IS an error here
+    (#427, wave r1 fable): the producer whitelist now routes fresh rows to
+    the error shape at ingestion, and this sink-side closure makes the
+    ON-DISK population — rows the buggy producer persisted — retried on
+    resume too, instead of adopted as complete with a verdict every
+    finding-first sink drops.
     """
     if not isinstance(res, dict):
         # A hand-edited/corrupt "result": null row must not crash the
@@ -226,7 +229,14 @@ def analyze_result_is_error(res) -> bool:
         return True
     has_verdict = isinstance(verdict, str) and verdict.strip() != ""
     has_finding = isinstance(finding, str) and finding.strip() != ""
-    return not (has_verdict or has_finding)
+    if not (has_verdict or has_finding):
+        return True
+    # #427: an unrecognized-but-effective verdict is a malformed model reply
+    # — retried, never adopted (the shared STAGE1_VERDICTS vocabulary).
+    from core.verdict_taxonomy import STAGE1_VERDICTS
+    if has_verdict and verdict.strip().upper() not in STAGE1_VERDICTS:
+        return True
+    return False
 
 
 class StepCheckpoint:

--- a/libs/openant-core/core/verdict_taxonomy.py
+++ b/libs/openant-core/core/verdict_taxonomy.py
@@ -54,6 +54,17 @@ _SEVERITIES = frozenset(SEVERITIES)
 # The verdicts that carry a severity (see SEVERITIES above).
 SEVERITY_FINDING_VERDICTS = ("vulnerable", "bypassable")
 
+# --- Stage-1 verdict vocabulary ----------------------------------------------
+# Every verdict a Stage-1 result may carry (the `_normalize_result`
+# finding_to_verdict map, plus ERROR). #427: `_normalize_result`'s verdict
+# whitelist — a non-empty verdict outside this set is unrecognized model
+# output and routes to the error accounting (mirroring the finding-key fix
+# #426 applied to the same garbage-reply class).
+STAGE1_VERDICTS = frozenset({
+    "VULNERABLE", "SAFE", "PROTECTED", "BYPASSABLE", "INCONCLUSIVE",
+    "INSUFFICIENT_CONTEXT", "ERROR",
+})
+
 # --- Stage-2 verification verdicts -------------------------------------------
 # ``core/reporter.py`` maps the Stage-2 ``verification`` dict onto these.
 STAGE2_VERDICTS = frozenset({

--- a/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
+++ b/libs/openant-core/tests/report/test_results_bucket_reconciliation.py
@@ -106,20 +106,18 @@ def test_graceful_when_no_errors(metrics, expected_errors):
             + r["protected"] + r["inconclusive"] + r["errors"]) == r["total"]
 
 
-def test_count_verdicts_drops_unrecognized_verdict():
-    """DOCUMENTS the pre-existing partition gap F13 does NOT close: a row with an
-    unrecognized verdict is dropped from every bucket, so the produced metrics
-    already under-sum `total`. Kept as a red-flag guard: if a future change makes
-    _count_verdicts total-preserving, update F13's scope note.
-
-    #316/#324: the NEITHER-KEY shape is now partitioned into `errors` (see the
-    scope note above); the unrecognized-VERDICT drop remains the gap."""
+def test_count_verdicts_partitions_every_row():
+    """#427 (wave r1) — the F13 gap CLOSED (this pin existed as the red-flag
+    guard for exactly this change): an unrecognized verdict is a malformed
+    model reply and buckets as an error, so the produced metrics reconcile
+    to `total` with no dropped rows."""
     rows = [
         {"finding": "vulnerable"},
         {"verdict": "ERROR"},
-        {"verdict": "SOMETHING_WEIRD"},  # neither a bucket nor "ERROR" -> dropped
-        {"reasoning": "no verdict keys"},  # neither-key -> counted as an error (#324)
+        {"verdict": "SOMETHING_WEIRD"},  # #427: buckets as an error now
+        {"reasoning": "no verdict keys"},  # neither-key -> error (#324)
     ]
     counts = _count_verdicts(rows)
-    assert sum(counts.values()) == 3          # 3 of 4 rows partitioned
-    assert sum(counts.values()) < len(rows)   # the unrecognized-verdict gap is real
+    assert sum(counts.values()) == len(rows)   # every row partitioned
+    assert counts["vulnerable"] == 1
+    assert counts["errors"] == 3

--- a/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
+++ b/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
@@ -89,10 +89,14 @@ def test_neither_key_stamps_error():
 
 
 def test_verdict_present_passthrough_unchanged():
-    """Guard: a reply that already carries a verdict keeps it (the residual
-    for unrecognized VERDICT strings is #324's documented gap, unchanged)."""
+    """Guard: a reply that already carries a CANONICAL verdict keeps it.
+    #427 closed the residual this test used to pin ("weird" passing through
+    as "WEIRD" — the verdict-key asymmetry where the same garbage-reply class
+    failed CLOSED for the finding key and OPEN for the verdict key): an
+    unrecognized non-empty verdict now routes to the error accounting with
+    the raw preserved (see test_issue427_verdict_whitelist)."""
     assert _normalize_result({"verdict": "SAFE"})["verdict"] == "SAFE"
-    assert _normalize_result({"verdict": "weird"})["verdict"] == "WEIRD"
+    assert _normalize_result({"verdict": "INSUFFICIENT_CONTEXT"})["verdict"] == "INSUFFICIENT_CONTEXT"
 
 
 def test_nonstring_finding_stamps_error_shape():

--- a/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
+++ b/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
@@ -132,12 +132,15 @@ def test_count_verdicts_neither_key_counts_as_error():
     assert sum(counts.values()) == len(rows)  # the partition closes
 
 
-def test_count_verdicts_unrecognized_verdict_still_dropped():
-    """Residual, pinned: an unrecognized VERDICT string remains the
-    F13-documented gap (see test_results_bucket_reconciliation)."""
+def test_count_verdicts_unrecognized_verdict_now_counts_in_errors():
+    """#427 (wave r1): the F13-documented gap CLOSED — this pin existed so a
+    future fix would update it consciously. An unrecognized VERDICT string
+    is a malformed model reply: the error bucket (the partition reconciles,
+    and the sink-side analyze_result_is_error agrees so resume retries it)."""
     rows = [{"verdict": "SOMETHING_WEIRD"}]
     counts = _count_verdicts(rows)
-    assert sum(counts.values()) == 0
+    assert counts["errors"] == 1
+    assert sum(counts.values()) == 1
 
 
 def test_count_verdicts_producer_error_shape_counts():
@@ -156,12 +159,12 @@ def test_cp_is_error_neither_key_retried():
 
     assert _cp_is_error({"result": {"reasoning": "cannot determine"}}) is True
     assert _cp_is_error({"result": {"verdict": "VULNERABLE"}}) is False
-    # Legacy residual, pinned: a PRE-fix garbage-verdict row (finding present,
-    # unrecognized; verdict neither ERROR nor a bucket) is still adopted —
-    # post-fix runs never write that shape.
+    # #427 (wave r1): a garbage-verdict row — including the ON-DISK
+    # population the pre-fix producer persisted — is RETRIED, never
+    # adopted (the sink-side closure; post-fix runs never write the shape).
     assert _cp_is_error(
         {"result": {"finding": "maybe exploitable", "verdict": "MAYBE EXPLOITABLE"}}
-    ) is False
+    ) is True
 
 
 def test_null_and_empty_verdicts_are_the_error_shape():
@@ -197,10 +200,11 @@ def test_count_verdicts_fallback_shapes_preserved():
     counts = _count_verdicts([
         {"verdict": "SAFE"},             # finding falls back to verdict
         {"finding": "safe"},             # finding direct
-        {"verdict": "SOMETHING_WEIRD"},  # F13-documented drop, still dropped
+        {"verdict": "SOMETHING_WEIRD"},  # #427: the error bucket now
     ])
     assert counts["safe"] == 2
-    assert sum(counts.values()) == 2
+    assert counts["errors"] == 1
+    assert sum(counts.values()) == 3
 
 
 def _write_checkpoint(tmp_path, rows):
@@ -314,18 +318,21 @@ def test_counter_agrees_with_predicate_on_error_finding():
 
 
 def test_both_keys_disagreement_residual_pinned():
-    """Wave round-2 finding (both reviewers): a row with BOTH keys present
-    but disagreeing ({"verdict": "SAFE", "finding": "garbage"}) is adopted
-    (effective verdict short-circuits the finding branch) and counted in no
-    bucket (finding-first counter drops it). PRE-EXISTING family, NOT
-    produced by the fixed producers, deliberately out of scope (#316/#324
-    fix the unrecognized/absent verdicts). Pinned so a future fix updates
-    this consciously — see FOLLOW-UPS."""
+    """Wave round-2 finding, UPDATED by #427's round (the pin existed for
+    this): a row with BOTH keys present but disagreeing
+    ({"verdict": "SAFE", "finding": "garbage"}) — the verdict short-circuits
+    the finding branch (the producer leaves the disagreement; #331 owns the
+    stage-1 producer's co-write), and the finding-first counter now buckets
+    the unrecognized finding as an ERROR (the #427 partition closure — the
+    row was previously dropped from every bucket). Resume adopts it (the
+    VERDICT is canonical — the transient-disagreement semantics in
+    analyze_result_is_error's docstring: the retried outcome replaces the
+    row only if the verdict is also bad)."""
     out = _normalize_result({"verdict": "SAFE", "finding": "garbage"})
     assert out["verdict"] == "SAFE" and out["finding"] == "garbage"
     counts = _count_verdicts([out])
-    assert sum(counts.values()) == 0  # dropped — the documented residual
-    assert analyze_result_is_error(out) is False  # adopted on resume
+    assert counts["errors"] == 1  # the unrecognized finding buckets as error
+    assert analyze_result_is_error(out) is False  # canonical verdict: adopted
 
 
 # ---------------------------------------------------------------------------

--- a/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
+++ b/libs/openant-core/tests/test_issue316_324_verdict_accounting.py
@@ -480,3 +480,23 @@ def test_context_corrector_error_break_stamps_failure(monkeypatch, tmp_path):
     assert out["raw_finding"] == "not sure, maybe"
     assert corrector.correction_stats["failures"] == 1
     assert corrector.correction_stats["successes"] == 0
+
+
+def test_finding_kept_row_normalizes_its_verdict():
+    """famBCR panel (sonnet): a garbage verdict + canonical kept finding must
+    ALSO normalize the verdict to match — the severity stamping keys on
+    `verdict`, and leaving the garbage there silently dropped severity for
+    exactly these rows. Both the analysis_core and context_corrector twins."""
+    from core.analysis_core import _normalize_result as nr_core
+    from utilities.context_corrector import ContextCorrector
+
+    row = {"verdict": "SAY WHAT", "finding": "vulnerable"}
+    out = nr_core(dict(row))
+    assert out["verdict"] == "VULNERABLE", out
+    assert out["finding"] == "vulnerable"
+    assert out.get("severity") in ("high", "medium", "low", "critical"), (
+        f"the severity stamp must fire on the normalized verdict: {out}")
+
+    nr_ctx = ContextCorrector._normalize_result
+    out2 = nr_ctx(dict(row))
+    assert out2["verdict"] == "VULNERABLE", out2

--- a/libs/openant-core/tests/test_issue427_verdict_whitelist.py
+++ b/libs/openant-core/tests/test_issue427_verdict_whitelist.py
@@ -16,6 +16,7 @@ with the raw value preserved for manual review. The #426 pin test's
 `{"verdict": "weird"} == "WEIRD"` line (documented there as "the residual ... #324's
 documented gap, unchanged") is updated with this fix — this issue is that gap's closure.
 """
+import re
 import sys
 from pathlib import Path
 
@@ -24,6 +25,7 @@ if str(_CORE) not in sys.path:
     sys.path.insert(0, str(_CORE))
 
 from core.analysis_core import _normalize_result  # noqa: E402
+from core.verdict_taxonomy import STAGE1_VERDICTS  # noqa: E402
 from core.analyzer import _count_verdicts  # noqa: E402
 
 
@@ -33,22 +35,63 @@ def _is_error(r):
 
 
 def test_unrecognized_verdict_routes_to_error():
-    """The passthrough escape: `weird` must not land in verdict uppercased —
-    it is the same garbage-reply class the finding-key fix fails CLOSED on."""
+    """The passthrough escape (no usable finding): `weird` must not land in
+    verdict uppercased — it is the same garbage-reply class the finding-key
+    fix fails CLOSED on."""
     out = _normalize_result({"verdict": "weird"})
     assert out["verdict"] == "ERROR", out
     assert out["finding"] == "error"
     assert out["raw_verdict"] == "weird", "the raw value stays for manual review"
 
 
-def test_unrecognized_verdict_with_valid_finding_stamps_both():
-    """The issue's exact row: a garbage verdict beside a valid finding — the
-    ROW routes to the error accounting; both raws preserved."""
+def test_stripped_verdict_is_stored_stripped():
+    """Wave r1 (fable): the check strips; the store must too — a "safe "
+    passed the whitelist and was stored unstripped, which the sinks then
+    dropped: the exact fail-open, for an input the check classified
+    canonical."""
+    out = _normalize_result({"verdict": " safe "})
+    assert out["verdict"] == "SAFE", out
+
+
+def test_conformance_the_whitelist_is_the_finding_to_verdict_map():
+    """Wave r1 (sonnet): STAGE1_VERDICTS is synchronized with
+    analysis_core's own finding_to_verdict map + ERROR — the shared-constant
+    pattern the Stage-2 vocabulary already uses
+    (test_F3_verdict_taxonomy_shared_constant). A future edit to either
+    without the other silently reopens the asymmetry this fix closes."""
+    import inspect
+    src = inspect.getsource(_normalize_result)
+    m = re.search(r"finding_to_verdict = \{(.*?)\}", src, re.S)
+    assert m, "the inline map not found"
+    vals = set(re.findall(r':\s*"([A-Z_]+)"', m.group(1)))
+    assert vals | {"ERROR"} == STAGE1_VERDICTS, (
+        f"the whitelist drifted from the map: {STAGE1_VERDICTS - vals - {'ERROR'}} "
+        f"or the map gained {vals - STAGE1_VERDICTS}"
+    )
+
+
+def test_unrecognized_verdict_with_valid_finding_keeps_the_finding():
+    """Wave r1 (opus) — the finding-kept redesign: the issue's exact row did
+    NOT fail open before (the finding-first sinks counted it vulnerable,
+    Stage-2 verified it, disclosure kept it), and routing the whole row to
+    error EXCLUDED it from all three — a false negative for a row whose
+    model reply asserted vulnerable. The garbage verdict is discarded (raw
+    preserved); the canonical finding is KEPT."""
     out = _normalize_result({"verdict": "SAY WHAT", "finding": "vulnerable"})
-    assert out["verdict"] == "ERROR"
-    assert out["finding"] == "error"
+    assert out["finding"] == "vulnerable", (
+        "a usable canonical finding is kept — the row keeps its "
+        "finding-driven accounting and disclosure"
+    )
     assert out["raw_verdict"] == "SAY WHAT"
-    assert out["raw_finding"] == "vulnerable"
+    assert "raw_finding" not in out
+    # an unusable/non-string finding beside the garbage verdict DOES route:
+    out2 = _normalize_result({"verdict": "SAY WHAT", "finding": ["vulnerable"]})
+    assert out2["verdict"] == "ERROR"
+    assert out2["finding"] == "error"
+    assert out2["raw_verdict"] == "SAY WHAT"
+    assert out2["raw_finding"] == ["vulnerable"], (
+        "non-string raws preserved (wave r1 fable)"
+    )
 
 
 def test_canonical_verdicts_pass_unchanged():
@@ -62,9 +105,13 @@ def test_canonical_verdicts_pass_unchanged():
 
 
 def test_error_shape_reaches_every_sink():
-    """The closed sinks: counted in errors (sum reconciles), classified as
-    error (resume does NOT adopt as complete), and never in disclosure."""
-    row = _normalize_result({"verdict": "SAY WHAT", "finding": "vulnerable"})
+    """The closed sinks for the ERROR-SHAPE row (finding absent/unusable):
+    counted in errors (sum reconciles), classified as error (resume does
+    NOT adopt it as complete). The disclosure claim corrected (wave r1
+    fable): the error shape is DISCLOSURE-ELIGIBLE (error is in
+    DISCLOSURE_ELIGIBLE by design — surfaced for manual triage), so the fix
+    moves the row from silently-dropped to eligible-as-error."""
+    row = _normalize_result({"verdict": "weird"})
     counts = _count_verdicts([dict(row)])
     assert counts["errors"] == 1
     assert sum(v for k, v in counts.items() if k != "errors") == 0

--- a/libs/openant-core/tests/test_issue427_verdict_whitelist.py
+++ b/libs/openant-core/tests/test_issue427_verdict_whitelist.py
@@ -1,0 +1,71 @@
+"""#427: an unrecognized non-empty VERDICT routes to the error accounting.
+
+#426 closed the unrecognized-FINDING case and the absent/null/empty-verdict case — but
+an unrecognized non-empty VERDICT string ({"verdict": "SAY WHAT", "finding":
+"vulnerable"} — producible by the same untrusted model JSON that produced #316's garbage
+findings) still passed through `_normalize_result` unchanged and then FAILED OPEN at
+every accounting sink: (a) dropped from all `_count_verdicts` buckets (sum < total
+persists); (b) `analyze_result_is_error` -> False -> adopted as complete on resume,
+never retried; (c) counted as `completed` by the summary seeding; (d) never in the
+disclosure set. The asymmetry: the same garbage-reply class failed CLOSED for the
+finding key and OPEN for the verdict key.
+
+The fix mirrors the finding-key fix at the verdict key: a canonical whitelist in the
+passthrough branch — known verdicts pass; anything else routes to the error accounting
+with the raw value preserved for manual review. The #426 pin test's
+`{"verdict": "weird"} == "WEIRD"` line (documented there as "the residual ... #324's
+documented gap, unchanged") is updated with this fix — this issue is that gap's closure.
+"""
+import sys
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+from core.analysis_core import _normalize_result  # noqa: E402
+from core.analyzer import _count_verdicts  # noqa: E402
+
+
+def _is_error(r):
+    from core.analyzer import analyze_result_is_error
+    return analyze_result_is_error(r)
+
+
+def test_unrecognized_verdict_routes_to_error():
+    """The passthrough escape: `weird` must not land in verdict uppercased —
+    it is the same garbage-reply class the finding-key fix fails CLOSED on."""
+    out = _normalize_result({"verdict": "weird"})
+    assert out["verdict"] == "ERROR", out
+    assert out["finding"] == "error"
+    assert out["raw_verdict"] == "weird", "the raw value stays for manual review"
+
+
+def test_unrecognized_verdict_with_valid_finding_stamps_both():
+    """The issue's exact row: a garbage verdict beside a valid finding — the
+    ROW routes to the error accounting; both raws preserved."""
+    out = _normalize_result({"verdict": "SAY WHAT", "finding": "vulnerable"})
+    assert out["verdict"] == "ERROR"
+    assert out["finding"] == "error"
+    assert out["raw_verdict"] == "SAY WHAT"
+    assert out["raw_finding"] == "vulnerable"
+
+
+def test_canonical_verdicts_pass_unchanged():
+    """The whitelist over-blocks nothing: every canonical Stage-1 verdict
+    keeps its shape (casing normalized)."""
+    for v in ("SAFE", "VULNERABLE", "PROTECTED", "BYPASSABLE", "INCONCLUSIVE",
+              "INSUFFICIENT_CONTEXT", "ERROR"):
+        out = _normalize_result({"verdict": v.lower()})
+        assert out["verdict"] == v, (v, out)
+        assert "raw_verdict" not in out
+
+
+def test_error_shape_reaches_every_sink():
+    """The closed sinks: counted in errors (sum reconciles), classified as
+    error (resume does NOT adopt as complete), and never in disclosure."""
+    row = _normalize_result({"verdict": "SAY WHAT", "finding": "vulnerable"})
+    counts = _count_verdicts([dict(row)])
+    assert counts["errors"] == 1
+    assert sum(v for k, v in counts.items() if k != "errors") == 0
+    assert _is_error(row) is True

--- a/libs/openant-core/utilities/context_corrector.py
+++ b/libs/openant-core/utilities/context_corrector.py
@@ -650,6 +650,12 @@ class ContextCorrector:
                     result["raw_finding"] = _finding
                 result["verdict"] = "ERROR"
                 result["finding"] = "error"
+            else:
+                # famBCR panel (sonnet): the KEPT verdict must be normalized
+                # to match the kept finding — the severity stamping keys on
+                # `verdict`, and the garbage "SAY WHAT" left in place
+                # silently dropped severity for exactly these rows.
+                result["verdict"] = _finding.strip().upper()
         if not has_verdict and "finding" in result:
             finding = result["finding"]
             mapping = {

--- a/libs/openant-core/utilities/context_corrector.py
+++ b/libs/openant-core/utilities/context_corrector.py
@@ -14,6 +14,8 @@ import json
 import os
 import subprocess
 import sys
+
+from core.verdict_taxonomy import STAGE1_VERDICTS
 from pathlib import Path
 from typing import Optional
 
@@ -629,6 +631,25 @@ class ContextCorrector:
         """
         verdict = result.get("verdict")
         has_verdict = isinstance(verdict, str) and verdict.strip() != ""
+        # #427 (wave r1, opus+fable): the unrecognized-VERDICT branch,
+        # mirrored — the twin's passthrough adopted a garbage verdict as
+        # "Correction successful! New verdict: SAY WHAT" and returned it to
+        # experiment.py as the analysis result. The finding-kept redesign
+        # applies here too: the garbage verdict is discarded (raw
+        # preserved); a usable canonical finding is KEPT; only an
+        # absent/unusable finding routes to the error shape.
+        if has_verdict and verdict.strip().upper() not in STAGE1_VERDICTS:
+            result["raw_verdict"] = verdict
+            _finding = result.get("finding")
+            from core.verdict_taxonomy import FINDING_VERDICT_ORDER as _FVO
+            _canonical = frozenset(_FVO) | {"error"}
+            if not (isinstance(_finding, str)
+                    and _finding.strip().lower() in _canonical):
+                if _finding is not None and (
+                        not isinstance(_finding, str) or _finding.strip()):
+                    result["raw_finding"] = _finding
+                result["verdict"] = "ERROR"
+                result["finding"] = "error"
         if not has_verdict and "finding" in result:
             finding = result["finding"]
             mapping = {
@@ -651,7 +672,7 @@ class ContextCorrector:
             result["verdict"] = "ERROR"
             result["finding"] = "error"
         if "verdict" in result and isinstance(result["verdict"], str):
-            result["verdict"] = result["verdict"].upper()
+            result["verdict"] = result["verdict"].strip().upper()
         # #215 mirror: the finding-gated severity stamp, AFTER the uppercase
         # fold (core's order — stamping before it lost a model severity on a
         # lowercase-verdict reply, wave round-2). The shared enum comes from


### PR DESCRIPTION
#426 closed the unrecognized-FINDING case and the absent/null/empty-VERDICT case, but an unrecognized non-empty VERDICT string ({"verdict": "SAY WHAT", "finding": "vulnerable"} — producible by the same untrusted model JSON that produced #316's garbage findings) still passed through `_normalize_result` unchanged and then failed open at the accounting sinks: dropped from `_count_verdicts` buckets (sum < total), `analyze_result_is_error` → False (adopted as complete on resume, never retried), counted as completed by the summary seeding. The asymmetry: the same garbage-reply class failed CLOSED for the finding key and OPEN for the verdict key.

**The fix (base commit):** the matching whitelist at the verdict key (the new `core.verdict_taxonomy.STAGE1_VERDICTS` — the `_normalize_result` finding_to_verdict map plus ERROR): known verdicts pass; anything else routes to the error accounting with the raw preserved. The #426 pin test's `weird == "WEIRD"` line updated with the closure (the issue offers "close it, or retitle #426 honestly"; this closes it).

**The wave-r1 round (three axes, all confirmed — a substantial redesign):**
- THE HEADLINE ROW'S DIRECTION WAS WRONG (opus): {"verdict": "SAY WHAT", "finding": "vulnerable"} did NOT fail open at every sink — the finding-first counters counted it vulnerable, Stage-2 verified it, disclosure kept it — and routing the whole row to ERROR EXCLUDED it from all three: a false negative for a row whose model reply asserted vulnerable. The finding-kept redesign: the garbage VERDICT is discarded (raw preserved); a USABLE canonical finding is KEPT (the row keeps its finding-driven accounting and disclosure); only an absent/unusable finding routes to the error shape (with non-string raws preserved);
- THE TWIN (opus+fable): `context_corrector._normalize_result` — pinned by its own test as a FULL MIRROR — adopted garbage verdicts ("Correction successful! New verdict: SAY WHAT") and returned them to experiment.py as the analysis result. The whitelist + the finding-kept redesign mirrored there (the #316 precedent: all copies patched);
- THE SINK-SIDE CLOSURE (fable): the producer fix alone left the ON-DISK population — rows the buggy producer persisted — adopted as complete on resume. `analyze_result_is_error` now treats an unrecognized verdict as an error (the shared STAGE1_VERDICTS), so resume RETRIES them; `_count_verdicts`' F13 else-branch buckets them as errors — the partition closes, and every sink agrees;
- the strip-before-store fix (the check stripped while the store kept `"safe "` — which the sinks then dropped: the exact fail-open for an input the check had classified canonical);
- the conformance test (sonnet): `STAGE1_VERDICTS` asserted equal to analysis_core's own finding_to_verdict map + ERROR, the shared-constant pattern the Stage-2 vocabulary already uses;
- the pins updated CONSCIOUSLY (their stated purpose): the F13 unrecognized-drop guard (now partitions every row), the #316/#324 residual pins (the gap they documented is closed), the disagreement row (the unrecognized finding now buckets as error; the canonical verdict still adopts); the claims corrected (the error shape IS disclosure-eligible — error is in DISCLOSURE_ELIGIBLE by design).

**Evidence:** 6 tests in this PR's file (the finding-kept shapes incl. the non-string raw; the strip-store pin; the conformance; the every-sink closure) + the #316/#324/F13 families green with their updated pins (31 passed together); the full suite 3522/1 (the known macOS artifact); ruff clean; hermeticity green.

Fixes #427