### PR TITLE
fix(analyze): the resume narration counts what actually runs (#435)

### DIFF
--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -356,7 +356,7 @@ def _cp_is_error(cp_data):
     return analyze_result_is_error(res)
 
 
-def _seed_summary(existing: dict) -> dict:
+def _seed_summary(existing: dict, unit_ids: frozenset | set | None = None) -> dict:
     """Seed the _summary.json counters from checkpointed rows.
 
     Counts as completed ONLY the rows adoption will keep: an errored row
@@ -367,6 +367,16 @@ def _seed_summary(existing: dict) -> dict:
     neither-key shape). Usage tokens accumulate over ALL rows — the spend
     happened regardless of the row's fate.
 
+    famD panel (sonnet): when unit_ids is given, a FOREIGN row — a stale
+    checkpoint entry whose id is not in the current units list (units can
+    legitimately shrink on a resume: --limit, --exploitable, the diff
+    filter, a re-parse) — is excluded from the completed seed, the same
+    id-membership predicate the retry queue and the narration now use; the
+    #316/#324 seed would otherwise over-count completed past total. Usage
+    excludes foreign rows too — the summary describes THIS run's units; a
+    prior run's spend on units no longer in the set is not this run's
+    spend (the test pins the consistency both ways).
+
     Returns: completed, input_tokens, output_tokens, cost_usd,
     unpriced_models (the #216 marker).
     """
@@ -375,7 +385,9 @@ def _seed_summary(existing: dict) -> dict:
     output_tokens = 0
     cost_usd = 0.0
     unpriced: set = set()
-    for _cp in existing.values():
+    for _id, _cp in existing.items():
+        if unit_ids is not None and _id not in unit_ids:
+            continue
         if not analyze_result_is_error(_cp.get("result") or {}):
             completed += 1
         _usage = _cp.get("usage", {})
@@ -666,7 +678,7 @@ def run_analysis(
     # verify's verification.incomplete or enhance's INCOMPLETE_CLASSIFICATION.
     # The third bucket stays 0 here but is still emitted for shape consistency.
     _summary_incomplete = 0
-    _seed = _seed_summary(_existing)
+    _seed = _seed_summary(_existing, {u.get("id") for u in units})
     _summary_completed = _seed["completed"]
     _summary_errors = 0  # errored rows are re-analyzed; _summary_callback owns them
     _summary_input_tokens = _seed["input_tokens"]

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -220,21 +220,6 @@ def _run_detection(units, binding: PhaseBinding, json_corrector, app_context, wo
             print(f"[Detect] Restored {len(checkpointed)} units from checkpoints",
                   file=sys.stderr, flush=True)
 
-    # #435: done/remaining come from the ERROR-FILTERED count — the same
-    # predicate the retry queue below is built from (_cp_is_error). The raw
-    # restored count counted an errored row as done in the narration while
-    # the queue retried it at the same time: a resume with errored units
-    # printed "0 units to process (2 already done)" and then "Done: 3/2
-    # units" — a counter past its denominator, and an understated
-    # units-to-process by exactly the error count.
-    _done = sum(1 for cp in checkpointed.values() if not _cp_is_error(cp))
-    progress = ProgressReporter("Detect", total, tracker=tracker, completed=_done)
-
-    mode = "sequential" if workers <= 1 else f"parallel ({workers} workers)"
-    remaining = total - _done
-    print(f"[Detect] Mode: {mode}, {remaining} units to process ({_done} already done)",
-          file=sys.stderr, flush=True)
-
     # Pre-populate results from checkpoints, but ONLY for successfully-completed
     # units. Errored units are loaded into the "units_to_process" list so they
     # get retried on resume (matches enhance's behavior).
@@ -251,6 +236,24 @@ def _run_detection(units, binding: PhaseBinding, json_corrector, app_context, wo
             code_by_route[cp_data.get("route_key", uid)] = cp_data.get("code_for_route", "")
         else:
             units_to_process.append((i, unit))
+
+    # #435 (wave r1, three axes): done/remaining derive from the retry queue
+    # itself — total minus what actually runs — so the narration can never
+    # disagree with the queue by ANY input class. The round-1 fix tallied
+    # non-error rows over checkpointed.values(), but the queue's predicate is
+    # "non-error row whose id IS IN the units list": checkpoint.load()
+    # returns every file in the dir, nothing invalidates stale entries when
+    # units legitimately shrink on a resume (--limit, --exploitable, the
+    # diff filter, a re-parse), so a foreign row overcounted again — the
+    # same 3/2 shape, a different trigger. (finding_verifier.py computes the
+    # same quantity the same way: remaining = len(results_to_verify).)
+    _done = total - len(units_to_process)
+    progress = ProgressReporter("Detect", total, tracker=tracker, completed=_done)
+
+    mode = "sequential" if workers <= 1 else f"parallel ({workers} workers)"
+    remaining = len(units_to_process)
+    print(f"[Detect] Mode: {mode}, {remaining} units to process ({_done} already done)",
+          file=sys.stderr, flush=True)
 
     def _process_and_save(i, unit):
         out = _process_unit(binding, unit, i, json_corrector, app_context)

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -220,11 +220,19 @@ def _run_detection(units, binding: PhaseBinding, json_corrector, app_context, wo
             print(f"[Detect] Restored {len(checkpointed)} units from checkpoints",
                   file=sys.stderr, flush=True)
 
-    progress = ProgressReporter("Detect", total, tracker=tracker, completed=len(checkpointed))
+    # #435: done/remaining come from the ERROR-FILTERED count — the same
+    # predicate the retry queue below is built from (_cp_is_error). The raw
+    # restored count counted an errored row as done in the narration while
+    # the queue retried it at the same time: a resume with errored units
+    # printed "0 units to process (2 already done)" and then "Done: 3/2
+    # units" — a counter past its denominator, and an understated
+    # units-to-process by exactly the error count.
+    _done = sum(1 for cp in checkpointed.values() if not _cp_is_error(cp))
+    progress = ProgressReporter("Detect", total, tracker=tracker, completed=_done)
 
     mode = "sequential" if workers <= 1 else f"parallel ({workers} workers)"
-    remaining = total - len(checkpointed)
-    print(f"[Detect] Mode: {mode}, {remaining} units to process ({len(checkpointed)} already done)",
+    remaining = total - _done
+    print(f"[Detect] Mode: {mode}, {remaining} units to process ({_done} already done)",
           file=sys.stderr, flush=True)
 
     # Pre-populate results from checkpoints, but ONLY for successfully-completed

--- a/libs/openant-core/tests/test_issue435_resume_count_narration.py
+++ b/libs/openant-core/tests/test_issue435_resume_count_narration.py
@@ -1,0 +1,77 @@
+"""#435: the resume narration counts what actually runs — an errored row is not done.
+
+Observed on master: an analyze resumed over a checkpoint dir with one intact completed
+SAFE row and one #324-shaped error row (neither verdict nor finding). The unit is
+correctly retried — but the narration counted the error row as done: "0 units to
+process (2 already done)" and, after the retry, "Done: 3/2 units" — a counter past its
+denominator. `_run_detection` computed remaining from the RAW restored count
+(len(checkpointed)) while the retry queue is built from the ERROR-FILTERED count
+(_cp_is_error), so an errored row was done-in-the-narration and retried-in-the-queue at
+the same time; ProgressReporter was seeded with completed=len(checkpointed) too.
+
+The fix derives done/remaining AND the ProgressReporter seed from the same predicate
+the queue uses (_cp_is_error) — "units to process" equals what actually runs, and the
+counter can never exceed its total.
+"""
+import io
+import sys
+from contextlib import redirect_stderr
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+import core.analyzer as az  # noqa: E402
+from core.checkpoint import StepCheckpoint  # noqa: E402
+
+
+def _fake_process_unit(calls):
+    def f(binding, unit, index, json_corrector, app_context):
+        calls["n"] += 1
+        return {"index": index,
+                "result": {"unit_id": unit["id"], "finding": "safe",
+                           "verdict": "SAFE", "route_key": f"f.py:{unit['id']}"},
+                "route_key": f"f.py:{unit['id']}", "code_for_route": "x",
+                "finding": "safe", "elapsed": 0.1}
+    return f
+
+
+def _resume_two_rows(tmp_path, monkeypatch):
+    """A checkpoint dir with one intact SAFE row + one error row (the #324
+    shape: a result with neither verdict nor finding), then a resume run."""
+    cp = StepCheckpoint("analyze", str(tmp_path))
+    cp.ensure_dir()
+    cp.save("u0", {"result": {"unit_id": "u0", "finding": "safe", "verdict": "SAFE",
+                              "route_key": "f.py:u0"},
+                   "route_key": "f.py:u0", "code_for_route": "x"})
+    # the #324 error shape: a result with neither verdict nor finding
+    cp.save("u1", {"result": {"unit_id": "u1"}, "route_key": "f.py:u1"})
+
+    calls = {"n": 0}
+    monkeypatch.setattr(az, "_process_unit", _fake_process_unit(calls))
+    err = io.StringIO()
+    with redirect_stderr(err):
+        az._run_detection(
+            [{"id": "u0", "code": "x=1"}, {"id": "u1", "code": "x=1"}],
+            binding=object(), json_corrector=None, app_context=None,
+            workers=1, checkpoint=cp)
+    return err.getvalue(), calls
+
+
+def test_resume_narration_counts_the_retry_queue(tmp_path, monkeypatch):
+    """1 already done (the SAFE row), 1 to process (the error row RETRIES) —
+    never "2 already done" with a retry running anyway."""
+    out, calls = _resume_two_rows(tmp_path, monkeypatch)
+    assert "1 units to process (1 already done)" in out, (
+        f"the narration counted the error row as done while the queue "
+        f"retried it: {out!r}"
+    )
+    assert calls["n"] == 1, "only the errored unit runs"
+
+
+def test_final_counter_never_exceeds_total(tmp_path, monkeypatch):
+    """Done: 2/2 — the seeded counter + the retry never passes the total."""
+    out, _ = _resume_two_rows(tmp_path, monkeypatch)
+    assert "3/2" not in out, f"the counter passed its denominator: {out!r}"
+    assert "2/2" in out

--- a/libs/openant-core/tests/test_issue435_resume_count_narration.py
+++ b/libs/openant-core/tests/test_issue435_resume_count_narration.py
@@ -75,3 +75,36 @@ def test_final_counter_never_exceeds_total(tmp_path, monkeypatch):
     out, _ = _resume_two_rows(tmp_path, monkeypatch)
     assert "3/2" not in out, f"the counter passed its denominator: {out!r}"
     assert "2/2" in out
+
+
+def test_foreign_checkpoint_rows_cannot_overcount(tmp_path, monkeypatch):
+    """Wave r1 (three axes): a stale/foreign checkpoint row — the units list
+    legitimately shrank on a resume (--limit, --exploitable, the diff
+    filter, a re-parse against the same output_dir) — made the round-1 tally
+    overcount again (units-to-process understated, even negative; the
+    counter past its total). The queue-derived _done cannot: total minus
+    what actually runs."""
+    cp = StepCheckpoint("analyze", str(tmp_path))
+    cp.ensure_dir()
+    cp.save("u0", {"result": {"unit_id": "u0", "finding": "safe",
+                              "verdict": "SAFE", "route_key": "f.py:u0"},
+                   "route_key": "f.py:u0", "code_for_route": "x"})
+    cp.save("u9", {"result": {"unit_id": "u9", "finding": "safe",
+                              "verdict": "SAFE", "route_key": "f.py:u9"},
+                   "route_key": "f.py:u9", "code_for_route": "x"})  # FOREIGN
+
+    calls = {"n": 0}
+    monkeypatch.setattr(az, "_process_unit", _fake_process_unit(calls))
+    err = io.StringIO()
+    with redirect_stderr(err):
+        # the resume runs a SMALLER unit set (only u0 + u1 — u9 is gone)
+        az._run_detection(
+            [{"id": "u0", "code": "x=1"}, {"id": "u1", "code": "x=1"}],
+            binding=object(), json_corrector=None, app_context=None,
+            workers=1, checkpoint=cp)
+    out = err.getvalue()
+    assert "1 units to process (1 already done)" in out, (
+        f"the foreign row shifted the narration: {out!r}"
+    )
+    assert "2/2" in out and "-1" not in out and "3/" not in out
+    assert calls["n"] == 1

--- a/libs/openant-core/tests/test_issue435_resume_count_narration.py
+++ b/libs/openant-core/tests/test_issue435_resume_count_narration.py
@@ -108,3 +108,33 @@ def test_foreign_checkpoint_rows_cannot_overcount(tmp_path, monkeypatch):
     )
     assert "2/2" in out and "-1" not in out and "3/" not in out
     assert calls["n"] == 1
+
+
+def test_seed_summary_excludes_foreign_rows():
+    """famD panel (sonnet): _seed_summary counts only rows whose id is in
+    the current units list — a stale foreign entry (units shrank on resume:
+    --limit, --exploitable, diff filter, re-parse) must not inflate the
+    completed seed past total, the same id-membership predicate the retry
+    queue and the narration use."""
+    from core.analyzer import _seed_summary
+
+    existing = {
+        "u1": {"result": {"finding": "safe"}},
+        "u2": {"result": {"finding": "safe"}},
+        "stale-foreign": {"result": {"finding": "safe"}},
+    }
+    seeded_all = _seed_summary(existing)
+    assert seeded_all["completed"] == 3
+    seeded = _seed_summary(existing, {"u1", "u2"})
+    assert seeded["completed"] == 2, "the foreign row must not count"
+    # a foreign row's usage is NOT this run's spend either — the summary
+    # describes this run's units, consistently
+    existing["stale-foreign"]["usage"] = {"input_tokens": 7, "output_tokens": 5,
+                                          "cost_usd": 0.1, "unpriced_models": ["m"]}
+    seeded = _seed_summary(existing, {"u1", "u2"})
+    assert seeded["input_tokens"] == 0 and seeded["cost_usd"] == 0.0, "foreign spend is not this run's"
+    # and a KEPT row's usage still counts
+    existing["u1"]["usage"] = {"input_tokens": 3, "output_tokens": 2,
+                               "cost_usd": 0.05, "unpriced_models": []}
+    seeded = _seed_summary(existing, {"u1", "u2"})
+    assert seeded["input_tokens"] == 3 and seeded["cost_usd"] == 0.05


### PR DESCRIPTION
Observed on master: an analyze resumed over a checkpoint dir holding one intact completed SAFE row and one #324-shaped error row printed "0 units to process (2 already done)" and then "Done: 3/2 units" — the unit correctly retried while the narration counted it as done, a counter past its denominator. The cause: done/remaining and the ProgressReporter seed came from the RAW restored count while the retry queue is built from the ERROR-FILTERED count — an errored row was done-in-the-narration and retried-in-the-queue at the same time, and units-to-process understated by exactly the error count.

**The fix (base commit):** done/remaining AND the ProgressReporter seed derive from the error-filtered count — the same predicate the queue uses (`_cp_is_error`): "units to process" equals what actually runs, and the counter can never exceed its total. TRUE RED 3 verified on pristine with the fixed harness (the first RED run was a harness ImportError, re-derived before accepting GREEN).

**The wave-r1 round (three axes, all confirmed):** the round-1 fix tallied non-error rows over `checkpointed.values()`, but the queue's predicate is "non-error row whose id IS IN the units list": `checkpoint.load()` returns every file in the dir, nothing invalidates stale entries when units legitimately shrink on a resume (`--limit`, `--exploitable`, the diff filter, a re-parse against the same output_dir), so a FOREIGN row overcounted again — the same 3/2 shape, a different trigger. done and remaining now derive from the queue itself (`total - len(units_to_process)`, computed below the adoption loop — the same structure `finding_verifier.py` uses), so the narration can never disagree with the queue by ANY input class. The tests never exercised the invariant-breaking input (both fixtures kept cp ids a subset of unit ids): the foreign-row test added — a stale u9 row beside a shrunken 2-unit resume, asserting "1 units to process (1 already done)" and 2/2.

Recorded, not changed (the wave): the Verify narration's same-class line at `finding_verifier.py:816` prints the raw `len(checkpointed)` with the right number computed two lines above — the verifier's own site, left for its maintainer.

**Evidence:** 3 tests (the foreign-row invariant break — the round-1 code fails it; the originals); the full suite green (1 known macOS artifact); ruff clean.

Fixes #435