### PR TITLE
fix(dynamic-test): _summary.json's error_breakdown is derived from the unit files (#432)

### DIFF
--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -606,7 +606,13 @@ class StepCheckpoint:
             # Dynamic-test-style: top-level status == "ERROR"
             elif data.get("status") == "ERROR":
                 is_error = True
-                err_type = "test_error"
+                # famD panel (opus): status()'s dynamic-test arm now buckets
+                # by the SAME #432 failure-stage vocabulary the summary
+                # derivation uses (generation/build/timeout/execution/other)
+                # — the old flat "test_error" reintroduced the #311
+                # summary-vs-status drift this PR exists to close.
+                from utilities.dynamic_tester import _error_category
+                err_type = _error_category(data.get("details"))
 
             # #286/#293: a top-level "error" key (the verify adapter-raise
             # marker) beats every other classification — an errored verify

--- a/libs/openant-core/tests/test_issue311_dynamic_test_counters.py
+++ b/libs/openant-core/tests/test_issue311_dynamic_test_counters.py
@@ -49,7 +49,9 @@ def test_generation_failure_counts_as_error():
     counts = _summary_counts_from_checkpoints({
         "f1": _cp("ERROR", details="Test generation failed — LLM did not return valid test code"),
     })
-    assert counts == {"completed": 0, "errors": 1}
+    # #432 added error_breakdown (derived in the same pass — the categories
+    # are pinned in test_issue432_error_breakdown).
+    assert counts == {"completed": 0, "errors": 1, "error_breakdown": {"generation": 1}}
 
 
 def test_mixed_statuses_disjoint():
@@ -58,12 +60,14 @@ def test_mixed_statuses_disjoint():
         "f2": _cp("ERROR"),
         "f3": _cp("INCONCLUSIVE"),
     })
-    assert counts == {"completed": 2, "errors": 1}
+    assert counts["completed"] == 2 and counts["errors"] == 1
 
 
 def test_empty_and_absent():
-    assert _summary_counts_from_checkpoints({}) == {"completed": 0, "errors": 0}
-    assert _summary_counts_from_checkpoints(None) == {"completed": 0, "errors": 0}
+    counts = _summary_counts_from_checkpoints({})
+    assert counts["completed"] == 0 and counts["errors"] == 0
+    counts = _summary_counts_from_checkpoints(None)
+    assert counts["completed"] == 0 and counts["errors"] == 0
 
 
 def test_summary_json_consistent_with_unit_files(tmp_path, monkeypatch):

--- a/libs/openant-core/tests/test_issue432_error_breakdown.py
+++ b/libs/openant-core/tests/test_issue432_error_breakdown.py
@@ -133,3 +133,30 @@ def test_real_timeout_rows_reach_the_breakdown():
     assert counts["completed"] == 1
     assert counts["errors"] == 1
     assert counts["error_breakdown"] == {"timeout": 1, "build": 1}
+
+
+def test_status_uses_the_same_breakdown_vocabulary():
+    """famD panel (opus): StepCheckpoint.status()'s dynamic-test arm buckets
+    ERROR rows with the SAME #432 stage vocabulary as the summary derivation
+    (generation/build/execution/other) — not a flat 'test_error' that
+    reintroduces the #311 summary-vs-status drift."""
+    import json as _json
+    import tempfile, os
+    from core.checkpoint import StepCheckpoint
+
+    with tempfile.TemporaryDirectory() as d:
+        for name, details in [
+            ("V1", "Test generation raised: filtered"),
+            ("V2", "Docker build failed: no manifest"),
+            ("V3", "Container did not produce valid JSON output"),
+            ("V4", "mystery"),
+        ]:
+            (open(os.path.join(d, f"{name}.json"), "w")).write(_json.dumps(
+                {"id": name, "status": "ERROR", "details": details}))
+        st = StepCheckpoint.status(d)
+        bd = st["error_breakdown"]
+        assert bd.get("generation") == 1, bd
+        assert bd.get("build") == 1, bd
+        assert bd.get("execution") == 1, bd
+        assert bd.get("other") == 1, bd
+        assert "test_error" not in bd, bd

--- a/libs/openant-core/tests/test_issue432_error_breakdown.py
+++ b/libs/openant-core/tests/test_issue432_error_breakdown.py
@@ -117,3 +117,19 @@ def test_derivation_empty_states():
     assert counts["error_breakdown"] == {}
     counts = _summary_counts_from_checkpoints(None)
     assert counts["error_breakdown"] == {}
+
+
+def test_real_timeout_rows_reach_the_breakdown():
+    """Wave r1 (sonnet): the collector writes "Container execution timed out"
+    with status INCONCLUSIVE, never ERROR — the timeout bucket was DEAD CODE
+    (the old test fabricated a status/details combo production never
+    produces). A real timed-out row counts in the timeout bucket WITHOUT
+    inflating `errors` (the #311 disjoint semantics hold)."""
+    cps = {
+        "u1": {"status": "INCONCLUSIVE", "details": "Container execution timed out"},
+        "u2": {"status": "ERROR", "details": "Docker build failed: exit 1"},
+    }
+    counts = _summary_counts_from_checkpoints(cps)
+    assert counts["completed"] == 1
+    assert counts["errors"] == 1
+    assert counts["error_breakdown"] == {"timeout": 1, "build": 1}

--- a/libs/openant-core/tests/test_issue432_error_breakdown.py
+++ b/libs/openant-core/tests/test_issue432_error_breakdown.py
@@ -1,0 +1,119 @@
+"""#432: _summary.json's error_breakdown is derived from the unit files — self-sufficient for triage.
+
+Live-observed on master: a content-filtered model produced 5 errors with
+`error_breakdown: {}` — all four checkpoint.write_summary call sites in the
+dynamic-tester pass a hardcoded `{}`, though core/checkpoint.py supports the
+error_type -> count dict and the analyze pipeline populates one. The counts are
+correct post-#311, but a post-mortem must open all 5 unit files to learn they were
+all GENERATION failures (content filter) rather than Docker/execution failures.
+
+The fix extends _summary_counts_from_checkpoints (#311's derivation — the same
+source status() recomputes from) to also bucket ERROR unit files by category,
+derived from the details prefixes the collector writes: `Test generation ...` ->
+generation; `Docker build failed` -> build; `Container execution timed out` ->
+timeout; the remaining execution shapes (`Docker execution was not attempted`,
+`Container did not produce valid JSON output`) -> execution; anything else ->
+other. Threaded through all four call sites in place of the hardcoded {}.
+"""
+import json
+import sys
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+import utilities.dynamic_tester as dt  # noqa: E402
+from utilities.llm import PhaseBinding  # noqa: E402
+from utilities.dynamic_tester import _summary_counts_from_checkpoints  # noqa: E402
+
+
+class _NoopAdapter:
+    name = "anthropic"
+    supports_tools = True
+
+    def complete(self, **kwargs):  # pragma: no cover - mocked away
+        raise AssertionError("should not reach the adapter")
+
+    def validate(self, model):
+        pass
+
+
+def _run_generation_failures(tmp_path):
+    """Drive the real loop with a failing generator: two units, both ERROR at
+    the generation stage (the live-run class: a content-filtered model)."""
+    pipeline = tmp_path / "pipeline_output.json"
+    pipeline.write_text(json.dumps({
+        "repository": {"name": "t", "language": "python"},
+        "application_type": "unknown",
+        "findings": [
+            {"id": "f1", "name": "X", "short_name": "x", "location": "a.py:1",
+             "cwe_id": 79, "stage2_verdict": "confirmed",
+             "vulnerable_code": "eval(x)", "attack_vector": "a",
+             "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f"},
+            {"id": "f2", "name": "Y", "short_name": "y", "location": "b.py:1",
+             "cwe_id": 79, "stage2_verdict": "confirmed",
+             "vulnerable_code": "eval(y)", "attack_vector": "a",
+             "steps_to_reproduce": "s", "impact": "i", "suggested_fix": "f"},
+        ],
+    }))
+
+    class _FakeRegistry:
+        def get(self, phase):
+            return PhaseBinding(phase=phase, adapter=_NoopAdapter(),
+                                model="m", provider_name="anthropic")
+
+    orig = dt.generate_test
+    dt.generate_test = lambda *a, **k: None
+    try:
+        dt.run_dynamic_tests(
+            pipeline_output_path=str(pipeline),
+            output_dir=str(tmp_path / "out"),
+            checkpoint_path=str(tmp_path / "cp"),
+            registry=_FakeRegistry(),
+        )
+    finally:
+        dt.generate_test = orig
+    return json.loads((tmp_path / "cp" / "_summary.json").read_text())
+
+
+def test_summary_error_breakdown_buckets_generation_failures(tmp_path):
+    """The live-run shape: all errors at the generation stage must be
+    categorized — self-sufficient triage without opening unit files."""
+    summary = _run_generation_failures(tmp_path)
+    assert summary["errors"] == 2
+    breakdown = summary.get("error_breakdown")
+    assert breakdown == {"generation": 2}, (
+        f"error_breakdown = {breakdown} (the hardcoded {{}} — a post-mortem "
+        "must open every unit file to learn the stage)"
+    )
+
+
+def test_derivation_buckets_each_category():
+    """The category derivation, from the details prefixes the collector
+    writes (result_collector.py's vocabulary)."""
+    cps = {
+        "u1": {"status": "ERROR", "details": "Test generation failed — LLM did not return valid test code"},
+        "u2": {"status": "ERROR", "details": "Test generation raised ValueError: bad"},
+        "u3": {"status": "ERROR", "details": "Docker build failed: exit 1"},
+        "u4": {"status": "ERROR", "details": "Container execution timed out"},
+        "u5": {"status": "ERROR", "details": "Container did not produce valid JSON output. x"},
+        "u6": {"status": "ERROR", "details": "Docker execution was not attempted"},
+        "u7": {"status": "ERROR", "details": "something unprecedented"},
+        "u8": {"status": "ERROR"},
+        "ok": {"status": "CONFIRMED"},
+    }
+    counts = _summary_counts_from_checkpoints(cps)
+    assert counts["completed"] == 1
+    assert counts["errors"] == 8
+    assert counts["error_breakdown"] == {
+        "generation": 2, "build": 1, "timeout": 1,
+        "execution": 2, "other": 2,
+    }
+
+
+def test_derivation_empty_states():
+    counts = _summary_counts_from_checkpoints({})
+    assert counts["error_breakdown"] == {}
+    counts = _summary_counts_from_checkpoints(None)
+    assert counts["error_breakdown"] == {}

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -112,6 +112,13 @@ def _error_category(details) -> str:
     if d.startswith("Docker build failed"):
         return "build"
     if d.startswith("Container execution timed out"):
+        # famD panel (opus, documented-not-deleted): today the collector
+        # writes this details prefix with status INCONCLUSIVE (counted on
+        # the completed side by the wave-r1 timeout bucket, not as an
+        # error) — this branch is unreachable for the CURRENT collector.
+        # Kept as a defensive fallback: if a future collector ever writes
+        # an ERROR row with this prefix, it must bucket to timeout, not
+        # "other".
         return "timeout"
     if (d.startswith("Docker execution was not attempted")
             or d.startswith("Container did not produce valid JSON output")):

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -64,18 +64,49 @@ def _summary_counts_from_checkpoints(checkpointed) -> dict:
     source `status()` reads makes the two structurally incapable of
     drifting. The retry contract is unchanged: an ERROR checkpoint is
     still classified not-done and retried on resume.
+
+    #432: also derive error_breakdown — the error_type -> count dict the
+    summary schema supports and the analyze pipeline populates, which this
+    stage hardcoded to {} (a live content-filtered run produced 5 errors
+    with an EMPTY breakdown, forcing a post-mortem to open every unit file
+    to learn they were all generation failures). The category comes from
+    the details prefixes result_collector.py writes: `Test generation ...`
+    -> generation; `Docker build failed` -> build; `Container execution
+    timed out` -> timeout; the remaining execution shapes -> execution;
+    anything else (including absent details) -> other.
     """
     if not checkpointed:
-        return {"completed": 0, "errors": 1 if checkpointed is False else 0}
+        return {"completed": 0, "errors": 1 if checkpointed is False else 0,
+                "error_breakdown": {}}
     completed = errors = 0
+    breakdown: dict = {}
     for cp in checkpointed.values():
         if not isinstance(cp, dict):
             continue
         if cp.get("status") == "ERROR":
             errors += 1
+            cat = _error_category(cp.get("details"))
+            breakdown[cat] = breakdown.get(cat, 0) + 1
         else:
             completed += 1
-    return {"completed": completed, "errors": errors}
+    return {"completed": completed, "errors": errors, "error_breakdown": breakdown}
+
+
+def _error_category(details) -> str:
+    """Bucket an ERROR unit file by its failure stage (#432)."""
+    if not isinstance(details, str) or not details:
+        return "other"
+    d = details.strip()
+    if d.startswith("Test generation"):
+        return "generation"
+    if d.startswith("Docker build failed"):
+        return "build"
+    if d.startswith("Container execution timed out"):
+        return "timeout"
+    if (d.startswith("Docker execution was not attempted")
+            or d.startswith("Container did not produce valid JSON output")):
+        return "execution"
+    return "other"
 
 
 def run_dynamic_tests(
@@ -202,7 +233,7 @@ def run_dynamic_tests(
     _completed = _counts["completed"]
     _errors = _counts["errors"]
     checkpoint.ensure_dir()
-    checkpoint.write_summary(total, _completed, _errors, {}, phase="in_progress")
+    checkpoint.write_summary(total, _completed, _errors, _counts["error_breakdown"], phase="in_progress")
 
     print(f"Dynamic testing {total} findings from {repo_info['name']} "
           f"({restored} already done, {remaining} remaining)",
@@ -311,7 +342,7 @@ def run_dynamic_tests(
                 _counts = _summary_counts_from_checkpoints(checkpoint.load())
                 _completed = _counts["completed"]
                 _errors = _counts["errors"]
-                checkpoint.write_summary(total, _completed, _errors, {},
+                checkpoint.write_summary(total, _completed, _errors, _counts["error_breakdown"],
                                          phase="in_progress")
             continue
 
@@ -398,7 +429,7 @@ def run_dynamic_tests(
             _counts = _summary_counts_from_checkpoints(checkpoint.load())
             _completed = _counts["completed"]
             _errors = _counts["errors"]
-            checkpoint.write_summary(total, _completed, _errors, {}, phase="in_progress")
+            checkpoint.write_summary(total, _completed, _errors, _counts["error_breakdown"], phase="in_progress")
 
         print(f"  Result: {result.status} ({result.elapsed_seconds:.1f}s)",
               file=sys.stderr)
@@ -434,6 +465,6 @@ def run_dynamic_tests(
         # authoritative record, structurally identical to status().
         _counts = _summary_counts_from_checkpoints(checkpoint.load())
         checkpoint.write_summary(total, _counts["completed"],
-                                 _counts["errors"], {}, phase="done")
+                                 _counts["errors"], _counts["error_breakdown"], phase="done")
 
     return results

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -89,6 +89,16 @@ def _summary_counts_from_checkpoints(checkpointed) -> dict:
             breakdown[cat] = breakdown.get(cat, 0) + 1
         else:
             completed += 1
+            # wave r1 (sonnet): the collector writes "Container execution
+            # timed out" with status INCONCLUSIVE, never ERROR — the timeout
+            # bucket was dead code (real timeouts invisible in BOTH errors
+            # and the breakdown). A timed-out unit is a timeout for triage
+            # regardless of its terminal status: counted here WITHOUT
+            # inflating `errors` (it is not an error; the counts stay the
+            # #311 disjoint semantics).
+            det = cp.get("details")
+            if isinstance(det, str) and det.strip().startswith("Container execution timed out"):
+                breakdown["timeout"] = breakdown.get("timeout", 0) + 1
     return {"completed": completed, "errors": errors, "error_breakdown": breakdown}
 
 


### PR DESCRIPTION
Live-observed on master: a content-filtered model produced 5 errors with `error_breakdown: {}` — all four `checkpoint.write_summary` call sites in the dynamic-tester passed a hardcoded `{}`, though `core/checkpoint.py` supports the error_type -> count dict and the analyze pipeline populates one. The counts were correct post-#311, but a post-mortem had to open all 5 unit files to learn they were all GENERATION failures (content filter) rather than Docker/execution failures.

**The fix (base commit):** `_summary_counts_from_checkpoints` (#311's derivation — the same source `status()` recomputes from, so the two cannot drift) also buckets ERROR unit files by category, derived from the details prefixes `result_collector.py` writes: `Test generation ...` -> generation; `Docker build failed` -> build; `Container execution timed out` -> timeout; the remaining execution shapes -> execution; anything else -> other. Threaded through all four call sites in place of the hardcoded `{}` — the summary is now self-sufficient for triage.

**The wave-r1 round (sonnet, confirmed):** the "timeout" bucket was DEAD CODE — the collector writes "Container execution timed out" with status `INCONCLUSIVE`, never `ERROR`, so the category derivation never saw a real timeout row in production (the round-1 test fabricated a status/details combo production never produces; real timeouts were invisible in both `errors` and the breakdown). A timed-out unit is a timeout for triage regardless of its terminal status: the INCONCLUSIVE-with-timeout-details rows are counted in the timeout bucket WITHOUT inflating `errors` (the #311 disjoint semantics hold — completed/errors unchanged, the bucket is the triage signal).

**Evidence:** 4 tests (the real-shape test — an INCONCLUSIVE timeout row + an ERROR build row → breakdown {timeout: 1, build: 1} with completed=1/errors=1; the generation-failure driven run; the category derivation over the collector vocabulary; the empty states); the dynamic-tester families 9/0 together; the full suite green (1 known macOS artifact); ruff clean.

Fixes #432