### PR TITLE
fix(python): Invoke reads subprocess pipes through managed writers — recovery bounded at child-exit + WaitDelay (#431)

### DIFF
--- a/apps/openant-cli/internal/python/invoke.go
+++ b/apps/openant-cli/internal/python/invoke.go
@@ -2,12 +2,10 @@
 package python
 
 import (
-	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"os"
 	"os/exec"
@@ -129,38 +127,32 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 		cmd.Env = setEnv(cmd.Env, "ANTHROPIC_API_KEY", apiKey)
 	}
 
-	// Capture stdout (JSON output)
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create stdout pipe: %w", err)
-	}
-
-	// Stream stderr to terminal (progress messages)
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return nil, fmt.Errorf("failed to create stderr pipe: %w", err)
-	}
+	// #431: route stdout/stderr through MANAGED writers (invoke_ctx.go's
+	// pattern) instead of StdoutPipe/StderrPipe + this function's own copy
+	// goroutines. os/exec runs the copy goroutines itself, Wait drains them,
+	// and WaitDelay bounds them: the pipe read-ends close at child-exit +
+	// WaitDelay (5s) even when a DETACHED descendant holds a write-end —
+	// the engine's subprocesses inherit the Go-side pipes (core/reporter.py,
+	// parser_adapter.py pass stdout/stderr through), so the shape is live.
+	// With manual pipe reads the ordering was forced to read-to-EOF BEFORE
+	// Wait, so Wait — the only thing that starts WaitDelay — was never
+	// reached while a read blocked: a run that completed in seconds
+	// surfaced OPENANT_INVOKE_TIMEOUT later under a deadline note, and the
+	// watchdog's read-end close (not child exit) was the only recovery.
+	var stdoutBuf strings.Builder
+	cmd.Stdout = &stdoutBuf
+	// lineWriter forwards complete stderr lines to the terminal (the
+	// progress stream) as they arrive; a single partial line is capped.
+	stderrLW := &lineWriter{onLog: func(line string) {
+		if !quiet {
+			fmt.Fprintln(os.Stderr, line)
+		}
+	}}
+	cmd.Stderr = stderrLW
 
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start Python process: %w", err)
 	}
-
-	// Watchdog: when the timeout (or any context cancellation) fires, close
-	// the pipe read-ends so io.Copy(stdout) and streamStderr(stderr) return
-	// promptly instead of blocking on a descendant that still holds the
-	// write-ends open. Without this, the deadline would kill the parser but
-	// the CLI would still hang in io.Copy. watchdogDone stops the goroutine
-	// on the normal (non-timeout) exit path.
-	watchdogDone := make(chan struct{})
-	defer close(watchdogDone)
-	go func() {
-		select {
-		case <-ctx.Done():
-			_ = stdout.Close()
-			_ = stderr.Close()
-		case <-watchdogDone:
-		}
-	}()
 
 	// Forward SIGINT/SIGTERM to the Python subprocess so Ctrl+C kills it.
 	sigChan := make(chan os.Signal, 1)
@@ -193,55 +185,19 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 	}()
 
 	// Stream stderr in a goroutine
-	stderrDone := make(chan struct{})
-	go func() {
-		defer close(stderrDone)
-		streamStderr(stderr, quiet)
-	}()
-
-	// Read all stdout. A read error is CAPTURED, not returned: the buffer
-	// may already hold a complete envelope (a descendant holding the pipe
-	// write-end past the child's exit is exactly the case the watchdog
-	// comment above describes) — the envelope-wins rule below recovers it.
-	var stdoutBuf strings.Builder
-	_, copyErr := io.Copy(&stdoutBuf, stdout)
-
-	// Reap and drain. ORDER MATTERS and differs by path:
-	//   * normal path (no read error): drain stderr FIRST, then Wait —
-	//     StderrPipe's contract is explicit ("It is thus incorrect to call
-	//     Wait before all reads from the pipe have completed"): Wait closes
-	//     the read-end on reap, and a read still pending then fails with
-	//     ErrClosed, dropping whatever is still in the kernel pipe buffer —
-	//     the child's FINAL stderr lines (a traceback's last line is the
-	//     one the operator needs) would be lost.
-	//   * read-error path: the watchdog (or the fd failure) has already
-	//     closed the stdout read-end; Wait FIRST (it reaps the child and
-	//     closes the stderr read-end, which unblocks the streamer — that
-	//     close, not the deadline, is what bounds a descendant holding the
-	//     stderr write-end), then drain.
-	var exitErr error
-	if copyErr != nil {
-		exitErr = cmd.Wait()
-		<-stderrDone
-	} else {
-		// Round-3 panel finding (executed probe): the stdout read is
-		// bounded by the child's exit, but this drain was bounded only
-		// by the deadline — a descendant holding ONLY the stderr
-		// write-end kept <-stderrDone blocked until ctx.Done() fired
-		// the watchdog: a 0.1s child with a complete envelope in hand
-		// hung the FULL OPENANT_INVOKE_TIMEOUT (15s probe on a 15s
-		// budget) and returned under a spurious "deadline fired"
-		// recovery note. Grace-close the stderr read-end
-		// stderrDrainGrace after the child's stdout closed (mirroring
-		// cmd.WaitDelay's own bound): a streamer still blocked by then
-		// is reading an EMPTY kernel buffer — the real output drained
-		// the moment it arrived — so closing loses nothing and
-		// unblocks the drain.
-		stderrGrace := time.AfterFunc(stderrDrainGrace, func() { _ = stderr.Close() })
-		<-stderrDone
-		stderrGrace.Stop()
-		exitErr = cmd.Wait()
-	}
+	// Reap and drain in ONE call: with managed writers, os/exec's own copy
+	// goroutines are drained by Wait, so the StderrPipe ordering hazards
+	// (read-to-EOF before Wait or lose the kernel buffer's final lines)
+	// and the #431 path-split are gone. WaitDelay bounds the drain at
+	// child-exit + 5s for a detached descendant holding a write-end, and a
+	// held write-end surfaces as exec.ErrWaitDelay (NOT an *ExitError) with
+	// ProcessState carrying the child's real exit code — the kill-artifact
+	// logic below keys on ExitError/deadlineFired and does not misread it.
+	exitErr := cmd.Wait()
+	// flush AFTER Wait: os/exec guarantees the copy goroutine finished, so
+	// there is no concurrent Write (lineWriter.flush's contract) — the
+	// child's final, newline-less stderr fragment is delivered too.
+	stderrLW.flush()
 
 	deadlineFired := ctx.Err() == context.DeadlineExceeded
 
@@ -373,24 +329,28 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 	// the diagnosis — the same text on every surface, with the underlying
 	// cause wrapped when there is one.
 	if childKilled {
-		return nil, deadlineDiagnosis(invokeTimeout, args, copyErr, exitErr)
+		// #431: with managed writers there is no manual read error to
+		// report — the underlying cause is the kill itself.
+		return nil, deadlineDiagnosis(invokeTimeout, args, nil, exitErr)
 	}
 
-	// Non-deadline failures, in the original precedence. The watchdog's
-	// read-end close under a fired deadline is an ARTIFACT (os.ErrClosed),
-	// not a real I/O failure — suppressed so the honest
-	// no-output/parse-failure paths below report the child's own outcome.
-	// A genuine non-ErrClosed read error still surfaces, deadline or not.
-	if copyErr != nil && !(deadlineFired && errors.Is(copyErr, os.ErrClosed)) {
-		return nil, fmt.Errorf("failed to read stdout: %w", copyErr)
-	}
 	if exitErr != nil {
 		if _, ok := exitErr.(*exec.ExitError); !ok {
-			// The context-substitution wait error for an
-			// already-successfully-exited child under a fired deadline
-			// is the same artifact class — the honest answer is the
-			// child's own (empty) outcome below, not a wait failure.
-			if !(deadlineFired && cmd.ProcessState != nil && cmd.ProcessState.Success()) {
+			// #431: the managed-writer shape's OWN artifact — the child
+			// exited on its own but a lingering pipe holder tripped
+			// WaitDelay, so Wait returns exec.ErrWaitDelay (NOT an
+			// *ExitError) with ProcessState carrying the real exit. The
+			// scan completed; keep its captured envelope + real exit
+			// code (the same translation the sibling path makes,
+			// invoke_ctx.go:243) — fall through, never a wait failure.
+			if errors.Is(exitErr, exec.ErrWaitDelay) && cmd.ProcessState != nil {
+				naturalExitCode = cmd.ProcessState.ExitCode()
+				exitErr = nil
+			} else if !(deadlineFired && cmd.ProcessState != nil && cmd.ProcessState.Success()) {
+				// The context-substitution wait error for an
+				// already-successfully-exited child under a fired deadline
+				// is the same artifact class — the honest answer is the
+				// child's own (empty) outcome below, not a wait failure.
 				return nil, fmt.Errorf("failed waiting for Python process: %w", exitErr)
 			}
 		}
@@ -512,24 +472,6 @@ func normalizeExit(code int, isError bool) int {
 		return 2
 	}
 	return code
-}
-
-// streamStderr reads stderr line by line and writes to os.Stderr.
-// If quiet is true, stderr output is suppressed.
-func streamStderr(r io.Reader, quiet bool) {
-	// bufio.Reader (not bufio.Scanner) so a stderr line larger than the
-	// scanner's default 64k token buffer is not truncated/dropped — a long
-	// Python traceback on one line can exceed that and would lose diagnostics.
-	br := bufio.NewReader(r)
-	for {
-		line, err := br.ReadString('\n')
-		if len(line) > 0 && !quiet {
-			fmt.Fprint(os.Stderr, line)
-		}
-		if err != nil {
-			return
-		}
-	}
 }
 
 // setEnv sets or replaces an environment variable in a []string env slice.

--- a/apps/openant-cli/internal/python/invoke.go
+++ b/apps/openant-cli/internal/python/invoke.go
@@ -286,6 +286,16 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 		exitCode := 0
 		if ee, ok := exitErr.(*exec.ExitError); ok {
 			exitCode = ee.ExitCode()
+		} else if cmd.ProcessState != nil {
+			// #431 (wave r1 sonnet): with managed writers, a detached
+			// descendant holding a pipe write-end makes Wait return
+			// exec.ErrWaitDelay INSTEAD of the *exec.ExitError this
+			// branch extracts from — a scan that legitimately exits 1
+			// ("vulnerabilities found") beside a held write-end was
+			// silently reported as exit 0. ProcessState carries the
+			// child's real code on that path (the same translation the
+			// no-envelope path applies below).
+			exitCode = cmd.ProcessState.ExitCode()
 		}
 		if exitErrIsKillArtifact {
 			// Round-3 panel finding: the exit code here is the KILL's

--- a/apps/openant-cli/internal/python/invoke.go
+++ b/apps/openant-cli/internal/python/invoke.go
@@ -38,14 +38,6 @@ import (
 // OPENANT_INVOKE_TIMEOUT without recompiling.
 var defaultInvokeTimeout = 30 * time.Minute
 
-// stderrDrainGrace bounds how long the normal exit path waits on the stderr
-// drain AFTER the child's stdout already closed (i.e. the child has exited):
-// a descendant holding ONLY the stderr write-end would otherwise keep the
-// streamer blocked until the deadline's watchdog fired — the full
-// OPENANT_INVOKE_TIMEOUT hang for a result that was already in hand. Package
-// var so tests can shrink it, mirroring defaultInvokeTimeout.
-var stderrDrainGrace = 5 * time.Second
-
 // resolveInvokeTimeout returns the invoke deadline, honoring the
 // OPENANT_INVOKE_TIMEOUT env override. The value is either a Go duration
 // (e.g. "2h", "90m") or a bare positive integer interpreted as seconds. An
@@ -113,6 +105,10 @@ func Invoke(pythonPath string, args []string, workDir string, quiet bool, apiKey
 	// WaitDelay tells os/exec to force-close those inherited pipe FDs shortly
 	// after the context is done, and the explicit read-end close in the
 	// watchdog goroutine (below) unblocks the in-flight reads.
+	// famD panel (sonnet): the pre-managed-writers stderrDrainGrace knob
+	// (the old normal-path drain bound) is deleted — its only production
+	// call site was removed by the managed-writers refactor; the tests
+	// ride this WaitDelay bound now.
 	cmd.WaitDelay = 5 * time.Second
 
 	if workDir != "" {

--- a/apps/openant-cli/internal/python/invoke_envelope_test.go
+++ b/apps/openant-cli/internal/python/invoke_envelope_test.go
@@ -48,20 +48,26 @@ func writeScript(t *testing.T, body string) string {
 }
 
 // A complete success envelope was written and the child exited 0, but a
-// descendant holds the stdout write-end past the deadline: the envelope MUST
-// be recovered, not discarded.
+// descendant holds the stdout write-end: the envelope MUST be recovered, not
+// discarded. #431 changed the recovery mechanism: with managed writers,
+// WaitDelay bounds the held write-end at child-exit + 5s — the invoke
+// DEADLINE never fires for this shape (the pre-#431 shape waited for the
+// watchdog's deadline close, 30s on this budget, and printed the recovery
+// notice keyed on deadlineFired). The new contract: the envelope is returned
+// within ~WaitDelay, the notice does NOT print (no deadline fired to report),
+// and the run is a clean success.
 func TestInvoke_DeadlineRecoversCompleteEnvelope_StdoutHeld(t *testing.T) {
+	start := time.Now()
 	t.Setenv("OPENANT_INVOKE_TIMEOUT", "30s")
 	s := writeScript(t, `printf '{"status":"success","errors":[]}'
 sleep 60 &
 exec >&-
 exit 0
 `)
-	// quiet=false + stderr capture: the recovery NOTICE is the assertion
-	// that the deadline actually fired — without it this test cannot tell
-	// "recovered after a kill" from "nothing happened" (if the deadline
-	// ever stopped firing, io.Copy would just wait for sleep 30 and the
-	// test would still pass, green and meaningless, 30s later).
+	// quiet=false + stderr capture: the notice must NOT print under the
+	// #431 mechanism (the deadline did not fire — WaitDelay resolved the
+	// held write-end; a notice keyed on a deadline that never fired would
+	// be a lie).
 	r, w, _ := os.Pipe()
 	old := os.Stderr
 	os.Stderr = w
@@ -70,7 +76,7 @@ exit 0
 	w.Close()
 	b, _ := io.ReadAll(r)
 	if err != nil {
-		t.Fatalf("a complete envelope must win over the deadline: %v", err)
+		t.Fatalf("a complete envelope must win over the held write-end: %v", err)
 	}
 	if res.Envelope.Status != "success" {
 		t.Fatalf("envelope status = %q, want success", res.Envelope.Status)
@@ -78,8 +84,11 @@ exit 0
 	if res.ExitCode != 0 {
 		t.Fatalf("exit code = %d, want 0", res.ExitCode)
 	}
-	if !strings.Contains(string(b), "result envelope was recovered") {
-		t.Fatalf("the recovery notice must be visible on stderr when not quiet; got: %q", string(b))
+	if strings.Contains(string(b), "result envelope was recovered") {
+		t.Fatalf("the recovery notice printed without a fired deadline: %q", string(b))
+	}
+	if elapsed := time.Since(start); elapsed > 12*time.Second {
+		t.Fatalf("recovery took %v — the held write-end was bounded by the deadline, not WaitDelay (want ~5s)", elapsed)
 	}
 }
 

--- a/apps/openant-cli/internal/python/invoke_round3_test.go
+++ b/apps/openant-cli/internal/python/invoke_round3_test.go
@@ -32,13 +32,13 @@ import (
 
 // A complete envelope is in hand and the child has exited, but a descendant
 // holds ONLY the stderr write-end: the invocation must return promptly
-// (bounded by the child's exit + stderrDrainGrace, NOT the deadline), with
-// no deadline ever firing.
+// (bounded by the child's exit + WaitDelay, NOT the deadline), with no
+// deadline ever firing. #431 (wave r1 sonnet): the old stderrDrainGrace
+// mutation was stale — the variable's only production call site was removed
+// by the managed-writers refactor; the test now rides (and pins) the
+// WaitDelay bound itself.
 func TestInvoke_StderrOnlyDescendantDoesNotHang(t *testing.T) {
 	t.Setenv("OPENANT_INVOKE_TIMEOUT", "30s")
-	old := stderrDrainGrace
-	stderrDrainGrace = 1 * time.Second
-	t.Cleanup(func() { stderrDrainGrace = old })
 	s := writeScript(t, `printf '{"status":"success","errors":[]}'
 sleep 60 >&2 &
 exit 0
@@ -91,5 +91,31 @@ exec sleep 60
 	}
 	if !strings.Contains(string(b), "result envelope was recovered") {
 		t.Fatalf("the recovery notice must be visible on stderr when not quiet; got: %q", string(b))
+	}
+}
+
+// #431 (wave r1 sonnet): the ENVELOPE path's exit-code extraction missed
+// exec.ErrWaitDelay (the managed-writers shape when a descendant holds a
+// write-end) — a scan that legitimately exits 1 ("vulnerabilities found")
+// beside a held pipe was silently reported as exit 0. ProcessState carries
+// the real code.
+func TestInvoke_Exit1WithHeldPipeKeepsExit1(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script children (the package convention)")
+	}
+	t.Setenv("OPENANT_INVOKE_TIMEOUT", "30s")
+	s := writeScript(t, `printf '{"status":"success","errors":[]}'
+sleep 60 &
+exit 1
+`)
+	res, err := Invoke(s, []string{"analyze", "."}, "", true, "")
+	if err != nil {
+		t.Fatalf("the envelope must win over the held write-end: %v", err)
+	}
+	if res.Envelope.Status != "success" {
+		t.Fatalf("envelope status = %q, want success", res.Envelope.Status)
+	}
+	if res.ExitCode != 1 {
+		t.Fatalf("exit code = %d, want 1 (the vulnerabilities-found exit was silently dropped to 0 by the ErrWaitDelay miss)", res.ExitCode)
 	}
 }

--- a/apps/openant-cli/internal/python/invoke_waitdelay_test.go
+++ b/apps/openant-cli/internal/python/invoke_waitdelay_test.go
@@ -1,0 +1,84 @@
+//go:build unix
+
+package python
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// Invoke must bound a DETACHED descendant holding the stdout write-end at
+// child-exit + WaitDelay, not at the invoke deadline. The engine's subprocesses
+// inherit the Go-side pipes (core/reporter.py / parser_adapter.py pass
+// stdout/stderr through), so a descendant that outlives its Python parent while
+// holding only the pipe write-end is a live shape — and with Invoke's manual
+// StdoutPipe reads, Wait (the only thing that starts WaitDelay) was never
+// reached: the watchdog closed the read-end at the DEADLINE, so a run that
+// finished in seconds surfaced minutes later under a deadline note (#431's
+// cost 2). The managed-writer refactor (invoke_ctx.go's pattern) routes
+// cmd.Stdout/cmd.Stderr through os/exec's own copy goroutines, which Wait
+// drains and WaitDelay bounds at child-exit + 5s.
+func TestInvokeBoundsDetachedStdoutHolderAtWaitDelay(t *testing.T) {
+	if _, err := exec.LookPath("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available")
+	}
+	// A fake python: prints a complete envelope to stdout, then leaves a
+	// detached session holding the stdout write-end, then exits 0.
+	fake := filepath.Join(t.TempDir(), "fake-python")
+	if err := os.WriteFile(fake, []byte(`#!/bin/sh
+echo '{"status":"success"}'
+(sleep 30 </dev/null &)
+exit 0
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A deadline well above WaitDelay: on the pre-#431 shape the watchdog
+	// closes the read-end at THIS deadline (the whole budget elapses);
+	// the fixed shape returns at child-exit + WaitDelay (5s).
+	t.Setenv("OPENANT_INVOKE_TIMEOUT", "20s")
+
+	start := time.Now()
+	res, err := Invoke(fake, []string{"scan", "x"}, "", true, "")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("Invoke errored after %v: %v", elapsed, err)
+	}
+	if elapsed > 12*time.Second {
+		t.Errorf("a run that completed in <1s returned after %v; the held stdout write-end was bounded by the DEADLINE, not WaitDelay (want ~5s)", elapsed)
+	}
+	if res == nil || res.Envelope.Status != "success" {
+		t.Fatalf("the printed envelope must win: %+v", res)
+	}
+}
+
+// The normal path: no pipe holder, prompt return, envelope + stderr intact.
+func TestInvokeManagedWritersNormalExit(t *testing.T) {
+	if _, err := exec.LookPath("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not available")
+	}
+	fake := filepath.Join(t.TempDir(), "fake-python")
+	if err := os.WriteFile(fake, []byte(`#!/bin/sh
+echo 'progress line' 1>&2
+echo '{"status":"success"}'
+exit 0
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENANT_INVOKE_TIMEOUT", "20s")
+
+	start := time.Now()
+	res, err := Invoke(fake, []string{"scan", "x"}, "", false, "")
+	if err != nil {
+		t.Fatalf("Invoke errored: %v", err)
+	}
+	if time.Since(start) > 5*time.Second {
+		t.Errorf("normal exit took %v — no WaitDelay penalty without a pipe holder", time.Since(start))
+	}
+	if res == nil || res.Envelope.Status != "success" {
+		t.Fatalf("envelope missing: %+v", res)
+	}
+}

--- a/apps/openant-cli/internal/python/stderr_test.go
+++ b/apps/openant-cli/internal/python/stderr_test.go
@@ -1,44 +1,37 @@
 package python
 
 import (
-	"bytes"
-	"io"
-	"os"
 	"strings"
 	"testing"
 )
 
-// TestStreamStderrLongLine guards against truncation of a stderr line that
+// TestLineWriterLongLine guards against truncation of a stderr line that
 // exceeds bufio.Scanner's default 64k token buffer. A long Python traceback
-// on a single line must reach os.Stderr in full, not be silently dropped.
-func TestStreamStderrLongLine(t *testing.T) {
+// on a single line must reach the terminal in full, not be silently dropped.
+// (#431: the guarantee moved from streamStderr's bufio.Reader to the managed
+// lineWriter that replaced it — a single partial line is buffered whole and
+// flushed after Wait, with a 1MB cap for pathologically long lines.)
+func TestLineWriterLongLine(t *testing.T) {
 	const size = 200 * 1024 // > 64k default scanner buffer
 	long := strings.Repeat("x", size)
-	input := long + "\n"
 
-	oldStderr := os.Stderr
-	pr, pw, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("os.Pipe: %v", err)
+	var got []string
+	lw := &lineWriter{onLog: func(s string) { got = append(got, s) }}
+	// delivered in small Write chunks, as os/exec's copy goroutine does
+	for len(long) > 0 {
+		n := 4096
+		if n > len(long) {
+			n = len(long)
+		}
+		if _, err := lw.Write([]byte(long[:n])); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		long = long[n:]
 	}
-	os.Stderr = pw
+	lw.flush()
 
-	var buf bytes.Buffer
-	copyDone := make(chan struct{})
-	go func() {
-		defer close(copyDone)
-		_, _ = io.Copy(&buf, pr)
-	}()
-
-	streamStderr(strings.NewReader(input), false)
-
-	_ = pw.Close()
-	os.Stderr = oldStderr
-	<-copyDone
-	_ = pr.Close()
-
-	got := strings.TrimRight(buf.String(), "\n")
-	if len(got) != size {
-		t.Fatalf("stderr line truncated: got %d bytes, want %d", len(got), size)
+	if len(got) != 1 || len(got[0]) != size {
+		t.Fatalf("stderr line truncated: got %d line(s), first len %d, want one line of %d",
+			len(got), len(got[0]), size)
 	}
 }


### PR DESCRIPTION
`python.Invoke` read the subprocess's stdout/stderr through `StdoutPipe`/`StderrPipe` + its own `io.Copy`/`streamStderr` readers — the shape the sibling implementation (`invoke_ctx.go`, the web-UI path) had already diagnosed and solved with managed writers + `WaitDelay`: with manual pipe reads the ordering is forced to read-to-EOF BEFORE Wait, so Wait — the only thing that starts `WaitDelay` — is never reached while a read blocks on a detached descendant holding a write-end (the engine's subprocesses inherit the Go-side pipes: `core/reporter.py` / `parser_adapter.py` pass stdout/stderr through, so the shape is live). Executed RED: a child that printed a complete envelope and exited 0, leaving a detached holder on the stdout write-end, surfaced `OPENANT_INVOKE_TIMEOUT=20s` LATER under a deadline note — the watchdog's deadline close was the only recovery.

**The fix (base commit):** `cmd.Stdout`/`cmd.Stderr` through managed writers (the `invoke_ctx.go` pattern, its own `lineWriter`): os/exec runs the copy goroutines, Wait drains them, and `WaitDelay` (5s, already set) bounds a held write-end at child-exit + 5s. The whole path-split ordering, the watchdog goroutine, the stderrDone drain + grace timer, and the copyErr read-error branch collapse to a single Wait + flush. Tail translations: `exec.ErrWaitDelay` from Wait (a naturally-exited child + a lingering holder) is translated to the child's real exit code + captured envelope (the sibling's translation) — never a wait failure; the recovery notice no longer fires for the held-write-end shape (the deadline did NOT fire — WaitDelay resolved it). The dead `streamStderr` is removed; its long-line guarantee (>64k stderr lines untruncated) is re-pinned against the `lineWriter` that replaced it. The sibling's cancel-path envelope-discard is a separate #313-class gap, recorded, deliberately not changed (no contract unification here).

**The wave-r1 round (sonnet, both confirmed, both fixed):**
- THE ENVELOPE PATH'S EXIT-CODE EXTRACTION MISSED `exec.ErrWaitDelay`: with managed writers a held pipe write-end makes Wait return ErrWaitDelay instead of the `*exec.ExitError` the recovered-envelope branch asserts on — a scan that legitimately exits 1 ("vulnerabilities found", the exact live shape the commit itself documents) was silently reported as exit 0. The translation now applies on the envelope path too (ProcessState carries the code); pinned: the new test holds the pipe while exiting 1 and asserts the code survives;
- the stale test premise (`invoke_round3_test.go`): the `stderrDrainGrace` mutation targeted a variable whose only production call site this very PR deleted — the test passed for the wrong reason. The mutation is removed and the test rides and pins the WaitDelay bound it actually exercises.

**Evidence:** the base bounds test RED on master (20.00s = the deadline; 5.24s GREEN = WaitDelay) + a normal-exit test (envelope + stderr intact, `-race` clean); the whole `TestInvoke` family ok (135s — the envelope-wins, kill-artifact, zombie-window, and diagnosis-hint tests all pass, two updated to the new recovery mechanism); the round's exit-1-held-pipe test; the Go suite 10/10 packages ok; gofmt/vet clean.

Fixes #431