### PR TITLE
docs(report): the 4-model panel's doc-polish round (stale tailwind example, ceiling dead-end, vendorScripts comment)

### DIFF
--- a/apps/openant-cli/internal/report/report.go
+++ b/apps/openant-cli/internal/report/report.go
@@ -27,9 +27,11 @@ var reskinFS embed.FS
 //go:embed vendor/tailwindcss-3.4.17.js vendor/chart-4.5.1.umd.min.js vendor/chartjs-plugin-datalabels-2.2.0.min.js
 var vendorFS embed.FS
 
-// vendorScripts holds the embedded script contents. A wrong name in a
-// template is a compile-time failure (go:embed), so the map is built once
-// and the read cannot fail.
+// vendorScripts holds the embedded script contents. go:embed validates the
+// directive's patterns at COMPILE time (a missing vendored file fails the
+// build); a wrong name in a TEMPLATE is a render-time failure — vendorJS
+// fails loud when the literal names nothing embedded (see below), so the
+// map is built once and a stale literal cannot pass silently.
 var vendorScripts = func() map[string]template.JS {
 	m := make(map[string]template.JS, 3)
 	for _, n := range []string{

--- a/apps/openant-cli/internal/report/vendor/SOURCES.txt
+++ b/apps/openant-cli/internal/report/vendor/SOURCES.txt
@@ -24,7 +24,13 @@
 #         releases past 3.4.17, so renovate's npm-datasource notifier will
 #         propose versions with NO published Play-CDN artifact — those
 #         branches are read-before-acting: verify the CDN actually serves
-#         the version before attempting this recipe.
+#         the version before attempting this recipe. The verification will
+#         fail for EVERY version past 3.4.17 — this vendored blob is frozen
+#         on this channel (including for future security fixes; the npm
+#         dist carries no play-cdn script — verified by tarball listing, so
+#         there is no second source to dual-verify against either). A
+#         security bump means executing the prebuilt-CSS/CLI follow-up
+#         direction recorded above, not a re-vendor.
 #   sha256: 176e894661aa9cdc9a5cba6c720044cbbf7b8bd80d1c9a142a7c24b1b6c50d15
 #
 # chart-4.5.1.umd.min.js

--- a/renovate.json
+++ b/renovate.json
@@ -22,7 +22,7 @@
     },
     {
       "customType": "regex",
-      "description": "#332/#476 vendored report scripts \u2014 tailwindcss. Same rules as the chart.js manager above (static packageNameTemplate + value-only matchStrings; never add a packageName capture group to this manager \u2014 #485's lesson; the file name needs the static template because tailwindcss-3.4.16.js matches the npm package tailwindcss). Notifier-only: the vendored blob/sha do not move on a branch; see the chart.js manager entry for the full rules.",
+      "description": "#332/#476 vendored report scripts \u2014 tailwindcss. Same rules as the chart.js manager above (static packageNameTemplate + value-only matchStrings; never add a packageName capture group to this manager \u2014 #485's lesson; the file name needs the static template because tailwindcss-<version>.js matches the npm package tailwindcss). Notifier-only: the vendored blob/sha do not move on a branch; see the chart.js manager entry for the full rules.",
       "fileMatch": [
         "^apps/openant-cli/internal/report/templates/.*\\.gohtml$",
         "^apps/openant-cli/internal/report/report_vendor_test\\.go$",


### PR DESCRIPTION
The final review panel (4 independent reviewers on PR #497, converged: code/recipe/integrity CLEAN) left four LOW doc-level findings — all fixed here, doc/comment-only, no behavior change: (1) the tailwind manager's example filename was the last non-historical `3.4.16` survivor after the 3.4.17 bump → now version-generic; (2) the SOURCES.txt artifact-space-ceiling note dead-ended for the security case — it now states the verification fails for every version past 3.4.17 (the blob is frozen on this channel; no second source exists) and links the prebuilt-CSS/CLI escape hatch; (3) the vendorScripts comment claimed compile-time name checking, contradicting the vendorJS fail-loud render-time path → corrected; (4) the panel's kimi finding — the PR-body '(recorded in SOURCES.txt)' attribution over-reached — resolved by actually recording those two lines in SOURCES.txt (folded into fix 2). Evidence: `renovate-config-validator --strict` → Config validated successfully; gofmt/vet clean; `go test ./internal/report/ -count=1` → ok.