### PR TITLE
feat(registry): price z-ai/glm-5.3 + glm-5.3-flash — found by the first live glm-5.3 e2e scan

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment — see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
+  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment \u2014 see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
   "schema_version": 1,
   "models": [
     {
@@ -10,7 +10,7 @@
         "input": 5.0,
         "output": 25.0
       },
-      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) — both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
+      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) \u2014 both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
       "retrieved": "2026-09-01"
     },
     {
@@ -69,7 +69,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-opus-4-8",
@@ -92,7 +92,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-sonnet-4-6",
@@ -115,7 +115,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -510,7 +510,7 @@
         "input": 0.75,
         "output": 3.75
       },
-      "source": "verified against Google's own pricing page (ai.google.dev/gemini-api/docs/pricing: gemini-3.7-flash $0.75/$3.75 per 1M, 2026-09-01 — the page documents a scheduled step to $1.50/$7.50 on 2027-01-01; revisit then) and the live OpenRouter catalogue (google/gemini-3.7-flash $0.75/$3.75) — both live sources agree (#434's stale-family gap)",
+      "source": "verified against Google's own pricing page (ai.google.dev/gemini-api/docs/pricing: gemini-3.7-flash $0.75/$3.75 per 1M, 2026-09-01 \u2014 the page documents a scheduled step to $1.50/$7.50 on 2027-01-01; revisit then) and the live OpenRouter catalogue (google/gemini-3.7-flash $0.75/$3.75) \u2014 both live sources agree (#434's stale-family gap)",
       "retrieved": "2026-09-01"
     },
     {
@@ -532,7 +532,7 @@
         "input": 0.0,
         "output": 0.0
       },
-      "source": "verified on ollama.com/library/qwen3.8 (18GB, 256K ctx); local inference is free — $0 by definition, not an unverified vendor price",
+      "source": "verified on ollama.com/library/qwen3.8 (18GB, 256K ctx); local inference is free \u2014 $0 by definition, not an unverified vendor price",
       "retrieved": "2026-08-27"
     },
     {
@@ -543,7 +543,7 @@
         "input": 0.0,
         "output": 0.0
       },
-      "source": "modest-hardware alternative; verified on ollama.com/library/qwen3.5 (6.6GB); local inference is free — $0 by definition",
+      "source": "modest-hardware alternative; verified on ollama.com/library/qwen3.5 (6.6GB); local inference is free \u2014 $0 by definition",
       "retrieved": "2026-08-27"
     },
     {
@@ -554,8 +554,30 @@
         "input": 0.0,
         "output": 0.0
       },
-      "source": "verified live end-to-end: planted-vuln scan, both CWE-89 findings detected (2026-08-25); local inference is free — $0 by definition",
+      "source": "verified live end-to-end: planted-vuln scan, both CWE-89 findings detected (2026-08-25); local inference is free \u2014 $0 by definition",
       "retrieved": "2026-08-27"
+    },
+    {
+      "id": "z-ai/glm-5.3",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 1.4,
+        "output": 4.4
+      },
+      "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models, 2026-09-05), per-token rates converted to per-1M",
+      "retrieved": "2026-09-05"
+    },
+    {
+      "id": "z-ai/glm-5.3-flash",
+      "provider": "openrouter",
+      "status": "current",
+      "price": {
+        "input": 0.075,
+        "output": 0.25
+      },
+      "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models, 2026-09-05), per-token rates converted to per-1M",
+      "retrieved": "2026-09-05"
     }
   ]
 }


### PR DESCRIPTION
> **CORRECTION (post-merge, from this window's fable re-review): the scan figures below were 2× the truth** — an aggregate double-count (the sum included `scan.report.json`, which is itself the per-step aggregate; the project journal recorded fixing this error class on 08-29). Corrected: **73,202 in / 24,104 out; true cost ≈ $0.21** (pre-entry scan) and the post-entry scan recorded **$0.142** (not $0.284 — its own `scan.report.json` says 0.142023; the per-step costs listed below sum to 0.142, confirming). The RED→GREEN finding and the entries themselves are unaffected.

## Why

The first live **glm-5.3 full-pipeline e2e scan** (via OpenRouter — the wire path through openai 3.8.0) recorded `cost_incomplete: true` + the unpriced-model warning on **every** LLM step: the registry's 51 entries carried no `z-ai/*` models (the #434/#437 family). With the entries below, the same scan records real per-step costs and the warning clears.

## The entries (live-verified pricing)

| id | input $/MTok | output $/MTok |
|---|---|---|
| `z-ai/glm-5.3` | 1.40 | 4.40 |
| `z-ai/glm-5.3-flash` | 0.075 | 0.25 |

Source: `GET https://openrouter.ai/api/v1/models` (2026-09-05), per-token rates converted to per-1M — the same verification method as the existing 19 openrouter entries.

## RED→GREEN (executed scans, same corpus + config)

- **RED** (pre-entry): every LLM step `cost_incomplete=true` + `unpriced_models`; recorded cost \$0 despite real tokens.
- **GREEN** (post-entry): per-step costs record (analyze \$0.0444 · enhance \$0.0766 · app-context \$0.0055 · report \$0.0155 — **total \$0.142**), `cost_incomplete` cleared everywhere; verdicts correct (4 pure functions SAFE; 2 command-injection shapes VULNERABLE — found by glm-5.3 end to end).

## Tests

The registry suite is green with the entries — including `test_every_record_has_the_required_shape`, which caught the first draft missing the `retrieved` field (the shape guard works). Registry/consistency set: **25 passed / 2 skipped**.

## The e2e receipt (the scan that found this gap)

Full pipeline through `--llm-config via-glm53` (z-ai/glm-5.3 via openrouter): parse → app-context → llm-reachability → enhance → analyze → verify (the 5-tool agent loop) → build-output → report — the end-to-end wire-path verification of the merged openai 3.8.0 pin (#490). Corrected figures: **73,202 in / 24,104 out tokens; true cost ≈ $0.21**.