### PR TITLE
test(llm): the installed-SDK contract floor — declared-ness + construct-then-extract for every field the adapters read

### DIFF
--- a/libs/openant-core/tests/test_issue211_usage_details_capture.py
+++ b/libs/openant-core/tests/test_issue211_usage_details_capture.py
@@ -144,7 +144,7 @@ def test_openai_chat_absent_details_absent():
 
 
 def test_openai_responses_extracts_reasoning_and_cached_tokens():
-    """Field names verified against pinned openai SDK 2.37.0 ResponseUsage."""
+    """Field names verified against the installed SDK — tests/test_llm_sdk_contract_floor.py re-derives them against the installed version on every run."""
     from utilities.llm.providers.openai import _extract_usage_details_responses
     usage = SimpleNamespace(
         input_tokens=100, output_tokens=50,

--- a/libs/openant-core/tests/test_llm_sdk_contract_floor.py
+++ b/libs/openant-core/tests/test_llm_sdk_contract_floor.py
@@ -1,0 +1,363 @@
+"""The installed-SDK contract floor (the ARCHITECTURE §1 seam, machine-checked).
+
+The adapter tests elsewhere stub the SDK boundary with SimpleNamespace
+fakes (``tests/_llm_factories/``) — they pin OUR code's contract, not the
+SDK's. A usage-field rename in a future openai / google-genai release keeps
+every fake-based test green while the adapters' getattr walks silently
+degrade to ``None`` (the known installed-SDK↔extractor seam: openai 2.37→2.54
+and anthropic 0.125→1.1 moved usage/exception shapes mid-campaign).
+
+This floor closes that gap TWO ways, because construction alone is circular
+(a pydantic model with extra="allow" would store a renamed field as an extra
+attribute and getattr would still find it):
+
+1. **Declared-ness** — every field the adapters read is asserted to be a
+   DECLARED field of the installed SDK's type (``"<field>" in
+   Type.model_fields``). A rename removes the declaration and turns this
+   file RED.
+2. **Construct-then-extract** — real objects drive the real extractors, so
+   the values (not just the names) flow end to end.
+
+Both SDKs are hard pins in requirements.txt (CI installs them); a missing
+SDK fails loudly here rather than skipping silently — a silent skip would
+defeat the floor.
+
+Coverage (mirrors the adapters' consumed surface; the refusal set is built
+from ``_GEMINI_REFUSAL_NAMES`` into ``_GEMINI_REFUSAL_FINISH_REASONS``, and
+the finish map at ``_GEMINI_FINISH_REASONS``):
+  * openai chat usage: completion_tokens_details.reasoning_tokens,
+    prompt_tokens_details.cached_tokens / cache_write_tokens
+  * openai Responses usage: output_tokens_details.reasoning_tokens,
+    input_tokens_details.cached_tokens (+ the version fact that the detail
+    fields are required and non-nullable, machine-checked via a
+    ValidationError construction)
+  * openai exception taxonomy incl. APITimeoutError, and the retry-after
+    parse driven over a real RateLimitError
+  * openai finish_reason Literal (content_filter) + message.refusal declared
+  * google-genai usage_metadata fields + the candidates+thoughts billing
+    helper (_gemini_output_tokens — the single source of the rule) +
+    thoughts/cached_content detail fields
+  * google-genai FinishReason members behind BOTH google maps
+    (_GEMINI_REFUSAL_NAMES and _GEMINI_FINISH_REASONS keys)
+  * google-genai HttpRetryOptions.attempts declared (the retry-parity field)
+  * ClientError construction with the .code attribute the adapter maps
+  * the installed versions tied to the requirements.txt pins
+
+Executed self-controls at authoring time (the PR body carries the outputs):
+misspelling the extractor field names made this suite RED (7 tests); and
+misspelling a DECLARED-NESS assertion (reasoning_tokens -> reasoning_tokenz)
+made the declared-ness test RED — both directions of the rename detection.
+"""
+
+from __future__ import annotations
+
+import typing
+from types import SimpleNamespace
+
+import httpx
+import openai
+import pytest
+
+from utilities.llm.providers import google as google_provider
+from utilities.llm.providers import openai as openai_provider
+
+
+# --------------------------------------------------------------------------- #
+# Version provenance — the floor is only meaningful against the pinned SDKs  #
+# --------------------------------------------------------------------------- #
+
+
+def _requirements_pins() -> dict[str, str]:
+    import re
+    from pathlib import Path
+
+    pins: dict[str, str] = {}
+    root = Path(__file__).resolve().parents[1]
+    for line in (root / "requirements.txt").read_text().splitlines():
+        m = re.match(r"^(openai|google-genai)==([0-9.]+)", line.strip())
+        if m:
+            pins[m.group(1)] = m.group(2)
+    return pins
+
+
+def test_installed_sdks_match_the_requirements_pins():
+    """Records WHICH versions the floor re-derived against and fails if the
+    environment's installed SDKs drift from the pins (a stale cached wheel
+    would otherwise validate the wrong version silently)."""
+    import google.genai
+
+    pins = _requirements_pins()
+    assert openai.__version__ == pins["openai"], (
+        f"installed openai {openai.__version__} != requirements pin {pins['openai']}"
+    )
+    assert google.genai.__version__ == pins["google-genai"], (
+        f"installed google-genai {google.genai.__version__} != pin {pins['google-genai']}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# openai — DECLARED-NESS of every field the adapters read                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_openai_usage_detail_fields_are_declared():
+    from openai.types import CompletionUsage
+    from openai.types.completion_usage import CompletionTokensDetails, PromptTokensDetails
+    from openai.types.responses import ResponseUsage
+    from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+    assert "reasoning_tokens" in CompletionTokensDetails.model_fields
+    assert {"cached_tokens", "cache_write_tokens"} <= set(PromptTokensDetails.model_fields)
+    assert {"completion_tokens_details", "prompt_tokens_details"} <= set(CompletionUsage.model_fields)
+
+    assert "reasoning_tokens" in OutputTokensDetails.model_fields
+    assert "cached_tokens" in InputTokensDetails.model_fields
+    assert {"input_tokens_details", "output_tokens_details"} <= set(ResponseUsage.model_fields)
+
+
+def test_openai_finish_reason_literal_declares_content_filter():
+    from openai.types.chat import chat_completion
+
+    choice_cls = chat_completion.Choice
+    annotation = choice_cls.model_fields["finish_reason"].annotation
+    args = typing.get_args(annotation)
+    assert "content_filter" in args, (
+        "the adapter maps 'content_filter' (its _OPENAI_CONTENT_FILTER_REASON); "
+        "the installed SDK's finish_reason Literal no longer declares it"
+    )
+
+
+def test_openai_message_refusal_is_declared():
+    from openai.types.chat import ChatCompletionMessage
+
+    assert "refusal" in ChatCompletionMessage.model_fields, (
+        "the adapter surfaces message.refusal (#212); the installed SDK's "
+        "chat message type no longer declares it"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# openai — construct-then-extract over the REAL types                         #
+# --------------------------------------------------------------------------- #
+
+
+def _real_chat_usage() -> "openai.types.CompletionUsage":
+    from openai.types import CompletionUsage
+    from openai.types.completion_usage import CompletionTokensDetails, PromptTokensDetails
+
+    return CompletionUsage(
+        prompt_tokens=10,
+        completion_tokens=20,
+        total_tokens=30,
+        completion_tokens_details=CompletionTokensDetails(reasoning_tokens=5),
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=3, cache_write_tokens=1),
+    )
+
+
+def test_openai_chat_usage_details_from_real_sdk_type():
+    details = openai_provider._extract_usage_details_chat(_real_chat_usage())
+    assert details == {"reasoning_tokens": 5, "cached_tokens": 3, "cache_write_tokens": 1}
+
+
+def test_openai_chat_usage_absent_details_is_none():
+    from openai.types import CompletionUsage
+
+    bare = CompletionUsage(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    assert openai_provider._extract_usage_details_chat(bare) is None
+    assert openai_provider._extract_usage_details_chat(None) is None
+
+
+def _real_responses_usage() -> "openai.types.responses.ResponseUsage":
+    from openai.types.responses import ResponseUsage
+    from openai.types.responses.response_usage import InputTokensDetails, OutputTokensDetails
+
+    return ResponseUsage(
+        input_tokens=7,
+        output_tokens=8,
+        total_tokens=15,
+        output_tokens_details=OutputTokensDetails(reasoning_tokens=4),
+        input_tokens_details=InputTokensDetails(cached_tokens=2, cache_write_tokens=1),
+    )
+
+
+def test_openai_responses_usage_details_from_real_sdk_type():
+    details = openai_provider._extract_usage_details_responses(_real_responses_usage())
+    assert details == {"reasoning_tokens": 4, "cached_tokens": 2}
+
+
+def test_openai_responses_detail_fields_required_and_non_nullable():
+    """The version fact behind the absent-arm: at 3.6.0 the detail fields on
+    ResponseUsage are required AND non-nullable, so 'no details' materializes
+    as usage=None. If a bump makes them optional, this construction starts
+    succeeding — RED here means the absent-arm test above must be widened."""
+    from pydantic import ValidationError
+    from openai.types.responses import ResponseUsage
+
+    with pytest.raises(ValidationError):
+        ResponseUsage(input_tokens=7, output_tokens=8, total_tokens=15)
+
+
+# --------------------------------------------------------------------------- #
+# openai — the exception taxonomy + retry-after the adapter consumes          #
+# --------------------------------------------------------------------------- #
+
+
+def _fake_httpx_response(status: int, retry_after: str | None = None) -> httpx.Response:
+    headers = {"retry-after": retry_after} if retry_after is not None else {}
+    return httpx.Response(
+        status, request=httpx.Request("POST", "https://api.example.com/v1/x"), headers=headers
+    )
+
+
+def test_openai_exception_classes_construct_with_real_signatures():
+    cases = [
+        (openai.AuthenticationError, {"message": "bad key", "response": _fake_httpx_response(401), "body": None}, 401),
+        (openai.PermissionDeniedError, {"message": "denied", "response": _fake_httpx_response(403), "body": None}, 403),
+        (openai.RateLimitError, {"message": "slow down", "response": _fake_httpx_response(429, retry_after="7"), "body": None}, 429),
+        (openai.NotFoundError, {"message": "no model", "response": _fake_httpx_response(404), "body": None}, 404),
+        (openai.APIStatusError, {"message": "boom", "response": _fake_httpx_response(500), "body": None}, 500),
+    ]
+    for exc_cls, args, expected_status in cases:
+        exc = exc_cls(**args)
+        assert exc.response.status_code == expected_status, exc_cls.__name__
+
+    openai.APIConnectionError(
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    )
+    openai.APITimeoutError(
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    )
+
+
+def test_openai_retry_after_over_real_rate_limit_error():
+    """The retry-after parse the adapter consumes on RateLimitError — driven
+    over the REAL exception carrying a REAL httpx.Response header."""
+    exc = openai.RateLimitError(
+        message="slow down",
+        response=_fake_httpx_response(429, retry_after="7"),
+        body=None,
+    )
+    assert openai_provider._retry_after_from(exc) == 7.0
+
+
+# --------------------------------------------------------------------------- #
+# google-genai — DECLARED-NESS                                                #
+# --------------------------------------------------------------------------- #
+
+
+def test_gemini_usage_metadata_fields_are_declared():
+    from google.genai import types as genai_types
+
+    um = genai_types.GenerateContentResponseUsageMetadata
+    assert {
+        "prompt_token_count",
+        "candidates_token_count",
+        "thoughts_token_count",
+        "cached_content_token_count",
+    } <= set(um.model_fields)
+
+
+def test_gemini_retry_options_attempts_is_declared():
+    """The retry-parity field: the adapter passes
+    HttpRetryOptions(attempts=max_retries+1) — the field name is load-bearing
+    (a rename silently changes retry counts)."""
+    from google.genai import types as genai_types
+
+    assert "attempts" in genai_types.HttpRetryOptions.model_fields
+
+
+def test_gemini_finish_reason_members_back_both_adapter_maps():
+    """Every raw name in BOTH google maps must exist as a FinishReason member
+    at the installed version — the sets are built by getattr and silently
+    shrink on a member rename."""
+    from google.genai import types as genai_types
+
+    for name in google_provider._GEMINI_REFUSAL_NAMES:
+        assert hasattr(genai_types.FinishReason, name), (
+            f"FinishReason.{name} (refusal set) is absent from the installed google-genai"
+        )
+    for key in google_provider._GEMINI_FINISH_REASONS:
+        # the map keys carry both raw names ("STOP") and str(member) forms
+        # ("FinishReason.STOP") — only the raw names name enum members
+        if key.startswith("FinishReason."):
+            continue
+        assert hasattr(genai_types.FinishReason, key), (
+            f"FinishReason.{key} (finish map) is absent from the installed google-genai"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# google-genai — construct-then-extract over the REAL types                   #
+# --------------------------------------------------------------------------- #
+
+
+def _real_gemini_usage_metadata() -> object:
+    from google.genai import types as genai_types
+
+    return genai_types.GenerateContentResponseUsageMetadata(
+        prompt_token_count=11,
+        candidates_token_count=6,
+        thoughts_token_count=4,
+        cached_content_token_count=2,
+    )
+
+
+def test_google_usage_details_from_real_sdk_type():
+    details = google_provider._extract_usage_details(_real_gemini_usage_metadata())
+    assert details == {"thoughts_token_count": 4, "cached_content_token_count": 2}
+
+
+def test_google_output_tokens_is_the_adapters_own_helper():
+    """The billing rule (output = candidates + thoughts) driven through the
+    ADAPTER'S helper — not a re-implementation of its arithmetic."""
+    usage = _real_gemini_usage_metadata()
+    assert google_provider._gemini_output_tokens(usage) == 10  # 6 candidates + 4 thoughts
+    bare = SimpleNamespace(candidates_token_count=0, thoughts_token_count=0)
+    assert google_provider._gemini_output_tokens(bare) == 0
+
+
+def test_google_usage_absent_details_is_none():
+    from google.genai import types as genai_types
+
+    bare = genai_types.GenerateContentResponseUsageMetadata(prompt_token_count=1)
+    assert google_provider._extract_usage_details(bare) is None
+    assert google_provider._extract_usage_details(None) is None
+
+
+def test_client_error_constructs_with_code():
+    from google.genai import errors as genai_errors
+
+    response_json = {"error": {"code": 429, "message": "slow down", "status": ""}}
+    err = genai_errors.ClientError(429, response_json, _fake_httpx_response(429))
+    assert err.code == 429
+
+
+# --------------------------------------------------------------------------- #
+# The discrimination proof (negative controls)                                #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "wrong",
+    [
+        SimpleNamespace(completion_tokens_details=SimpleNamespace(reasoning_tokenz=5)),
+        SimpleNamespace(prompt_tokens_details=SimpleNamespace(cached_tokenz=3)),
+        SimpleNamespace(),
+    ],
+)
+def test_openai_wrong_shapes_extract_none(wrong):
+    """The extractors return exactly None for wrong-shaped input — never a
+    partial dict of garbage values."""
+    assert openai_provider._extract_usage_details_chat(wrong) is None
+
+
+@pytest.mark.parametrize(
+    "wrong",
+    [
+        SimpleNamespace(thoughtz_token_count=1),
+        SimpleNamespace(cached_content_tokenz=1),
+        SimpleNamespace(),
+    ],
+)
+def test_google_wrong_shapes_extract_none(wrong):
+    assert google_provider._extract_usage_details(wrong) is None

--- a/libs/openant-core/utilities/llm/providers/google.py
+++ b/libs/openant-core/utilities/llm/providers/google.py
@@ -99,7 +99,8 @@ _GEMINI_FINISH_REASONS: dict[str, StopReason] = {
 # ``LLMRefusalError`` so a security scan doesn't read a safety-blocked
 # candidate as a clean, finding-free pass.
 #
-# We verified against the pinned google-genai SDK (v2.4.0) that
+# We verified (and tests/test_llm_sdk_contract_floor.py re-derives against the
+# INSTALLED SDK) that
 # ``types.FinishReason`` exposes SAFETY / RECITATION / BLOCKLIST /
 # PROHIBITED_CONTENT / SPII (among others). We build the comparison set
 # from the enum when importable so the names stay in sync with the SDK,
@@ -142,6 +143,20 @@ def reset_warnings() -> None:
     """Clear this adapter's one-time-warning memory (for tests / new scans)."""
     with _warned_finish_reasons_lock:
         _warned_finish_reasons.clear()
+
+
+def _gemini_output_tokens(usage: Any) -> int:
+    """Gemini's output-token billing rule, as the single source of truth.
+
+    Gemini bills output as candidates + thoughts (thinking models like
+    gemini-2.5-* emit ``thoughts_token_count``); count both so the cost
+    isn't undercounted. ``tests/test_llm_sdk_contract_floor.py`` drives
+    this against the INSTALLED SDK's ``usage_metadata`` type — a field
+    rename in a future google-genai turns that floor RED.
+    """
+    return (getattr(usage, "candidates_token_count", 0) or 0) + (
+        getattr(usage, "thoughts_token_count", 0) or 0
+    )
 
 
 def _extract_usage_details(usage: Any) -> Optional[dict]:
@@ -197,8 +212,11 @@ class GoogleAdapter:
             max_retries: Forwarded to the SDK as
                 ``HttpOptions(retry_options=HttpRetryOptions(attempts=...))``.
                 The google-genai SDK DOES expose retry configuration this
-                way (verified against the pinned v2.4.0:
-                ``HttpRetryOptions.attempts``); on top of the SDK's own
+                way (``HttpRetryOptions.attempts`` is a declared field of
+                the installed SDK — tests/test_llm_sdk_contract_floor.py
+                re-derives the field's existence on every run; the attempt-
+                COUNTING semantics below are documented, not machine-checked);
+                on top of the SDK's own
                 retry, our rate limiter coordinates 429 backoff across
                 workers — same division of labour as the other adapters.
             _client: Injected SDK instance for testing.
@@ -222,7 +240,9 @@ class GoogleAdapter:
         if max_retries is not None:
             # F3 (round-5): the SDK's ``attempts`` field is the "Maximum
             # number of attempts, INCLUDING the original request" (verified
-            # against pinned google-genai v2.4.0: "If 0 or 1, it means no
+            # against the installed google-genai (the FIELD is re-derived by
+            # tests/test_llm_sdk_contract_floor.py; this counting SEMANTICS is
+            # documented, not machine-checked): "If 0 or 1, it means no
             # retries"). OpenAI/Anthropic ``max_retries`` instead counts
             # retries BEYOND the first request. So forwarding
             # ``attempts=max_retries`` was off-by-one — ``max_retries=5``
@@ -454,13 +474,7 @@ def _response_to_unified(response: Any) -> CompletionResult:
     usage = getattr(response, "usage_metadata", None)
     if usage is not None:
         input_tokens = getattr(usage, "prompt_token_count", 0) or 0
-        # Gemini bills output as candidates + thoughts (thinking models
-        # like gemini-2.5-* emit thoughts_token_count); count both so the
-        # cost isn't undercounted.
-        output_tokens = (
-            (getattr(usage, "candidates_token_count", 0) or 0)
-            + (getattr(usage, "thoughts_token_count", 0) or 0)
-        )
+        output_tokens = _gemini_output_tokens(usage)
     usage_details = _extract_usage_details(usage)
 
     # R4-2: a safety/blocked candidate finish reason is the more

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -676,7 +676,8 @@ def _extract_usage_details_responses(usage: Any) -> Optional[dict]:
     Same contract as :func:`_extract_usage_details_chat` but for the
     Responses API field names (``output_tokens_details.reasoning_tokens``,
     ``input_tokens_details.cached_tokens`` — field names verified against
-    the pinned openai SDK 2.37.0 ``ResponseUsage`` types). Verbatim,
+    the INSTALLED SDK's ``ResponseUsage`` types — tests/test_llm_sdk_contract_floor.py
+    re-derives the names against the installed version on every run). Verbatim,
     present-only, never in the cost math.
     """
     if usage is None:


### PR DESCRIPTION
## Why

The adapter tests stub the SDK boundary with SimpleNamespace fakes — they pin **our** contract, not the SDK's. A usage-field rename in a future openai / google-genai release keeps the whole fake-based suite green while the adapters' getattr walks silently degrade to `None` (the known installed-SDK↔extractor seam: openai 2.37→2.54 and anthropic 0.125→1.1 moved usage/exception shapes mid-campaign).

## The floor — two legs, because construction alone is circular

A pydantic model with `extra="allow"` would store a renamed field as an *extra* attribute and `getattr` would still find it — so construct-only tests cannot detect renames. This floor closes the gap with:

1. **Declared-ness** — every field the adapters read is asserted to be a **declared** field of the installed type (`"<field>" in Type.model_fields`). A rename removes the declaration → RED, regardless of the extra policy.
2. **Construct-then-extract** — real objects drive the real extractors end to end.

Both SDKs are hard `requirements.txt` pins (CI installs them); a missing SDK fails loudly rather than skipping silently — a silent skip would defeat the floor.

## Coverage

- openai chat + Responses usage detail fields, incl. the machine-checked version fact that Responses detail fields are **required and non-nullable** (`pytest.raises(ValidationError)` — a bump making them optional goes RED and forces the absent-arm to widen)
- `finish_reason` Literal (`content_filter`) + `message.refusal` declared-ness
- The exception taxonomy (per-class status equality, incl. `APITimeoutError`) and the **retry-after parse driven over a real `RateLimitError`**
- google-genai `usage_metadata` fields, the billing rule via the adapter's own new `_gemini_output_tokens()` helper (single source — no test-side re-implementation), FinishReason members behind **both** google maps, `HttpRetryOptions.attempts` declared, `ClientError` construction
- The installed versions **tied to the requirements.txt pins** — a stale cached wheel validates the wrong version silently otherwise

## Must-trips (executed, both directions)

- Misspelling the **extractor** field names in the providers → this suite **FAILED 7 tests**; reverted → green.
- Misspelling a **declared-ness** assertion → the declared-ness test **FAILED**; reverted → green.
- Negative controls: wrong-shaped objects extract exactly `None` (pinned `is None`), never garbage.

## Evidence

(venv built from `requirements.txt`: openai 3.6.0, google-genai 2.21.0)
- `python -m pytest tests/test_llm_sdk_contract_floor.py` → **23 passed**
- `python -m pytest tests/ -q -x --ignore=tests/report` → **3721 passed / 33 skipped / 0 failed** (with the floor included)
- `python -m ruff check .` → All checks passed!
- Stale-cite sweep: `grep -rn '2\.37\.0|v2\.4\.0' utilities/ tests/*.py` → 0 hits

## Also

- The frozen-version docstring cites refreshed (`pinned openai SDK 2.37.0`, `v2.4.0` ×3, `test_issue211:147`) — a frozen cite goes stale **by design**. Where the floor genuinely re-derives (FinishReason members, field names) the cite says so; where it does not (the `HttpRetryOptions.attempts` **counting semantics**) the cite now honestly says *"documented, not machine-checked"* — no live-but-false provenance claims.
- `google.py`'s output-token billing rule moved into `_gemini_output_tokens()` so the floor drives the adapter's own arithmetic.

**Sequencing note:** deliberately opened **before** the openai 3.8.0 / google-genai 2.22.0 pin bumps (#490/#489) — once merged, their CI runs this floor against the new SDKs, so the bumps get machine-verified field-by-field instead of riding green-but-blind.
