### PR TITLE
fix(config): one customManager per vendored report package — the shared static packageNameTemplate overrode every capture group (#485's lesson)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,19 +6,49 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "#332/#476: the vendored report scripts \u2014 versions live in the file names, the go:embed list, and the template literals; nothing else would look at them. The regex manager substitutes named groups only \u2014 a CONDITIONAL packageNameTemplate is invalid config and halted renovate; a STATIC packageNameTemplate is valid. tailwindcss and chartjs-plugin-datalabels read their packageName from the named capture group; chart.js keeps its chart- literal prefix (the vendored file is chart-X.umd.min.js \u2014 a chart\\.js literal never matches) and pins its packageName statically.",
+      "description": "#332/#476 vendored report scripts \u2014 chart.js. Versions live in the vendored file names, the go:embed list and vendorScripts names, the template literals, and the test pins in report_vendor_test.go and report_issue332_test.go (filename lists + the 'Chart.js v<version>' banner marker). RULES BOUGHT WITH INCIDENTS: (1) A CONDITIONAL packageNameTemplate is invalid config for the regex manager and halted renovate (#476) \u2014 do not reintroduce one. (2) A STATIC packageNameTemplate overrides the packageName capture group of every matchString in its manager \u2014 observed behavior, renovate CLI 37.440.7 (--dry-run=extract at 1a6fa1be); #485's single shared manager used one static template for three matchStrings, so tailwindcss-3.4.16.js and chartjs-plugin-datalabels-2.2.0.min.js extracted as chart.js@3.4.16 / chart.js@2.2.0 and spawned the invalid #487/#488 branches. THE INVARIANT: never mix a static packageNameTemplate with a matchString carrying a packageName capture group \u2014 the group is silently overridden. Every manager here uses value-only matchStrings + its own static template; DO NOT add a matchString with a packageName group to any of these managers. chart.js needs the static template because the vendored file name (chart-X.umd.min.js) carries no literal matching the npm package name chart.js; the second matchString tracks the banner marker pinned by report_issue332_test.go. vendor/SOURCES.txt (the provenance record) is deliberately NOT tracked: config:recommended's :ignoreModulesAndTests preset adds **/vendor/** to ignorePaths (verified: a no-extends config extracts it, the preset one does not), we deliberately do not override the standard ignores \u2014 provenance there is hand-maintained per the #332 recipe. These managers are NOTIFIERS, not fixers: a vendored bump always needs the manual #332 recipe (the vendored blob + the sha256 pin + the go:embed/vendorScripts names + the template literals + both test files' pins \u2014 all in one commit); the branch rewrites the name literals (including the go:embed list in report.go, which makes the branch BUILD-red, not just test-red) while the vendored blob and its sha256 pin do not move, so every branch from this surface is unmergeable as-authored by design.",
       "fileMatch": [
         "^apps/openant-cli/internal/report/templates/.*\\.gohtml$",
         "^apps/openant-cli/internal/report/report_vendor_test\\.go$",
-        "^apps/openant-cli/internal/report/vendor/SOURCES\\.txt$"
+        "^apps/openant-cli/internal/report/report_issue332_test\\.go$",
+        "^apps/openant-cli/internal/report/report\\.go$"
       ],
       "matchStrings": [
-        "(?<packageName>tailwindcss)-(?<currentValue>[0-9.]+)\\.js",
         "chart-(?<currentValue>[0-9.]+)\\.umd\\.min\\.js",
-        "(?<packageName>chartjs-plugin-datalabels)-(?<currentValue>[0-9.]+)\\.min\\.js"
+        "Chart\\.js v(?<currentValue>[0-9.]+)"
       ],
       "datasourceTemplate": "npm",
       "packageNameTemplate": "chart.js"
+    },
+    {
+      "customType": "regex",
+      "description": "#332/#476 vendored report scripts \u2014 tailwindcss. Same rules as the chart.js manager above (static packageNameTemplate + value-only matchStrings; never add a packageName capture group to this manager \u2014 #485's lesson; the file name needs the static template because tailwindcss-3.4.16.js matches the npm package tailwindcss). Notifier-only: the vendored blob/sha do not move on a branch; see the chart.js manager entry for the full rules.",
+      "fileMatch": [
+        "^apps/openant-cli/internal/report/templates/.*\\.gohtml$",
+        "^apps/openant-cli/internal/report/report_vendor_test\\.go$",
+        "^apps/openant-cli/internal/report/report_issue332_test\\.go$",
+        "^apps/openant-cli/internal/report/report\\.go$"
+      ],
+      "matchStrings": [
+        "tailwindcss-(?<currentValue>[0-9.]+)\\.js"
+      ],
+      "datasourceTemplate": "npm",
+      "packageNameTemplate": "tailwindcss"
+    },
+    {
+      "customType": "regex",
+      "description": "#332/#476 vendored report scripts \u2014 chartjs-plugin-datalabels. Same rules as the chart.js manager above (static packageNameTemplate + value-only matchStrings; never add a packageName capture group to this manager \u2014 #485's lesson; the file name matches the npm package chartjs-plugin-datalabels). Notifier-only: the vendored blob/sha do not move on a branch; see the chart.js manager entry for the full rules.",
+      "fileMatch": [
+        "^apps/openant-cli/internal/report/templates/.*\\.gohtml$",
+        "^apps/openant-cli/internal/report/report_vendor_test\\.go$",
+        "^apps/openant-cli/internal/report/report_issue332_test\\.go$",
+        "^apps/openant-cli/internal/report/report\\.go$"
+      ],
+      "matchStrings": [
+        "chartjs-plugin-datalabels-(?<currentValue>[0-9.]+)\\.min\\.js"
+      ],
+      "datasourceTemplate": "npm",
+      "packageNameTemplate": "chartjs-plugin-datalabels"
     }
   ]
 }


### PR DESCRIPTION
## Why

#485's `renovate.json` carried **one** regex customManager: three `matchStrings` (two with `packageName` capture groups) plus a **manager-level static** `packageNameTemplate: "chart.js"`. A static template overrides the `packageName` group of **every** matchString in its manager, so:

- `tailwindcss-3.4.16.js` extracted as **chart.js@3.4.16**
- `chartjs-plugin-datalabels-2.2.0.min.js` extracted as **chart.js@2.2.0**
- `chart-4.4.7.umd.min.js` extracted as chart.js@4.4.7

and renovate opened branches for each fake "current": **#487** (chart.js 2.2.0→2.9.4 — actually rewrites the *datalabels* file name to a nonexistent `-2.9.4`, keeping the stale 2.2.0 sha256) and **#488** (3.4.16→3.9.1 — rewrites the *tailwind* file name). Both are red-by-construction and unmergeable. This was our own bug introduced by #485; its verification matrix checked match-counts per file, never **attribution** per dep — the extraction semantics were never tested. That lesson is recorded in the config descriptions.

## The fix

Three per-package managers, each **static `packageNameTemplate` + value-only matchStrings** (no `packageName` groups anywhere — the invariant that makes the override trap unexpressible). Coverage added vs #485: **`report.go`** (the `go:embed` list + `vendorScripts` names) and **`report_issue332_test.go`** (filename pins + the `Chart.js v<version>` banner marker, via a second value-only matchString on the chart manager).

`vendor/SOURCES.txt` is deliberately **not** tracked: `config:recommended`'s `:ignoreModulesAndTests` preset adds `**/vendor/**` to `ignorePaths` — verified with a discriminating probe (a no-`extends` repo config extracts the file; the preset config does not). The standard ignores are deliberately not overridden; provenance there is hand-maintained per the #332 recipe.

## Evidence (executed, reproducible)

`LOG_LEVEL=debug npx --package renovate renovate --platform=local --dry-run=extract` from the repo root (renovate CLI **37.440.7**; newer CLIs ≥39 rename `fileMatch`→`managerFilePatterns`, auto-migrated at runtime):

- **RED** at base `1a6fa1b`: 9/9 report-file rows → `chart.js`.
- **GREEN** with this config: **15/15 entries, 0 misattributions** — the full per-file matrix is in the commit body (report.go ×4 incl the banner, report_issue332_test.go ×3, report_vendor_test.go ×3, both templates).
- `renovate-config-validator --strict` passes (at the pinned CLI).

The validator alone would **not** have caught the #485 bug (it was validator-clean) — the extract run is the load-bearing half; this failure class remains unguarded by CI (the local guard is the two commands above).

## Pre-declared consequences

- **These managers are notifiers, not fixers.** A vendored bump always needs the manual #332 recipe (blob + sha256 + `go:embed` + `vendorScripts` + template literals + both test files' pins — one commit). Every future branch from this surface stays **structurally red** as-authored — with `report.go` now tracked, a branch goes **build-red** at the embed directive rather than only test-red (louder, earlier).
- Expected new notifier PRs post-merge (**re-derived from the npm registry**): `chartjs-plugin-datalabels` 2.2.0 **is npm latest** → 0 branches; `tailwindcss` → 2 (in-range 3.4.x + a 4.x major); `chart.js` 4.4.7→4.5.1 continues as #491. ~3 total red PRs is the steady state; closing them is normal hygiene, merging any as-authored is never correct.
- **#487/#488 will be closed with evidence** (merging either writes a bogus file name into master — e.g. `chartjs-plugin-datalabels-2.9.4.min.js`, which the *new* config would then dutifully extract as datalabels@2.9.4: a self-consistent-looking lie caught only by the sha256 pin). Renovate may auto-close them on its first post-merge run; the evidence comments go on regardless.
- **#491 stays open until the manual 4.4.7→4.5.1 completion lands** (a separate PR — `fix/chart-451-vendored` — carries the full recipe with a dual-source sha256; once it merges, #491 goes stale and closes).
- The open requirements.txt bumps (#486/#489/#490) are untouched by this change, but merging any config change causes renovate to re-evaluate and may rebase them — their CI runs will refresh (poll the new run, not the stale one).
- If the maintainer prefers **no red PRs at all** on this surface, the alternative is scoping `dependencyDashboardApproval: true` to these managers via `packageRules` — a workflow choice deliberately left open here, since the current PR-pool watching treats the red branches as the notification.

## Notes

- npm `tailwindcss` 3.4.x continues past 3.4.16 and `cdn.tailwindcss.com` serves the matching Play-CDN builds (verified for 3.4.17, HTTP 200), so the npm datasource gives honest version comparisons for the vendored artifact; a future 4.x major proposal is read-before-acting (v4's CDN story differs).
- Extraction runs against the base branch only, so a rebased stale branch cannot re-poison extraction.