### PR TITLE
test(llm): the SDK-contract floor's third leg — anthropic

### DIFF
--- a/libs/openant-core/tests/test_llm_sdk_contract_floor.py
+++ b/libs/openant-core/tests/test_llm_sdk_contract_floor.py
@@ -361,3 +361,92 @@ def test_openai_wrong_shapes_extract_none(wrong):
 )
 def test_google_wrong_shapes_extract_none(wrong):
     assert google_provider._extract_usage_details(wrong) is None
+
+
+# --------------------------------------------------------------------------- #
+# anthropic — the seam's third leg (same shape as openai/google above)        #
+# --------------------------------------------------------------------------- #
+
+
+def test_anthropic_pin_tied_to_requirements():
+    import re
+    from pathlib import Path
+
+    import anthropic
+
+    root = Path(__file__).resolve().parents[1]
+    pin = None
+    for line in (root / "requirements.txt").read_text().splitlines():
+        m = re.match(r"^anthropic\[bedrock\]==([0-9.]+)", line.strip())
+        if m:
+            pin = m.group(1)
+    assert pin is not None, "requirements.txt must carry the anthropic[bedrock] pin"
+    assert anthropic.__version__ == pin, (
+        f"installed anthropic {anthropic.__version__} != requirements pin {pin}"
+    )
+
+
+def test_anthropic_usage_fields_are_declared():
+    from anthropic.types import Usage
+
+    # the adapter's consumed surface: anthropic.py _extract_usage_details reads
+    # cache_read_input_tokens / cache_creation_input_tokens; the response walk
+    # reads input_tokens / output_tokens
+    assert {
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+        "input_tokens",
+        "output_tokens",
+    } <= set(Usage.model_fields)
+
+
+def test_anthropic_usage_details_from_real_sdk_type():
+    from anthropic.types import Usage
+
+    from utilities.llm.providers import anthropic as anthropic_provider
+
+    usage = Usage(input_tokens=10, output_tokens=20)
+    details = anthropic_provider._extract_usage_details(usage)
+    # absent cache fields extract None-details (absent != 0, same contract)
+    assert details is None
+
+    cached = Usage(
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_input_tokens=3,
+        cache_creation_input_tokens=1,
+    )
+    assert anthropic_provider._extract_usage_details(cached) == {
+        "cache_read_input_tokens": 3,
+        "cache_creation_input_tokens": 1,
+    }
+
+
+def test_anthropic_exception_classes_construct_with_real_signatures():
+    import anthropic
+
+    cases = [
+        (anthropic.AuthenticationError, 401),
+        (anthropic.PermissionDeniedError, 403),
+        (anthropic.RateLimitError, 429),
+        (anthropic.NotFoundError, 404),
+        (anthropic.APIStatusError, 500),
+    ]
+    for exc_cls, status in cases:
+        exc = exc_cls(
+            message="m",
+            response=_fake_httpx_response(status),
+            body=None,
+        )
+        assert exc.response.status_code == status, exc_cls.__name__
+
+    anthropic.APIConnectionError(
+        request=httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    )
+
+
+def test_anthropic_wrong_shapes_extract_none():
+    from utilities.llm.providers import anthropic as anthropic_provider
+
+    assert anthropic_provider._extract_usage_details(SimpleNamespace(cache_read_input_tokenz=1)) is None
+    assert anthropic_provider._extract_usage_details(None) is None


### PR DESCRIPTION
## Why

#496's floor covers openai + google-genai but **not anthropic** — the third adapter riding an installed SDK whose usage/exception shapes move across versions (the seam's original incident: anthropic 0.125→1.1 moved shapes mid-campaign). **#498 (anthropic 1.3.0→1.4.0) is open right now** — this lands first so that bump's CI verifies against the floor, same discipline as #496-before-#490.

## Coverage (the same two legs as the openai/google sections)

1. **Declared-ness** — the adapter's consumed fields asserted declared on the installed `anthropic.types.Usage`: `cache_read_input_tokens`, `cache_creation_input_tokens`, `input_tokens`, `output_tokens` (all verified declared at 1.3.0).
2. **Construct-then-extract** — a real `Usage` without cache fields → `_extract_usage_details` returns `None` (the absent≠0 contract); with them → the verbatim dict.
3. The exception taxonomy with real constructors (per-class status equality), the pin-tie to `requirements.txt` (`anthropic[bedrock]==X`), and the wrong-shape negative control (`is None`, never garbage).

## Must-trip (executed)

Misspelling the declared-ness field (`cache_read_input_tokens` → `cache_read_input_tokenz`) → the test **FAILED**; restored → green.

## Evidence

(venv from `requirements.txt`: anthropic 1.3.0) — floor **28 passed** (23 + 5 anthropic); `ruff check .` clean; full suite **3591 passed / 0 failed**.
