### PR TITLE
test(infra): the bare-open class retired — ast conformance scan + SIM115 backstop

### DIFF
--- a/libs/openant-core/pyproject.toml
+++ b/libs/openant-core/pyproject.toml
@@ -55,12 +55,25 @@ target-version = "py311"
 # parser import blocks + the core/utilities refactor residue, re-export-
 # adjudicated with 0 cross-file traps) was cleaned in the same commit the
 # scope expanded (the #481 prod half — the #483 test half preceded it).
-select = ["F821", "F811", "F823", "F401", "F841"]
+# SIM115 (open-without-with) flags unmanaged open-family calls EXCEPT in
+# return statements, behind ExitStack/enterContext, immediately .close()d,
+# or inside __enter__ — the return shape and Name/BinOp ``.open`` receivers
+# are its blind spot; the tests-tree conformance scan in
+# tests/test_issue481_bare_open_conformance.py closes those.
+select = ["F821", "F811", "F823", "F401", "F841", "SIM115"]
 
 [tool.ruff.lint.per-file-ignores]
-# fable (prod-cleanup panel, the #483 carryover): the efficacy fixtures are
-# BENCHMARK DATA — the oracle scores them; style rules never touch them.
-"tests/efficacy/fixtures/**" = ["F401", "F841"]
+# NOTE: the SIM115 entries below are also consumed (via fnmatch) by the
+# AST conformance sweep in tests/test_issue481_bare_open_conformance.py —
+# keep slash-containing path forms; a basename-only pattern matches for
+# ruff (basename) but not the sweep (full relative path).
+# The efficacy fixtures are BENCHMARK DATA — the oracle scores them; style
+# rules never touch them (a deliberate bare open lives at
+# tests/efficacy/fixtures/webapp/src/app_a.py:15 and must stay).
+"tests/efficacy/fixtures/**" = ["F401", "F841", "SIM115"]
+# The sample repos are parser INPUT DATA — arbitrary target-repo code the
+# language parsers consume, not this project's own test logic.
+"tests/fixtures/**" = ["SIM115"]
 
 [tool.hatch.build.targets.wheel]
 packages = [

--- a/libs/openant-core/tests/parsers/javascript/test_arrow_const_collision.py
+++ b/libs/openant-core/tests/parsers/javascript/test_arrow_const_collision.py
@@ -8,6 +8,7 @@ that function and its calls. Other emit paths use a first-wins skip guard.
 import json
 import os
 import tempfile
+from pathlib import Path
 
 from core.parser_adapter import parse_repository
 
@@ -22,7 +23,7 @@ def _functions(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="javascript", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))["functions"]
+    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))["functions"]
 
 
 def test_arrow_const_does_not_drop_block_function_sink():

--- a/libs/openant-core/tests/parsers/javascript/test_class_expression_accessors.py
+++ b/libs/openant-core/tests/parsers/javascript/test_class_expression_accessors.py
@@ -8,6 +8,7 @@ getGetAccessors()/getSetAccessors().
 import json
 import os
 import tempfile
+from pathlib import Path
 
 
 from core.parser_adapter import parse_repository
@@ -23,7 +24,7 @@ def _functions(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="javascript", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))["functions"]
+    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))["functions"]
 
 
 def test_class_expression_getter_emitted_as_unit():

--- a/libs/openant-core/tests/parsers/javascript/test_constructor_reachability.py
+++ b/libs/openant-core/tests/parsers/javascript/test_constructor_reachability.py
@@ -9,6 +9,7 @@ constructor only within the same file; a cross-file `new X()`, `new Map()`, and 
 import json
 import os
 import tempfile
+from pathlib import Path
 
 from core.parser_adapter import parse_repository
 
@@ -23,7 +24,7 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="javascript", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/javascript/test_local_objlit_methods.py
+++ b/libs/openant-core/tests/parsers/javascript/test_local_objlit_methods.py
@@ -9,6 +9,7 @@ file must never resolve to it -- no phantom, whether the object is exported or n
 import json
 import os
 import tempfile
+from pathlib import Path
 
 from core.parser_adapter import parse_repository
 
@@ -23,7 +24,7 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="javascript", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/javascript/test_seed_colon_id_resolution.py
+++ b/libs/openant-core/tests/parsers/javascript/test_seed_colon_id_resolution.py
@@ -9,6 +9,7 @@ FIRST colon (relative paths contain no colon).
 import json
 import os
 import tempfile
+from pathlib import Path
 
 from core.parser_adapter import parse_repository
 
@@ -23,7 +24,7 @@ def _call_graph(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="javascript", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
 
 
 def test_route_seed_with_colon_id_resolves_callee():

--- a/libs/openant-core/tests/parsers/zig/test_callgraph_funcptr_field.py
+++ b/libs/openant-core/tests/parsers/zig/test_callgraph_funcptr_field.py
@@ -8,6 +8,7 @@ param/runtime funcptr never over-connects.
 import json
 import os
 import tempfile
+from pathlib import Path
 
 from core.parser_adapter import parse_repository
 
@@ -22,7 +23,7 @@ def _cg(files: dict):
     out = tempfile.mkdtemp()
     parse_repository(repo, out, language="zig", processing_level="all",
                      skip_tests=True, name="r")
-    return json.load(open(os.path.join(out, "call_graph.json")))
+    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/test_agreement_filter.py
+++ b/libs/openant-core/tests/test_agreement_filter.py
@@ -214,7 +214,7 @@ def test_verifier_confirmed_findings_includes_disagree_vulnerable():
 
     try:
         _write_verified_results(path, experiment, merged, verified_only)
-        data = json.loads(open(path).read())
+        data = json.loads(Path(path).read_text(encoding="utf-8"))
         confirmed = data["confirmed_findings"]
         assert len(confirmed) == 1, f"expected 1 confirmed (login), got {len(confirmed)}"
         assert confirmed[0]["route_key"] == "app.py:login"

--- a/libs/openant-core/tests/test_bughunt2_regressions.py
+++ b/libs/openant-core/tests/test_bughunt2_regressions.py
@@ -4,6 +4,7 @@ Each test fails on the pre-fix code and passes after. Kept together for traceabi
 the fixes live in html_report.py, context/threat_model.py, core/analysis_core.py.
 """
 import os
+from pathlib import Path
 import tempfile
 
 import pytest
@@ -19,7 +20,7 @@ def test_go1_verdict_badge_is_escaped():
                         "finding": "<img src=x onerror=alert(1)>"}]}
     out = os.path.join(tempfile.mkdtemp(), "r.html")
     H.generate_html_report(exp, {"units": []}, "", out)
-    html = open(out).read()
+    html = Path(out).read_text(encoding="utf-8")
     assert "<img src=x onerror=alert(1)>" not in html      # raw injection blocked
     assert "&lt;img src=x onerror=alert(1)&gt;" in html    # escaped form present
 
@@ -30,7 +31,7 @@ def test_go2_null_reasoning_no_crash():
     H.prepare_findings_summary(exp, {"units": []})          # was None[:300] TypeError
     out = os.path.join(tempfile.mkdtemp(), "r.html")
     H.generate_html_report(exp, {"units": []}, "", out)     # end-to-end
-    html = open(out).read()
+    html = Path(out).read_text(encoding="utf-8")
     # not just no-crash: the finding must actually render (else a refactor that skips
     # the row for a non-fix reason would keep the test green)
     assert "a.py:f" in html and "vulnerable" in html
@@ -41,7 +42,7 @@ def test_go3_error_verdict_surfaced():
     exp = {"results": [{"route_key": "a.py:f", "finding": "error"}]}
     out = os.path.join(tempfile.mkdtemp(), "r.html")
     H.generate_html_report(exp, {"units": []}, "", out)
-    html = open(out).read()
+    html = Path(out).read_text(encoding="utf-8")
     assert "Errored (unanalyzed)" in html          # stat card
     assert '"error"' in html                        # AND the charts (not just the card)
 
@@ -55,7 +56,7 @@ def test_go3_chart_does_not_reintroduce_injection():
     ]}
     out = os.path.join(tempfile.mkdtemp(), "r.html")
     H.generate_html_report(exp, {"units": []}, "", out)
-    html = open(out).read()
+    html = Path(out).read_text(encoding="utf-8")
     assert '"error"' in html                        # sentinel charted
     assert "<svg onload=alert(1)>" not in html      # arbitrary verdict NOT injected
 

--- a/libs/openant-core/tests/test_docker_scaffold.py
+++ b/libs/openant-core/tests/test_docker_scaffold.py
@@ -84,7 +84,7 @@ def test_write_test_files_stages_source(tmp_path):
 
     staged = os.path.join(work_dir, "app.py")
     assert os.path.exists(staged), "source file must be staged into work_dir"
-    assert open(staged).read() == "def vuln(): pass"
+    assert Path(staged).read_text(encoding="utf-8") == "def vuln(): pass"
 
 
 def test_write_test_files_works_without_source(tmp_path):

--- a/libs/openant-core/tests/test_fence_live_sites_escape.py
+++ b/libs/openant-core/tests/test_fence_live_sites_escape.py
@@ -16,6 +16,7 @@ Sites (independently re-derived as LIVE this session):
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
 # The breakout payload: a bare closing fence, injected instructions, then a
 # reopen. If any site fences with < 4 backticks (or not at all), the injected
@@ -212,7 +213,7 @@ def test_collapse_inline_has_a_single_home():
             if not fn.endswith(".py"):
                 continue
             p = os.path.join(dp, fn)
-            txt = open(p, encoding="utf-8", errors="ignore").read()
+            txt = Path(p).read_text(encoding="utf-8", errors="ignore")
             rel = os.path.relpath(p, core_root).replace(os.sep, "/")
             if "def _oneline" in txt:
                 offenders_oneline.append(rel)

--- a/libs/openant-core/tests/test_identity_gate_wiring.py
+++ b/libs/openant-core/tests/test_identity_gate_wiring.py
@@ -4,6 +4,7 @@ uses without any billed API call.
 """
 
 import json
+from pathlib import Path
 import os
 import types
 
@@ -121,7 +122,7 @@ def test_base_url_credentials_never_persisted_to_sidecar(tmp_path):
                  base_url="https://user:pass@host/v1?api_key=SECRET#frag"),
         ["S", "U"])
     cp.sync_identity(fp)
-    raw = open(os.path.join(cp.dir, FINGERPRINT_FILE)).read()
+    raw = Path(os.path.join(cp.dir, FINGERPRINT_FILE)).read_text(encoding="utf-8")
     for banned in ("user:pass", "SECRET", "api_key=", "#frag"):
         assert banned not in raw, f"{banned} leaked into the persisted sidecar"
     persisted = json.loads(raw)
@@ -142,7 +143,7 @@ def test_archive_stale_results_preserves_prior_report(tmp_path):
     assert not os.path.exists(results)
     archived = os.path.join(str(tmp_path), "results__OLD.json")
     assert os.path.isfile(archived)
-    assert json.load(open(archived))["results"] == [1, 2, 3]
+    assert json.loads(Path(archived).read_text(encoding="utf-8"))["results"] == [1, 2, 3]
 
 
 def test_archive_stale_results_noop_when_fingerprint_matches(tmp_path):
@@ -207,5 +208,5 @@ def test_archive_stale_results_never_clobbers_existing_archive(tmp_path):
         json.dump({"results": ["second"]}, fh)
     _archive_stale_results(d, "NEW")
     # Both preserved — neither clobbered.
-    assert json.load(open(os.path.join(d, "results__legacy.json")))["results"] == ["first"]
-    assert json.load(open(os.path.join(d, "results__legacy-1.json")))["results"] == ["second"]
+    assert json.loads(Path(os.path.join(d, "results__legacy.json")).read_text(encoding="utf-8"))["results"] == ["first"]
+    assert json.loads(Path(os.path.join(d, "results__legacy-1.json")).read_text(encoding="utf-8"))["results"] == ["second"]

--- a/libs/openant-core/tests/test_installed_layout.py
+++ b/libs/openant-core/tests/test_installed_layout.py
@@ -117,7 +117,8 @@ def test_a_built_wheel_carries_the_config(tmp_path: Path):
 
     wheels = list(tmp_path.glob("*.whl"))
     assert wheels, "no wheel produced"
-    names = zipfile.ZipFile(wheels[0]).namelist()
+    with zipfile.ZipFile(wheels[0]) as zf:
+        names = zf.namelist()
     assert any("languages.json" in n for n in names), (
         f"wheel ships no language config; installed users get zero languages. "
         f"Entries: {[n for n in names if 'config' in n]}"
@@ -149,7 +150,8 @@ def test_wheel_omits_test_artifacts_and_carries_runtime_modules(tmp_path: Path):
 
     wheels = list(tmp_path.glob("*.whl"))
     assert wheels, "no wheel produced"
-    names = zipfile.ZipFile(wheels[0]).namelist()
+    with zipfile.ZipFile(wheels[0]) as zf:
+        names = zf.namelist()
 
     banned = [n for n in names
               if "/test_output/" in n or "/test_data/" in n

--- a/libs/openant-core/tests/test_issue216_unpriced_models_loud.py
+++ b/libs/openant-core/tests/test_issue216_unpriced_models_loud.py
@@ -208,7 +208,7 @@ def test_analyzer_resume_restores_marker(tmp_path, monkeypatch):
     tracker.reset()
     # drive the same accumulation the resume loop performs
     _existing = {"unit_a": json.loads(
-        open(os.path.join(td, "unit_a.json")).read())}
+        Path(os.path.join(td, "unit_a.json")).read_text(encoding="utf-8"))}
     unpriced = set()
     for _uid, _cp in _existing.items():
         unpriced.update(_cp.get("usage", {}).get("unpriced_models") or [])

--- a/libs/openant-core/tests/test_issue326_csv_both_keys.py
+++ b/libs/openant-core/tests/test_issue326_csv_both_keys.py
@@ -16,6 +16,7 @@ The fix (the issue's suggested reading, with the key-name mapping the issue insi
   first) — this file's half of #321's producer (the single-shot half is #321's own PR).
 """
 import csv
+import io
 import json
 import sys
 import tempfile
@@ -169,7 +170,7 @@ def test_nonstring_agent_context_degrades_not_crashes():
             {"id": "app.py:x", "agent_context": "garbage", "code": "x=1"}]}))
         out = Path(d) / "r.csv"
         _ex(str(exp), str(ds), str(out))
-        row = list(_csv.DictReader(open(out)))[0]
+        row = list(_csv.DictReader(io.StringIO(Path(out).read_text(encoding="utf-8"))))[0]
         assert row["unit_description"] == ""
 
 

--- a/libs/openant-core/tests/test_issue432_error_breakdown.py
+++ b/libs/openant-core/tests/test_issue432_error_breakdown.py
@@ -151,8 +151,9 @@ def test_status_uses_the_same_breakdown_vocabulary():
             ("V3", "Container did not produce valid JSON output"),
             ("V4", "mystery"),
         ]:
-            (open(os.path.join(d, f"{name}.json"), "w")).write(_json.dumps(
-                {"id": name, "status": "ERROR", "details": details}))
+            (Path(os.path.join(d, f"{name}.json"))).write_text(_json.dumps(
+                {"id": name, "status": "ERROR", "details": details}),
+                encoding="utf-8")
         st = StepCheckpoint.status(d)
         bd = st["error_breakdown"]
         assert bd.get("generation") == 1, bd

--- a/libs/openant-core/tests/test_issue481_bare_open_conformance.py
+++ b/libs/openant-core/tests/test_issue481_bare_open_conformance.py
@@ -1,0 +1,302 @@
+"""#481: the bare-open class stays retired — a structural conformance scan.
+
+The review-corpus sweep (the 11-comment not-always-closed class) was retired
+by converting every inline bare open to the pathlib idiom. This test is the
+lock: it re-parses the tests tree and fails if a bare ``open()`` ever comes
+back.
+
+Policy points, so a future reader knows the intent:
+
+1. **AST, not regex.** The tests tree embeds ``open(`` inside string
+   literals as parser fixture data (e.g. the C-parser tests), so a regex
+   scan needs a hand-rolled scrubber to avoid false positives. AST sees
+   string data as Constant nodes, never as calls — the false-positive
+   class is gone by construction.
+2. **with-management is the property — for the object the with receives.**
+   Managed calls are the OUTERMOST call of each ``with`` item's context
+   expression (a plain Call; a parenthesized ``with (a as x, b as y):``
+   parses as separate items, and a walrus or await in the header is
+   unwrapped). An open nested as an ARGUMENT (``with tarfile.open(fileobj=
+   open(p)) as t:``) is NOT managed — the with closes the tarfile, not the
+   handle passed to it — and is flagged. Likewise ``with pytest.raises(...):
+   open(missing)`` in the body is flagged although no handle survives, and
+   ``fh = open(p)`` + ``with fh:`` is flagged even though it does close at
+   runtime — for test code, never holding an unmanaged handle (not even
+   to hand it back, not even in a raise-path) is the policy, and the open
+   belongs IN the with-header. Wrapper idioms that DO close
+   their argument (``contextlib.closing(open(p))``, ``ExitStack.
+   enter_context``) are not recognized — no test uses them today; if one
+   ever needs one, extend the managed set here, in one place.
+   ``os.open`` is exempt (fd-based, not a handle; the low-level idiom in
+   test_hostile_repo.py is correct). Everything else with an ``.open``
+   attribute is flagged — including ``Path.open``/``tmp_path.open()``, which
+   ruff's SIM115 cannot see on a Name or BinOp receiver.
+3. **What ruff covers vs this scan.** SIM115 flags unmanaged open-family
+   calls EXCEPT in a ``with``/``return`` statement, behind ExitStack/
+   unittest ``enterContext``, immediately ``.close()``d, or inside
+   ``__enter__`` — its blind spot is the return statement (that is exactly
+   how the six shared ``_graph()`` helpers escaped it), plus non-Call
+   ``.open`` receivers, plus anything outside its stdlib opener list —
+   notably the project's own ``open_utf8`` wrapper, invisible to SIM115 in
+   every shape. This scan closes those gaps for the open family. Among
+   constructor-style openers, ruff's list reaches the tempfile family,
+   ``lzma.LZMAFile`` and ``fileinput.FileInput`` (subject to the same
+   with/return/ExitStack/immediate-close exemptions above); the
+   CONSTRUCTORS ``zipfile.ZipFile(...)``, ``tarfile.TarFile(...)``,
+   ``bz2.BZ2File(...)``, ``io.FileIO``, ``gzip.GzipFile`` and ``os.fdopen``
+   are invisible to BOTH arms — though the ``.open()`` MEMBER on a
+   ``ZipFile(...)``/``LZMAFile(...)``/``TarFile(...)`` receiver IS visible
+   to both (zero unmanaged constructor sites today; if one appears, add
+   the constructor names here). Known limits of any name-based detector
+   apply to it too: an ``import os as o`` alias would false-positive, an opener
+   imported under a different name would be a silent miss, and ANY
+   non-``os`` ``.open`` flags — including non-handle openers
+   (``webbrowser.open``) and an ``IfExp`` with-header (both arms of a
+   ``with open(a) if c else open(b):`` flag although one is managed at
+   runtime) — the tests tree uses none of these (if one appears, extend
+   the name sets here in one place). The two arms together are the guard,
+   which is why the config pin below asserts SIM115 cannot silently
+   disappear from the ruff select.
+4. **The exemption list is derived, not duplicated.** Paths exempt from
+   this scan are the pyproject per-file-ignores entries that list SIM115
+   — the efficacy fixtures and the sample-repo fixtures are parser
+   input/benchmark data, not test logic (a deliberate bare open lives at
+   tests/efficacy/fixtures/webapp/src/app_a.py:15), and the two gates
+   move together — EXCEPT that pytest-collected logic (test_*.py /
+   *_test.py / conftest.py) is scanned even under an exempt glob: a
+   planted test file under fixture data is logic, not data. (fnmatch's
+   ``*`` crosses directory separators and ruff additionally matches a
+   slash-less pattern against basenames; only exact ``SIM115`` mentions
+   are honored — keep both in mind when adding entries.)
+"""
+from __future__ import annotations
+
+import ast
+import fnmatch
+import tomllib
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+CORE_ROOT = TESTS_DIR.parent
+PYPROJECT = CORE_ROOT / "pyproject.toml"
+
+# Name-form openers that return a file handle: the builtin, and the
+# project's own utf-8 wrapper (utilities/file_io.py — the with-target).
+_OPENER_NAMES = {"open", "open_utf8"}
+
+
+def _bare_open_sites(source: str, filename: str = "<source>") -> list[int]:
+    """Line numbers of every open-family call not managed by a ``with``.
+
+    Managed = the outermost call of a with-item's context expression
+    (walrus in the header is unwrapped); argument-nested opens are NOT
+    managed (the with closes its own object, not the arguments handed to
+    it). A parenthesized ``with (open(a), open(b)) as (fa, fb):`` never
+    reaches the managed arm — a bare tuple has no ``__enter__``, the code
+    itself raises at runtime — so both opens flag.
+    """
+    tree = ast.parse(source, filename=filename)
+    managed: set[int] = set()
+
+    def _outer_calls(expr) -> list[ast.Call]:
+        # A walrus or await in the with-header is genuinely managed;
+        # unwrap to the call underneath.
+        if isinstance(expr, (ast.NamedExpr, ast.Await)):
+            return _outer_calls(expr.value)
+        if isinstance(expr, ast.Call):
+            return [expr]
+        return []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.With, ast.AsyncWith)):
+            for item in node.items:
+                for call in _outer_calls(item.context_expr):
+                    managed.add(id(call))
+    sites: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or id(node) in managed:
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id in _OPENER_NAMES:
+            sites.append(node.lineno)
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "open"
+            and not (isinstance(func.value, ast.Name) and func.value.id == "os")
+        ):
+            sites.append(node.lineno)
+    return sites
+
+
+@pytest.mark.parametrize("source,expected", [
+    # Must trip: the retired class, every face of it.
+    pytest.param("import json\ndef f(p):\n    return json.load(open(p))\n", 1,
+                 id="return-json-load-open"),
+    pytest.param("def f(p):\n    return open(p).read()\n", 1,
+                 id="return-open-read"),
+    pytest.param("def f(p):\n    fh = open(p)\n    return fh.read()\n", 1,
+                 id="assigned-open"),
+    pytest.param("def f(p):\n    return open(p)\n", 1,
+                 id="return-open-bare"),
+    pytest.param("import io\ndef f(p):\n    return io.open(p)\n", 1,
+                 id="io-open-unmanaged"),
+    pytest.param("def f(p):\n    return open_utf8(p)\n", 1,
+                 id="wrapper-unmanaged"),
+    pytest.param("def f(x):\n    return x.open()\n", 1,
+                 id="attribute-open-name-receiver"),  # Path.open too
+    pytest.param("def f(d):\n    return (d / 'x.json').open()\n", 1,
+                 id="attribute-open-binop-receiver"),
+    # Argument-nested opens: the with closes its object, not its arguments.
+    pytest.param(
+        "import tarfile\ndef f(p):\n"
+        "    with tarfile.open(fileobj=open(p, 'rb')) as t:\n        return t\n",
+        1, id="argument-nested-open"),
+    pytest.param(
+        "import contextlib\ndef f(p):\n"
+        "    with contextlib.suppress(open(p)):\n        return t\n",
+        1, id="suppress-argument-open"),
+    # The documented policy: a raise-path holds no handle either.
+    pytest.param(
+        "import pytest\ndef f(p):\n"
+        "    with pytest.raises(FileNotFoundError):\n        open(p)\n",
+        1, id="raise-path-open"),
+    # Must NOT trip: managed or exempt.
+    pytest.param("def f(p):\n    with open(p) as fh:\n        return fh.read()\n", 0,
+                 id="with-open-managed"),
+    pytest.param(
+        "def f(a, b):\n    with (open(a) as fa, open(b) as fb):\n"
+        "        return fa.read() + fb.read()\n",
+        0, id="parenthesized-with-items-managed"),
+    # A bare tuple has no __enter__ — the code raises at runtime and both
+    # handles leak; the scan must NOT bless this shape as managed.
+    pytest.param(
+        "def f(a, b):\n    with (open(a), open(b)) as (fa, fb):\n"
+        "        return fa.read() + fb.read()\n",
+        2, id="bare-tuple-with-flags-both"),
+    pytest.param("def f(p):\n    with (fh := open(p)):\n        return fh.read()\n", 0,
+                 id="walrus-header-managed"),
+    # An await in the header unwraps to the managed call.
+    pytest.param(
+        "async def f(p):\n    async with (await open(p)) as fh:\n"
+        "        return fh.read()\n",
+        0, id="await-header-managed"),
+    pytest.param("import os\ndef f(p):\n    return os.open(p, os.O_RDONLY)\n", 0,
+                 id="os-open-exempt"),
+    pytest.param(
+        "import tarfile\nimport gzip\n"
+        "def f(p):\n    with tarfile.open(p) as t, gzip.open(p) as g:\n"
+        "        return t, g\n",
+        0, id="multi-item-with-managed"),
+    pytest.param("def f(p):\n    with open_utf8(p) as fh:\n        return fh.read()\n", 0,
+                 id="wrapper-with-managed"),
+])
+def test_scanner_semantics(source, expected):
+    assert len(_bare_open_sites(source)) == expected
+
+
+def _load_ruff_config() -> dict:
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh).get("tool", {}).get("ruff", {})
+
+
+def _sim115_exempt_globs() -> list[str]:
+    ruff = _load_ruff_config()
+    lint = ruff.get("lint", {})
+    # ruff UNIONS per-file-ignores with extend-per-file-ignores per glob —
+    # mirror that (a replace-merge would drop a base-table SIM115 entry).
+    merged: dict[str, set] = {}
+    for table in ("per-file-ignores", "extend-per-file-ignores"):
+        for glob, rules in lint.get(table, {}).items():
+            merged.setdefault(glob, set()).update(rules)
+    return [glob for glob, rules in merged.items() if "SIM115" in rules]
+
+
+def test_sim115_config_is_pinned():
+    """The ruff backstop must not silently appear, disappear, or widen.
+
+    SIM115 is one of the two arms (it misses return-statement opens and
+    Name/BinOp ``.open`` receivers; this scan closes those). The pin is
+    tamper-evident in BOTH directions: dropping SIM115 disarms one arm,
+    and ADDING a SIM115 exemption silently blinds both arms for that
+    path (the sweep derives its exemptions from the same pyproject
+    keys). The exemption set is pinned exactly — a new entry must be a
+    conscious decision recorded here.
+    """
+    ruff = _load_ruff_config()
+    lint = ruff.get("lint", {})
+    # WHOLE-TABLE ALLOWLIST, not a per-key blocklist: a blocklist always
+    # trails ruff's growing options surface (ignore/exclude/include/
+    # force-exclude/fix-only/extend-inheritance/deprecated top-level
+    # forms each disarm SIM115 somewhere). The allowlist pins the exact
+    # ruff config shape: ANY new top-level or lint key — whatever ruff
+    # names it next — trips this pin and becomes a conscious decision.
+    assert set(ruff) == {"target-version", "lint"}, (
+        f"unexpected top-level ruff keys: {sorted(set(ruff) - {'target-version', 'lint'})} "
+        "— any scope/fix/ignore key disarms the ruff arm somewhere; "
+        "if deliberate, update this pin consciously")
+    assert set(lint) == {"select", "per-file-ignores"}, (
+        f"unexpected ruff.lint keys: {sorted(set(lint) - {'select', 'per-file-ignores'})} "
+        "— same reason; if deliberate, update this pin consciously")
+    assert "SIM115" in lint["select"], (
+        "SIM115 is no longer exactly in ruff select (dropped, or renamed/"
+        "broadened?) — one arm of the bare-open guard is gone (see this "
+        "file's docstring for the two-arm design)")
+    expected_ignores = {
+        "tests/efficacy/fixtures/**": {"F401", "F841", "SIM115"},
+        "tests/fixtures/**": {"SIM115"},
+    }
+    actual_ignores = {glob: sorted(rules)
+                      for glob, rules in lint["per-file-ignores"].items()}
+    assert actual_ignores == {g: sorted(r) for g, r in expected_ignores.items()}, (
+        f"the ruff per-file-ignores map changed — expected exactly "
+        f"{ {g: sorted(r) for g, r in expected_ignores.items()} }, found {actual_ignores}. "
+        "An entry or a prefix selector (SIM/ALL) blinds BOTH gates for "
+        "that path (sweep + ruff); if deliberate, update this pin "
+        "consciously")
+    # Named residuals this pin cannot reach: any noqa form in prod
+    # (``# noqa: SIM115``, bare ``# noqa``, file-level ``# ruff: noqa``),
+    # CI workflow flags (--config/--ignore/--exit-zero), sibling/nested
+    # ruff.toml/.ruff.toml files, and .gitignore-driven exclusion
+    # (respect-gitignore). None exist today; each would be a visible
+    # repo change on review.
+
+
+def test_no_bare_opens_in_the_test_tree():
+    """The sweep: every test file parses clean of unmanaged opens.
+
+    Pytest-collected logic (test_*.py / *_test.py / conftest.py) is NEVER
+    exempt — a planted test file under a fixture glob is test logic,
+    not data.
+    """
+    exempt = _sim115_exempt_globs()
+    offenders: list[str] = []
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        rel = path.relative_to(CORE_ROOT).as_posix()
+        is_collected_logic = (
+            path.name.startswith("test_")
+            or path.name.endswith("_test.py")
+            or path.name == "conftest.py")
+        if not is_collected_logic and any(fnmatch.fnmatch(rel, glob) for glob in exempt):
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            offenders.append(f"{rel}: unreadable as utf-8 — fixture data? "
+                             "add a SIM115 per-file-ignore")
+            continue
+        try:
+            sites = _bare_open_sites(source, filename=str(path))
+        except SyntaxError as exc:
+            offenders.append(f"{rel}:{exc.lineno}: does not parse — "
+                             "fixture data? add a SIM115 per-file-ignore")
+            continue
+        offenders.extend(f"{rel}:{lineno}" for lineno in sites)
+    assert not offenders, (
+        "Unmanaged open() calls in the tests tree (the #481 class is "
+        f"back): {offenders}\n"
+        "Fix idiom: ``with open(p) as fh:`` for handles, "
+        "``Path(p).read_text(encoding='utf-8')`` for one-line reads, "
+        "``Path(p).write_text(..., encoding='utf-8')`` for one-line "
+        "writes — the open belongs IN the with-header")

--- a/libs/openant-core/tests/test_issue481_bare_open_conformance.py
+++ b/libs/openant-core/tests/test_issue481_bare_open_conformance.py
@@ -38,17 +38,15 @@ Policy points, so a future reader knows the intent:
    how the six shared ``_graph()`` helpers escaped it), plus non-Call
    ``.open`` receivers, plus anything outside its stdlib opener list —
    notably the project's own ``open_utf8`` wrapper, invisible to SIM115 in
-   every shape. This scan closes those gaps for the open family. Among
-   constructor-style openers, ruff's list reaches the tempfile family,
-   ``lzma.LZMAFile`` and ``fileinput.FileInput`` (subject to the same
-   with/return/ExitStack/immediate-close exemptions above); the
-   CONSTRUCTORS ``zipfile.ZipFile(...)``, ``tarfile.TarFile(...)``,
-   ``bz2.BZ2File(...)``, ``io.FileIO``, ``gzip.GzipFile`` and ``os.fdopen``
-   are invisible to BOTH arms — though the ``.open()`` MEMBER on a
-   ``ZipFile(...)``/``LZMAFile(...)``/``TarFile(...)`` receiver IS visible
-   to both (zero unmanaged constructor sites today; if one appears, add
-   the constructor names here). Known limits of any name-based detector
-   apply to it too: an ``import os as o`` alias would false-positive, an opener
+   every shape. This scan closes those gaps for the open family, and it
+   is the ONLY arm covering the constructor-style openers
+   (``zipfile.ZipFile``, ``tarfile.TarFile``, ``bz2.BZ2File``,
+   ``gzip.GzipFile``, ``io.FileIO``, ``lzma.LZMAFile``,
+   ``os.fdopen`` — which returns a handle, unlike the exempt
+   ``os.open``): ruff's list reaches only the tempfile family and
+   ``fileinput``, and only where its with/return/ExitStack/
+   immediate-close exemptions do not apply. Known limits
+   of any name-based detector apply to it too: an ``import os as o`` alias would false-positive, an opener
    imported under a different name would be a silent miss, and ANY
    non-``os`` ``.open`` flags — including non-handle openers
    (``webbrowser.open``) and an ``IfExp`` with-header (both arms of a
@@ -85,6 +83,16 @@ PYPROJECT = CORE_ROOT / "pyproject.toml"
 # Name-form openers that return a file handle: the builtin, and the
 # project's own utf-8 wrapper (utilities/file_io.py — the with-target).
 _OPENER_NAMES = {"open", "open_utf8"}
+
+# Constructor-style openers invisible to ruff's SIM115 in every shape
+# (its list reaches only the tempfile family). os.fdopen joins them as a
+# special case: it RETURNS a handle, unlike os.open which returns an fd
+# and stays exempt.
+_OPENER_CTORS = {"ZipFile", "TarFile", "BZ2File", "GzipFile", "FileIO",
+                 "LZMAFile", "FileInput", "NamedTemporaryFile",
+                 "TemporaryFile", "SpooledTemporaryFile"}
+_OPENER_CTOR_MODULES = {"zipfile", "tarfile", "bz2", "gzip", "io", "lzma",
+                        "fileinput", "tempfile"}
 
 
 def _bare_open_sites(source: str, filename: str = "<source>") -> list[int]:
@@ -127,6 +135,24 @@ def _bare_open_sites(source: str, filename: str = "<source>") -> list[int]:
             and not (isinstance(func.value, ast.Name) and func.value.id == "os")
         ):
             sites.append(node.lineno)
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr == "fdopen"
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "os"
+        ):
+            sites.append(node.lineno)  # os.fdopen returns a handle; os.open does not
+        elif (
+            isinstance(func, ast.Name) and func.id in _OPENER_CTORS
+        ):
+            sites.append(node.lineno)
+        elif (
+            isinstance(func, ast.Attribute)
+            and func.attr in _OPENER_CTORS
+            and isinstance(func.value, ast.Name)
+            and func.value.id in _OPENER_CTOR_MODULES
+        ):
+            sites.append(node.lineno)
     return sites
 
 
@@ -162,9 +188,18 @@ def _bare_open_sites(source: str, filename: str = "<source>") -> list[int]:
         "import pytest\ndef f(p):\n"
         "    with pytest.raises(FileNotFoundError):\n        open(p)\n",
         1, id="raise-path-open"),
+    # Constructor-style openers: ruff's SIM115 is blind to these in every
+    # shape; this scan is their only gate (os.fdopen returns a handle,
+    # unlike the exempt os.open).
+    pytest.param("import zipfile\ndef f(p):\n    z = zipfile.ZipFile(p)\n    return z.namelist()\n", 1,
+                 id="zipfile-constructor-unmanaged"),
+    pytest.param("import os\ndef f(p):\n    fd = os.open(p, os.O_RDONLY)\n    fh = os.fdopen(fd)\n    return fh\n", 1,
+                 id="os-fdopen-unmanaged"),
     # Must NOT trip: managed or exempt.
     pytest.param("def f(p):\n    with open(p) as fh:\n        return fh.read()\n", 0,
                  id="with-open-managed"),
+    pytest.param("import zipfile\ndef f(p):\n    with zipfile.ZipFile(p) as z:\n        return z.namelist()\n", 0,
+                 id="zipfile-constructor-with-managed"),
     pytest.param(
         "def f(a, b):\n    with (open(a) as fa, open(b) as fb):\n"
         "        return fa.read() + fb.read()\n",
@@ -213,16 +248,43 @@ def _sim115_exempt_globs() -> list[str]:
     return [glob for glob, rules in merged.items() if "SIM115" in rules]
 
 
-def test_sim115_config_is_pinned():
-    """The ruff backstop must not silently appear, disappear, or widen.
+def test_sim115_per_file_ignores_map_is_pinned():
+    """The exemption map is pinned exactly — the assertion that matters.
+
+    An exemption entry blinds BOTH gates for its path (the sweep derives
+    its exemptions from these same keys), so any change here must be a
+    conscious decision. This assertion stands on its own function so it
+    survives independent review of the scope-key allowlist below.
+    """
+    lint = _load_ruff_config().get("lint", {})
+    expected_ignores = {
+        "tests/efficacy/fixtures/**": {"F401", "F841", "SIM115"},
+        "tests/fixtures/**": {"SIM115"},
+    }
+    actual_ignores = {glob: sorted(rules)
+                      for glob, rules in lint.get("per-file-ignores", {}).items()}
+    assert actual_ignores == {g: sorted(r) for g, r in expected_ignores.items()}, (
+        f"the ruff per-file-ignores map changed — expected exactly "
+        f"{ {g: sorted(r) for g, r in expected_ignores.items()} }, found {actual_ignores}. "
+        "An entry or a prefix selector (SIM/ALL) blinds BOTH gates for "
+        "that path (sweep + ruff); if deliberate, update this pin "
+        "consciously")
+
+
+def test_sim115_scope_keys_do_not_disarm():
+    """The ruff arm's scope keys are allowlisted.
 
     SIM115 is one of the two arms (it misses return-statement opens and
-    Name/BinOp ``.open`` receivers; this scan closes those). The pin is
-    tamper-evident in BOTH directions: dropping SIM115 disarms one arm,
-    and ADDING a SIM115 exemption silently blinds both arms for that
-    path (the sweep derives its exemptions from the same pyproject
-    keys). The exemption set is pinned exactly — a new entry must be a
-    conscious decision recorded here.
+    Name/BinOp ``.open`` receivers; this scan closes those). A blocklist
+    would trail ruff's growing options surface (ignore/exclude/include/
+    force-exclude/fix-only/extend-inheritance/deprecated top-level forms
+    each disarm SIM115 somewhere), so the whole config shape is pinned:
+    ANY new top-level or lint key — whatever ruff names it next — trips
+    this pin and becomes a conscious decision. NOTE: unlike the map pin
+    above, this allowlist is intentionally opinionated (it will trip on
+    unrelated keys like a future line-length too); if it proves friction,
+    narrow it to a disarm-keys denylist rather than deleting the pin —
+    the per-file-ignores pin lives in its own function and survives.
     """
     ruff = _load_ruff_config()
     lint = ruff.get("lint", {})
@@ -243,18 +305,6 @@ def test_sim115_config_is_pinned():
         "SIM115 is no longer exactly in ruff select (dropped, or renamed/"
         "broadened?) — one arm of the bare-open guard is gone (see this "
         "file's docstring for the two-arm design)")
-    expected_ignores = {
-        "tests/efficacy/fixtures/**": {"F401", "F841", "SIM115"},
-        "tests/fixtures/**": {"SIM115"},
-    }
-    actual_ignores = {glob: sorted(rules)
-                      for glob, rules in lint["per-file-ignores"].items()}
-    assert actual_ignores == {g: sorted(r) for g, r in expected_ignores.items()}, (
-        f"the ruff per-file-ignores map changed — expected exactly "
-        f"{ {g: sorted(r) for g, r in expected_ignores.items()} }, found {actual_ignores}. "
-        "An entry or a prefix selector (SIM/ALL) blinds BOTH gates for "
-        "that path (sweep + ruff); if deliberate, update this pin "
-        "consciously")
     # Named residuals this pin cannot reach: any noqa form in prod
     # (``# noqa: SIM115``, bare ``# noqa``, file-level ``# ruff: noqa``),
     # CI workflow flags (--config/--ignore/--exit-zero), sibling/nested
@@ -263,22 +313,34 @@ def test_sim115_config_is_pinned():
     # repo change on review.
 
 
-def test_no_bare_opens_in_the_test_tree():
-    """The sweep: every test file parses clean of unmanaged opens.
+def test_no_bare_opens_in_collected_test_logic():
+    """The sweep: tests tree + collected logic outside it parses clean.
 
-    Pytest-collected logic (test_*.py / *_test.py / conftest.py) is NEVER
-    exempt — a planted test file under a fixture glob is test logic,
-    not data.
+    Scope: every *.py under tests/ (exempt globs apply, EXCEPT that
+    pytest-collected logic — test_*.py / *_test.py / conftest.py — is
+    NEVER exempt: a planted test file under a fixture glob is logic, not
+    data), PLUS every collected-logic file OUTSIDE tests/ (the root
+    conftest.py, the parsers/*/test_pipeline.py harnesses) — where
+    neither the sweep nor ruff previously reached. Prod files are NOT
+    swept: the two by-design prod sites (utilities/file_io.py's open_utf8
+    wrapper; core/parser_adapter.py's lock handle, closed in an outer
+    try/finally) are intentional and out of scope.
     """
     exempt = _sim115_exempt_globs()
     offenders: list[str] = []
-    for path in sorted(TESTS_DIR.rglob("*.py")):
+
+    def _is_collected_logic(path: Path) -> bool:
+        return (path.name.startswith("test_")
+                or path.name.endswith("_test.py")
+                or path.name == "conftest.py")
+
+    for path in sorted(CORE_ROOT.rglob("*.py")):
         rel = path.relative_to(CORE_ROOT).as_posix()
-        is_collected_logic = (
-            path.name.startswith("test_")
-            or path.name.endswith("_test.py")
-            or path.name == "conftest.py")
-        if not is_collected_logic and any(fnmatch.fnmatch(rel, glob) for glob in exempt):
+        in_tests = rel.startswith("tests/")
+        if not in_tests and not _is_collected_logic(path):
+            continue  # prod: out of the sweep's scope by design
+        if in_tests and not _is_collected_logic(path) and any(
+                fnmatch.fnmatch(rel, glob) for glob in exempt):
             continue
         try:
             source = path.read_text(encoding="utf-8")
@@ -294,8 +356,8 @@ def test_no_bare_opens_in_the_test_tree():
             continue
         offenders.extend(f"{rel}:{lineno}" for lineno in sites)
     assert not offenders, (
-        "Unmanaged open() calls in the tests tree (the #481 class is "
-        f"back): {offenders}\n"
+        "Unmanaged open() calls in collected test logic (the #481 class "
+        f"is back): {offenders}\n"
         "Fix idiom: ``with open(p) as fh:`` for handles, "
         "``Path(p).read_text(encoding='utf-8')`` for one-line reads, "
         "``Path(p).write_text(..., encoding='utf-8')`` for one-line "

--- a/libs/openant-core/tests/test_issue481_bare_open_conformance.py
+++ b/libs/openant-core/tests/test_issue481_bare_open_conformance.py
@@ -38,14 +38,16 @@ Policy points, so a future reader knows the intent:
    how the six shared ``_graph()`` helpers escaped it), plus non-Call
    ``.open`` receivers, plus anything outside its stdlib opener list —
    notably the project's own ``open_utf8`` wrapper, invisible to SIM115 in
-   every shape. This scan closes those gaps for the open family, and it
-   is the ONLY arm covering the constructor-style openers
-   (``zipfile.ZipFile``, ``tarfile.TarFile``, ``bz2.BZ2File``,
-   ``gzip.GzipFile``, ``io.FileIO``, ``lzma.LZMAFile``,
-   ``os.fdopen`` — which returns a handle, unlike the exempt
-   ``os.open``): ruff's list reaches only the tempfile family and
-   ``fileinput``, and only where its with/return/ExitStack/
-   immediate-close exemptions do not apply. Known limits
+   every shape. This scan closes those gaps for the open family. For the
+   constructor-style openers, ruff's list reaches the tempfile family,
+   ``lzma.LZMAFile`` and ``fileinput.FileInput`` (wherever its with/return/
+   ExitStack/immediate-close exemptions do not apply); this scan is the
+   only arm for ``zipfile.ZipFile``, ``tarfile.TarFile``, ``bz2.BZ2File``,
+   ``gzip.GzipFile``, ``io.FileIO`` and ``os.fdopen`` (which returns a
+   handle, unlike the exempt ``os.open``), and the only arm for the
+   tempfile/LZMAFile/FileInput family in RETURN shapes. ``os.popen`` and
+   subprocess pipe handles are the named remaining blind spot of both
+   arms (zero sites today). Known limits
    of any name-based detector apply to it too: an ``import os as o`` alias would false-positive, an opener
    imported under a different name would be a silent miss, and ANY
    non-``os`` ``.open`` flags — including non-handle openers
@@ -84,10 +86,11 @@ PYPROJECT = CORE_ROOT / "pyproject.toml"
 # project's own utf-8 wrapper (utilities/file_io.py — the with-target).
 _OPENER_NAMES = {"open", "open_utf8"}
 
-# Constructor-style openers invisible to ruff's SIM115 in every shape
-# (its list reaches only the tempfile family). os.fdopen joins them as a
-# special case: it RETURNS a handle, unlike os.open which returns an fd
-# and stays exempt.
+# Constructor-style openers this scan gates. ruff's SIM115 also sees some
+# of these in non-exempt shapes (the tempfile family, LZMAFile,
+# FileInput) — the scan is the sole arm for the REST and for return
+# shapes. os.fdopen is a special case: it RETURNS a handle, unlike
+# os.open which returns an fd and stays exempt.
 _OPENER_CTORS = {"ZipFile", "TarFile", "BZ2File", "GzipFile", "FileIO",
                  "LZMAFile", "FileInput", "NamedTemporaryFile",
                  "TemporaryFile", "SpooledTemporaryFile"}
@@ -195,6 +198,13 @@ def _bare_open_sites(source: str, filename: str = "<source>") -> list[int]:
                  id="zipfile-constructor-unmanaged"),
     pytest.param("import os\ndef f(p):\n    fd = os.open(p, os.O_RDONLY)\n    fh = os.fdopen(fd)\n    return fh\n", 1,
                  id="os-fdopen-unmanaged"),
+    pytest.param("from zipfile import ZipFile\ndef f(p):\n    z = ZipFile(p)\n    return z.namelist()\n", 1,
+                 id="ctor-from-import-unmanaged"),
+    pytest.param("import tempfile\ndef f(p):\n    t = tempfile.NamedTemporaryFile()\n    return t.name\n", 1,
+                 id="tempfile-ctor-unmanaged"),
+    # Must NOT trip: managed or exempt.
+    pytest.param("def f(x):\n    return x.ZipFile(p)\n", 0,
+                 id="ctor-attribute-on-non-module-receiver-not-flagged"),
     # Must NOT trip: managed or exempt.
     pytest.param("def f(p):\n    with open(p) as fh:\n        return fh.read()\n", 0,
                  id="with-open-managed"),
@@ -306,42 +316,97 @@ def test_sim115_scope_keys_do_not_disarm():
         "broadened?) — one arm of the bare-open guard is gone (see this "
         "file's docstring for the two-arm design)")
     # Named residuals this pin cannot reach: any noqa form in prod
-    # (``# noqa: SIM115``, bare ``# noqa``, file-level ``# ruff: noqa``),
-    # CI workflow flags (--config/--ignore/--exit-zero), sibling/nested
-    # ruff.toml/.ruff.toml files, and .gitignore-driven exclusion
-    # (respect-gitignore). None exist today; each would be a visible
-    # repo change on review.
+    # (line, bare, or file-level noqa directives), CI workflow flags
+    # (--config/--ignore/--exit-zero), sibling/nested ruff.toml/.ruff.toml
+    # files, and .gitignore-driven exclusion (respect-gitignore). None
+    # exist today; each would be a visible repo change on review.
+
+
+_ENV_OR_BUILD_DIRS = {"__pycache__", "build", "dist", "node_modules"}
+
+
+def _is_collected_logic(path: Path) -> bool:
+    return (path.name.startswith("test_")
+            or path.name.endswith("_test.py")
+            or path.name == "conftest.py")
+
+
+def _is_swept(path: Path, root: Path, exempt: list[str]) -> bool:
+    """The scope rule, extracted so its properties are unit-testable.
+
+    Swept: the tests tree (minus exempt fixture DATA), plus TEST-SHAPED
+    files anywhere else in the source tree — an over-approximation that
+    deliberately admits the parser CLI harnesses (parsers/*/test_pipeline.py,
+    which pytest.ini and the root conftest exclude from COLLECTION, and
+    which use open_utf8 — invisible to ruff's SIM115) and the
+    test-*generator* utility, and would sweep any future test-shaped file
+    without a scope edit. NOT swept: env/build trees (dot-dirs — .venv et
+    al. — __pycache__, build, dist, node_modules: machine-dependent
+    content a repo gate must not depend on; the sibling scanner
+    test_file_io._iter_python_sources uses the same exclusions) and prod
+    files that are not test-shaped.
+    """
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        return False
+    if any(part.startswith(".") or part in _ENV_OR_BUILD_DIRS
+           for part in rel_parts):
+        return False
+    rel = path.relative_to(root).as_posix()
+    in_tests = rel.startswith("tests/")
+    if not in_tests and not _is_collected_logic(path):
+        return False
+    if in_tests and not _is_collected_logic(path) and any(
+            fnmatch.fnmatch(rel, glob) for glob in exempt):
+        return False
+    return True
+
+
+def test_scope_rule_is_pinned():
+    """The sweep's scope properties, pinned on a planted tree (so a
+    future 'simplify the walker' edit cannot silently narrow it)."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        exempt = ["tests/efficacy/fixtures/**", "tests/fixtures/**"]
+        cases = [
+            ("tests/a/test_x.py", True, "tests-tree logic"),
+            ("tests/fixtures/sample/test_p.py", True, "logic under an exempt glob stays swept"),
+            ("tests/fixtures/sample/data.py", False, "data under an exempt glob stays exempt"),
+            ("tests/efficacy/fixtures/webapp/conftest.py", True, "conftest is always logic"),
+            ("parsers/c/test_pipeline.py", True, "the CLI harnesses are swept (open_utf8 is ruff-blind)"),
+            ("utilities/dynamic_tester/test_generator.py", True, "the test-shape over-approximation admits it"),
+            ("core/scanner.py", False, "prod out of scope by design"),
+            (".venv/lib/site-packages/test_x.py", False, "env trees never swept"),
+            ("build/pkg/test_x.py", False, "build trees never swept"),
+        ]
+        for rel, expected, why in cases:
+            f = root / rel
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text("")
+            assert _is_swept(f, root, exempt) == expected, f"{rel}: {why}"
 
 
 def test_no_bare_opens_in_collected_test_logic():
-    """The sweep: tests tree + collected logic outside it parses clean.
+    """The sweep: the tests tree + test-shaped files elsewhere, clean.
 
-    Scope: every *.py under tests/ (exempt globs apply, EXCEPT that
-    pytest-collected logic — test_*.py / *_test.py / conftest.py — is
-    NEVER exempt: a planted test file under a fixture glob is logic, not
-    data), PLUS every collected-logic file OUTSIDE tests/ (the root
-    conftest.py, the parsers/*/test_pipeline.py harnesses) — where
-    neither the sweep nor ruff previously reached. Prod files are NOT
-    swept: the two by-design prod sites (utilities/file_io.py's open_utf8
-    wrapper; core/parser_adapter.py's lock handle, closed in an outer
-    try/finally) are intentional and out of scope.
+    Scope rule (extracted into _is_swept, unit-pinned above): the tests
+    tree minus exempt fixture DATA, plus test-SHAPED files anywhere in
+    the source tree — the root conftest.py and the parsers/*/test_pipeline.py
+    CLI harnesses (which the repo's own pytest.ini/conftest EXCLUDE from
+    collection and whose open_utf8 idiom ruff's SIM115 cannot see), and
+    by over-approximation the test-generator utility too. NOT swept:
+    env/build trees and non-test-shaped prod files (the two by-design
+    prod open sites are utilities/file_io.py's open_utf8 wrapper and
+    core/parser_adapter.py's try/finally-closed lock handle).
     """
     exempt = _sim115_exempt_globs()
     offenders: list[str] = []
-
-    def _is_collected_logic(path: Path) -> bool:
-        return (path.name.startswith("test_")
-                or path.name.endswith("_test.py")
-                or path.name == "conftest.py")
-
     for path in sorted(CORE_ROOT.rglob("*.py")):
-        rel = path.relative_to(CORE_ROOT).as_posix()
-        in_tests = rel.startswith("tests/")
-        if not in_tests and not _is_collected_logic(path):
-            continue  # prod: out of the sweep's scope by design
-        if in_tests and not _is_collected_logic(path) and any(
-                fnmatch.fnmatch(rel, glob) for glob in exempt):
+        if not _is_swept(path, CORE_ROOT, exempt):
             continue
+        rel = path.relative_to(CORE_ROOT).as_posix()
         try:
             source = path.read_text(encoding="utf-8")
         except (OSError, UnicodeDecodeError):

--- a/libs/openant-core/tests/test_issue481_bare_open_conformance.py
+++ b/libs/openant-core/tests/test_issue481_bare_open_conformance.py
@@ -322,7 +322,7 @@ def test_sim115_scope_keys_do_not_disarm():
     # exist today; each would be a visible repo change on review.
 
 
-_ENV_OR_BUILD_DIRS = {"__pycache__", "build", "dist", "node_modules"}
+_ENV_OR_BUILD_DIRS = {"__pycache__", "build", "dist", "node_modules", "venv", "env"}
 
 
 def _is_collected_logic(path: Path) -> bool:
@@ -342,8 +342,10 @@ def _is_swept(path: Path, root: Path, exempt: list[str]) -> bool:
     test-*generator* utility, and would sweep any future test-shaped file
     without a scope edit. NOT swept: env/build trees (dot-dirs — .venv et
     al. — __pycache__, build, dist, node_modules: machine-dependent
-    content a repo gate must not depend on; the sibling scanner
-    test_file_io._iter_python_sources uses the same exclusions) and prod
+    content a repo gate must not depend on; note the sibling scanner
+    test_file_io._iter_python_sources excludes a slightly different set
+    (it keeps venv/ and drops node_modules) — the two sweeps are
+    independent; drift between them is friction, not a hole) and prod
     files that are not test-shaped.
     """
     try:

--- a/libs/openant-core/tests/test_macro_scan_budget_redos.py
+++ b/libs/openant-core/tests/test_macro_scan_budget_redos.py
@@ -10,6 +10,7 @@ zero call-graph edge change), truncating only pathological bodies with a logged 
 RED pre-fix: utilities.scan_budget.bound_macro_scan_text does not exist.
 """
 import re
+from pathlib import Path
 import time
 
 
@@ -64,8 +65,8 @@ def test_rust_and_zig_regex_unchanged():
     possessive both fails to fix the DoS and regresses rust's scoped-turbofish match."""
     import os
     here = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    rust = open(os.path.join(here, "parsers/rust/call_graph_builder.py")).read()
-    zig = open(os.path.join(here, "parsers/zig/call_graph_builder.py")).read()
+    rust = Path(os.path.join(here, "parsers/rust/call_graph_builder.py")).read_text(encoding="utf-8")
+    zig = Path(os.path.join(here, "parsers/zig/call_graph_builder.py")).read_text(encoding="utf-8")
     assert r"(?:[A-Za-z_][A-Za-z0-9_]*::)+[A-Za-z_][A-Za-z0-9_]*" in rust
     assert r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*" in rust
     assert r"[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)*" in zig

--- a/libs/openant-core/tests/test_rust_literal_stripper_differential.py
+++ b/libs/openant-core/tests/test_rust_literal_stripper_differential.py
@@ -13,6 +13,7 @@
      callee silently dropped from the graph = an unreachable false-negative).
 """
 import glob
+from pathlib import Path
 import os
 import random
 import time
@@ -61,7 +62,7 @@ def test_differential_on_real_source_windows():
     files = glob.glob(os.path.join(here, "**", "*.py"), recursive=True)
     assert files, "no corpus files found"
     for fp in files:
-        txt = open(fp, encoding="utf-8", errors="ignore").read()
+        txt = Path(fp).read_text(encoding="utf-8", errors="ignore")
         for chunk in [txt] + [txt[k:k + 500] for k in range(0, len(txt), 500)]:
             assert _blank_rust_literals(chunk) == _old(chunk), f"{os.path.basename(fp)}"
 


### PR DESCRIPTION
## What this fixes

Closes #481's remaining test-tree half (the prod half landed in #484, the config/conftest half in #483). The review-bot corpus sweep that filed this issue found no unaddressed behavioral finding — its yield was three infrastructure classes, and this PR retires the last one: the **not-always-closed class**, i.e. hand-rolled `open()` blocks in the tests tree that sometimes missed their close. (Claim-ok: the class's 11-comment count is issue #481's own census, quoted from its body.)

Three parts:

A note on item 3's either-arm wording ("a `write(path, text)` helper or uniform `.write_text`"): neither literal arm shipped — an initially-built helper fixture was dropped as zero-adopter dead infra, and `with open(p, "w") as fh:` remains a common (managed, closed) idiom. What retired the class is its actual property — no unmanaged handles anywhere in the tree, enforced by the two arms below. The adjacent encoding sibling (`encoding=` unspecified) is deliberately out of scope here and disclosed in the residuals.

1. **Every inline bare open is converted** to the pathlib idiom — `Path.read_text(encoding="utf-8")` / `Path.write_text(..., encoding="utf-8")` — 16 files (`git diff origin/master..HEAD --name-only | grep -c 'tests/test_\|tests/parsers/'` → 17 incl. the ZipFile fix below), including the six shared parser-test `_graph()` helper sites and the two `zipfile.ZipFile(wheel).namelist()` handles in `test_installed_layout.py`, now `with`-managed. The `call_graph.json` reads are now encoding-symmetric with the utf-8-forced writes the prod side enforces.

2. **A structural conformance scan locks the retirement** (`tests/test_issue481_bare_open_conformance.py`, new): an AST-based sweep over the tests tree that fails if an unmanaged open ever comes back. Managed = the outermost call of a `with`-item's context expression (walrus/await unwrapped; argument-nested opens flag — the `with` closes its object, not the handle handed to it); `os.open` is exempt (fd-based); the project's `open_utf8` wrapper and every non-`os` `.open` are covered. AST rather than regex because the tree embeds `open(` inside string fixtures as parser input data, which a regex scan needs a scrubber to survive. 25 self-identifying teeth pin the scanner semantics, plus 4 test functions (the sweep, its extracted scope rule unit-pinned on a planted tree, and the two config pins) — `pytest -q tests/test_issue481_bare_open_conformance.py` → `29 passed`; the sweep's RED evidence: the recorded run (taken mid-conversion, with the first ten files already staged) caught the six remaining `_graph()`-helper sites — the pristine-base census is **23 non-exempt sites across 16 files** under the original scanner — **25 across 17** once the constructor gate the final scanner ships is included (the two `zipfile.ZipFile` handles it adds are the very sites this PR converts) — coverage 25 → 0, confirmed by two independent census oracles. The sweep also covers pytest-collected logic OUTSIDE `tests/` (the root `conftest.py`, the `parsers/*/test_pipeline.py` harnesses — where ruff and the tests-tree-only sweep previously had zero reach), and constructor-style openers (`zipfile.ZipFile`, `os.fdopen`, …) are the scan's teeth — ruff's SIM115 covers only the tempfile family.

3. **The lint backstop joins the config**: `SIM115` in the whole-tree ruff `select`. Its actual blind spot (from its implementation) is the return statement — which is precisely how the six `return json.load(open(...))` helpers escaped it — plus non-Call `.open` receivers; the scan closes both. The fixture data joins the per-file-ignores (`tests/efficacy/fixtures/**`, `tests/fixtures/**` — a deliberate bare open lives at `efficacy/fixtures/webapp/src/app_a.py:15`), and the scan derives its exemption globs from those same pyproject entries so the two gates cannot drift apart. A **whole-table allowlist pin** asserts the exact ruff config shape — any future config key, whatever ruff names it next, trips the pin consciously instead of silently disarming an arm.

## Why the gates are shaped this way

- **Two arms, not one:** ruff's SIM115 is real for assigned opens (`f = open(...)`) but blind to return-shapes and Name/BinOp `.open` receivers; the AST scan covers those. The pin keeps SIM115 from silently disappearing (or the ruff arm from being disarmed via `ignore`/`exclude`/`fix-only`/a new key) — all must-tripped with route-specific messages.
- **Collected logic is never exempt:** `test_*.py` / `*_test.py` / `conftest.py` are scanned even under an exempt glob — a planted test file under fixture data is logic, not data.
- **Known limits are documented in the scan's docstring** (name-based detector limits, the constructor openers invisible to both arms — zero such sites today), rather than claimed away.

## Verification

- Full suite: `3805 passed, 33 skipped` at the first commit; the final state (the scope-rule pins) re-verified `3674 passed, 168 skipped` in a venv-less worktree (the skip delta is environmental — tests that need the repo-local `.venv`; CI's matrix is the arbiter) (venv synced to the requirements pins; `pip install` churn three times this session was the #496 contract test correctly catching the local venv lagging the merged renovate bumps).
- `ruff check .` whole-tree clean under the new config; the prod tree has zero SIM115-flaggable sites (`utilities/file_io.py`'s `open_utf8` return-shape is ruff-exempt by design — the sanctioned wrapper).
- SAST (re-run over the final state, incl. every amend line): semgrep clean on the changed files; CodeQL 601/601 scanned → 0 findings in changed files (3 pre-existing intentional vulns live in the efficacy benchmark fixtures); semgrep over the changed files clean.
- Go build + vet clean (no Go surfaces touched; parity check).
- No behavioral change: the 16 conversions are I/O-idiom-only; every converted test's assertions are unchanged, and the suite green on the union base (every merged PR's regression tests included) is the union-state check.

<details>
<summary>Residuals (disclosed, not fixed here)</summary>

- CI installs ruff unpinned; `SIM115`'s return-statement exemption and opener list are what the whole-tree policy leans on — a future ruff release could shift coverage. The allowlist pin catches config edits but not ruff behavior changes; the scan arm is unaffected.
- `os.popen` and subprocess pipe handles are the remaining handle-returning openers neither arm sees (zero sites today; named in the scan's known-limits paragraph). Aliased imports (`import os as _os`, an opener imported under another name) are the detector's named name-based limits.
- `utilities/file_io.py:223`'s `return open(...)` (the `open_utf8` wrapper) is ruff-exempt by the return-statement rule — fine today; a `# noqa: SIM115` at that line is the pre-authorized remedy if a ruff release ever flags it.
- The adjacent idiom-debt classes are deliberately out of scope here and filed separately: the unspecified-encoding sibling (#504 — text I/O without `encoding=`, a Windows/cp1252 latent class) and the `tempfile.mkdtemp()` accumulation class (#505).
</details>
