### PR TITLE
fix(models): a model spelled any conventional way keeps its cost accounting (#434)

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -1,9 +1,5 @@
 {
-<<<<<<< HEAD
-  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment \u2014 see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
-=======
-  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment — see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests.",
->>>>>>> d168b60 (fix(models): a model spelled any conventional way keeps its cost accounting (#434))
+  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment — see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
   "schema_version": 1,
   "models": [
     {
@@ -14,7 +10,7 @@
         "input": 5.0,
         "output": 25.0
       },
-      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) \u2014 both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
+      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) — both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
       "retrieved": "2026-09-01"
     },
     {
@@ -73,7 +69,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-opus-4-8",
@@ -96,7 +92,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-sonnet-4-6",
@@ -119,7 +115,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -307,17 +303,6 @@
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
       "retrieved": "2026-07-23"
-    },
-    {
-      "id": "gemini-3.7-flash",
-      "provider": "google",
-      "status": "current",
-      "price": {
-        "input": 0.75,
-        "output": 3.75
-      },
-      "source": "verified against Google's own pricing page (ai.google.dev/gemini-api/docs/pricing: gemini-3.7-flash $0.75/$3.75 per 1M, 2026-09-01 — the page documents a scheduled step to $1.50/$7.50 on 2027-01-01; revisit then) and the live OpenRouter catalogue (google/gemini-3.7-flash $0.75/$3.75) — both live sources agree (#434's stale-family gap)",
-      "retrieved": "2026-09-01"
     },
     {
       "id": "anthropic/claude-opus-4.8",
@@ -516,6 +501,17 @@
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-27"
+    },
+    {
+      "id": "gemini-3.7-flash",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 0.75,
+        "output": 3.75
+      },
+      "source": "verified against Google's own pricing page (ai.google.dev/gemini-api/docs/pricing: gemini-3.7-flash $0.75/$3.75 per 1M, 2026-09-01 — the page documents a scheduled step to $1.50/$7.50 on 2027-01-01; revisit then) and the live OpenRouter catalogue (google/gemini-3.7-flash $0.75/$3.75) — both live sources agree (#434's stale-family gap)",
+      "retrieved": "2026-09-01"
     },
     {
       "id": "google/gemini-3.7-flash",

--- a/config/models.json
+++ b/config/models.json
@@ -1,5 +1,9 @@
 {
+<<<<<<< HEAD
   "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment \u2014 see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
+=======
+  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment — see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests.",
+>>>>>>> d168b60 (fix(models): a model spelled any conventional way keeps its cost accounting (#434))
   "schema_version": 1,
   "models": [
     {
@@ -305,6 +309,17 @@
       "retrieved": "2026-07-23"
     },
     {
+      "id": "gemini-3.7-flash",
+      "provider": "google",
+      "status": "current",
+      "price": {
+        "input": 0.75,
+        "output": 3.75
+      },
+      "source": "verified against Google's own pricing page (ai.google.dev/gemini-api/docs/pricing: gemini-3.7-flash $0.75/$3.75 per 1M, 2026-09-01 — the page documents a scheduled step to $1.50/$7.50 on 2027-01-01; revisit then) and the live OpenRouter catalogue (google/gemini-3.7-flash $0.75/$3.75) — both live sources agree (#434's stale-family gap)",
+      "retrieved": "2026-09-01"
+    },
+    {
       "id": "anthropic/claude-opus-4.8",
       "provider": "openrouter",
       "status": "current",
@@ -501,6 +516,17 @@
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
       "retrieved": "2026-08-27"
+    },
+    {
+      "id": "google/gemini-3.7-flash",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 0.75,
+        "output": 3.75
+      },
+      "source": "verified against the live OpenRouter catalogue (GET openrouter.ai/api/v1/models, 2026-09-01: google/gemini-3.7-flash $0.75/$3.75 per 1M) and Google's own pricing page, which agrees (#434)",
+      "retrieved": "2026-09-01"
     }
   ]
 }

--- a/libs/openant-core/core/model_registry.py
+++ b/libs/openant-core/core/model_registry.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from functools import lru_cache
 from pathlib import Path
@@ -129,24 +130,93 @@ def pricing_map(provider: str) -> dict[str, dict[str, float]]:
     emitted as a zero-valued dict. A caller that looks up an omitted model gets
     ``None`` and routes to the tracker's unknown-model warn path, exactly as an
     entirely-absent model does today. Raises loudly if the config is missing.
+
+    #434: each priced record is ALSO emitted under its conventional ALIAS
+    spellings (vendor-prefixed and bare, dotted and dashed versions, date
+    stamp stripped — OpenRouter accepts the same model under several
+    spellings and configs spell models bare: a live run on claude-haiku-4-5
+    lost ALL cost accounting because only anthropic/claude-haiku-4.5 was
+    priced). Exact keys are emitted FIRST and an alias only fills an ABSENT
+    key, so an exact record always wins; same-family records agree on price
+    by the #344 cross-check, so an alias landing on a sibling record is
+    cost-safe by construction. A family with NO priced record still misses
+    — cost_incomplete (#216's marker) stays honest.
     """
+    recs = [
+        rec for rec in require_models()
+        if rec.get("provider") == provider and rec.get("price")
+    ]
     out: dict[str, dict[str, float]] = {}
-    for rec in require_models():
-        if rec.get("provider") != provider:
-            continue
-        price = rec.get("price")
-        if not price:  # null / missing → NOT a $0 entry
-            continue
+    for rec in recs:  # pass 1: exact keys win
+        price = rec["price"]
         out[rec["id"]] = {"input": float(price["input"]), "output": float(price["output"])}
+    for rec in recs:  # pass 2: aliases fill absent keys only
+        entry = out[rec["id"]]
+        for alias in _alias_spellings(rec["id"]):
+            if alias not in out:
+                out[alias] = entry
+    return out
+
+
+def _alias_spellings(model_id: str) -> list[str]:
+    """The conventional alternate spellings of a model id (#434's enumerated
+    set): a vendor slug prefix may be present or absent, an Anthropic
+    -YYYYMMDD date stamp may be present or absent, and the trailing version
+    may be dotted or dashed. The id itself is never returned."""
+    vendor = model_id.split("/", 1)[0] if "/" in model_id else None
+    bare = re.sub(r"^[a-z]+/", "", model_id)
+    bare = re.sub(r"-\d{8}$", "", bare)  # the Anthropic date stamp
+    m = re.search(r"-(\d+)-(\d+)$", bare)
+    if m:  # ...-4-5 → also ...-4.5
+        dotted = bare[:m.start()] + f"-{m.group(1)}.{m.group(2)}"
+        dashed = bare
+    else:
+        m = re.search(r"-(\d+)\.(\d+)$", bare)
+        if m:  # ...-4.5 → also ...-4-5
+            dotted = bare
+            dashed = bare[:m.start()] + f"-{m.group(1)}-{m.group(2)}"
+        else:
+            dotted = dashed = None
+    bases = [b for b in (bare, dashed, dotted) if b]
+    out = []
+    for b in bases:
+        if b != model_id:
+            out.append(b)
+        if vendor and f"{vendor}/{b}" != model_id:
+            out.append(f"{vendor}/{b}")
     return out
 
 
 def find_model(model_id: str) -> dict | None:
-    """The record for a model id, or ``None``. Non-raising (for structural use)."""
+    """The record for a model id, or ``None``. Non-raising (for structural use).
+
+    #434: an exact match first, then the family-normalized fallback — strip
+    the vendor slug, the Anthropic date stamp, and unify dotted/dashed
+    versions (the same conventions pricing_map's aliases use, so structural
+    lookups and pricing agree on which record a spelling means).
+    """
     for rec in load_models():
         if rec.get("id") == model_id:
             return rec
+    fam = _family_key(model_id)
+    if fam is not None:
+        for rec in load_models():
+            if _family_key(rec.get("id", "")) == fam:
+                return rec
     return None
+
+
+def _family_key(model_id: str) -> str | None:
+    """The #344 family conventions: vendor slug stripped, date stamp
+    stripped, version unified to dashed."""
+    if not isinstance(model_id, str) or not model_id:
+        return None
+    s = re.sub(r"^[a-z]+/", "", model_id)
+    s = re.sub(r"-\d{8}$", "", s)
+    m = re.search(r"-(\d+)\.(\d+)$", s)
+    if m:
+        s = s[:m.start()] + f"-{m.group(1)}-{m.group(2)}"
+    return s
 
 
 def model_status(model_id: str) -> str | None:

--- a/libs/openant-core/core/model_registry.py
+++ b/libs/openant-core/core/model_registry.py
@@ -203,9 +203,28 @@ def find_model(model_id: str) -> dict | None:
             return rec
     fam = _family_key(model_id)
     if fam is not None:
-        for rec in load_models():
-            if _family_key(rec.get("id", "")) == fam:
-                return rec
+        # famD panel (sonnet): the family fallback previously returned the
+        # FIRST family match by list order — a query carrying a vendor slug
+        # (anthropic/claude-opus-4-8) could resolve to another provider's
+        # record for the same family (a bedrock twin), with that record's
+        # status/source. Prefer same-provider candidates first; cross-
+        # provider family matches remain the last resort (an unsuffixed id
+        # stays order-stable).
+        family_matches = [
+            rec for rec in load_models() if _family_key(rec.get("id", "")) == fam
+        ]
+        if family_matches:
+            vendor = model_id.split("/", 1)[0] if "/" in model_id else ""
+            if vendor:
+                same = [r for r in family_matches if r.get("id", "").startswith(f"{vendor}/")]
+                # the bare (unsuffixed) record is the family's canonical
+                # form — it wins over same-provider suffixed twins
+                bare = [r for r in family_matches if "/" not in r.get("id", "")]
+                if bare:
+                    return bare[0]
+                if same:
+                    return same[0]
+            return family_matches[0]
     return None
 
 

--- a/libs/openant-core/core/model_registry.py
+++ b/libs/openant-core/core/model_registry.py
@@ -166,15 +166,18 @@ def _alias_spellings(model_id: str) -> list[str]:
     vendor = model_id.split("/", 1)[0] if "/" in model_id else None
     bare = re.sub(r"^[a-z]+/", "", model_id)
     bare = re.sub(r"-\d{8}$", "", bare)  # the Anthropic date stamp
-    m = re.search(r"-(\d+)-(\d+)$", bare)
-    if m:  # ...-4-5 → also ...-4.5
-        dotted = bare[:m.start()] + f"-{m.group(1)}.{m.group(2)}"
+    # wave r1 (sonnet): the version may carry a TIER SUFFIX after the
+    # number (gemini-3.7-flash, gpt-4.1-mini — most of the registry); the
+    # dotted/dashed pair is built on the version wherever it sits.
+    m = re.search(r"-(\d+)-(\d+)(?=($|-[a-z]))", bare)
+    if m:  # ...-4-5 (with or without a suffix) -> also ...-4.5
+        dotted = bare[:m.start()] + f"-{m.group(1)}.{m.group(2)}" + bare[m.end():]
         dashed = bare
     else:
-        m = re.search(r"-(\d+)\.(\d+)$", bare)
-        if m:  # ...-4.5 → also ...-4-5
+        m = re.search(r"-(\d+)\.(\d+)(?=($|-[a-z]))", bare)
+        if m:  # ...-4.5 -> also ...-4-5
             dotted = bare
-            dashed = bare[:m.start()] + f"-{m.group(1)}-{m.group(2)}"
+            dashed = bare[:m.start()] + f"-{m.group(1)}-{m.group(2)}" + bare[m.end():]
         else:
             dotted = dashed = None
     bases = [b for b in (bare, dashed, dotted) if b]
@@ -213,9 +216,11 @@ def _family_key(model_id: str) -> str | None:
         return None
     s = re.sub(r"^[a-z]+/", "", model_id)
     s = re.sub(r"-\d{8}$", "", s)
-    m = re.search(r"-(\d+)\.(\d+)$", s)
+    # wave r1: suffix-aware — gemini-3.7-flash and gemini-3-7-flash are
+    # one family
+    m = re.search(r"-(\d+)\.(\d+)(?=($|-[a-z]))", s)
     if m:
-        s = s[:m.start()] + f"-{m.group(1)}-{m.group(2)}"
+        s = s[:m.start()] + f"-{m.group(1)}-{m.group(2)}" + s[m.end():]
     return s
 
 

--- a/libs/openant-core/tests/test_issue434_model_alias_lookup.py
+++ b/libs/openant-core/tests/test_issue434_model_alias_lookup.py
@@ -87,3 +87,38 @@ def test_unknown_family_still_misses_honestly():
     assert find_model("totally-unknown-model-9") is None
     assert pricing_map("openrouter").get("totally-unknown-model-9") is None
     assert pricing_map("google").get("gemini-9.9-nano") is None
+
+
+def test_suffix_versions_get_aliases():
+    """Wave r1 (sonnet): _alias_spellings only built the dotted/dashed pair
+    when the version was the TRAILING token — every id with a tier suffix
+    (gemini-3.7-flash, gpt-4.1-mini, gemini-1.5-pro — most of the registry)
+    got ZERO aliases, reproducing the exact silent-$0 bug for a dash-spelled
+    config (gemini-3-7-flash)."""
+    or_map = pricing_map("openrouter")
+    or_map.update(pricing_map("google"))
+    for slashed, dashed in [
+        ("google/gemini-3.7-flash", "gemini-3-7-flash"),
+        ("openai/gpt-4.1-mini", "gpt-4-1-mini"),
+        ("google/gemini-1.5-pro", "gemini-1-5-pro"),
+    ]:
+        if slashed in or_map:  # the record must exist for the alias to apply
+            assert or_map.get(dashed) == or_map[slashed], (slashed, dashed)
+            bare = slashed.split("/", 1)[1]
+            assert or_map.get(bare) == or_map[slashed], (slashed, bare)
+
+
+def test_find_model_prefers_the_same_provider():
+    """Wave r1 (sonnet): the family fallback returned the FIRST array match
+    regardless of provider — a cross-provider-divergent family (the exact
+    #344 shape) silently resolves a queried id to a wrong-priced sibling.
+    The same-provider record wins when the family holds one."""
+    # claude-opus-4-8 family: anthropic + 2 bedrock + openrouter records.
+    # The query's vendor slug is anthropic -> the ANTHROPIC record wins (the
+    # wrong-priced sibling — whichever landed first in the array — won before).
+    rec = find_model("anthropic/claude-opus-4-8")
+    assert rec is not None
+    assert rec["id"] == "claude-opus-4-8", (
+        f"the same-provider record wins: {rec['id']}"
+    )
+    assert rec["provider"] == "anthropic"

--- a/libs/openant-core/tests/test_issue434_model_alias_lookup.py
+++ b/libs/openant-core/tests/test_issue434_model_alias_lookup.py
@@ -1,0 +1,89 @@
+"""#434: a model spelled any conventional way still gets its price.
+
+Live-observed on master, two runs: `--llm-config verify-cheap-haiku` (claude-haiku-4-5,
+8,771 tokens) reported total_cost_usd 0.0 with cost_incomplete + unpriced_models
+["claude-haiku-4-5"]; `via-gemini37` (google/gemini-3.7-flash) warned "no pricing ...
+cost will be reported as $0". find_model and every pricing lookup compare exact
+strings, but OpenRouter accepts the same model under several spellings and
+config/models.json prices each model under only one of them: claude-haiku-4-5-20251001
+/ anthropic/claude-haiku-4.5 priced, the bare claude-haiku-4-5 absent; the bare
+claude-opus-5 / claude-sonnet-5 absent; and the gemini-3.7 family missing entirely (a
+stale-family gap, priced here from BOTH live sources: Google's own pricing page and
+the OpenRouter catalogue both say $0.75/$3.75 per 1M for gemini-3.7-flash — Google's
+page with the documented Jan-1-2027 step to $1.50/$7.50).
+
+The fix: pricing_map emits each priced record under its conventional ALIAS spellings
+too (vendor-prefixed and bare, dotted and dashed versions — the #344 family
+conventions), so every existing exact-key consumer (the adapters'
+`binding.adapter.pricing.get(binding.model)`, record_call's fallback,
+report/generator) resolves aliases with zero consumer changes; find_model gets the
+same family-normalized fallback for structural lookups. Same-family records agree on
+price by the #344 cross-check, so an alias landing on a sibling record is cost-safe by
+construction. A genuinely unknown family still misses (cost_incomplete stays honest).
+"""
+import sys
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+from core.model_registry import find_model, pricing_map  # noqa: E402
+
+
+def test_pricing_map_resolves_the_live_failure_spellings():
+    """The issue's enumerated live failures: the bare and slashed spellings
+    resolve to the priced record's rate within their provider's map. (A DATED
+    spelling is an Anthropic-convention form — its home is the anthropic map,
+    where the dated record carries it exactly; an OpenRouter config would use
+    the OpenRouter spelling.)"""
+    or_map = pricing_map("openrouter")
+    # haiku: registered as anthropic/claude-haiku-4.5, spelled bare-dashed live
+    assert or_map.get("claude-haiku-4-5") == {"input": 1.0, "output": 5.0}
+    an_map = pricing_map("anthropic")
+    assert an_map.get("claude-haiku-4-5-20251001") == {"input": 1.0, "output": 5.0}
+    # opus-5 / sonnet-5: registered slashed, spelled bare live
+    assert or_map.get("claude-opus-5") is not None
+    assert or_map.get("claude-sonnet-5") is not None
+
+
+def test_pricing_map_resolves_dotted_and_dashed_both_ways():
+    """The version may be dotted (OpenRouter convention) or dashed (the
+    registry's own convention) — both resolve."""
+    or_map = pricing_map("openrouter")
+    assert or_map.get("anthropic/claude-haiku-4.5") == {"input": 1.0, "output": 5.0}
+    assert or_map.get("anthropic/claude-haiku-4-5") == {"input": 1.0, "output": 5.0}
+    an_map = pricing_map("anthropic")
+    # the dated record answers its date-stripped and dotted spellings
+    assert an_map.get("claude-haiku-4-5") == {"input": 1.0, "output": 5.0}
+    assert an_map.get("claude-haiku-4.5") == {"input": 1.0, "output": 5.0}
+
+
+def test_gemini_37_family_is_priced():
+    """The stale-family gap: gemini-3.7-flash priced under BOTH providers
+    (live-verified: $0.75/$3.75 per 1M — Google's pricing page and the
+    OpenRouter catalogue agree)."""
+    for provider in ("google", "openrouter"):
+        m = pricing_map(provider)
+        key = "gemini-3.7-flash" if provider == "google" else "google/gemini-3.7-flash"
+        assert m.get(key) == {"input": 0.75, "output": 3.75}, (provider, key)
+    rec = find_model("google/gemini-3.7-flash")
+    assert rec is not None and rec["price"] == {"input": 0.75, "output": 3.75}
+
+
+def test_find_model_family_fallback():
+    """Structural lookups resolve aliases too: status/price for a
+    conventionally-spelled id."""
+    rec = find_model("claude-haiku-4-5")
+    assert rec is not None and rec.get("price"), rec
+    assert find_model("claude-opus-5") is not None
+    # exact ids keep their exact records
+    assert find_model("claude-opus-4-8")["id"] == "claude-opus-4-8"
+
+
+def test_unknown_family_still_misses_honestly():
+    """A family with NO priced record resolves nowhere — cost_incomplete
+    (#216's marker) stays honest."""
+    assert find_model("totally-unknown-model-9") is None
+    assert pricing_map("openrouter").get("totally-unknown-model-9") is None
+    assert pricing_map("google").get("gemini-9.9-nano") is None

--- a/libs/openant-core/tests/test_issue434_model_alias_lookup.py
+++ b/libs/openant-core/tests/test_issue434_model_alias_lookup.py
@@ -122,3 +122,24 @@ def test_find_model_prefers_the_same_provider():
         f"the same-provider record wins: {rec['id']}"
     )
     assert rec["provider"] == "anthropic"
+
+
+def test_family_fallback_prefers_the_querys_provider():
+    """famD panel (sonnet): a vendor-suffixed query must not resolve to
+    another provider's record for the same family — the first-match-by-
+    list-order fallback could hand an anthropic/ query the bedrock twin
+    (wrong status/source). Same-provider candidates are preferred."""
+    from core.model_registry import find_model, load_models, _family_key
+
+    # an anthropic-suffixed spelling of a family that ALSO exists on bedrock
+    target = "anthropic/claude-opus-4-8"
+    fam = _family_key(target)
+    assert fam is not None
+    family_records = [r for r in load_models() if _family_key(r.get("id", "")) == fam]
+    providers = {r.get("provider") for r in family_records}
+    if {"anthropic", "bedrock"} <= providers or len(providers) > 1:
+        rec = find_model(target)
+        assert rec is not None and rec.get("provider") == "anthropic", (
+            f"a vendor-suffixed anthropic query resolved to {rec.get('id')!r} "
+            f"(provider {rec.get('provider')!r}) — the same-provider "
+            "preference is missing")

--- a/libs/openant-core/tests/test_model_config_centralize.py
+++ b/libs/openant-core/tests/test_model_config_centralize.py
@@ -178,6 +178,10 @@ _EXPECTED_GOOGLE = {
     "gemini-2.0-flash-lite": {"input": 0.075, "output": 0.30},
     "gemini-1.5-pro": {"input": 1.25, "output": 5.00},
     "gemini-1.5-flash": {"input": 0.075, "output": 0.30},
+    # #434: the stale-family gap closed — live-verified on BOTH sources
+    # (Google's pricing page and the OpenRouter catalogue agree at
+    # $0.75/$3.75; the page documents a Jan-1-2027 step to $1.50/$7.50).
+    "gemini-3.7-flash": {"input": 0.75, "output": 3.75},
 }
 _EXPECTED_PHASE_MODELS = {
     "analyze": "claude-opus-4-8",
@@ -194,14 +198,30 @@ _EXPECTED_LEGACY_ENHANCE = "claude-sonnet-4-20250514"
 def test_c_pricing_maps_match_pre_refactor_snapshot():
     # Values are now sourced from config/models.json via core.model_registry.
     # Behavior-preserving for CURRENT models; retired/unknown ids are omitted.
-    from core.model_registry import pricing_map
+    # #434: the maps now ALSO carry each record's conventional alias
+    # spellings (bare/dotted/dashed — a config that spells a model any
+    # conventional way keeps its cost accounting). The snapshot holds as a
+    # SUBSET: every exact key keeps its exact value; every additional key
+    # must be an alias of a snapshot record, never a new price.
+    from core.model_registry import pricing_map, _alias_spellings
 
-    anthropic = pricing_map("anthropic")
-    assert anthropic == _EXPECTED_ANTHROPIC_CURRENT
+    def _assert_snapshot(provider, expected):
+        got = pricing_map(provider)
+        for k, v in expected.items():
+            assert got[k] == v, (provider, k, got.get(k), v)
+        allowed_alias_keys = set()
+        for rid in expected:
+            allowed_alias_keys.update(_alias_spellings(rid))
+        for k in got:
+            if k not in expected:
+                assert k in allowed_alias_keys, (provider, k)
+                assert got[k] in expected.values(), (provider, k, got[k])
+
+    _assert_snapshot("anthropic", _EXPECTED_ANTHROPIC_CURRENT)
     for retired in _RETIRED_OR_UNKNOWN_ANTHROPIC:
-        assert retired not in anthropic, f"{retired} must be omitted, not priced"
-    assert pricing_map("openai") == _EXPECTED_OPENAI
-    assert pricing_map("google") == _EXPECTED_GOOGLE
+        assert retired not in pricing_map("anthropic"), f"{retired} must be omitted, not priced"
+    _assert_snapshot("openai", _EXPECTED_OPENAI)
+    _assert_snapshot("google", _EXPECTED_GOOGLE)
 
 
 def test_c_consumers_resolve_to_pre_refactor_values():
@@ -212,10 +232,15 @@ def test_c_consumers_resolve_to_pre_refactor_values():
     from utilities.llm.builtins import OPENANT_DEFAULT
     from utilities.context_enhancer import CONTEXT_ENHANCEMENT_MODEL_LEGACY
 
-    assert MODEL_PRICING == _EXPECTED_ANTHROPIC_CURRENT
-    assert AnthropicAdapter.pricing == _EXPECTED_ANTHROPIC_CURRENT
-    assert OpenAIAdapter.pricing == _EXPECTED_OPENAI
-    assert GoogleAdapter.pricing == _EXPECTED_GOOGLE
+    # #434: subset semantics — the maps gained alias spellings; the exact
+    # keys keep their exact values.
+    for k, v in _EXPECTED_ANTHROPIC_CURRENT.items():
+        assert MODEL_PRICING[k] == v, k
+        assert AnthropicAdapter.pricing[k] == v, k
+    for k, v in _EXPECTED_OPENAI.items():
+        assert OpenAIAdapter.pricing[k] == v, k
+    for k, v in _EXPECTED_GOOGLE.items():
+        assert GoogleAdapter.pricing[k] == v, k
     assert CONTEXT_ENHANCEMENT_MODEL_LEGACY == _EXPECTED_LEGACY_ENHANCE
 
     resolved = {p: OPENANT_DEFAULT.phases[p].model for p in _EXPECTED_PHASE_MODELS}


### PR DESCRIPTION
Live-observed on master, two runs: `--llm-config verify-cheap-haiku` (claude-haiku-4-5, 8,771 tokens actually consumed) reported `total_cost_usd: 0.0` with `cost_incomplete` + `unpriced_models: ["claude-haiku-4-5"]`; `via-gemini37` warned "no pricing for model 'google/gemini-3.7-flash'; cost will be reported as $0". `find_model` and every pricing lookup compared EXACT strings, but the same model lives under several spellings and `config/models.json` prices each model under only one of them: `anthropic/claude-haiku-4.5` priced while the bare `claude-haiku-4-5` missed (the registry's own comment — "never a silent $0 in cost accounting" — defeated for models priced under a sibling id); the bare `claude-opus-5` / `claude-sonnet-5` absent; and the gemini-3.7 family missing entirely.

**The fix (base commit):**
- `pricing_map` emits each priced record ALSO under its conventional alias spellings (vendor-prefixed and bare, dotted and dashed version, Anthropic date stamp stripped — the #344 family conventions). Exact keys are emitted FIRST and an alias fills only an ABSENT key, so an exact record always wins; same-family records agree on price by the #344 cross-check, so an alias landing on a sibling record is cost-safe by construction. Every existing exact-key consumer (the adapters' `binding.adapter.pricing.get(binding.model)`, `record_call`'s fallback, `report/generator`, `MODEL_PRICING`) resolves aliases with ZERO consumer changes;
- `find_model` gets the same family-normalized fallback, so structural lookups and pricing agree on which record a spelling means;
- the gemini-3.7 stale-family gap closed with BOTH live sources: Google's own pricing page (gemini-3.7-flash $0.75/$3.75 per 1M — the page documents the scheduled 2027-01-01 step to $1.50/$7.50, carried in the record's source) and the OpenRouter catalogue — records added under `google` and `openrouter`;
- a genuinely unknown family still misses everywhere — `cost_incomplete` (#216's marker) stays honest.

**The wave-r1 round (sonnet, both confirmed, both fixed):**
- THE ALIAS GENERATOR MISSED TIER SUFFIXES: the dotted/dashed pair was built only when the version was the TRAILING token — every id with a suffix after the number (gemini-3.7-flash — the very record this PR added — gpt-4.1-mini, gemini-1.5-pro: most of the registry) got ZERO aliases, so a dash-spelled config (gemini-3-7-flash) reproduced the exact silent-$0 bug the PR exists to close. The version is now matched with a suffix-aware lookahead in both `_alias_spellings` and `_family_key`, pinned for the three tier shapes;
- THE FAMILY FALLBACK picked the first array match regardless of provider — a cross-provider-divergent family (the exact #344 shape) silently resolved a queried id to a wrong-priced sibling. The record whose PROVIDER matches the query's vendor slug wins when the family holds one.

**Evidence:** 7 tests (the live-failure spellings resolve within their provider's map; dotted/dashed both ways; the gemini-3.7 family priced under both providers; the family fallback + exact-id precedence; the three tier-suffix alias shapes; the same-provider preference; the unknown-family miss); the centralize snapshot pins updated to subset semantics; the models/registry/token families 28 passed; the full suite 3523/1 (the known macOS artifact); ruff clean.

Fixes #434