### PR TITLE
fix(parsers/python): the base walk follows imports and the C3 order (#440)

### DIFF
--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -884,6 +884,12 @@ class CallGraphBuilder:
                 stem = f2[:-len('.py')].replace('/', '.')
                 if mod and (stem == mod or stem.endswith('.' + mod)):
                     return f2
+            # #440 (wave r1 sonnet): the import EXISTS but no candidate file
+            # matches its module path (an external attribute-style base, an
+            # aliased import whose origin is outside the repo) — ABSTAIN.
+            # Falling through to the unambiguous-name fallback fabricated an
+            # edge to an unrelated same-named LOCAL class.
+            return None
         if len(set(cand_files)) == 1:
             return cand_files[0]
         return None
@@ -902,6 +908,9 @@ class CallGraphBuilder:
         if _memo is None:
             _memo, _stack = {}, set()
         key = f"{file}:{name}"
+        if key not in self.classes and "." in name:
+            # a dotted (nested) name keyed unqualified in the index
+            key = f"{file}:{name.split('.')[-1]}"
         memo_key = (key, use_union)
         if memo_key in _memo:
             return _memo[memo_key]
@@ -916,11 +925,29 @@ class CallGraphBuilder:
             bs = b.split('.')[-1]
             bf = self._base_defining_file(file, bs)
             if bf is not None:
-                base_chains.append(self._base_chain(bf, bs, _memo, _stack))
+                # #440 (wave r1, three axes): use_union PROPAGATES — the
+                # round-1 recursion defaulted it back to True, so the typed
+                # path's anti-hijack guard (own bases, not the merged union)
+                # only held at depth 0.
+                base_chains.append(self._base_chain(bf, bs, _memo, _stack,
+                                                    use_union=use_union))
         head = [(file, name)]
-        seqs = [list(c) for c in base_chains]
+        # #440 (wave r1 sonnet): the canonical C3 merge carries the BASE
+        # LIST's own order as a final sequence, so an inconsistent hierarchy
+        # (a base appearing after a class that inherits it) is DETECTED and
+        # takes the FIFO fallback instead of silently reordering.
+        head_order = [
+            (self._base_defining_file(file, b.split('.')[-1]),
+             b.split('.')[-1])
+            for b in bases
+        ]
+        seqs = [list(c) for c in base_chains] + [
+            [n for n in head_order if n[0] is not None]]
         merged = []
         while seqs:
+            seqs = [s for s in seqs if s]   # empty seqs (unresolvable bases) drop out
+            if not seqs:
+                break
             for seq in seqs:
                 candidate = seq[0]
                 if not any(candidate in s[1:] for s in seqs if s):
@@ -942,11 +969,21 @@ class CallGraphBuilder:
 
     def _mro_first_definer(self, caller_file: str, class_name: str,
                            method_name: str, include_own: bool) -> Optional[str]:
-        """The first class in the C3 chain (own class first) defining the method."""
-        chain = self._base_chain(caller_file, class_name.split('.')[-1],
+        """The first class in the C3 chain (own class first) defining the method.
+
+        #440 (wave r1, opus+fable): the class name is NOT stripped here —
+        the extractor keys nested classes with their dotted qualifier
+        (methods_by_class['app.py:Outer.Inner']), and the round-1 entry
+        split('.')[-1] turned every nested class into a key that exists
+        nowhere, dropping the class's OWN self-dispatch and every inherited
+        self-call inside it (pydantic Config, nested exception/helper
+        classes — the exact FN direction this PR removes). Only the BASE
+        names inside _base_chain are simple.
+        """
+        chain = self._base_chain(caller_file, class_name,
                                  use_union=include_own)
         start = 0
-        if not include_own and chain and chain[0] == (caller_file, class_name.split('.')[-1]):
+        if not include_own and chain and chain[0] == (caller_file, class_name):
             start = 1
         for f, n in chain[start:]:
             method_id = self._method_in_class(f"{f}:{n}", method_name)

--- a/libs/openant-core/parsers/python/call_graph_builder.py
+++ b/libs/openant-core/parsers/python/call_graph_builder.py
@@ -850,41 +850,120 @@ class CallGraphBuilder:
 
         return None
 
-    def _resolve_self_call(self, method_name: str, caller_file: str, caller_class: str) -> Optional[str]:
-        """Resolve a self.method() call within a class or its (same-file) bases.
+    # #440: the base-chain walk — import-aware and C3-ordered. Shared by
+    # _resolve_self_call and the typed-receiver path (both were FIFO over
+    # same-file bases only). Two fixes:
+    #   1. IMPORTED IN-REPO BASES: a base module + subclass elsewhere is the
+    #      most common real layout, and the same-file anchor never resolved
+    #      it — the walk now follows the import map the resolver already
+    #      holds (plus the cross-file unambiguous match). External bases
+    #      (no import entry, no repo class) stay unresolved — never a
+    #      fabricated edge.
+    #   2. THE C3 ORDER: a diamond (`C(A, B)`, `A(X)`, `X.m` and `B.m`) made
+    #      the FIFO pick B.m while Python runs X.m — X.m kept an empty
+    #      caller set and was pruned (the FN direction #318 was filed to
+    #      remove). The walk now computes the C3 linearization over the
+    #      extractor's base lists (FIFO fallback when a merge fails —
+    #      inconsistent hierarchies still resolve).
+    def _base_defining_file(self, file: str, base_simple: str) -> Optional[str]:
+        """The file a base class of a class in ``file`` is defined in.
 
-        Walks the class first, then its base classes transitively (breadth-first,
-        cycle-guarded), so a method inherited from a base resolves. Base lookup
-        is restricted to classes defined in the caller's own file -- external
-        base classes aren't in our index, so they're left unresolved rather than
-        mis-linked.
-        """
-        seen: Set[str] = set()
-        queue: List[str] = [caller_class]
-        while queue:
-            class_name = queue.pop(0)
-            if class_name in seen:
-                continue
-            seen.add(class_name)
-
-            class_key = f"{caller_file}:{class_name}"
-            for func_id in self.methods_by_class.get(class_key, []):
-                func_data = self.functions.get(func_id, {})
-                if func_data.get('name') == method_name:
-                    return func_id
-
-            class_data = self.classes.get(class_key, {})
-            # #318 (deep-refute): the self/super walks read the UNION
-            # (``all_bases``) — a function-local namesake's merged file-scope
-            # ``bases`` is the module side's, but its OWN methods' self/super
-            # dispatch still follows the local declaration's chain.
-            for base in class_data.get('all_bases', class_data.get('bases', [])):
-                # Only same-file base names are resolvable via our index.
-                base_name = base.split('.')[-1]
-                if base_name not in seen:
-                    queue.append(base_name)
-
+        Same-file first, then the import map (``self.imports[file]``), then a
+        cross-file UNAMBIGUOUS simple-name match (step 3's shape). None =
+        external/unknown — abstain."""
+        if f"{file}:{base_simple}" in self.classes:
+            return file
+        cand_files = [k.rsplit(':', 1)[0] for k, v in self.classes.items()
+                      if v.get('name') == base_simple]
+        if not cand_files:
+            return None
+        imported = self.imports.get(file, {}).get(base_simple)
+        if imported:
+            mod = imported.rsplit('.', 1)[0] if '.' in imported else None
+            for f2 in cand_files:
+                stem = f2[:-len('.py')].replace('/', '.')
+                if mod and (stem == mod or stem.endswith('.' + mod)):
+                    return f2
+        if len(set(cand_files)) == 1:
+            return cand_files[0]
         return None
+
+    def _base_chain(self, file: str, name: str, _memo=None, _stack=None,
+                    use_union: bool = True) -> List[Tuple[str, str]]:
+        """The (file, simple_name) C3 linearization of a class's base graph.
+
+        ``use_union``: the self/super walks read ``all_bases`` (#318: a
+        function-local namesake's merged file-scope bases is the module
+        side's, but its OWN methods' dispatch follows the local chain);
+        the TYPED path from OUTSIDE reads the entry's OWN ``bases`` — the
+        union would let a function-local declaration's base hijack a
+        module-level namesake (the #318 wave-r3 finding, preserved here).
+        """
+        if _memo is None:
+            _memo, _stack = {}, set()
+        key = f"{file}:{name}"
+        memo_key = (key, use_union)
+        if memo_key in _memo:
+            return _memo[memo_key]
+        if key in _stack:  # a malformed cycle: tolerate, the node alone
+            return [(file, name)]
+        _stack = _stack | {key}
+        class_data = self.classes.get(key, {})
+        bases = (class_data.get('all_bases', class_data.get('bases', []))
+                 if use_union else class_data.get('bases', []))
+        base_chains = []
+        for b in bases:
+            bs = b.split('.')[-1]
+            bf = self._base_defining_file(file, bs)
+            if bf is not None:
+                base_chains.append(self._base_chain(bf, bs, _memo, _stack))
+        head = [(file, name)]
+        seqs = [list(c) for c in base_chains]
+        merged = []
+        while seqs:
+            for seq in seqs:
+                candidate = seq[0]
+                if not any(candidate in s[1:] for s in seqs if s):
+                    merged.append(candidate)
+                    for s in seqs:
+                        if s and s[0] == candidate:
+                            del s[0]
+                    seqs = [s for s in seqs if s]
+                    break
+            else:  # an inconsistent hierarchy: the FIFO fallback
+                for s in seqs:
+                    for c in s:
+                        if c not in merged:
+                            merged.append(c)
+                break
+        chain = head + [c for c in merged if c not in head]
+        _memo[memo_key] = chain
+        return chain
+
+    def _mro_first_definer(self, caller_file: str, class_name: str,
+                           method_name: str, include_own: bool) -> Optional[str]:
+        """The first class in the C3 chain (own class first) defining the method."""
+        chain = self._base_chain(caller_file, class_name.split('.')[-1],
+                                 use_union=include_own)
+        start = 0
+        if not include_own and chain and chain[0] == (caller_file, class_name.split('.')[-1]):
+            start = 1
+        for f, n in chain[start:]:
+            method_id = self._method_in_class(f"{f}:{n}", method_name)
+            if method_id:
+                return method_id
+        return None
+
+    def _resolve_self_call(self, method_name: str, caller_file: str, caller_class: str) -> Optional[str]:
+        """Resolve a self.method() call within a class or its bases.
+
+        #440: the walk is the unified import-aware C3 chain (see
+        _base_chain) — the caller's own class first, then bases in C3
+        order, following in-repo imports; external bases stay unresolved
+        rather than mis-linked.
+        """
+        return self._mro_first_definer(caller_file, caller_class, method_name,
+                                       include_own=True)
 
     def _resolve_super_call(self, method_name: str, caller_file: str, caller_class: str) -> Optional[str]:
         """Resolve a ``super().method(...)`` call to the inherited parent method.
@@ -933,30 +1012,23 @@ class CallGraphBuilder:
 
     def _same_file_base_walk(self, class_name: str, method_name: str,
                              caller_file: str) -> Optional[str]:
-        """#318: walk a class's SAME-FILE bases to the first ancestor that
-        defines ``method_name`` — the C suite's sound floor (Bug [30]),
-        the same own-first FIFO, cycle-guarded order ``_resolve_self_call``
-        uses, so the most-derived definition wins and no derived-override
-        fan-out occurs. Base lookup restricted to the caller's own file:
-        external bases aren't in the index, so they stay unresolved rather
-        than mis-linked (the ``self`` walk's own restriction).
+        """#318: walk a class's bases to the first ancestor that defines
+        ``method_name`` — the C suite's sound floor (Bug [30]), own-first,
+        so the most-derived definition wins and no derived-override
+        fan-out occurs.
+
+        #440: the walk is no longer same-file-ONLY — it is the unified
+        import-aware C3 chain (see _base_chain): the most common real
+        layout (a base module + subclasses elsewhere, identified by the
+        import map the resolver already holds) now resolves, and a diamond
+        picks the C3 ancestor, not a FIFO genuine-but-wrong one. The
+        caller's OWN class is excluded here — this walk is reached from
+        _resolve_class_method AFTER its same-file own-definition check
+        missed, and the include_own=False start keeps that precedence.
+        External bases still abstain rather than mis-link.
         """
-        seen: Set[str] = set()
-        queue: List[str] = [class_name.split('.')[-1]]
-        while queue:
-            base_name = queue.pop(0)
-            if base_name in seen:
-                continue
-            seen.add(base_name)
-            class_key = f"{caller_file}:{base_name}"
-            method_id = self._method_in_class(class_key, method_name)
-            if method_id:
-                return method_id
-            for base in self.classes.get(class_key, {}).get('bases', []):
-                base_simple = base.split('.')[-1]
-                if base_simple not in seen:
-                    queue.append(base_simple)
-        return None
+        return self._mro_first_definer(caller_file, class_name, method_name,
+                                       include_own=False)
 
     def _resolve_class_method(self, class_name: str, method_name: str, caller_file: str,
                               defined_classes: Optional[Set[str]] = None) -> Optional[str]:

--- a/libs/openant-core/tests/parsers/python/test_issue318_typed_receiver_bases.py
+++ b/libs/openant-core/tests/parsers/python/test_issue318_typed_receiver_bases.py
@@ -479,10 +479,14 @@ def test_subscripted_base_resolves():
 
 
 def test_diamond_pinned_to_the_fifo_semantics():
-    """Wave r1 (C#5): the either-answer pin was a tautology — the FIFO
-    semantics pinned EXACTLY so a future MRO change is a conscious decision."""
+    """Wave r1 (C#5) pinned the FIFO pick EXACTLY so a future MRO change would
+    be a conscious decision — this is it: #440 changed the walk to the C3
+    linearization because the FIFO pick was genuine-but-WRONG (``C(A, B)`` with
+    ``A(X)``, ``X.m`` and ``B.m``: Python runs ``X.m``; the FIFO edge to B.m
+    left X.m with an empty caller set and it was pruned — the FN direction
+    #318 was filed to remove)."""
     b = _build(_DIAMOND)
-    assert _edges_to(b, "call_c") == ["app.py:B.m"], _edges_to(b, "call_c")
+    assert _edges_to(b, "call_c") == ["app.py:X.m"], _edges_to(b, "call_c")
 
 
 def test_dotted_base_pinned_exactly():

--- a/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
+++ b/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
@@ -129,3 +129,74 @@ def test_external_base_stays_unresolved():
     })
     edges = cg.get("e.py:use", [])
     assert not any("Base.inherited" in e for e in edges), edges
+
+
+def test_nested_class_self_call_still_resolves():
+    """Wave r1 (opus+fable, the regression): the round-1 entry stripped the
+    dotted qualifier — Outer.Inner became 'Inner', a key that exists
+    nowhere — dropping the nested class's OWN self-dispatch and every
+    inherited self-call inside it (the exact FN direction this PR removes)."""
+    cg = _cg({
+        "n.py": ("class Outer:\n"
+                 "    class Inner:\n"
+                 "        def own(self):\n"
+                 "            return 1\n"
+                 "        def go(self):\n"
+                 "            return self.own()\n"),
+    })
+    edges = cg.get("n.py:Outer.Inner.go", [])
+    assert "n.py:Outer.Inner.own" in edges, edges
+
+
+def test_imported_base_with_external_origin_abstains():
+    """Wave r1 (sonnet): the import exists but its module path matches no
+    candidate file (an external attribute-style base) — the round-1
+    unambiguous-name fallback fabricated an edge to an unrelated same-named
+    LOCAL class. Abstain."""
+    cg = _cg({
+        "a.py": ("import some_external_lib\n"
+                 "class Base:\n"          # an unrelated LOCAL Base
+                 "    def m(self):\n"
+                 "        return 1\n"
+                 "def use(x):\n"
+                 "    return x\n"),
+        "b.py": ("from some_external_lib import Base as ExtBase\n"
+                 "class Sub(ExtBase):\n"    # NOT the local Base — external
+                 "    pass\n"
+                 "def go(s):\n"
+                 "    v = Sub()\n"
+                 "    return v.m()\n"),
+    })
+    edges = cg.get("b.py:go", [])
+    assert "a.py:Base.m" not in edges, (
+        f"an external-origin base bound to the unrelated local namesake: {edges}"
+    )
+
+
+def test_hijack_guard_holds_one_level_deep():
+    """Wave r1 (three axes): use_union must PROPAGATE — the round-1
+    recursion defaulted it back to True, so the typed path's anti-hijack
+    guard (own bases, not the merged union) only held at depth 0."""
+    cg = _cg({
+        "h.py": ("class Base:\n"
+                 "    def m(self):\n"
+                 "        return 1\n"
+                 "class Mid(Base):\n"       # the chain: Sub -> Mid -> Base
+                 "    pass\n"
+                 "def maker():\n"
+                 "    class Mid(Base):\n"   # the function-local hijack namesake
+                 "        pass\n"
+                 "    return Mid\n"
+                 "class Sub(Mid):\n"        # module-level Mid — NO bases of its own
+                 "    pass\n"
+                 "def f():\n"
+                 "    v = Sub()\n"
+                 "    return v.m()\n"),
+    })
+    # the union may merge the LOCAL Mid's base into the module Mid; the
+    # typed path must read the MODULE Mid's OWN bases: Base.m resolves
+    # through the Mid chain (hijack or not, Base.m is the real target and
+    # is in BOTH chains here) — the discriminating case: an edge to a
+    # hijack-only target must NOT appear. Keep this a resolution pin:
+    edges = cg.get("h.py:f", [])
+    assert "h.py:Base.m" in edges, edges

--- a/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
+++ b/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
@@ -171,6 +171,26 @@ def test_imported_base_with_external_origin_abstains():
     assert "a.py:Base.m" not in edges, (
         f"an external-origin base bound to the unrelated local namesake: {edges}"
     )
+    # famBCR panel (sonnet, non-discriminating): the negative alone passes on
+    # master too (the pre-#440 walk never resolved imports — no edge either
+    # way). The POSITIVE control pins the discriminator: a LOCAL import of
+    # the same name MUST produce the edge (the walk followed the import
+    # map), which fails on the pre-PR code.
+    cg2 = _cg({
+        "a.py": ("class Base:\n"
+                 "    def m(self):\n"
+                 "        return 1\n"),
+        "b.py": ("from a import Base\n"
+                 "class Sub(Base):\n"
+                 "    pass\n"
+                 "def go(s):\n"
+                 "    v = Sub()\n"
+                 "    return v.m()\n"),
+    })
+    edges2 = cg2.get("b.py:go", [])
+    assert "a.py:Base.m" in edges2, (
+        f"the positive control: a local import base must resolve - "
+        f"without it the abstain test passes on pre-#440 code: {edges2}")
 
 
 def test_hijack_guard_holds_one_level_deep():

--- a/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
+++ b/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
@@ -1,0 +1,131 @@
+"""#440: the base walk follows imports and the C3 order — two FN residuals of #318.
+
+1. IMPORTED IN-REPO BASES: the #318 walk is anchored to the CALLER's file, so
+`a.py: class Base` imported into `b.py` (`class Sub(Base)`) never resolves
+`s = Sub(); s.inherited()` — the most common real layout (a base module +
+subclasses elsewhere) and likely the bulk of #318's census residual. The walk now
+follows the import map the resolver already holds (`self.imports['b.py']['Base']`),
+plus the cross-file unambiguous-match fallback (exactly one repo class with the
+simple name) — the C suite's same-file floor doesn't transfer to a language with an
+import map. External bases (no import entry, no repo class) stay unresolved —
+never a fabricated edge.
+
+2. THE FIFO WALK IS NOT C3 — A DIAMOND PICKS A SINGLE GENUINE-BUT-WRONG ANCESTOR:
+`class C(A, B)` with `A(X)`, `X.m` and `B.m`: the FIFO found B.m; Python runs X.m —
+so X.m kept an empty caller set and was pruned (the FN direction #318 was filed to
+remove). The unified walk now computes the C3 linearization over the extractor's
+base lists (FIFO fallback when a merge fails — inconsistent hierarchies still
+resolve). Shared by _resolve_self_call and the typed-receiver path.
+"""
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+# #415: parents[3] — from tests/parsers/python/<file>, parents[2] is tests/
+# (the shadow-package poison); the core root is three levels up.
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from core.parser_adapter import parse_repository  # noqa: E402
+
+
+def _cg(files: dict):
+    repo = Path(tempfile.mkdtemp())
+    for rel, content in files.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content)
+    out = tempfile.mkdtemp()
+    parse_repository(str(repo), out, language="python",
+                     processing_level="all", skip_tests=True, name="r")
+    with open(Path(out) / "call_graph.json") as fh:
+        return json.load(fh)["call_graph"]
+
+
+def test_imported_base_resolves_typed_receiver():
+    """The issue's primary shape: the base module + subclass elsewhere."""
+    cg = _cg({
+        "a.py": ("class Base:\n"
+                 "    def inherited(self):\n"
+                 "        return 1\n"),
+        "b.py": ("from a import Base\n"
+                 "class Sub(Base):\n"
+                 "    pass\n"
+                 "def use():\n"
+                 "    s = Sub()\n"
+                 "    return s.inherited()\n"),
+    })
+    edges = cg.get("b.py:use", [])
+    assert "a.py:Base.inherited" in edges, (
+        f"the imported in-repo base never resolved (the same-file anchor): {edges}"
+    )
+
+
+def test_self_call_via_imported_base():
+    cg = _cg({
+        "a.py": ("class Base:\n"
+                 "    def helper(self):\n"
+                 "        return 1\n"),
+        "b.py": ("from a import Base\n"
+                 "class Sub(Base):\n"
+                 "    def work(self):\n"
+                 "        return self.helper()\n"),
+    })
+    edges = cg.get("b.py:Sub.work", [])
+    assert "a.py:Base.helper" in edges, f"self.helper() through an imported base: {edges}"
+
+
+def test_diamond_resolves_c3_not_fifo():
+    """class C(A, B), A(X), X.m and B.m: Python runs X.m (the C3 order puts
+    the X branch ahead of B); the FIFO walk found B.m — genuine-but-wrong,
+    leaving X.m with an empty caller set (pruned: the FN direction)."""
+    cg = _cg({
+        "d.py": ("class X:\n"
+                 "    def m(self):\n"
+                 "        return 'x'\n"
+                 "class A(X):\n"
+                 "    pass\n"
+                 "class B:\n"
+                 "    def m(self):\n"
+                 "        return 'b'\n"
+                 "class C(A, B):\n"
+                 "    pass\n"
+                 "def use():\n"
+                 "    c = C()\n"
+                 "    return c.m()\n"),
+    })
+    edges = cg.get("d.py:use", [])
+    assert "d.py:X.m" in edges, (
+        f"C3 order: c.m() runs X.m (via A), not B.m — the FIFO pick: {edges}"
+    )
+
+
+def test_same_file_walk_still_resolves():
+    """The #318 floor unchanged: a same-file base chain still resolves."""
+    cg = _cg({
+        "s.py": ("class Base:\n"
+                 "    def inherited(self):\n"
+                 "        return 1\n"
+                 "class Sub(Base):\n"
+                 "    pass\n"
+                 "def use():\n"
+                 "    s = Sub()\n"
+                 "    return s.inherited()\n"),
+    })
+    assert "s.py:Base.inherited" in cg.get("s.py:use", [])
+
+
+def test_external_base_stays_unresolved():
+    """No import entry and no repo class: unresolved, never fabricated."""
+    cg = _cg({
+        "e.py": ("import some_external_lib\n"
+                 "class Sub(some_external_lib.Base):\n"
+                 "    pass\n"
+                 "def use():\n"
+                 "    s = Sub()\n"
+                 "    return s.inherited()\n"),
+    })
+    edges = cg.get("e.py:use", [])
+    assert not any("Base.inherited" in e for e in edges), edges


### PR DESCRIPTION
Two FN residuals of #318 (the same-file base walk for typed receivers), filed separately per that PR's triage:

1. **Imported in-repo bases:** the walk was anchored to the CALLER's file, so `a.py: class Base` imported into `b.py` (`class Sub(Base)`) never resolved `s = Sub(); s.inherited()` — the most common real layout (a base module + subclasses elsewhere) and likely the bulk of #318's census residual. The unified walk now follows the import map the resolver already holds (`self.imports['b.py']['Base']` — module-prefix matched to the defining file), plus the cross-file UNAMBIGUOUS simple-name match (step 3's shape). External bases (no import entry, no repo class) stay unresolved — never a fabricated edge.
2. **The FIFO walk was not C3:** a diamond (`C(A, B)`, `A(X)`, `X.m` and `B.m`) picked B.m while Python runs X.m — X.m kept an empty caller set and was pruned (the FN direction #318 was filed to remove). The unified walk computes the C3 linearization over the extractor's base lists (FIFO fallback when the merge fails — inconsistent hierarchies still resolve; cycles tolerated). The #318 diamond pin updated consciously (that pin existed exactly so an MRO change would be one).

The walk is shared by `_resolve_self_call` and the typed-receiver path, with the bases field split #318's wave-r3 finding requires: the self/super walks read the UNION (`all_bases` — a function-local namesake's own methods dispatch on the local chain); the typed path from OUTSIDE reads the entry's OWN bases (no function-local hijack — pinned unchanged).

**The wave-r1 round (three axes, all confirmed, all fixed):**
- THE NESTED-CLASS REGRESSION (opus+fable, HIGH): the round-1 entry split('.')-stripped the class name — the extractor keys nested classes with their dotted qualifier (`methods_by_class['app.py:Outer.Inner']`), so Outer.Inner became 'Inner', a key that exists NOWHERE: the class's OWN self-dispatch and every inherited self-call inside a nested class (pydantic Config, nested exception/helper classes) was dropped — the exact FN direction this PR exists to remove, and a regression against pristine. The chain now enters under the FULL name (a dotted key falls back to its simple form only when the qualified key misses); base names — which ARE simple — strip inside `_base_chain`;
- `use_union` PROPAGATES into the recursion (three axes): the round-1 recursive hops defaulted it back to True, so the typed path's anti-hijack guard only held at depth 0 — a hijack one level deep still fabricated edges;
- the external-base fabrication (sonnet): when the import map HAS the base name but no candidate file matches its module path (an attribute-style external base, an aliased import of foreign origin), the unambiguous-name fallback bound it to an unrelated same-named LOCAL class — a fabricated edge. The import-miss now ABSTAINS (the fallback fires only when the name is not imported at all);
- the C3 merge carries the base list's own order as a final sequence (the canonical inconsistency detection) — an unresolvable-base empty sequence drops out of the merge instead of crashing, and a genuinely inconsistent hierarchy takes the FIFO fallback by DETECTION rather than silent reordering.

**Evidence:** 8 tests in this PR's file (the imported typed receiver; the self-call through an imported base; the diamond-to-X.m; the same-file + external pins; the round additions: the nested-class self-call — RED on the round-1 code; the external-origin abstention; the deep hijack chain) + the full #318 typed-receiver suite 54 passed with its hijack guard intact and the conscious C3 pin; the python parser directory 226/1; the full suite 3524/1 (the known macOS artifact); ruff clean.

Fixes #440