### PR TITLE
fix(stage2): the consistency pass validates its should_be — the #425 escape's Stage-2 twin (#448)

### DIFF
--- a/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
+++ b/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
@@ -200,3 +200,98 @@ def test_uppercase_old_verdict_compare_is_normalized():
     # no update fired — the row's stored stamp is untouched (the write site
     # never runs on a normalized-equal compare; readers lowercase on read)
     assert row["verification"]["correct_finding"] == "VULNERABLE"
+
+
+def test_the_correctable_set_equals_the_finish_enum():
+    """Wave r2 (fable+opus): the gate depends on a coincidence across four
+    independently-maintained copies (the finish tool's enum, _VERIFY_JSON_SCHEMA,
+    json_corrector's schema, the display tuple). A conformance test ties the
+    correctable set to the finish enum so a change to either surfaces here —
+    the drift class verdict_taxonomy exists to prevent."""
+    import inspect
+    import utilities.finding_verifier as fv
+    from core.verdict_taxonomy import FINDING_VERDICT_ORDER
+    src = inspect.getsource(fv)
+    # the finish tool's correct_finding enum (the model-facing declaration)
+    assert '"safe | protected | bypassable | vulnerable | inconclusive"' in src or \
+        '"safe | protected | vulnerable | bypassable | inconclusive"' in src, (
+            "the finish tool's enum text not found — update this conformance pin "
+            "deliberately if the enum wording changed")
+    assert fv._CORRECTABLE_STAGE2_FINDINGS == frozenset(FINDING_VERDICT_ORDER), (
+        "the correctable set drifted from FINDING_VERDICT_ORDER — the gate "
+        "must stay exactly the finish enum"
+    )
+
+
+def test_audit_from_keeps_the_raw_stored_stamp():
+    """Wave r2 (fable+sonnet+opus): `from` records the RAW stored value —
+    a case/whitespace anomaly in stored data is itself an upstream-bug
+    signal (experiment.py prints it verbatim); the normalized form is for
+    the compare only."""
+    out = _run(_verifier(), "safe",
+               rows=[{"route_key": VULN_RK, "finding": "vulnerable",
+                      "verification": {"correct_finding": "VULNERABLE"}},
+                     {"route_key": SAFE_RK, "finding": "safe",
+                      "verification": {"correct_finding": "safe"}}])
+    row = _by_rk(out, VULN_RK)
+    assert "consistency_update" in row, "the (real) case difference must fire"
+    assert row["consistency_update"]["from"] == "VULNERABLE", (
+        f"the audit from-field lost the raw stamp: {row['consistency_update']}"
+    )
+    assert row["consistency_update"]["to"] == "safe"
+
+
+def test_case_only_group_is_not_inconsistent():
+    """Wave r2 (opus): the DETECTOR compares raw — an all-vulnerable group
+    stamped VULNERABLE/vulnerable previously read as inconsistent and spent
+    a full LLM resolution call every batch."""
+    v = _verifier()
+    called = {"n": 0}
+
+    def _fake_resolve(group, cbr):
+        called["n"] += 1
+        return None
+
+    v._resolve_inconsistency = _fake_resolve
+    v._check_consistency([
+        {"route_key": VULN_RK, "finding": "vulnerable",
+         "verification": {"correct_finding": "VULNERABLE"}},
+        {"route_key": SAFE_RK, "finding": "vulnerable",
+         "verification": {"correct_finding": "vulnerable"}},
+    ], {})
+    assert called["n"] == 0, (
+        "a case-only difference spent an LLM resolution call — the detector "
+        "must compare normalized"
+    )
+
+
+def test_malformed_nonstring_proposal_is_audited():
+    """Wave r2 (fable): a list/dict/number should_be is a MALFORMED proposal —
+    audited, not silently dropped. None/empty stay a silent no-proposal."""
+    out = _run(_verifier(), ["VULNERABLE"])
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "vulnerable"
+    assert "consistency_invalid_verdict_blocked" in row, (
+        "a structured malformed proposal must leave an audit record"
+    )
+    assert row["consistency_invalid_verdict_blocked"]["proposed"] == ["VULNERABLE"]
+
+
+def test_hallucinated_updates_do_not_apply_when_consistency_is_false():
+    """Wave r2 (fable): should_be_consistent=FALSE plus a hallucinated
+    findings_to_update — the one conformant field that says DO NOT APPLY
+    must win over the hallucinated payload."""
+    v = _verifier()
+    v._resolve_inconsistency = lambda group, cbr: None  # not reached
+    # drive through _resolve_inconsistency's parse path: stub the model text
+    # is heavier than the unit needs — the contract is pinned at the parse:
+    # simulate via the None-return shape and assert the apply loop's guard
+    # by calling _check_consistency with a stubbed resolver that returns the
+    # hallucinated result (the should_be_consistent gate lives one layer up;
+    # its unit is the _resolve_inconsistency parse — pin the composition:
+    # the resolver returns None when the reply says False).
+    out = _run(v, "safe")   # the False-gated path returns None -> no update
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "safe", (
+        "control: the non-gated path still applies"
+    )

--- a/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
+++ b/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
@@ -394,7 +394,6 @@ def test_malformed_payload_container_and_elements_never_crash(monkeypatch):
     untouched."""
     import json as _json
     import utilities.llm as fv_llm
-    from core.verdict_taxonomy import FINDING_VERDICT_ORDER
 
     rows = [{"route_key": VULN_RK, "finding": "vulnerable",
              "verification": {"correct_finding": "vulnerable"}},
@@ -417,10 +416,14 @@ def test_malformed_payload_container_and_elements_never_crash(monkeypatch):
                              "explanation": "x",
                              "findings_to_update": payload})
         monkeypatch.setattr(fv_llm, "simple_text", lambda *a, r=reply, **k: r)
-        got = v._resolve_inconsistency([dict(r) for r in rows], {})
-        # the resolver must return (None or an empty/ignored payload), never raise
-        out = v._check_consistency([dict(r) for r in rows], {}) if got is None else rows
+        # (wave r5 fable+opus: the r4 ternary was a TAUTOLOGY — got is never
+        # None for a well-formed reply, so _check_consistency was never
+        # called and the guards had zero coverage. The apply loop is driven
+        # unconditionally here — _check_consistency invokes the patched
+        # resolver itself.)
+        out = v._check_consistency([dict(r) for r in rows], {})
         vuln = next(r for r in out if r["route_key"] == VULN_RK)
         assert vuln["finding"] == "vulnerable", (
             f"payload {payload!r} moved or crashed a row"
         )
+        assert "consistency_update" not in vuln, payload

--- a/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
+++ b/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
@@ -427,3 +427,30 @@ def test_malformed_payload_container_and_elements_never_crash(monkeypatch):
             f"payload {payload!r} moved or crashed a row"
         )
         assert "consistency_update" not in vuln, payload
+
+
+def test_unhashable_verdict_never_crashes_the_detector():
+    """Wave r6 (opus): a non-string correct_finding (a list/dict from a
+    text-mode reply or a checkpoint restore — never type-coerced on the way
+    in) crashed the DETECTOR's set construction: unhashable TypeError, in the
+    code path that ALWAYS runs. The Stage-1 twin coerces to "" — same guard
+    here."""
+    v = _verifier()
+    called = {"n": 0}
+
+    def _fake_resolve(group, cbr):
+        called["n"] += 1
+        return None
+
+    v._resolve_inconsistency = _fake_resolve
+    out = v._check_consistency([
+        {"route_key": VULN_RK, "finding": ["safe"],
+         "verification": {"correct_finding": ["safe"]}},
+        {"route_key": SAFE_RK, "finding": "vulnerable",
+         "verification": {"correct_finding": "vulnerable"}},
+    ], {})
+    # no crash, and the malformed row was NOT treated as equal to the
+    # canonical one ("" from the list, "vulnerable" from the sibling ->
+    # inconsistent -> the resolver was called)
+    assert called["n"] == 1
+    assert all(isinstance(r["finding"], (str, list)) for r in out)

--- a/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
+++ b/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
@@ -1,0 +1,143 @@
+"""#448: finding_verifier._check_consistency validates its should_be — the Stage-2 twin.
+
+The Stage-2 consistency site is the exact twin of the stage1_consistency site #425 fixed:
+same `findings_to_update`/`should_be` contract, same F-KB-1b/F-KB-1a comment pairing — but
+it writes `finding` VERBATIM with no strip, no validation:
+
+```
+new_verdict = finding_update.get("should_be")      # unconstrained model output
+...
+old_verdict != new_verdict:
+    result["finding"] = new_verdict                # the key _count_verdicts + disclosure read FIRST
+    result["verification"]["correct_finding"] = new_verdict
+```
+
+A garbage `should_be` ("MAYBE VULNERABLE") passes the downgrade guard (not in
+DISCLOSURE_DROPPED) and is written into `finding` — the row drops from every `_count_verdicts`
+bucket (the F13 else-branch, not even `errors`) and from disclosure: a real VULNERABLE finding
+vanishes silently, on the more load-bearing key. Weaker than the pre-#425 Stage-1 site: not even
+`.strip()`, so "  VULNERABLE  " lands padded and the comparison is raw.
+
+The #316/#324/#425/#427 producer discipline at this site: normalize (strip/lower — this
+module's storage convention is lowercase `correct_finding`), validate against the canonical
+`finding` vocabulary (STAGE1_VERDICTS ∪ STAGE2_VERDICTS — every value `finding`/
+`correct_finding` legitimately takes), reject-audit unrecognized values (the
+`consistency_invalid_verdict_blocked` pattern). Found during #425's wave review (opus, three
+axes: "the commit says 'the one producer that runs LAST' — it isn't").
+"""
+import sys
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parents[1]
+if str(_CORE) not in sys.path:
+    sys.path.insert(0, str(_CORE))
+
+from utilities.finding_verifier import FindingVerifier, ConsistencyCheckResult  # noqa: E402
+
+
+FILE = "pkg/logger/console.go"
+VULN_RK = f"{FILE}:runMsg.json"      # groups with the safe sibling (same .json pattern)
+SAFE_RK = f"{FILE}:infoMsg.json"
+
+
+def _verifier():
+    v = FindingVerifier.__new__(FindingVerifier)
+    v._use_logger = False
+    v.verbose = False
+    return v
+
+
+def _rows(finding_vuln="vulnerable", finding_safe="safe"):
+    return [
+        {"route_key": VULN_RK, "finding": finding_vuln,
+         "verification": {"correct_finding": finding_vuln}},
+        {"route_key": SAFE_RK, "finding": finding_safe,
+         "verification": {"correct_finding": finding_safe}},
+    ]
+
+
+def _run(v, should_be, rows=None):
+    v._resolve_inconsistency = lambda group, cbr: ConsistencyCheckResult(
+        "logger json emitter", should_be,
+        [{"route_key": VULN_RK, "should_be": should_be, "reason": "x"}], "g")
+    return v._check_consistency(rows or _rows(), {})
+
+
+def _by_rk(out, rk):
+    return next(r for r in out if r["route_key"] == rk)
+
+
+def test_unrecognized_should_be_is_rejected_not_written():
+    """The issue's headline: a garbage should_be passes the downgrade guard and
+    lands in `finding` verbatim — the row drops from every count and from
+    disclosure. Rejected with an audit record; the row keeps its verdict."""
+    out = _run(_verifier(), "MAYBE VULNERABLE")
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "vulnerable", (
+        f"a garbage should_be landed in finding verbatim: {row['finding']!r}"
+    )
+    assert row["verification"]["correct_finding"] == "vulnerable"
+    assert "consistency_invalid_verdict_blocked" in row, (
+        "the rejected proposal must be audited, not silent"
+    )
+    assert "consistency_update" not in row
+
+
+def test_padded_should_be_is_normalized():
+    """The #448 body's weaker-than-stage-1 case: '  vulnerable  ' landed PADDED
+    (the raw compare old != new fired, the raw string was written) — the padded
+    value then failed every downstream lowercase vocabulary read. Normalized."""
+    out = _run(_verifier(), "  vulnerable  ")
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "vulnerable", (
+        f"the padded should_be was written raw: {row['finding']!r}"
+    )
+    assert row["verification"]["correct_finding"] == "vulnerable"
+
+
+def test_uppercase_should_be_normalizes_to_the_storage_convention():
+    """The site's storage convention is lowercase correct_finding; a model's
+    'VULNERABLE' was written UPPERCASE and then missed the lowercase reads."""
+    out = _run(_verifier(), "VULNERABLE")
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "vulnerable", row["finding"]
+
+
+def test_empty_should_be_writes_nothing():
+    """should_be=None previously OVERWROTE finding with None (the raw compare
+    vulnerable != None is True) — the row degraded to its verdict fallback.
+    An empty proposal applies nothing."""
+    out = _run(_verifier(), None)
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "vulnerable"
+    assert "consistency_update" not in row
+
+
+def test_legitimate_correction_still_lands():
+    """A canonical downgrade on a NON-conclusive row still applies (the pass's
+    whole purpose) — the gate must not over-block."""
+    out = _run(_verifier(), "safe")
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "safe"
+    assert row["verification"]["correct_finding"] == "safe"
+    assert "consistency_update" in row
+
+
+def test_conclusive_exploitable_guard_unchanged():
+    """The F-KB-1b pin: a conclusively-EXPLOITABLE row is never downgraded to a
+    DROPPED verdict by pattern matching — the validity gate must not disturb
+    the guard's precedence."""
+    v = _verifier()
+    rows = [
+        {"route_key": VULN_RK, "finding": "vulnerable",
+         "verification": {"correct_finding": "vulnerable",
+                           "exploit_path": {"entry_point": "h", "sink_reached": True,
+                                            "attacker_control_at_sink": "full",
+                                            "path_broken_at": None}}},
+        {"route_key": SAFE_RK, "finding": "safe",
+         "verification": {"correct_finding": "safe"}},
+    ]
+    out = _run(v, "safe", rows=rows)
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "vulnerable", "the conclusive-exploitable guard was disturbed"
+    assert "consistency_downgrade_blocked" in row

--- a/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
+++ b/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
@@ -203,23 +203,22 @@ def test_uppercase_old_verdict_compare_is_normalized():
 
 
 def test_the_correctable_set_equals_the_finish_enum():
-    """Wave r2 (fable+opus): the gate depends on a coincidence across four
-    independently-maintained copies (the finish tool's enum, _VERIFY_JSON_SCHEMA,
-    json_corrector's schema, the display tuple). A conformance test ties the
-    correctable set to the finish enum so a change to either surfaces here —
-    the drift class verdict_taxonomy exists to prevent."""
-    import inspect
-    import utilities.finding_verifier as fv
+    """Wave r2 (fable+opus) + wave r3 (all three axes): the round-2 pin located
+    the PROSE copy (_VERIFY_JSON_SCHEMA's docstring) — appending a value to
+    the finish TOOL'S enum left it green, and the set-against-its-definition
+    assertion was a tautology. The real pin: read VERIFICATION_TOOLS, select
+    the finish entry, and assert its correct_finding ENUM as a set equals the
+    correctable set — a change to either copy now surfaces HERE."""
     from core.verdict_taxonomy import FINDING_VERDICT_ORDER
-    src = inspect.getsource(fv)
-    # the finish tool's correct_finding enum (the model-facing declaration)
-    assert '"safe | protected | bypassable | vulnerable | inconclusive"' in src or \
-        '"safe | protected | vulnerable | bypassable | inconclusive"' in src, (
-            "the finish tool's enum text not found — update this conformance pin "
-            "deliberately if the enum wording changed")
-    assert fv._CORRECTABLE_STAGE2_FINDINGS == frozenset(FINDING_VERDICT_ORDER), (
-        "the correctable set drifted from FINDING_VERDICT_ORDER — the gate "
-        "must stay exactly the finish enum"
+    import utilities.finding_verifier as fv
+    finish = next(t for t in fv.VERIFICATION_TOOLS if t["name"] == "finish")
+    enum_vals = set(finish["input_schema"]["properties"]["correct_finding"]["enum"])
+    assert enum_vals == set(FINDING_VERDICT_ORDER), (
+        f"the finish tool's enum drifted from FINDING_VERDICT_ORDER: {enum_vals}"
+    )
+    assert fv._CORRECTABLE_STAGE2_FINDINGS == enum_vals, (
+        "the correctable set drifted from the finish tool's enum — the gate "
+        "must stay exactly the model-facing declaration"
     )
 
 
@@ -277,21 +276,110 @@ def test_malformed_nonstring_proposal_is_audited():
     assert row["consistency_invalid_verdict_blocked"]["proposed"] == ["VULNERABLE"]
 
 
-def test_hallucinated_updates_do_not_apply_when_consistency_is_false():
-    """Wave r2 (fable): should_be_consistent=FALSE plus a hallucinated
-    findings_to_update — the one conformant field that says DO NOT APPLY
-    must win over the hallucinated payload."""
+def test_hallucinated_updates_do_not_apply_when_consistency_is_false(monkeypatch):
+    """Wave r2 (fable) + wave r3 (all three axes): should_be_consistent=FALSE
+    plus a hallucinated findings_to_update — the one conformant field that
+    says DO NOT APPLY must win over the hallucinated payload. Driven through
+    the REAL _resolve_inconsistency parse path (the round-2 test stubbed the
+    resolver and degenerated into a duplicate of the apply control)."""
+    import json as _json
+    import utilities.llm as fv_llm
     v = _verifier()
-    v._resolve_inconsistency = lambda group, cbr: None  # not reached
-    # drive through _resolve_inconsistency's parse path: stub the model text
-    # is heavier than the unit needs — the contract is pinned at the parse:
-    # simulate via the None-return shape and assert the apply loop's guard
-    # by calling _check_consistency with a stubbed resolver that returns the
-    # hallucinated result (the should_be_consistent gate lives one layer up;
-    # its unit is the _resolve_inconsistency parse — pin the composition:
-    # the resolver returns None when the reply says False).
-    out = _run(v, "safe")   # the False-gated path returns None -> no update
-    row = _by_rk(out, VULN_RK)
-    assert row["finding"] == "safe", (
-        "control: the non-gated path still applies"
+    v.binding = object()
+    v.tracker = None            # the method passes tracker= to simple_text
+
+    the_reply = _json.dumps({
+        "should_be_consistent": False,
+        "consistent_verdict": "safe",
+        "explanation": "not actually the same",
+        "findings_to_update": [{"route_key": VULN_RK, "should_be": "safe"}],
+    })
+    monkeypatch.setattr(fv_llm, "simple_text", lambda *a, **k: the_reply)
+    got = v._resolve_inconsistency(
+        [{"route_key": VULN_RK, "finding": "vulnerable",
+          "verification": {"correct_finding": "vulnerable"}},
+         {"route_key": SAFE_RK, "finding": "safe",
+          "verification": {"correct_finding": "safe"}}], {})
+    assert got is None, (
+        "a FALSE should_be_consistent must gate its hallucinated payload"
     )
+    # the tolerant read (wave r3): the string "false" and 0 gate too
+    for falsy in ("false", 0, "no"):
+        reply = _json.dumps({
+            "should_be_consistent": falsy,
+            "consistent_verdict": "safe",
+            "explanation": "x",
+            "findings_to_update": [{"route_key": VULN_RK, "should_be": "safe"}],
+        })
+        monkeypatch.setattr(fv_llm, "simple_text", lambda *a, r=reply, **k: r)
+        got = v._resolve_inconsistency(
+            [{"route_key": VULN_RK, "finding": "vulnerable",
+              "verification": {"correct_finding": "vulnerable"}},
+             {"route_key": SAFE_RK, "finding": "safe",
+              "verification": {"correct_finding": "safe"}}], {})
+        assert got is None, f"should_be_consistent={falsy!r} must gate"
+    # the control: a TRUE reply still parses its payload
+    reply = _json.dumps({
+        "should_be_consistent": True,
+        "consistent_verdict": "safe",
+        "explanation": "x",
+        "findings_to_update": [{"route_key": VULN_RK, "should_be": "safe"}],
+    })
+    monkeypatch.setattr(fv_llm, "simple_text", lambda *a, r=reply, **k: r)
+    got = v._resolve_inconsistency(
+        [{"route_key": VULN_RK, "finding": "vulnerable",
+          "verification": {"correct_finding": "vulnerable"}},
+         {"route_key": SAFE_RK, "finding": "safe",
+          "verification": {"correct_finding": "safe"}}], {})
+    assert got is not None and got.findings_updated, (
+        "control: a TRUE reply's payload still flows"
+    )
+
+
+def test_out_of_group_route_key_is_ignored():
+    """Wave r3 (opus): an update is scoped to the GROUP that fired the call —
+    a hallucinated route_key naming any OTHER row in the batch previously
+    moved that row (or stamped its audit) regardless of the pattern the
+    model was shown. The apply gate's threat model is precisely the
+    fully-hallucinated payload."""
+    OTHER_RK = f"{FILE}:otherFn.json"
+
+    def resolver(group, code_by_route):
+        return ConsistencyCheckResult(
+            "logger json emitter", "safe",
+            [{"route_key": OTHER_RK, "should_be": "safe", "reason": "x"}], "g")
+
+    rows = _rows() + [{"route_key": OTHER_RK, "finding": "vulnerable",
+                       "verification": {"correct_finding": "vulnerable"}}]
+    v = _verifier()
+    v._resolve_inconsistency = resolver
+    out = v._check_consistency(rows, {})
+    other = _by_rk(out, OTHER_RK)
+    assert other["finding"] == "vulnerable", (
+        f"an out-of-group route_key was moved: {other}"
+    )
+    assert "consistency_invalid_verdict_blocked" not in other
+    assert "consistency_update" not in other
+
+
+def test_group_route_key_still_applies():
+    """The group scoping must not over-block: an update naming an IN-group
+    row still applies."""
+    def resolver(group, code_by_route):
+        return ConsistencyCheckResult(
+            "logger json emitter", "safe",
+            [{"route_key": VULN_RK, "should_be": "safe", "reason": "x"}], "g")
+
+    v = _verifier()
+    v._resolve_inconsistency = resolver
+    out = v._check_consistency(_rows(), {})
+    assert _by_rk(out, VULN_RK)["finding"] == "safe"
+
+
+def test_whitespace_only_should_be_is_a_silent_no_proposal():
+    """Wave r3 (opus): '   ' normalizes empty — a no-proposal, not a
+    malformed-structured audit (the comment and the code agree now)."""
+    out = _run(_verifier(), "   ")
+    row = _by_rk(out, VULN_RK)
+    assert row["finding"] == "vulnerable"
+    assert "consistency_invalid_verdict_blocked" not in row

--- a/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
+++ b/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
@@ -141,3 +141,62 @@ def test_conclusive_exploitable_guard_unchanged():
     row = _by_rk(out, VULN_RK)
     assert row["finding"] == "vulnerable", "the conclusive-exploitable guard was disturbed"
     assert "consistency_downgrade_blocked" in row
+
+
+def test_stage2_vocabulary_is_rejected_not_written():
+    """Wave r1 (three axes): STAGE2_VERDICTS is the reporter's DERIVED
+    stage2_verdict key — no producer ever writes confirmed/agreed/unverified/
+    rejected into `finding`. The round-1 gate admitted them, and a
+    conformant-looking "confirmed" (a MORE plausible model emission than the
+    garbage string) reproduced the exact bucket-drop: _count_verdicts' F13
+    else-branch + the reporter's disclosure filter. Rejected now."""
+    for token in ("confirmed", "agreed", "unverified", "rejected"):
+        out = _run(_verifier(), token)
+        row = _by_rk(out, VULN_RK)
+        assert row["finding"] == "vulnerable", (
+            f"{token!r} — a stage2_verdict value — was written into finding: {row}"
+        )
+        assert "consistency_invalid_verdict_blocked" in row, token
+
+
+def test_error_is_not_a_correction_target_on_conclusive_rows():
+    """Wave r1 (fable, the F-KB-1b bypass): error is a legitimate STATE of
+    finding but not a legitimate CORRECTION TARGET — it is outside
+    DISCLOSURE_DROPPED, so admitting it let a pattern-similarity pass move a
+    conclusively-EXPLOITABLE row to the error shape PAST the guard (the exact
+    class #195/#243 closed)."""
+    v = _verifier()
+    rows = [
+        {"route_key": VULN_RK, "finding": "vulnerable",
+         "verification": {"correct_finding": "vulnerable",
+                          "exploit_path": {"entry_point": "h", "sink_reached": True,
+                                           "attacker_control_at_sink": "full",
+                                           "path_broken_at": None}}},
+        {"route_key": SAFE_RK, "finding": "safe",
+         "verification": {"correct_finding": "safe"}},
+    ]
+    for token in ("error", "insufficient_context"):
+        out = _run(v, token, rows=[dict(r) for r in rows])
+        row = _by_rk(out, VULN_RK)
+        assert row["finding"] == "vulnerable", (
+            f"{token!r} moved a conclusively-exploitable row past the guard: {row}"
+        )
+        assert "consistency_invalid_verdict_blocked" in row, token
+
+
+def test_uppercase_old_verdict_compare_is_normalized():
+    """Wave r1 (fable): _parse_finish_result stores correct_finding verbatim —
+    an uppercase-stamped row vs a normalized proposal previously produced a
+    spurious consistency_update record. The old side is normalized too."""
+    out = _run(_verifier(), "vulnerable",
+               rows=[{"route_key": VULN_RK, "finding": "vulnerable",
+                      "verification": {"correct_finding": "VULNERABLE"}},
+                     {"route_key": SAFE_RK, "finding": "safe",
+                      "verification": {"correct_finding": "safe"}}])
+    row = _by_rk(out, VULN_RK)
+    assert "consistency_update" not in row, (
+        f"a case-only difference produced a spurious update record: {row}"
+    )
+    # no update fired — the row's stored stamp is untouched (the write site
+    # never runs on a normalized-equal compare; readers lowercase on read)
+    assert row["verification"]["correct_finding"] == "VULNERABLE"

--- a/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
+++ b/libs/openant-core/tests/test_issue448_stage2_should_be_valid.py
@@ -383,3 +383,44 @@ def test_whitespace_only_should_be_is_a_silent_no_proposal():
     row = _by_rk(out, VULN_RK)
     assert row["finding"] == "vulnerable"
     assert "consistency_invalid_verdict_blocked" not in row
+
+
+def test_malformed_payload_container_and_elements_never_crash(monkeypatch):
+    """Wave r4 (fable+opus): the hallucinated payload's container and
+    elements are shape-checked — "findings_to_update": null / a string / a
+    dict, and list members that are strings or null, previously crashed the
+    Verify phase AFTER every per-unit LLM call was paid (TypeError at the
+    for; AttributeError at .get). All three shapes now leave every row
+    untouched."""
+    import json as _json
+    import utilities.llm as fv_llm
+    from core.verdict_taxonomy import FINDING_VERDICT_ORDER
+
+    rows = [{"route_key": VULN_RK, "finding": "vulnerable",
+             "verification": {"correct_finding": "vulnerable"}},
+            {"route_key": SAFE_RK, "finding": "safe",
+             "verification": {"correct_finding": "safe"}}]
+    v = _verifier()
+    v.binding = object()
+    v.tracker = None
+    bad_payloads = [
+        None,                                   # null container
+        "all",                                  # a string container
+        {"route": "safe"},                      # a dict container
+        [VULN_RK],                              # a list of strings
+        [None, 3],                              # non-dict elements
+        [{"route_key": ["a", "b"], "should_be": "safe"}],  # unhashable route_key
+    ]
+    for payload in bad_payloads:
+        reply = _json.dumps({"should_be_consistent": True,
+                             "consistent_verdict": "safe",
+                             "explanation": "x",
+                             "findings_to_update": payload})
+        monkeypatch.setattr(fv_llm, "simple_text", lambda *a, r=reply, **k: r)
+        got = v._resolve_inconsistency([dict(r) for r in rows], {})
+        # the resolver must return (None or an empty/ignored payload), never raise
+        out = v._check_consistency([dict(r) for r in rows], {}) if got is None else rows
+        vuln = next(r for r in out if r["route_key"] == VULN_RK)
+        assert vuln["finding"] == "vulnerable", (
+            f"payload {payload!r} moved or crashed a row"
+        )

--- a/libs/openant-core/tests/test_verifier_consistency_disclosure_dropped_downgrade.py
+++ b/libs/openant-core/tests/test_verifier_consistency_disclosure_dropped_downgrade.py
@@ -65,16 +65,24 @@ def test_exploitable_not_downgraded_to_rejected():
 
 def test_exploitable_not_downgraded_to_any_disclosure_dropped_verdict():
     # Full sweep: no verdict in DISCLOSURE_DROPPED may silently drop the finding.
-    # #448 (wave r1): values NOT in the correctable vocabulary (rejected) now
-    # take the invalid-verdict branch — either breadcrumb satisfies the
-    # preserved+audited contract.
+    # #448 (wave r2 fable+opus): PER-VERDICT branch precision — the values IN
+    # the correctable vocabulary (safe/protected/inconclusive) MUST reach the
+    # F-KB-1b guard's downgrade_blocked branch (a later change that swallowed
+    # them into the validity gate would otherwise keep this sweep green while
+    # the #195/#243 defense never fired); the out-of-vocabulary value
+    # (rejected) takes the invalid-verdict branch.
+    from core.verdict_taxonomy import FINDING_VERDICT_ORDER
     for dv in sorted(DISCLOSURE_DROPPED):
         got = _run_downgrade(dv)
         verdict = got.get("verification", {}).get("correct_finding") or got.get("finding")
         assert verdict == "vulnerable", f"downgrade to {dv!r} silently dropped the finding"
-        assert ("consistency_downgrade_blocked" in got
-                or "consistency_invalid_verdict_blocked" in got), (
-            f"no audit breadcrumb for {dv!r}")
+        if dv in FINDING_VERDICT_ORDER:
+            assert "consistency_downgrade_blocked" in got, (
+                f"{dv!r} is in the correctable vocabulary — the F-KB-1b guard "
+                "must be the branch that fires")
+        else:
+            assert "consistency_invalid_verdict_blocked" in got, (
+                f"{dv!r} is out-of-vocabulary — the validity gate fires")
 
 
 def test_non_exploitable_downgrade_still_applies():

--- a/libs/openant-core/tests/test_verifier_consistency_disclosure_dropped_downgrade.py
+++ b/libs/openant-core/tests/test_verifier_consistency_disclosure_dropped_downgrade.py
@@ -52,19 +52,29 @@ def test_exploitable_not_downgraded_to_inconclusive():
 
 
 def test_exploitable_not_downgraded_to_rejected():
+    # #448 (wave r1): "rejected" is now rejected by the VALIDITY gate first
+    # (it is not in FINDING_VERDICT_ORDER — no producer writes it into
+    # `finding`), so the breadcrumb is consistency_invalid_verdict_blocked;
+    # the outcome contract is unchanged — preserved + audited.
     got = _run_downgrade("rejected")
     verdict = got.get("verification", {}).get("correct_finding") or got.get("finding")
     assert verdict == "vulnerable", f"exploitable finding was dropped to {verdict!r}"
-    assert "consistency_downgrade_blocked" in got
+    assert ("consistency_downgrade_blocked" in got
+            or "consistency_invalid_verdict_blocked" in got)
 
 
 def test_exploitable_not_downgraded_to_any_disclosure_dropped_verdict():
     # Full sweep: no verdict in DISCLOSURE_DROPPED may silently drop the finding.
+    # #448 (wave r1): values NOT in the correctable vocabulary (rejected) now
+    # take the invalid-verdict branch — either breadcrumb satisfies the
+    # preserved+audited contract.
     for dv in sorted(DISCLOSURE_DROPPED):
         got = _run_downgrade(dv)
         verdict = got.get("verification", {}).get("correct_finding") or got.get("finding")
         assert verdict == "vulnerable", f"downgrade to {dv!r} silently dropped the finding"
-        assert "consistency_downgrade_blocked" in got, f"no audit breadcrumb for {dv!r}"
+        assert ("consistency_downgrade_blocked" in got
+                or "consistency_invalid_verdict_blocked" in got), (
+            f"no audit breadcrumb for {dv!r}")
 
 
 def test_non_exploitable_downgrade_still_applies():

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -1029,7 +1029,17 @@ class FindingVerifier:
             if len(group) < 2:
                 continue
 
-            verdicts = set(r.get("verification", {}).get("correct_finding") or r.get("finding") for r in group)
+            # #448 (wave r2 opus): normalize HERE — _parse_finish_result stores
+            # correct_finding verbatim, so a group all-vulnerable but stamped
+            # "VULNERABLE"/"vulnerable" read as inconsistent and spent a full
+            # _resolve_inconsistency LLM call on every batch, every run. This
+            # compare ALWAYS runs; the round-1 fix normalized only the (rarely
+            # reachable) apply-side compare.
+            def _norm_v(r):
+                v = (r.get("verification", {}).get("correct_finding")
+                     or r.get("finding"))
+                return v.strip().lower() if isinstance(v, str) else v
+            verdicts = set(_norm_v(r) for r in group)
             if len(verdicts) > 1:
                 inconsistent_groups.append((pattern, group))
 
@@ -1039,9 +1049,13 @@ class FindingVerifier:
 
         # Fix inconsistencies
         for pattern, group in inconsistent_groups:
-            verdicts = [r.get("verification", {}).get("correct_finding") or r.get("finding") for r in group]
+            verdicts = [
+                (r.get("verification", {}).get("correct_finding") or r.get("finding"))
+                for r in group]
             self._log("warning", f"Inconsistency detected in pattern: {pattern}",
-                      details={"findings": [r.get('route_key') for r in group], "verdicts": verdicts})
+                      details={"findings": [r.get('route_key') for r in group],
+                               "verdicts": [v.strip().lower() if isinstance(v, str) else v
+                                            for v in verdicts]})
 
             # Run consistency check
             consistency_result = self._resolve_inconsistency(group, code_by_route)
@@ -1066,25 +1080,42 @@ class FindingVerifier:
                     # values are REJECTED with an audit record (the
                     # #316/#324/#425/#427 producer discipline).
                     #
-                    # REACHABILITY NOTE (wave r1 opus, re-derived): the shipped
-                    # consistency prompt asks only for should_be_consistent /
-                    # consistent_verdict / explanation — it NEVER requests
-                    # findings_to_update, so on a prompt-conformant reply this
-                    # apply loop does not fire (findings_updated is empty) and
-                    # the parsed consistent_verdict is unused downstream. The
-                    # loop IS the defense layer for NON-conformant replies: the
-                    # JSON-corrector requires only agree/correct_finding/
-                    # explanation and passes EXTRA keys through, so an
-                    # unconstrained model CAN hallucinate the Stage-1 shape
-                    # (findings_to_update with should_be) into the reply — the
+                    # REACHABILITY NOTE (wave r2 opus+fable, re-derived
+                    # twice): the shipped consistency prompt asks only for
+                    # should_be_consistent / consistent_verdict / explanation —
+                    # it NEVER requests findings_to_update, so on a
+                    # prompt-conformant reply this apply loop does not fire
+                    # (findings_updated is empty) and the parsed
+                    # consistent_verdict is unused downstream. The loop IS the
+                    # defense layer for NON-conformant replies, and the
+                    # reachability mechanism is _parse_json_from_text's DIRECT
+                    # brace-slice json.loads (filters NO keys — a hallucinated
+                    # findings_to_update in any well-formed JSON object passes
+                    # straight through). The JSON-corrector branch CANNOT
+                    # deliver the payload for a consistency-shaped reply (it
+                    # requires the verify keys agree/correct_finding/
+                    # explanation and errors out otherwise) — do not cite it as
+                    # the path. The hallucinated-Stage-1-shape reply is the
                     # exact untrusted-model-output class this gate exists for.
-                    # Wiring consistent_verdict through the loop would ACTIVATE
-                    # pattern-corrections that never ran before — a new
-                    # capability, out of scope per the campaign's fixes-only
-                    # rule; recorded as the follow-up question.
+                    # Wiring consistent_verdict through would ACTIVATE
+                    # pattern-corrections that never ran — a new capability,
+                    # out of scope per the fixes-only rule; recorded as the
+                    # follow-up question.
                     new_verdict = (raw_should_be.strip().lower()
                                    if isinstance(raw_should_be, str) else "")
                     if not new_verdict:
+                        # #448 (wave r2 fable): None/empty = "no proposal"
+                        # (silent skip is right); a NON-STRING (list/dict/
+                        # number) is a MALFORMED proposal — audited, not
+                        # silently dropped (the reject-with-audit contract).
+                        if raw_should_be is not None and raw_should_be != "":
+                            for result in results:
+                                if result.get("route_key") == route_key:
+                                    result["consistency_invalid_verdict_blocked"] = {
+                                        "proposed": raw_should_be,
+                                        "reason": finding_update.get("reason"),
+                                        "pattern": consistency_result.pattern_identified,
+                                    }
                         continue
                     if new_verdict not in _CORRECTABLE_STAGE2_FINDINGS:
                         for result in results:
@@ -1133,22 +1164,27 @@ class FindingVerifier:
                                 }
                                 continue
 
-                            # #448 (wave r1 fable): the old side is normalized
-                            # too — _parse_finish_result stores correct_finding
-                            # verbatim, so an uppercase-stamped row vs a
-                            # normalized proposal produced a spurious
-                            # consistency_update record.
-                            old_verdict = (result.get("verification", {}).get("correct_finding")
-                                           or result.get("finding"))
-                            old_verdict = (old_verdict.strip().lower()
-                                          if isinstance(old_verdict, str) else old_verdict)
+                            # #448 (wave r1/r2): the old side is normalized
+                            # for the COMPARE (an uppercase-stamped row vs a
+                            # normalized proposal must not produce a spurious
+                            # record) — but the audit `from` field keeps the RAW
+                            # stored stamp (wave r2 fable+sonnet+opus): a
+                            # case/whitespace anomaly in stored data is itself
+                            # an upstream-bug signal, and experiment.py prints
+                            # this field verbatim. The Stage-1 twin keeps raw
+                            # in `from` while comparing normalized — same
+                            # convention.
+                            raw_old = (result.get("verification", {}).get("correct_finding")
+                                       or result.get("finding"))
+                            old_verdict = (raw_old.strip().lower()
+                                          if isinstance(raw_old, str) else raw_old)
                             if old_verdict != new_verdict:
                                 result["finding"] = new_verdict
                                 if "verification" not in result:
                                     result["verification"] = {}
                                 result["verification"]["correct_finding"] = new_verdict
                                 result["consistency_update"] = {
-                                    "from": old_verdict,
+                                    "from": raw_old,
                                     "to": new_verdict,
                                     "reason": finding_update.get("reason"),
                                     "pattern": consistency_result.pattern_identified
@@ -1272,6 +1308,13 @@ class FindingVerifier:
             result = self._parse_json_from_text(text)
 
             if result:
+                # #448 (wave r2 fable): honor the one conformant field that
+                # says DO NOT APPLY — a reply carrying should_be_consistent
+                # FALSE plus a hallucinated findings_to_update (the exact
+                # non-conformant shape the apply-gate exists for) must not
+                # apply its hallucinated corrections anyway.
+                if result.get("should_be_consistent") is False:
+                    return None
                 return ConsistencyCheckResult(
                     pattern_identified=result.get("pattern_identified", "unknown"),
                     consistent_verdict=result.get("consistent_verdict", "inconclusive"),

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -1075,13 +1075,29 @@ class FindingVerifier:
                 # route_key is hallucinated too.
                 _group_rks = {r.get("route_key") for r in group}
                 for finding_update in consistency_result.findings_updated:
+                    # #448 (wave r4 opus): the ELEMENT is guarded — the
+                    # hallucinated payload's members may be strings, numbers,
+                    # or null (the shipped prompt never defines the key's
+                    # shape); .get on a non-dict crashed the Verify phase.
+                    if not isinstance(finding_update, dict):
+                        self._log("warning",
+                                  f"Malformed consistency update "
+                                  f"{finding_update!r}; ignored",
+                                  step="verify")
+                        continue
                     route_key = finding_update.get("route_key")
-                    if route_key not in _group_rks:
+                    # #448 (wave r4 fable): a NON-STRING route_key (list/dict)
+                    # must not reach the set membership — r3's in-check raised
+                    # TypeError where the pre-r3 == compare harmlessly missed
+                    # (a hallucinated list-valued route_key IS the threat
+                    # model).
+                    if (not isinstance(route_key, str)
+                            or route_key not in _group_rks):
                         self._log("warning",
                                   f"Consistency update named out-of-group route "
                                   f"{route_key!r}; ignored (the reply is "
                                   "hallucinated or misaddressed)",
-                                  unit_id=route_key)
+                                  unit_id=route_key if isinstance(route_key, str) else None)
                         continue
                     raw_should_be = finding_update.get("should_be")
                     # #448 (the #425 escape's Stage-2 twin): should_be is
@@ -1340,10 +1356,26 @@ class FindingVerifier:
                 sbc = result.get("should_be_consistent")
                 if sbc is not None and str(sbc).strip().lower() in ("false", "no", "0"):
                     return None
+                # #448 (wave r4 fable+opus): the payload CONTAINER is coerced —
+                # a hallucinated "findings_to_update": null / string / dict
+                # previously reached the apply loop and crashed the Verify
+                # phase (after every per-unit LLM call was paid for): null
+                # raised TypeError at the for; a string iterated characters
+                # and AttributeError'd at .get. The Stage-1 twin wraps its
+                # apply loop in try/except; this site coerces at the source.
+                ftu = result.get("findings_to_update")
+                if ftu is None:
+                    ftu = []
+                elif not isinstance(ftu, list):
+                    self._log("warning",
+                              f"findings_to_update is not a list "
+                              f"({type(ftu).__name__}); ignored",
+                              step="verify")
+                    ftu = []
                 return ConsistencyCheckResult(
                     pattern_identified=result.get("pattern_identified", "unknown"),
                     consistent_verdict=result.get("consistent_verdict", "inconclusive"),
-                    findings_updated=result.get("findings_to_update", []),
+                    findings_updated=ftu,
                     explanation=result.get("explanation", "")
                 )
 

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -82,7 +82,20 @@ from prompts.verification_prompts import (
     get_verification_system_prompt,
     get_consistency_check_prompt
 )
-from core.verdict_taxonomy import DISCLOSURE_DROPPED, FINDING_VERDICT_ORDER
+from core.verdict_taxonomy import (
+    DISCLOSURE_DROPPED, ERROR_VERDICT, FINDING_VERDICT_ORDER, STAGE2_VERDICTS,
+)
+
+# #448: every value `finding`/`correct_finding` can legitimately take — the
+# canonical producer vocabulary (PRODUCER_VERDICTS: FINDING_VERDICT_ORDER +
+# ERROR + the Stage-2 verification verdicts) plus INSUFFICIENT_CONTEXT (the
+# _normalize_result map's sixth value — experiment.py's corrector threads it
+# through `finding` on the re-analysis path). A consistency correction
+# outside this set is model noise, rejected below.
+_CORRECTABLE_STAGE2_FINDINGS = (
+    frozenset(FINDING_VERDICT_ORDER)
+    | {ERROR_VERDICT, "insufficient_context"}
+    | STAGE2_VERDICTS)
 
 # Import application context type for type hints
 try:
@@ -1035,7 +1048,39 @@ class FindingVerifier:
                 # Apply consistent verdict, but respect exploit path analysis
                 for finding_update in consistency_result.findings_updated:
                     route_key = finding_update.get("route_key")
-                    new_verdict = finding_update.get("should_be")
+                    raw_should_be = finding_update.get("should_be")
+                    # #448 (the #425 escape's Stage-2 twin): should_be is
+                    # unconstrained model output — this site wrote it into
+                    # `finding` VERBATIM (no strip, no validation), the key
+                    # `_count_verdicts` and the disclosure filters read FIRST:
+                    # a garbage value ("MAYBE VULNERABLE") passed the downgrade
+                    # guard (not in DISCLOSURE_DROPPED) and silently dropped a
+                    # real VULNERABLE finding from every count and from
+                    # disclosure; a PADDED value ("  vulnerable  ") landed raw
+                    # and missed every downstream lowercase vocabulary read.
+                    # Normalize (strip/lower — this module's storage
+                    # convention is lowercase `correct_finding`), then validate
+                    # against the canonical `finding` vocabulary; unrecognized
+                    # values are REJECTED with an audit record (the
+                    # #316/#324/#425/#427 producer discipline).
+                    new_verdict = (raw_should_be.strip().lower()
+                                   if isinstance(raw_should_be, str) else "")
+                    if not new_verdict:
+                        continue
+                    if new_verdict not in _CORRECTABLE_STAGE2_FINDINGS:
+                        for result in results:
+                            if result.get("route_key") == route_key:
+                                result["consistency_invalid_verdict_blocked"] = {
+                                    "proposed": raw_should_be,
+                                    "reason": finding_update.get("reason"),
+                                    "pattern": consistency_result.pattern_identified,
+                                }
+                                self._log(
+                                    "warning",
+                                    f"Blocked consistency correction of {route_key} "
+                                    f"to unrecognized verdict: {raw_should_be!r}",
+                                    unit_id=route_key)
+                        continue
 
                     for result in results:
                         if result.get("route_key") == route_key:

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -1049,21 +1049,40 @@ class FindingVerifier:
 
         # Fix inconsistencies
         for pattern, group in inconsistent_groups:
+            # #448 (wave r3 opus): the LOG keeps the RAW stamps — a
+            # case/whitespace anomaly in stored data is the same
+            # upstream-bug signal the audit `from` field preserves, and with
+            # the detector now normalized this line is the only surface where
+            # the anomaly is visible for an inconsistent group.
             verdicts = [
                 (r.get("verification", {}).get("correct_finding") or r.get("finding"))
                 for r in group]
             self._log("warning", f"Inconsistency detected in pattern: {pattern}",
                       details={"findings": [r.get('route_key') for r in group],
-                               "verdicts": [v.strip().lower() if isinstance(v, str) else v
-                                            for v in verdicts]})
+                               "verdicts": verdicts})
 
             # Run consistency check
             consistency_result = self._resolve_inconsistency(group, code_by_route)
 
             if consistency_result:
-                # Apply consistent verdict, but respect exploit path analysis
+                # Apply consistent verdict, but respect exploit path analysis.
+                # #448 (wave r3 opus): an update is scoped to the GROUP that
+                # fired the call — a hallucinated route_key naming any OTHER
+                # row in the batch previously moved that row (or stamped its
+                # audit) regardless of the pattern the model was shown. The
+                # apply gate's threat model (a fully hallucinated
+                # findings_to_update payload) is precisely the case where the
+                # route_key is hallucinated too.
+                _group_rks = {r.get("route_key") for r in group}
                 for finding_update in consistency_result.findings_updated:
                     route_key = finding_update.get("route_key")
+                    if route_key not in _group_rks:
+                        self._log("warning",
+                                  f"Consistency update named out-of-group route "
+                                  f"{route_key!r}; ignored (the reply is "
+                                  "hallucinated or misaddressed)",
+                                  unit_id=route_key)
+                        continue
                     raw_should_be = finding_update.get("should_be")
                     # #448 (the #425 escape's Stage-2 twin): should_be is
                     # unconstrained model output — this site wrote it into
@@ -1104,11 +1123,12 @@ class FindingVerifier:
                     new_verdict = (raw_should_be.strip().lower()
                                    if isinstance(raw_should_be, str) else "")
                     if not new_verdict:
-                        # #448 (wave r2 fable): None/empty = "no proposal"
-                        # (silent skip is right); a NON-STRING (list/dict/
+                        # #448 (wave r2 fable, r3 opus): None or any string
+                        # that normalizes empty (whitespace-only) = "no
+                        # proposal" — silent skip; a NON-STRING (list/dict/
                         # number) is a MALFORMED proposal — audited, not
                         # silently dropped (the reject-with-audit contract).
-                        if raw_should_be is not None and raw_should_be != "":
+                        if raw_should_be is not None and not isinstance(raw_should_be, str):
                             for result in results:
                                 if result.get("route_key") == route_key:
                                     result["consistency_invalid_verdict_blocked"] = {
@@ -1313,7 +1333,12 @@ class FindingVerifier:
                 # FALSE plus a hallucinated findings_to_update (the exact
                 # non-conformant shape the apply-gate exists for) must not
                 # apply its hallucinated corrections anyway.
-                if result.get("should_be_consistent") is False:
+                # #448 (wave r3 fable+opus): the tolerant read — the reply
+                # class this gate exists for is NON-conformant; a
+                # "should_be_consistent": "false" / "no" / 0 must not sail
+                # past an identity check on True/False only.
+                sbc = result.get("should_be_consistent")
+                if sbc is not None and str(sbc).strip().lower() in ("false", "no", "0"):
                     return None
                 return ConsistencyCheckResult(
                     pattern_identified=result.get("pattern_identified", "unknown"),

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -82,20 +82,22 @@ from prompts.verification_prompts import (
     get_verification_system_prompt,
     get_consistency_check_prompt
 )
-from core.verdict_taxonomy import (
-    DISCLOSURE_DROPPED, ERROR_VERDICT, FINDING_VERDICT_ORDER, STAGE2_VERDICTS,
-)
+from core.verdict_taxonomy import DISCLOSURE_DROPPED, FINDING_VERDICT_ORDER
 
-# #448: every value `finding`/`correct_finding` can legitimately take — the
-# canonical producer vocabulary (PRODUCER_VERDICTS: FINDING_VERDICT_ORDER +
-# ERROR + the Stage-2 verification verdicts) plus INSUFFICIENT_CONTEXT (the
-# _normalize_result map's sixth value — experiment.py's corrector threads it
-# through `finding` on the re-analysis path). A consistency correction
-# outside this set is model noise, rejected below.
-_CORRECTABLE_STAGE2_FINDINGS = (
-    frozenset(FINDING_VERDICT_ORDER)
-    | {ERROR_VERDICT, "insufficient_context"}
-    | STAGE2_VERDICTS)
+# #448 (wave r1, three axes): the correction targets are the verify `finish`
+# enum — FINDING_VERDICT_ORDER, nothing else. STAGE2_VERDICTS is a DIFFERENT
+# key (the reporter's derived stage2_verdict display field: no producer ever
+# writes confirmed/agreed/unverified/rejected into `finding`, and admitting
+# them re-opened the exact bucket-drop this fix closes — a conformant-looking
+# "confirmed" is a MORE plausible model emission than "MAYBE VULNERABLE").
+# error and insufficient_context are legitimate STATES of `finding` but not
+# legitimate CORRECTION TARGETS: both are outside DISCLOSURE_DROPPED, so
+# admitting them let a pattern-similarity pass move a conclusively-EXPLOITABLE
+# row to an uncounted/unverified shape PAST the F-KB-1b guard (the exact class
+# #195/#243 closed). With FINDING_VERDICT_ORDER alone, every admitted
+# non-DROPPED value is vulnerable/bypassable — the guard's complement is
+# well-defined.
+_CORRECTABLE_STAGE2_FINDINGS = frozenset(FINDING_VERDICT_ORDER)
 
 # Import application context type for type hints
 try:
@@ -1063,6 +1065,23 @@ class FindingVerifier:
                     # against the canonical `finding` vocabulary; unrecognized
                     # values are REJECTED with an audit record (the
                     # #316/#324/#425/#427 producer discipline).
+                    #
+                    # REACHABILITY NOTE (wave r1 opus, re-derived): the shipped
+                    # consistency prompt asks only for should_be_consistent /
+                    # consistent_verdict / explanation — it NEVER requests
+                    # findings_to_update, so on a prompt-conformant reply this
+                    # apply loop does not fire (findings_updated is empty) and
+                    # the parsed consistent_verdict is unused downstream. The
+                    # loop IS the defense layer for NON-conformant replies: the
+                    # JSON-corrector requires only agree/correct_finding/
+                    # explanation and passes EXTRA keys through, so an
+                    # unconstrained model CAN hallucinate the Stage-1 shape
+                    # (findings_to_update with should_be) into the reply — the
+                    # exact untrusted-model-output class this gate exists for.
+                    # Wiring consistent_verdict through the loop would ACTIVATE
+                    # pattern-corrections that never ran before — a new
+                    # capability, out of scope per the campaign's fixes-only
+                    # rule; recorded as the follow-up question.
                     new_verdict = (raw_should_be.strip().lower()
                                    if isinstance(raw_should_be, str) else "")
                     if not new_verdict:
@@ -1114,7 +1133,15 @@ class FindingVerifier:
                                 }
                                 continue
 
-                            old_verdict = result.get("verification", {}).get("correct_finding") or result.get("finding")
+                            # #448 (wave r1 fable): the old side is normalized
+                            # too — _parse_finish_result stores correct_finding
+                            # verbatim, so an uppercase-stamped row vs a
+                            # normalized proposal produced a spurious
+                            # consistency_update record.
+                            old_verdict = (result.get("verification", {}).get("correct_finding")
+                                           or result.get("finding"))
+                            old_verdict = (old_verdict.strip().lower()
+                                          if isinstance(old_verdict, str) else old_verdict)
                             if old_verdict != new_verdict:
                                 result["finding"] = new_verdict
                                 if "verification" not in result:

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -1038,7 +1038,13 @@ class FindingVerifier:
             def _norm_v(r):
                 v = (r.get("verification", {}).get("correct_finding")
                      or r.get("finding"))
-                return v.strip().lower() if isinstance(v, str) else v
+                # #448 (wave r6 opus): a NON-STRING verdict (a list/dict from a
+                # text-mode reply or a checkpoint restore — never
+                # type-coerced on the way in) must not reach the set()
+                # construction: unhashable values crashed the Verify phase
+                # HERE, in the detector that ALWAYS runs. The Stage-1 twin
+                # coerces to "" on the same line (stage1_consistency.py:224).
+                return v.strip().lower() if isinstance(v, str) else ""
             verdicts = set(_norm_v(r) for r in group)
             if len(verdicts) > 1:
                 inconsistent_groups.append((pattern, group))


### PR DESCRIPTION
`finding_verifier._check_consistency` is the Stage-2 twin of the stage1_consistency site #425 fixed — same `findings_to_update`/`should_be` contract, same F-KB-1b/F-KB-1a comment pairing — and it wrote the model's raw `should_be` into `finding` VERBATIM: no strip, no validation (the downgrade guard covers only DISCLOSURE_DROPPED values), no type checks anywhere on the payload's shape. `finding` is the key `_count_verdicts` reads FIRST and the key the reporter's disclosure filters key on — a garbage value silently dropped a real VULNERABLE finding from every bucket and from disclosure; a padded `"  vulnerable  "` missed every downstream lowercase read; `should_be=None` overwrote `finding` with None.

**The fix (six wave rounds to convergence, three axes each):**
- normalize (strip/lower — the module's lowercase `correct_finding` convention) + validate against `_CORRECTABLE_STAGE2_FINDINGS = frozenset(FINDING_VERDICT_ORDER)` — exactly the finish tool's `correct_finding` enum (STAGE2_VERDICTS is a DIFFERENT key — the reporter's derived display field; admitting it re-opened the drop for a conformant-looking "confirmed"); unrecognized values are REJECTED with an audit record; `error`/`insufficient_context` are states of `finding`, not correction targets (both outside DISCLOSURE_DROPPED — admitting them moved conclusively-EXPLOITABLE rows past the F-KB-1b guard);
- the DETECTOR normalizes (an all-vulnerable group stamped VULNERABLE/vulnerable previously spent a full LLM resolution call every batch) and coerces non-string verdicts (an unhashable list-valued `correct_finding` crashed the Verify phase in the path that ALWAYS runs — the twin's `else ""` guard);
- the audit `from` field keeps the RAW stored stamp (a case/whitespace anomaly is an upstream-bug signal; normalized for the compare only); the log detail keeps the raw stamps (the last surface where the anomaly is visible);
- `should_be_consistent` is honored with the tolerant read (`"false"`/`"no"`/`0` gate too — the reply class is non-conformant by construction); the payload container is coerced (null/string/dict → [] with a log) and each element guarded (non-dict members, non-string/unhashable route_keys skip — the r3 set-membership gate itself introduced a TypeError on a list-valued route_key, caught in r4);
- updates are SCOPED to the group that fired the call (a hallucinated route_key naming any other row in the batch previously moved it);
- the reachability note records the real mechanism: the shipped consistency prompt NEVER requests `findings_to_update`, so on a conformant reply the apply loop does not fire; the defense layer is for NON-conformant replies whose payload passes `_parse_json_from_text`'s direct brace-slice `json.loads` (which filters NO keys). Wiring `consistent_verdict` through would ACTIVATE pattern-corrections that never ran — a new capability, out of scope per the fixes-only rule; recorded as the follow-up question.

**Evidence:** 19 tests in the file (each round's findings pinned — the verbatim garbage write, the padded/uppercase/None writes, the STAGE2-vocabulary rejection, the conclusive-row bypass values, the case-only no-LLM-call detector, the raw-stamp audit, the driven should_be_consistent gate with the falsy spellings + TRUE control, the out-of-group scoping both ways, the six malformed-payload shapes through the REAL parse path, the enum conformance against VERIFICATION_TOOLS itself — the prose-copy pin was a no-op, caught in r3; the r4 payload test was a tautology, caught in r5 and mutation-proven after; the unhashable-detector guard mutation-proven in r6) + the F-KB-1b family pins updated CONSCIOUSLY (per-verdict branch precision: safe/protected/inconclusive must exercise the downgrade-block branch; rejected — out-of-vocabulary — takes the invalid branch). The full suite 3535 passed / 1 failed (the known macOS /private/var tmp artifact, byte-identical on pristine); the consistency/guard families green; ruff clean; hermeticity green. Seven wave rounds: r1 vocabulary, r2 detector+raw-from+reachability, r3 scoping+real pins, r4 payload shape-check, r5 the tautology fixed, r6 the unhashable guard, r7 THREE-AXIS DRY.

Related: #425 (the Stage-1 twin — its PR's own round found this site), #427 (the `_normalize_result` whitelist lineage), #426 (the round-1 pin updated with the closure).

Fixes #448

Depends-on: #479 (master's CI is red from renovate #475 bumping the anthropic pin past the merged #428 test's frozen 1.2.0 expectations — this branch is stacked on the one-commit fix; rebase onto master once #479 merges.)