### PR TITLE
chore(tests): the corpus-cleanup sweep + the test-tree-scoped ruff gate (#481)

### DIFF
--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -69,6 +69,7 @@ select = ["F821", "F811", "F823", "F401", "F841"]
 "report/**" = ["F401", "F841"]
 "prompts/**" = ["F401", "F841"]
 "openant/**" = ["F401", "F841"]
+"github_scanner/**" = ["F401", "F841"]
 # root-level dev scripts (experiment.py etc.) keep the bug-only choice too
 "experiment.py" = ["F401", "F841"]
 "validate_dataset_schema.py" = ["F401", "F841"]

--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -49,9 +49,29 @@ build-backend = "hatchling.build"
 target-version = "py311"
 
 [tool.ruff.lint]
-# Only rules that catch actual bugs (will break at runtime)
-# F821: undefined name, F811: redefined unused name, F823: local var referenced before assignment
-select = ["F821", "F811", "F823"]
+# Bug-catching rules apply everywhere; the style/dead-code rules (F401
+# unused-import, F841 unused-local) apply to the TEST TREE only — the
+# comments-corpus sweep (#481) found the test tree carrying 93 unused
+# imports + 6 dead locals, invisible under the bug-only select. Prod keeps
+# the bug-rules-only choice: its 87 F401s live in the parser/idiom modules
+# (function_extractor 14, repository_scanner 12, call_graph_builder 8 ...)
+# where imports are re-export/module-idiom candidates — a separate
+# investigation (#481's prod half), never bulk-autofixed by a chore sweep.
+select = ["F821", "F811", "F823", "F401", "F841"]
+
+[tool.ruff.lint.per-file-ignores]
+# prod packages keep the bug-rules-only choice (the style rules are
+# test-tree-scoped)
+"core/**" = ["F401", "F841"]
+"utilities/**" = ["F401", "F841"]
+"parsers/**" = ["F401", "F841"]
+"context/**" = ["F401", "F841"]
+"report/**" = ["F401", "F841"]
+"prompts/**" = ["F401", "F841"]
+"openant/**" = ["F401", "F841"]
+# root-level dev scripts (experiment.py etc.) keep the bug-only choice too
+"experiment.py" = ["F401", "F841"]
+"validate_dataset_schema.py" = ["F401", "F841"]
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -60,6 +60,10 @@ target-version = "py311"
 select = ["F821", "F811", "F823", "F401", "F841"]
 
 [tool.ruff.lint.per-file-ignores]
+# fable (cleanup panel): the efficacy fixtures are BENCHMARK DATA — the
+# webapp oracle scores them; a style autofix mutating a fixture changes
+# the corpus under measurement. Style rules never touch them.
+"tests/efficacy/fixtures/**" = ["F401", "F841"]
 # prod packages keep the bug-rules-only choice (the style rules are
 # test-tree-scoped)
 "core/**" = ["F401", "F841"]

--- a/libs/openant-core/tests/efficacy/fixtures/webapp/src/app_b.py
+++ b/libs/openant-core/tests/efficacy/fixtures/webapp/src/app_b.py
@@ -1,7 +1,7 @@
 import sqlite3
 import subprocess
 
-from flask import Flask, request
+from flask import Flask
 
 app = Flask(__name__)
 

--- a/libs/openant-core/tests/efficacy/fixtures/webapp/src/app_b.py
+++ b/libs/openant-core/tests/efficacy/fixtures/webapp/src/app_b.py
@@ -1,7 +1,7 @@
 import sqlite3
 import subprocess
 
-from flask import Flask
+from flask import Flask, request
 
 app = Flask(__name__)
 

--- a/libs/openant-core/tests/parsers/c/test_unit_generator_u3.py
+++ b/libs/openant-core/tests/parsers/c/test_unit_generator_u3.py
@@ -19,7 +19,6 @@ at the same location as its sibling flags (unit['metadata']).
 import sys
 from pathlib import Path
 
-import pytest
 
 _CORE_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(_CORE_ROOT))

--- a/libs/openant-core/tests/parsers/go/test_go_schema_completeness.py
+++ b/libs/openant-core/tests/parsers/go/test_go_schema_completeness.py
@@ -33,7 +33,6 @@ normalization unit-test on a representative camelCase record still runs.
 """
 
 import json
-import os
 import shutil
 import subprocess
 import sys

--- a/libs/openant-core/tests/parsers/javascript/test_class_expression_accessors.py
+++ b/libs/openant-core/tests/parsers/javascript/test_class_expression_accessors.py
@@ -9,7 +9,6 @@ import json
 import os
 import tempfile
 
-import pytest
 
 from core.parser_adapter import parse_repository
 

--- a/libs/openant-core/tests/parsers/python/test_function_extractor_u9.py
+++ b/libs/openant-core/tests/parsers/python/test_function_extractor_u9.py
@@ -20,7 +20,6 @@ the real entry path: FunctionExtractor(repo).extract_all([rel_path])).
 import sys
 from pathlib import Path
 
-import pytest
 
 _CORE_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(_CORE_ROOT))

--- a/libs/openant-core/tests/parsers/python/test_issue312_shebang_discovery.py
+++ b/libs/openant-core/tests/parsers/python/test_issue312_shebang_discovery.py
@@ -23,9 +23,7 @@ registry-level behaviour):
 
 from __future__ import annotations
 
-import json
 import os
-import stat
 import sys
 import tempfile
 from pathlib import Path

--- a/libs/openant-core/tests/parsers/ruby/test_function_extractor.py
+++ b/libs/openant-core/tests/parsers/ruby/test_function_extractor.py
@@ -20,7 +20,6 @@ unambiguously.
 import sys
 from pathlib import Path
 
-import pytest
 
 _CORE_ROOT = Path(__file__).resolve().parents[3]
 if str(_CORE_ROOT) not in sys.path:

--- a/libs/openant-core/tests/parsers/ruby/test_repository_scanner_symlink_cycle.py
+++ b/libs/openant-core/tests/parsers/ruby/test_repository_scanner_symlink_cycle.py
@@ -10,7 +10,6 @@ bounded, duplicate-free result.
 import importlib.util
 import os
 import sys
-import tempfile
 from pathlib import Path
 
 import pytest

--- a/libs/openant-core/tests/parsers/swift/test_swift_overload_matching.py
+++ b/libs/openant-core/tests/parsers/swift/test_swift_overload_matching.py
@@ -208,7 +208,6 @@ def test_canonical_interface_methods_present(tmp_path):
     """PR-lessons NEW-4 (sibling lockstep): Swift builder has get_dependencies/
     get_callers like the Zig/C builders."""
     from _helpers import CallGraphBuilder, FunctionExtractor, RepositoryScanner  # noqa
-    import tempfile, os
     d = str(tmp_path)
     (tmp_path / "a.swift").write_text("func a(){ b() }\nfunc b(){ c() }\nfunc c(){}")
     b = CallGraphBuilder(FunctionExtractor(d, RepositoryScanner(d).scan()).extract())

--- a/libs/openant-core/tests/parsers/swift/test_swift_stage5_regressions.py
+++ b/libs/openant-core/tests/parsers/swift/test_swift_stage5_regressions.py
@@ -5,7 +5,7 @@ import pathlib
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
-from _helpers import build, extract, edges, leaf  # noqa: E402
+from _helpers import build, extract, edges  # noqa: E402
 
 
 def test_toplevel_try_await_daemon_root(tmp_path):

--- a/libs/openant-core/tests/parsers/zig/test_zig_alias_index_recursion_depth_bound.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_alias_index_recursion_depth_bound.py
@@ -33,7 +33,6 @@ Select the module under test with env CGB_PATH (defaults to the repo file):
     CGB_PATH=/path/to/call_graph_builder.py pytest test_...depth_bound.py
 """
 
-import importlib.util
 import os
 import sys
 from pathlib import Path

--- a/libs/openant-core/tests/parsers/zig/test_zig_extractor_followup.py
+++ b/libs/openant-core/tests/parsers/zig/test_zig_extractor_followup.py
@@ -27,7 +27,6 @@ importlib to avoid any sys.modules cache collision.
 """
 
 import importlib.util
-import os
 import sys
 import tempfile
 from pathlib import Path

--- a/libs/openant-core/tests/report/test_disclosure_source_fidelity.py
+++ b/libs/openant-core/tests/report/test_disclosure_source_fidelity.py
@@ -8,9 +8,7 @@ has the opportunity to rewrite it.
 """
 
 import json
-import os
 import sys
-import tempfile
 import types
 from pathlib import Path
 from unittest.mock import MagicMock

--- a/libs/openant-core/tests/report/test_poisoned_confirmed_findings_and_findings_fa18.py
+++ b/libs/openant-core/tests/report/test_poisoned_confirmed_findings_and_findings_fa18.py
@@ -33,7 +33,6 @@ import json
 import types
 from pathlib import Path
 
-import pytest
 
 from utilities.file_io import normalize_results, write_json
 

--- a/libs/openant-core/tests/report/test_poisoned_results_substrate.py
+++ b/libs/openant-core/tests/report/test_poisoned_results_substrate.py
@@ -33,7 +33,6 @@ import json
 import types
 from pathlib import Path
 
-import pytest
 
 from utilities.file_io import normalize_results
 

--- a/libs/openant-core/tests/report/test_sibling_result_iteration_guard_fa16.py
+++ b/libs/openant-core/tests/report/test_sibling_result_iteration_guard_fa16.py
@@ -25,7 +25,6 @@ import json
 import types
 from pathlib import Path
 
-import pytest
 
 import report.html_report as generate_report
 import report.csv_export as export_csv

--- a/libs/openant-core/tests/report/test_unguarded_iteration_fam_robust.py
+++ b/libs/openant-core/tests/report/test_unguarded_iteration_fam_robust.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 
 from core.reporter import _dedup_caller_callee, build_pipeline_output
 from utilities.file_io import write_json

--- a/libs/openant-core/tests/test_backend_identity.py
+++ b/libs/openant-core/tests/test_backend_identity.py
@@ -9,7 +9,6 @@ re-run, never adopt) and the results.json / preserve-not-destroy behaviour.
 import json
 import os
 
-import pytest
 
 from core import backend_identity as bi
 from core.checkpoint import StepCheckpoint, _RESERVED_FILES, FINGERPRINT_FILE

--- a/libs/openant-core/tests/test_call_graph_output.py
+++ b/libs/openant-core/tests/test_call_graph_output.py
@@ -24,7 +24,6 @@ from __future__ import annotations
 
 import json
 import shutil
-import sys
 from pathlib import Path
 
 import pytest

--- a/libs/openant-core/tests/test_docker_scaffold.py
+++ b/libs/openant-core/tests/test_docker_scaffold.py
@@ -77,10 +77,6 @@ def test_write_test_files_stages_source(tmp_path):
         "requirements": "flask",
     }
 
-    finding = {
-        "location": {"file": "app.py", "function": "app.py:vuln"},
-    }
-
     work_dir = str(tmp_path / "work")
     os.makedirs(work_dir)
 

--- a/libs/openant-core/tests/test_e2e_model_propagation.py
+++ b/libs/openant-core/tests/test_e2e_model_propagation.py
@@ -25,14 +25,13 @@ correctly" (which `test_llm_adapter_contract.py` covers).
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 import pytest
 
 from utilities.llm import (
     CompletionResult,
-    LLMAdapter,
     Message,
     PhaseBinding,
     PhaseRegistry,
@@ -288,7 +287,7 @@ class TestAnalyzeUnitPropagation:
             },
             "metadata": {"direct_calls": [], "direct_callers": []},
         }
-        result = analyze_unit(registry.get("analyze"), unit)
+        analyze_unit(registry.get("analyze"), unit)
         # The fake adapter returned `{"verdict": "SAFE"}` — analyze_unit
         # passes it through. We don't care about the verdict itself,
         # only that the call landed on the analyze adapter.

--- a/libs/openant-core/tests/test_enhance_failed_context_error_key.py
+++ b/libs/openant-core/tests/test_enhance_failed_context_error_key.py
@@ -11,7 +11,6 @@ Bug (enhancer-failed-context-no-error-key):
 
 No network: ``simple_text`` is monkeypatched to raise / return junk.
 """
-import pytest
 
 
 class _FakeAdapter:

--- a/libs/openant-core/tests/test_enhancer_tools.py
+++ b/libs/openant-core/tests/test_enhancer_tools.py
@@ -1,5 +1,4 @@
 """Tests for the agentic enhancer tools, specifically the get_static_dependencies tool."""
-import pytest
 
 from utilities.agentic_enhancer.repository_index import RepositoryIndex
 from utilities.agentic_enhancer.tools import ToolExecutor

--- a/libs/openant-core/tests/test_entry_point_detector.py
+++ b/libs/openant-core/tests/test_entry_point_detector.py
@@ -2,7 +2,6 @@
 produced by the JS analyzer are recognised as entry points and therefore
 survive the reachability filter.
 """
-import pytest
 
 from utilities.agentic_enhancer.entry_point_detector import (
     ENTRY_POINT_TYPES,

--- a/libs/openant-core/tests/test_evidence_tier.py
+++ b/libs/openant-core/tests/test_evidence_tier.py
@@ -9,7 +9,6 @@ import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
-import pytest
 
 _CORE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(_CORE_ROOT))

--- a/libs/openant-core/tests/test_file_io.py
+++ b/libs/openant-core/tests/test_file_io.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import json
-import os
 import re
 import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 
 CORE_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(CORE_ROOT))

--- a/libs/openant-core/tests/test_go_cli.py
+++ b/libs/openant-core/tests/test_go_cli.py
@@ -7,7 +7,6 @@ so they use parse-only commands that don't require an API key.
 import json
 import os
 import subprocess
-import shutil
 import sys
 from pathlib import Path
 

--- a/libs/openant-core/tests/test_issue211_usage_details_capture.py
+++ b/libs/openant-core/tests/test_issue211_usage_details_capture.py
@@ -239,7 +239,6 @@ def test_merge_usage_no_details_no_key():
 def test_verifier_real_loop_persists_usage_details():
     """Integration: the REAL Stage-2 loop records per-turn details to the
     tracker AND serializes them into the unit's verification record."""
-    import json
     from utilities.finding_verifier import FindingVerifier
     from utilities.llm.adapter import TextBlock, ToolUseBlock
     from utilities.llm.registry import PhaseBinding

--- a/libs/openant-core/tests/test_issue213_limit_bounds_enhance.py
+++ b/libs/openant-core/tests/test_issue213_limit_bounds_enhance.py
@@ -24,7 +24,7 @@ PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from core.schemas import AnalysisMetrics, ParseResult  # noqa: E402
+from core.schemas import AnalysisMetrics  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
@@ -158,7 +158,6 @@ def test_enhance_limit_slices_diff_selected_population():
     to the enhancer (the post-slice population)."""
     import os
     import tempfile
-    from pathlib import Path
     import unittest.mock as mock
 
     from core.enhancer import enhance_dataset

--- a/libs/openant-core/tests/test_issue215_severity_field.py
+++ b/libs/openant-core/tests/test_issue215_severity_field.py
@@ -37,7 +37,6 @@ findings to ERROR):
 import sys
 from pathlib import Path
 
-import pytest
 
 CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
 if CORE not in sys.path:
@@ -133,7 +132,6 @@ def test_corrector_schema_carries_severity_top_level():
     # puts it — otherwise a corrected reply and a clean reply carry severity
     # in two shapes.
     assert '"severity"' in _VULN_SCHEMA
-    import json as _json
     top = _VULN_SCHEMA
     assert top.index('"severity"') < top.index('"vulnerabilities"'), \
         "severity must appear at the top level, before the nested array"
@@ -170,7 +168,6 @@ def _finding_row(severity=None, source=None, **extra):
 
 
 def test_pipeline_output_finding_record_carries_severity():
-    from core.reporter import build_pipeline_output
 
     po = _build_po([_finding_row(severity="high", source="model")])
     recs = po["findings"]
@@ -182,7 +179,6 @@ def test_pipeline_output_finding_record_carries_severity():
 def test_pipeline_output_derives_severity_for_old_artifacts():
     """The read-time derivation site: pre-PR results carry no severity —
     the reporter derives + marks, so old scans rank in the new surfaces."""
-    from core.reporter import build_pipeline_output
 
     po = _build_po([_finding_row()])  # no severity anywhere
     assert po["findings"][0]["severity"] == "high"
@@ -434,7 +430,7 @@ def test_the_one_severity_enum_everywhere():
     import importlib
     import openant.cli as cli
     import report.csv_export as csvx
-    from core import analysis_core, reporter
+    from core import analysis_core
     from core.verdict_taxonomy import SEVERITIES
 
     assert analysis_core.SEVERITIES is SEVERITIES

--- a/libs/openant-core/tests/test_issue216_unpriced_models_loud.py
+++ b/libs/openant-core/tests/test_issue216_unpriced_models_loud.py
@@ -194,7 +194,6 @@ def test_analyzer_resume_restores_marker(tmp_path, monkeypatch):
     """The analyzer's checkpoint-restore path re-injects unpriced models
     from per-unit records into the tracker."""
     import json
-    from core import checkpoint as cp_mod
     from core import tracking
     from utilities.file_io import write_json
     import tempfile, os

--- a/libs/openant-core/tests/test_issue273_config_trust.py
+++ b/libs/openant-core/tests/test_issue273_config_trust.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-import pytest
 
 PROJECT_ROOT = Path(__file__).parent.parent
 if str(PROJECT_ROOT) not in sys.path:

--- a/libs/openant-core/tests/test_issue281_resume_baseline.py
+++ b/libs/openant-core/tests/test_issue281_resume_baseline.py
@@ -31,7 +31,6 @@ if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
 from core import tracking  # noqa: E402
-from utilities.llm_client import TokenTracker  # noqa: E402
 
 
 def _capture_usage_line(prefix="Stage 1", baseline=None):
@@ -108,7 +107,6 @@ def test_analyzer_resnapshot_is_placed_after_injection():
     """Source-placement contract: the analyzer's baseline re-snapshot must
     sit AFTER the add_prior_usage call (the mutation smoke's target —
     simulation tests can't catch a placement regression)."""
-    import re
     src = Path(__file__).parent.parent / "core" / "analyzer.py"
     text = src.read_text()
     # ORDER-SENSITIVE (wave catch: the old test was order-insensitive —

--- a/libs/openant-core/tests/test_issue302_stage2_scope_reporting.py
+++ b/libs/openant-core/tests/test_issue302_stage2_scope_reporting.py
@@ -227,7 +227,6 @@ def test_zero_findings_early_return_keeps_denominator():
     units_analyzed_total — a clean scan's persisted scope statement is
     "adjudicated 0 of N", never "0 of 0" beside total_units=N (review finding:
     self-inconsistent artifact in exactly the scan where scope IS the message)."""
-    from core.verifier import VerifyResult
     # drive the REAL early-return path via run_verification with no findings
     import json as _json
     from pathlib import Path as _Path

--- a/libs/openant-core/tests/test_issue307_coverage_fields.py
+++ b/libs/openant-core/tests/test_issue307_coverage_fields.py
@@ -148,7 +148,7 @@ def test_js_camelcase_alias_and_no_test_skip_disclosure():
     language that skips test files WITHOUT counting them (go/rust/swift/zig
     today) is disclosed in languages_without_test_skip_data, never silently
     absent-as-zero."""
-    from core.scanner import _read_coverage_stats, _collect_coverage
+    from core.scanner import _read_coverage_stats
     import json as _json
     import tempfile as _tf
     from pathlib import Path as _Path

--- a/libs/openant-core/tests/test_issue317_case_collision.py
+++ b/libs/openant-core/tests/test_issue317_case_collision.py
@@ -382,9 +382,8 @@ def test_behavioral_restore_case_pair_via_enhance(monkeypatch, tmp_path):
     The real path: a case-pair dataset resumed through the actual
     single-shot enhance loop — each unit must get its OWN context (the
     B-not-A hazard), and no unit may be re-enhanced."""
-    import sys as _sys
     sys.path.insert(0, str(Path(__file__).resolve().parent))  # for the helpers
-    from test_enhance_resilience import _fake_binding, _dataset
+    from test_enhance_resilience import _fake_binding
     from utilities.context_enhancer import ContextEnhancer
 
     cp_dir = str(tmp_path / "enhance_checkpoints")

--- a/libs/openant-core/tests/test_issue319_dynamic_status.py
+++ b/libs/openant-core/tests/test_issue319_dynamic_status.py
@@ -23,7 +23,6 @@ import sys
 import tempfile
 from pathlib import Path
 
-import pytest
 
 CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
 if CORE not in sys.path:
@@ -239,7 +238,7 @@ def test_preexisting_dynamic_blocks_are_cleared_by_merge(tmp_path):
     assert f.get("dynamic_testing_attempted", {}).get("status") == "ERROR"
 
     # SKIPPED: a forged block on a never-executed finding is cleared too
-    p2 = {"findings": [dict(forged := pipeline["findings"][0])]}
+    p2 = {"findings": [dict(pipeline["findings"][0])]}
     (d / "dynamic_test_results.json").write_text(_json.dumps({
         "results": [{"finding_id": "VULN-001", "identity_key": "k1",
                      "status": "SKIPPED", "evidence": []}]}))

--- a/libs/openant-core/tests/test_issue321_singleshot_classification.py
+++ b/libs/openant-core/tests/test_issue321_singleshot_classification.py
@@ -24,7 +24,6 @@ import os
 import sys
 from pathlib import Path
 
-import pytest
 
 CORE = str(Path(__file__).resolve().parents[2])  # libs/openant-core
 if CORE not in sys.path:

--- a/libs/openant-core/tests/test_issue322_repo_manual_bounds.py
+++ b/libs/openant-core/tests/test_issue322_repo_manual_bounds.py
@@ -26,9 +26,8 @@ if CORE not in sys.path:
     sys.path.insert(0, CORE)
 
 from context.application_context import (  # noqa: E402
-    ApplicationContext, check_manual_override, MAX_MANUAL_EXCLUSIONS,
+    check_manual_override, MAX_MANUAL_EXCLUSIONS,
 )
-from core.scanner import ScanResult  # noqa: E402
 from report.generator import _context_provenance_header  # noqa: E402
 
 

--- a/libs/openant-core/tests/test_issue326_csv_both_keys.py
+++ b/libs/openant-core/tests/test_issue326_csv_both_keys.py
@@ -157,7 +157,6 @@ def test_html_report_feeds_the_report_llm_the_agentic_description():
 def test_nonstring_agent_context_degrades_not_crashes():
     """A hand-edited dataset with a non-dict agent_context exports a blank
     description rather than raising (the analyzer's guard convention)."""
-    import tempfile as tf
     import csv as _csv
     from report.csv_export import export_csv as _ex
     with tempfile.TemporaryDirectory() as d:

--- a/libs/openant-core/tests/test_issue331_finding_shadow.py
+++ b/libs/openant-core/tests/test_issue331_finding_shadow.py
@@ -22,7 +22,6 @@ finding (still disclosed via the net) with the correction recorded in
 `stage1_consistency_update`.
 """
 from core.analyzer import _count_verdicts
-from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
 from utilities import stage1_consistency as s1
 
 VULN_RK = "libs/a/client_utils.py:build_async_httpx_client"

--- a/libs/openant-core/tests/test_issue333_dyn_test_cost_delta.py
+++ b/libs/openant-core/tests/test_issue333_dyn_test_cost_delta.py
@@ -19,7 +19,6 @@ import json
 import sys
 from pathlib import Path
 
-import pytest
 
 _CORE = Path(__file__).resolve().parents[1]
 if str(_CORE) not in sys.path:

--- a/libs/openant-core/tests/test_issue431_dyntest_raise_accounting.py
+++ b/libs/openant-core/tests/test_issue431_dyntest_raise_accounting.py
@@ -15,7 +15,6 @@ CONTINUES to the next finding (buckets sum to total).
 from __future__ import annotations
 
 import json
-import os
 import sys
 from pathlib import Path
 

--- a/libs/openant-core/tests/test_json_corrector_verify_schema.py
+++ b/libs/openant-core/tests/test_json_corrector_verify_schema.py
@@ -15,7 +15,6 @@ so a real verification result was silently dropped (mis-corrected/rejected).
 """
 import json
 
-import pytest
 
 from utilities.json_corrector import JSONCorrector
 

--- a/libs/openant-core/tests/test_language_registry_resolution.py
+++ b/libs/openant-core/tests/test_language_registry_resolution.py
@@ -11,7 +11,6 @@ degrade rather than die at flag-registration time). These tests hold the
 Python side to the same contract.
 """
 
-from pathlib import Path
 
 import pytest
 

--- a/libs/openant-core/tests/test_llm_config_schema.py
+++ b/libs/openant-core/tests/test_llm_config_schema.py
@@ -9,7 +9,6 @@ from utilities.llm import (
     ConfigError,
     LLMConfig,
     PhaseRef,
-    ProviderConfig,
     parse_config,
     serialise_config,
 )

--- a/libs/openant-core/tests/test_llm_helpers.py
+++ b/libs/openant-core/tests/test_llm_helpers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
 
 from utilities.llm import (
     CompletionResult,

--- a/libs/openant-core/tests/test_llm_helpers_unit.py
+++ b/libs/openant-core/tests/test_llm_helpers_unit.py
@@ -32,18 +32,14 @@ from typing import Optional
 import pytest
 
 from utilities.llm import (
-    CompletionResult,
     LLMAuthError,
     LLMConnectionError,
-    LLMError,
     LLMNotFoundError,
     PhaseBinding,
     PhaseRegistry,
-    TextBlock,
     lookup_pricing,
     probe_registry_or_raise,
 )
-from utilities.llm_client import TokenTracker
 
 
 # ---------------------------------------------------------------------------

--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -244,7 +244,6 @@ from utilities.llm.providers.openai import (
     _token_param,
     _RESPONSES_MIN_OUTPUT_TOKENS,
     _messages_to_responses,
-    _tool_to_responses,
 )
 
 G5 = "gpt-5.6"

--- a/libs/openant-core/tests/test_llm_registry.py
+++ b/libs/openant-core/tests/test_llm_registry.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -12,11 +12,8 @@ from utilities.llm import (
     PHASES,
     ConfigError,
     ConfigFile,
-    LLMAdapter,
     LLMAuthError,
     LLMConfig,
-    LLMNotFoundError,
-    PhaseBinding,
     PhaseRef,
     PhaseRegistry,
     ProviderConfig,
@@ -24,7 +21,6 @@ from utilities.llm import (
     empty_config,
     get_builtin_default,
     load_config_file,
-    parse_config,
     resolve_llm_config,
     resolve_provider,
     with_llm_config,
@@ -170,7 +166,7 @@ class TestBuildPhaseRegistry:
         # All six phases share the same provider → one adapter,
         # reused across phases. Not six adapters.
         llm_config = LLMConfig(name="foo", phases=_all_phases_ref("anthropic", "m"))
-        registry = self._build(llm_config)
+        self._build(llm_config)
         assert len(_FakeAdapter.instances) == 1
 
     def test_two_providers_yield_two_adapter_instances(self):
@@ -187,7 +183,7 @@ class TestBuildPhaseRegistry:
             "app_context": PhaseRef(provider="openrouter", model="qwen/qwen-3-coder-480b"),
         }
         llm_config = LLMConfig(name="foo", phases=phases)
-        registry = self._build(llm_config, cf)
+        self._build(llm_config, cf)
         # Two distinct provider entries → two adapter instances.
         assert len(_FakeAdapter.instances) == 2
 

--- a/libs/openant-core/tests/test_llm_round4_fixes.py
+++ b/libs/openant-core/tests/test_llm_round4_fixes.py
@@ -35,7 +35,6 @@ import openai
 import pytest
 from google import genai
 from google.genai import errors as genai_errors
-from google.genai import types as genai_types
 
 from utilities.llm import (
     LLMResponseError,

--- a/libs/openant-core/tests/test_llm_round5_fixes.py
+++ b/libs/openant-core/tests/test_llm_round5_fixes.py
@@ -32,7 +32,6 @@ Everything here stubs the SDK boundary; nothing hits the network.
 from __future__ import annotations
 
 import traceback
-from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import anthropic

--- a/libs/openant-core/tests/test_multilang_critical_regressions.py
+++ b/libs/openant-core/tests/test_multilang_critical_regressions.py
@@ -5,7 +5,6 @@ both are silent: the scan exits 0 and reports success while producing wrong or
 missing results.
 """
 
-import json
 
 import pytest
 

--- a/libs/openant-core/tests/test_p6_coverage.py
+++ b/libs/openant-core/tests/test_p6_coverage.py
@@ -1,7 +1,6 @@
 """P6 coverage-fill tests — real behaviors flagged untested by the test-exhaustiveness
 audit (tester-expert + auditor). Each exercises the production code path, not a stub."""
 import hashlib
-import os
 import sys
 import pathlib
 

--- a/libs/openant-core/tests/test_parse_fresh.py
+++ b/libs/openant-core/tests/test_parse_fresh.py
@@ -8,7 +8,6 @@ import json
 import os
 from pathlib import Path
 
-import pytest
 
 from core import parser_adapter
 from core.schemas import ParseResult

--- a/libs/openant-core/tests/test_parse_multi.py
+++ b/libs/openant-core/tests/test_parse_multi.py
@@ -19,7 +19,7 @@ import subprocess
 import pytest
 
 from core import parser_adapter
-from core.parser_adapter import LanguageParseOutcome, parse_repository_multi
+from core.parser_adapter import parse_repository_multi
 from core.schemas import ParseResult
 
 FIXTURE = os.path.join(os.path.dirname(__file__), "fixtures", "sample_multilang_repo")

--- a/libs/openant-core/tests/test_parser_adapter.py
+++ b/libs/openant-core/tests/test_parser_adapter.py
@@ -1,5 +1,4 @@
 """Tests for core/parser_adapter.py — language detection and Python parsing."""
-import os
 from pathlib import Path
 
 import pytest

--- a/libs/openant-core/tests/test_pr69_round5_unverified.py
+++ b/libs/openant-core/tests/test_pr69_round5_unverified.py
@@ -62,7 +62,7 @@ sys.path.insert(0, str(_CORE_ROOT))
 # that ``import anthropic`` for its real ``_exceptions`` types.
 
 from utilities.agentic_enhancer.repository_index import RepositoryIndex
-from utilities.finding_verifier import MAX_ITERATIONS, FindingVerifier, VerificationResult
+from utilities.finding_verifier import FindingVerifier, VerificationResult
 from utilities.llm import PhaseBinding, TextBlock, ToolUseBlock
 from utilities.llm.adapter import CompletionResult
 from utilities.llm_client import reset_warning_state

--- a/libs/openant-core/tests/test_reachability_prune_telemetry.py
+++ b/libs/openant-core/tests/test_reachability_prune_telemetry.py
@@ -73,22 +73,22 @@ def test_prune_buckets_and_sidecar(tmp_path):
     fns = {k: {} for k in ["a.swift:E", "a.swift:A", "a.swift:B", "b.swift:C", "b.swift:D"]}
     cg = {"a.swift:E": ["a.swift:A"], "b.swift:D": ["b.swift:C"]}
     rcg = {"a.swift:A": ["a.swift:E"], "b.swift:C": ["b.swift:D"]}
-    m = _run(tmp_path, fns, cg, rcg, list(fns), "a.swift:E")
-    assert m["reachable_units"] == 2                       # E, A
-    assert m["filtered_out"] == 3                          # B, C, D
-    assert m["pruned_orphan_count"] == 2                   # B, D (no caller)
-    assert m["pruned_in_dead_cluster_count"] == 1          # C (caller D is pruned)
-    assert m["pruned_forward_called_by_reachable_count"] == 0   # invariant: symmetric graph
+    result = _run(tmp_path, fns, cg, rcg, list(fns), "a.swift:E")
+    assert result["reachable_units"] == 2                       # E, A
+    assert result["filtered_out"] == 3                          # B, C, D
+    assert result["pruned_orphan_count"] == 2                   # B, D (no caller)
+    assert result["pruned_in_dead_cluster_count"] == 1          # C (caller D is pruned)
+    assert result["pruned_forward_called_by_reachable_count"] == 0   # invariant: symmetric graph
     # existing keys must be unchanged (additive only)
     for k in ("original_units", "entry_points", "reachable_units", "filtered_out", "reduction_percentage"):
-        assert k in m
+        assert k in result
     # sidecar written with EVERY pruned unit + classification
-    side = json.loads((tmp_path / m["pruned_units_path"]).read_text())
+    side = json.loads((tmp_path / result["pruned_units_path"]).read_text())
     ids = {u["id"]: u for u in side["units"]}
     assert set(ids) == {"a.swift:B", "b.swift:C", "b.swift:D"}
     assert ids["a.swift:B"]["bucket"] == "orphan"
     assert ids["b.swift:C"]["bucket"] == "dead_cluster"
-    assert "b.swift" in m["pruned_by_file"]
+    assert "b.swift" in result["pruned_by_file"]
 
 
 def test_forward_asymmetry_invariant_fires(tmp_path):
@@ -108,7 +108,6 @@ def test_empty_entrypoints_passthrough_schema_unchanged(tmp_path):
     # No entry points -> early pass-through branch. Telemetry keys must NOT be added there
     # (that branch has its own schema); nothing was pruned.
     fns = {"a:foo": {}, "a:bar": {}}
-    m = _run.__wrapped__ if False else None
     out = tmp_path
     (out / "call_graph.json").write_text(json.dumps(
         {"functions": fns, "call_graph": {}, "reverse_call_graph": {}}))

--- a/libs/openant-core/tests/test_repo_explorer.py
+++ b/libs/openant-core/tests/test_repo_explorer.py
@@ -9,7 +9,6 @@ negative controls for that trade.
 from __future__ import annotations
 
 import os
-from pathlib import Path
 
 import pytest
 
@@ -18,7 +17,6 @@ from context.repo_explorer import (
     ExplorationBudget,
     RepoExplorer,
 )
-from utilities.file_io import UnsafeRepoFile
 
 
 @pytest.fixture

--- a/libs/openant-core/tests/test_repo_explorer_loop.py
+++ b/libs/openant-core/tests/test_repo_explorer_loop.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 
 from context.repo_explorer import explore_repository, MAX_TURNS
-from utilities.llm.adapter import Message, TextBlock, ToolDef, ToolResultBlock, ToolUseBlock
+from utilities.llm.adapter import TextBlock, ToolDef, ToolResultBlock, ToolUseBlock
 
 
 class _Resp:

--- a/libs/openant-core/tests/test_reporter_coercion.py
+++ b/libs/openant-core/tests/test_reporter_coercion.py
@@ -23,11 +23,8 @@ list-of-dict ``data_flow``, or dict-shaped ``verification_explanation``.
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
 
-import pytest
 
 from core.reporter import _coerce_to_str, build_pipeline_output
 from utilities.file_io import write_json

--- a/libs/openant-core/tests/test_reporter_status_fidelity.py
+++ b/libs/openant-core/tests/test_reporter_status_fidelity.py
@@ -102,7 +102,6 @@ def test_step_context_swallow_path_records_skipped_status(tmp_path: Path):
     status='skipped' on the step report — not the default 'success' — so the
     HTML step table (success->green, else->grey) stops rendering a crashed
     verify as green. Mirrors the scanner pattern without running a full scan."""
-    import os
     from core.step_report import step_context
     with step_context("verify", str(tmp_path)) as ctx:
         # simulate run_verification raising and being caught locally (no re-raise)

--- a/libs/openant-core/tests/test_rust_literal_stripper_differential.py
+++ b/libs/openant-core/tests/test_rust_literal_stripper_differential.py
@@ -15,7 +15,6 @@
 import glob
 import os
 import random
-import re
 import time
 
 from parsers.rust.call_graph_builder import (

--- a/libs/openant-core/tests/test_scanner.py
+++ b/libs/openant-core/tests/test_scanner.py
@@ -179,7 +179,6 @@ def test_dynamic_test_failure_does_not_abort_scan(monkeypatch, tmp_path):
     """An exception in the OPTIONAL dynamic-test stage must be caught."""
     _install_minimal_pipeline(monkeypatch, vulnerable=1)
 
-    import shutil as _shutil
     import core.dynamic_tester as dynamic_tester
 
     # Force the "docker present" branch so we reach run_tests.

--- a/libs/openant-core/tests/test_scanner_refilter_multilang.py
+++ b/libs/openant-core/tests/test_scanner_refilter_multilang.py
@@ -12,7 +12,6 @@ persist one is no longer skipped just because it isn't the primary.
 
 import json
 
-import pytest
 
 from core.scanner import partition_units_by_language, resolve_call_graph_dirs
 

--- a/libs/openant-core/tests/test_threat_model_agent.py
+++ b/libs/openant-core/tests/test_threat_model_agent.py
@@ -7,7 +7,6 @@ Every test here runs against a fake adapter — zero API calls, zero cost.
 """
 
 import json
-from pathlib import Path
 
 from utilities.llm.adapter import CompletionResult, TextBlock, ToolUseBlock
 

--- a/libs/openant-core/tests/test_threat_model_prompts.py
+++ b/libs/openant-core/tests/test_threat_model_prompts.py
@@ -12,7 +12,6 @@ wording and because changing it would silently move every existing user's
 verdicts.
 """
 
-import pytest
 
 from context.application_context import ApplicationContext
 from prompts.vulnerability_analysis import (

--- a/libs/openant-core/tests/test_threat_model_provenance_guard.py
+++ b/libs/openant-core/tests/test_threat_model_provenance_guard.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import types
 
-import pytest
 
 from context.threat_model_agent import _finalize
 from utilities.file_io import repo_path_state

--- a/libs/openant-core/tests/test_threshold_exclusions_are_loud.py
+++ b/libs/openant-core/tests/test_threshold_exclusions_are_loud.py
@@ -18,7 +18,6 @@ allowed to skip work; they are not allowed to do it quietly.
 import json
 from pathlib import Path
 
-import pytest
 
 from openant.cli import build_parser, resolve_language_selection
 

--- a/libs/openant-core/tests/test_token_tracker.py
+++ b/libs/openant-core/tests/test_token_tracker.py
@@ -1,5 +1,5 @@
 """Tests for TokenTracker."""
-from utilities.llm_client import TokenTracker, MODEL_PRICING
+from utilities.llm_client import TokenTracker
 
 
 class TestTokenTracker:

--- a/libs/openant-core/tests/test_windows_path_handling.py
+++ b/libs/openant-core/tests/test_windows_path_handling.py
@@ -20,7 +20,6 @@ Coverage by platform:
 import importlib.util
 import io
 import json
-import os
 import re
 import shutil
 import subprocess


### PR DESCRIPTION
The comments-corpus sweep (#481, re-derived wholesale in the retro-scan) found the test tree carrying **93 unused imports + 6 dead locals**, invisible under the repo's bug-only ruff select (F821/F811/F823 — a deliberate choice). This PR is the cleanup half of #481's infra fix:

**The scope** (pyproject.toml): F401 + F841 added to the select, per-file-ignored for the 8 prod packages + the 2 root scripts — prod keeps the bug-rules-only choice (its 87 F401s are the parser/idiom re-export candidates, a **separate investigation**, never bulk-autofixed by a chore sweep). The **efficacy fixtures are per-file-ignored** (benchmark data — the webapp oracle scores them; a style autofix mutating a fixture changes the corpus under measurement, the fable panel's catch: ruff's autofix had touched app_b.py, reverted).

**The cleanup**: ruff --fix for the 93 (the cross-file re-export check over all 72 touched files found **0 traps** — the git-diff cross-reader sweep; the #482 lesson's executed form); the 6 dead locals by hand (1 walrus leftover, 3 pass-through/dead-reassignment locals, 1 dead intermediate dict, 1 dead rebind; one rename touched 3 sibling readers in test_reachability_prune_telemetry, all restored in-commit).

**RED→GREEN**: the new scope flags 99 on pristine master; after the fix `ruff check .` is fully green. **The full suite on the deletion: 3718 passed / 0 failed** (the re-export adjudication's executed proof — the adjudication ran the suite, not just the grep).

**Gates**: full panel (sonnet+opus+fable): opus APPROVE (its honesty caveat caught the 8th package — github_scanner, added); fable FIX → all resolved (the fixtures catch, github_scanner, the narrative); sonnet FIX → prose corrections (this body). Bug-research verification: the git-diff cross-reader sweep over all 72 files — 0 re-export traps. Collision: clean (only #480 open in tree — renovate.json, no overlap). CI below; E2E on the branch follows.