### PR TITLE
fix(config): renovate.json's regex customManager — named groups + the static template (#476; supersedes #480)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "#332/#476: the vendored report scripts \u2014 versions live in the file names, the go:embed list, and the template literals; nothing else would look at them. Each package gets its OWN matchString (the regex manager substitutes named groups only \u2014 a conditional packageNameTemplate is invalid config and halted renovate).",
+      "description": "#332/#476: the vendored report scripts \u2014 versions live in the file names, the go:embed list, and the template literals; nothing else would look at them. The regex manager substitutes named groups only \u2014 a CONDITIONAL packageNameTemplate is invalid config and halted renovate; a STATIC packageNameTemplate is valid. tailwindcss and chartjs-plugin-datalabels read their packageName from the named capture group; chart.js keeps its chart- literal prefix (the vendored file is chart-X.umd.min.js \u2014 a chart\\.js literal never matches) and pins its packageName statically.",
       "fileMatch": [
         "^apps/openant-cli/internal/report/templates/.*\\.gohtml$",
         "^apps/openant-cli/internal/report/report_vendor_test\\.go$",
@@ -14,10 +14,11 @@
       ],
       "matchStrings": [
         "(?<packageName>tailwindcss)-(?<currentValue>[0-9.]+)\\.js",
-        "(?<packageName>chart\\.js)-(?<currentValue>[0-9.]+)\\.umd\\.min\\.js",
+        "chart-(?<currentValue>[0-9.]+)\\.umd\\.min\\.js",
         "(?<packageName>chartjs-plugin-datalabels)-(?<currentValue>[0-9.]+)\\.min\\.js"
       ],
-      "datasourceTemplate": "npm"
+      "datasourceTemplate": "npm",
+      "packageNameTemplate": "chart.js"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,15 +6,18 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "#332: the vendored report scripts — versions live in the file names, the go:embed list, and the template literals; nothing else would look at them.",
-      "fileMatch": ["^apps/openant-cli/internal/report/templates/.*\\.gohtml$", "^apps/openant-cli/internal/report/report_vendor_test\\.go$", "^apps/openant-cli/internal/report/vendor/SOURCES\\.txt$"],
-      "matchStrings": [
-        "(?<depName>tailwindcss)-(?<currentValue>[0-9.]+)\\.js",
-        "chart-(?<currentValue>[0-9.]+)\\.umd\\.min\\.js",
-        "chartjs-plugin-datalabels-(?<currentValue>[0-9.]+)\\.min\\.js"
+      "description": "#332/#476: the vendored report scripts \u2014 versions live in the file names, the go:embed list, and the template literals; nothing else would look at them. Each package gets its OWN matchString (the regex manager substitutes named groups only \u2014 a conditional packageNameTemplate is invalid config and halted renovate).",
+      "fileMatch": [
+        "^apps/openant-cli/internal/report/templates/.*\\.gohtml$",
+        "^apps/openant-cli/internal/report/report_vendor_test\\.go$",
+        "^apps/openant-cli/internal/report/vendor/SOURCES\\.txt$"
       ],
-      "datasourceTemplate": "npm",
-      "packageNameTemplate": "{{#if matches.1}}tailwindcss{{else if matches.2}}chart.js{{else}}chartjs-plugin-datalabels{{/if}}"
+      "matchStrings": [
+        "(?<packageName>tailwindcss)-(?<currentValue>[0-9.]+)\\.js",
+        "(?<packageName>chart\\.js)-(?<currentValue>[0-9.]+)\\.umd\\.min\\.js",
+        "(?<packageName>chartjs-plugin-datalabels)-(?<currentValue>[0-9.]+)\\.min\\.js"
+      ],
+      "datasourceTemplate": "npm"
     }
   ]
 }


### PR DESCRIPTION
Supersedes #480 (rebased onto current master — the original branch was based pre-#483 and its diff would have reverted the ruff-scope PRs; the real change is renovate.json only).

**The original fix** (#332's wave-round debt): the regex customManager's Handlebars-style CONDITIONAL `packageNameTemplate` is invalid Renovate config — the regex manager substitutes named capture groups only — and Renovate halted ALL PRs for the repository (#476). The conditional dropped; each package reads its packageName from a named group.

**The panel round** — all three panels (sonnet+opus+fable, independently convergent) caught the same defect in the first draft: `(?<packageName>chart\.js)-` requires a literal `chart.js-` prefix, but the vendored file is `chart-4.4.7.umd.min.js` — the pattern could never match and chart.js coverage would have been silently dropped. Fixed: the chart entry keeps its `chart-` literal + a **STATIC** `packageNameTemplate: "chart.js"` (valid — the invalid shape was the conditional); the other two read their packageName from the named groups.

**Executed verification**: each of the 3 real vendored filenames (verified from the tree) matches exactly 1 pattern; the wrong shape (`chart.js-` prefix) matches 0. The invalid-config class is gone; the tracked surface unchanged.