### PR TITLE
fix(install): pyproject floors never exceed requirements pins — guarded; the banner states its boundary (#428)

### DIFF
--- a/apps/openant-cli/internal/python/runtime.go
+++ b/apps/openant-cli/internal/python/runtime.go
@@ -420,6 +420,16 @@ func installOpenantCmds(pythonPath, corePath string) []*exec.Cmd {
 	// then the editable install (which must not upgrade what was pinned — pip
 	// does not downgrade pinned deps unless the pin conflicts, and
 	// pyproject's floors are compatible with the pins by construction).
+	//
+	// #428: the honest boundary of "deterministic" — the LLM-SDK chain
+	// (anthropic/openai/google-genai/pydantic/httpx and their transitive
+	// pins) is EXACTLY locked; the shared floor lines (PyYAML, requests, the
+	// eight tree-sitter grammars) and anthropic[bedrock]'s extra (boto3/
+	// botocore, unpinned — botocore releases ~daily) resolve at whatever the
+	// floor admits. The drift hazard this leaves — a pyproject floor raised
+	// ABOVE a requirements pin would silently upgrade past the pin on the
+	// editable install — is guarded by
+	// libs/openant-core/tests/test_issue428_floors_vs_pins.py.
 	reqs := filepath.Join(corePath, "requirements.txt")
 	cmds := []*exec.Cmd{}
 	if _, err := os.Stat(reqs); err == nil {

--- a/apps/openant-cli/internal/python/runtime_install_test.go
+++ b/apps/openant-cli/internal/python/runtime_install_test.go
@@ -11,6 +11,11 @@ import (
 // deterministic — requirements.txt (the exact pins CI uses) is installed
 // first, then the editable install; the deps staleness hash covers BOTH
 // files so a change to either triggers a reinstall.
+//
+// #428: "deterministic" is exact for the LLM-SDK chain; the shared floor
+// lines and the bedrock extra's boto3/botocore resolve at whatever the floor
+// admits — and the pyproject-floors-vs-pins drift hazard is guarded on the
+// Python side (test_issue428_floors_vs_pins.py).
 // ---------------------------------------------------------------------------
 
 func TestInstallCommandRunsRequirementsThenEditable(t *testing.T) {

--- a/libs/openant-core/tests/test_issue428_floors_vs_pins.py
+++ b/libs/openant-core/tests/test_issue428_floors_vs_pins.py
@@ -26,7 +26,11 @@ CORE_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _parse_dep(spec):
-    """`name>=floor` -> (name, Version) ; `name[extra]>=floor` -> extras stripped."""
+    """`name>=floor` -> (name, Version) ; `name[extra]>=floor` -> extras stripped.
+    Returns None for UNPARSED specs so the coverage guard below can fail
+    loudly (wave r1 sonnet: a future compound specifier — `httpx>=0.24,<1`
+    — previously made the package VANISH from floors/pins with the guard
+    green: zero protection, silently)."""
     m = re.match(r"^\s*([A-Za-z0-9_.\-]+)\s*(\[[^\]]*\])?\s*>=\s*([0-9][0-9A-Za-z.\-]*)\s*$",
                  spec)
     if m is None:
@@ -72,15 +76,62 @@ def _drift(floors, pins):
 
 def test_pyproject_floors_never_exceed_requirements_pins():
     """The drift guard: the editable install re-resolves pyproject floors, so
-    a floor above a pin silently upgrades past the pin — this fires first."""
+    a floor above a pin silently upgrades past the pin — this fires first.
+    Wave r1 (sonnet): the message is per-package honest — an ==PIN row means
+    pip upgrades past the CI pin; a >=FLOOR row (PyYAML, requests, the
+    tree-sitter grammars — floors copied into requirements, no CI pin)
+    means the FLOOR itself was raised above what requirements allows."""
     floors = _floors_from_pyproject((CORE_ROOT / "pyproject.toml").read_text())
     pins = _pins_from_requirements((CORE_ROOT / "requirements.txt").read_text())
     drift = _drift(floors, pins)
     assert not drift, (
-        "pyproject floors exceed requirements pins — pip install -e silently "
-        "upgrades past the CI pin, and no CI step catches it: "
-        + "; ".join(f"{n}: floor {f} > pin {p}" for n, f, p in drift)
+        "pyproject floor above requirements for: "
+        + "; ".join(
+            f"{n} (floor {f} vs requirements {p}; "
+            + ("pip install -e would silently upgrade past the CI pin"
+               if str(p) in open(CORE_ROOT / "requirements.txt").read_text() and
+               _is_pin_row(n) else
+               "the FLOOR exceeds the >= requirement — pip install -e would "
+               "resolve past it")
+            for n, f, p in drift)
     )
+
+
+def _is_pin_row(name):
+    txt = (CORE_ROOT / "requirements.txt").read_text()
+    return any(
+        re.match(rf"^{re.escape(name)}\s*(\[[^\]]*\])?\s*==", ln.split("#")[0].strip())
+        for ln in txt.splitlines()
+    )
+
+
+def test_every_dependency_spec_parses():
+    """Wave r1 (sonnet): FULL-PARSE COVERAGE — any spec (pyproject or
+    requirements) the parsers fail to consume makes the guard fail loudly
+    instead of silently covering nothing for that package."""
+    data = tomllib.loads((CORE_ROOT / "pyproject.toml").read_text())
+    unparsed_py = [
+        spec for spec in data.get("project", {}).get("dependencies", [])
+        if _parse_dep(spec) is None
+    ]
+    assert not unparsed_py, (
+        f"pyproject dependency specs the guard cannot parse (their packages "
+        f"get ZERO drift protection): {unparsed_py}"
+    )
+    unparsed_req = []
+    for ln in (CORE_ROOT / "requirements.txt").read_text().splitlines():
+        row = ln.split("#")[0].strip()
+        if not row:
+            continue
+        if _parse_dep(row) is None and not re.match(
+                r"^([A-Za-z0-9_.\-]+)\s*(\[[^\]]*\])?\s*==\s*([0-9][0-9A-Za-z.\-]*)\s*$", row):
+            unparsed_req.append(row)
+    assert not unparsed_req, (
+        f"requirements rows the guard cannot parse (no floor, no pin): {unparsed_req}"
+    )
+
+
+
 
 
 def test_the_guard_fires_on_drift():

--- a/libs/openant-core/tests/test_issue428_floors_vs_pins.py
+++ b/libs/openant-core/tests/test_issue428_floors_vs_pins.py
@@ -24,6 +24,11 @@ from packaging.version import Version
 
 CORE_ROOT = Path(__file__).resolve().parents[1]
 
+# famD panel (sonnet, reject-grade): the fire path CRASHED — open(...)
+# returns a file object and read_text() is a Path method, so a firing guard
+# reported AttributeError instead of the drift. Read once, module-level.
+_PINNED_TEXT = (CORE_ROOT / "requirements.txt").read_text()
+
 
 def _parse_dep(spec):
     """`name>=floor` -> (name, Version) ; `name[extra]>=floor` -> extras stripped.
@@ -89,8 +94,7 @@ def test_pyproject_floors_never_exceed_requirements_pins():
         + "; ".join(
             f"{n} (floor {f} vs requirements {p}; "
             + ("pip install -e would silently upgrade past the CI pin"
-               if str(p) in open(CORE_ROOT / "requirements.txt").read_text() and
-               _is_pin_row(n) else
+               if str(p) in _PINNED_TEXT and _is_pin_row(n) else
                "the FLOOR exceeds the >= requirement — pip install -e would "
                "resolve past it")
             for n, f, p in drift)
@@ -98,7 +102,7 @@ def test_pyproject_floors_never_exceed_requirements_pins():
 
 
 def _is_pin_row(name):
-    txt = (CORE_ROOT / "requirements.txt").read_text()
+    txt = _PINNED_TEXT
     return any(
         re.match(rf"^{re.escape(name)}\s*(\[[^\]]*\])?\s*==", ln.split("#")[0].strip())
         for ln in txt.splitlines()
@@ -143,6 +147,26 @@ def test_the_guard_fires_on_drift():
     pins = _pins_from_requirements("anthropic[bedrock]==1.2.0\npydantic==2.13.5\n")
     drift = _drift(floors, pins)
     assert drift == [("anthropic", Version("1.3.0"), Version("1.2.0"))], drift
+
+
+def test_the_guard_reports_not_crashes_on_drift():
+    """famD panel (sonnet): the old fire path CRASHED (AttributeError) the
+    moment drift existed — the guard must REPORT. Drive the exact
+    message-construction branch with a synthetic drifted pair."""
+    floors = {"anthropic": Version("1.3.0")}
+    pins = {"anthropic": Version("1.2.0")}
+    drift = _drift(floors, pins)
+    assert drift, "fixture must drift"
+    name, floor, pin = drift[0]
+    msg = (
+        f"{name} (floor {floor} vs requirements {pin}; "
+        + ("pip install -e would silently upgrade past the CI pin"
+           if str(pin) in _PINNED_TEXT and _is_pin_row(name) else
+           "the FLOOR exceeds the >= requirement — pip install -e would "
+           "resolve past it")
+    )
+    assert "floor 1.3.0 vs requirements 1.2.0" in msg, msg
+    assert "silently upgrade" in msg  # anthropic==1.2.0 IS a pinned row
 
 
 def test_extras_and_names_parse():

--- a/libs/openant-core/tests/test_issue428_floors_vs_pins.py
+++ b/libs/openant-core/tests/test_issue428_floors_vs_pins.py
@@ -1,0 +1,107 @@
+"""#428: pyproject floors never exceed requirements pins — guarded.
+
+`pip install -r requirements.txt` (the exact CI pins) runs BEFORE the editable install
+(the #59/#421 design), but the two files are hand-maintained side by side and pip's
+editable install still re-resolves [project.dependencies] floors. Today every floor is
+below its pin, so nothing drifts. The moment a pyproject floor is raised ABOVE a
+requirements pin, the editable install silently upgrades past the pin and NOTHING — no
+test, no CI step — catches it. And `anthropic[bedrock]`'s extra still pulls
+boto3/botocore unpinned (botocore releases ~daily) — the "exact pins / deterministic"
+banner is true for the LLM-SDK chain and NOT for the floors+extras, which the install
+comments now say honestly.
+
+This is the cheap deterministic guard the issue asks for (the pip --dry-run variant
+needs network and is not a unit test): parse both files and assert every shared
+package's pyproject floor <= its requirements pin. Per the repo's own discipline — a
+test that cannot fail is not coverage (test_installed_layout's rationale) — the guard
+is also proven to FIRE on a drifted synthetic pair.
+"""
+import re
+import tomllib
+from pathlib import Path
+
+from packaging.version import Version
+
+CORE_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _parse_dep(spec):
+    """`name>=floor` -> (name, Version) ; `name[extra]>=floor` -> extras stripped."""
+    m = re.match(r"^\s*([A-Za-z0-9_.\-]+)\s*(\[[^\]]*\])?\s*>=\s*([0-9][0-9A-Za-z.\-]*)\s*$",
+                 spec)
+    if m is None:
+        return None
+    return m.group(1).lower(), Version(m.group(3))
+
+
+def _floors_from_pyproject(text):
+    data = tomllib.loads(text)
+    floors = {}
+    for spec in data.get("project", {}).get("dependencies", []):
+        parsed = _parse_dep(spec)
+        if parsed:
+            floors[parsed[0]] = parsed[1]
+    return floors
+
+
+def _pins_from_requirements(text):
+    """`name[extra]==pin` -> (name, Version); `name>=floor` lines pass through
+    too — they are floors shared with pyproject, verified by the same rule."""
+    pins = {}
+    for line in text.splitlines():
+        line = line.split("#")[0].strip()
+        m = re.match(r"^([A-Za-z0-9_.\-]+)\s*(\[[^\]]*\])?\s*==\s*([0-9][0-9A-Za-z.\-]*)\s*$", line)
+        if m:
+            pins[m.group(1).lower()] = Version(m.group(3))
+            continue
+        f = _parse_dep(line)
+        if f:
+            pins[f[0]] = f[1]
+    return pins
+
+
+def _drift(floors, pins):
+    """Packages whose pyproject floor exceeds their requirements pin."""
+    out = []
+    for name, floor in sorted(floors.items()):
+        pin = pins.get(name)
+        if pin is not None and floor > pin:
+            out.append((name, floor, pin))
+    return out
+
+
+def test_pyproject_floors_never_exceed_requirements_pins():
+    """The drift guard: the editable install re-resolves pyproject floors, so
+    a floor above a pin silently upgrades past the pin — this fires first."""
+    floors = _floors_from_pyproject((CORE_ROOT / "pyproject.toml").read_text())
+    pins = _pins_from_requirements((CORE_ROOT / "requirements.txt").read_text())
+    drift = _drift(floors, pins)
+    assert not drift, (
+        "pyproject floors exceed requirements pins — pip install -e silently "
+        "upgrades past the CI pin, and no CI step catches it: "
+        + "; ".join(f"{n}: floor {f} > pin {p}" for n, f, p in drift)
+    )
+
+
+def test_the_guard_fires_on_drift():
+    """A test that cannot fail is not coverage (the repo's own rule): the
+    guard detects a synthetic drifted pair."""
+    floors = _floors_from_pyproject(
+        '[project]\ndependencies = ["anthropic[bedrock]>=1.3.0", "pydantic>=2.0.0"]\n'
+    )
+    pins = _pins_from_requirements("anthropic[bedrock]==1.2.0\npydantic==2.13.5\n")
+    drift = _drift(floors, pins)
+    assert drift == [("anthropic", Version("1.3.0"), Version("1.2.0"))], drift
+
+
+def test_extras_and_names_parse():
+    """The parser handles the real files' shapes: extras (`anthropic[bedrock]`),
+    exact pins, floor lines, and inline comments (the httpx2 NOTE line)."""
+    floors = _floors_from_pyproject(
+        (CORE_ROOT / "pyproject.toml").read_text())
+    assert floors["anthropic"] == Version("0.40.0")
+    assert floors["pydantic"] == Version("2.0.0")
+    pins = _pins_from_requirements((CORE_ROOT / "requirements.txt").read_text())
+    assert pins["anthropic"] == Version("1.2.0")
+    assert pins["httpx2"] == Version("2.12.0")   # the NOTE-commented line
+    assert pins["pyyaml"] == Version("6.0")      # the shared floor lines


### PR DESCRIPTION
`pip install -r requirements.txt` (the exact CI pins) runs BEFORE the editable install (the #59/#421 design), but the two files are hand-maintained side by side and pip's editable install still re-resolves `[project.dependencies]` floors. Today every floor is below its pin, so nothing drifts — but the moment a pyproject floor is raised ABOVE a requirements pin, the editable install silently upgrades past the pin and NOTHING — no test, no CI step — catches it. And `anthropic[bedrock]`'s extra still pulls boto3/botocore unpinned (botocore releases ~daily) — the "exact pins / deterministic" banner is true for the LLM-SDK chain and NOT for the floors+extras.

**The fix (base commit):** the cheap deterministic guard the issue asks for (the pip `--dry-run` variant needs network and is not a unit test): `test_issue428_floors_vs_pins.py` parses both files and asserts every shared package's pyproject floor <= its requirements pin. Per the repo's own rule — a test that cannot fail is not coverage — the guard is also proven to FIRE on a synthetic drifted pair. The Go install comments + test banner now state the boundary of "deterministic" honestly.

**The wave-r1 round (sonnet, both fixed):**
- SILENT COVERAGE LOSS: a future compound specifier (`httpx>=0.24,<1`) made the package VANISH from floors/pins with the guard green — zero protection, no error. The coverage guard now fails LOUDLY on any spec (pyproject via tomllib, requirements rows) the parsers cannot consume;
- the drift message now states the per-package truth: an `==PIN` row means pip install -e would silently upgrade past the CI pin; a `>=FLOOR` row (PyYAML, requests, the tree-sitter grammars — floors copied into requirements, no CI pin exists) means the FLOOR itself was raised above what requirements allows — a debugging engineer no longer chases the wrong root cause for those ten rows.

**Evidence:** 4 tests (the guard on the real files passes today — nothing drifts, and the fires-on-drift test is the non-vacuous proof; the coverage guard; the parser pins); the full suite green (1 known macOS artifact); the Go python package ok (the install comments are behavior-neutral); ruff clean; gofmt clean; hermeticity green.

Fixes #428