### PR TITLE
fix(verify): a Stage-2 disagreement corrected to 'inconclusive' threads into metrics.inconclusive — never into safe (#509)

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -1106,7 +1106,13 @@ def scan_repository(
                     total=analyze_result.metrics.total,
                     vulnerable=verify_result.confirmed_vulnerabilities,
                     bypassable=0,
-                    inconclusive=analyze_result.metrics.inconclusive,
+                    # #509: a Stage-2 disagreement corrected to
+                    # ``inconclusive`` is an explicitly-unconfirmable finding —
+                    # it threads into inconclusive, NEVER into safe (the
+                    # plain-disagreement fold above covers only genuine
+                    # downgrades to safe).
+                    inconclusive=analyze_result.metrics.inconclusive
+                    + verify_result.disagreed_inconclusive,
                     protected=analyze_result.metrics.protected,
                     safe=analyze_result.metrics.safe + verify_result.disagreed,
                     errors=analyze_result.metrics.errors + verify_result.error_count,

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -320,18 +320,22 @@ def verify_step_summary(result: "VerifyResult") -> dict:
 
     Shared by every construction site — core/scanner.py (the pipeline),
     openant/cli.py's chained analyze --verify, and standalone openant
-    verify — so the sites cannot drift. All seven fields reconcile:
-    agreed + disagreed + needs_review + error_count accounts for every
-    findings_input finding except the disagreed-but-still-vulnerable
-    case, which increments only confirmed_vulnerabilities (see
-    core/verifier.py _count_verification_outcomes) — the four reconciliation
-    counters are therefore a bound (<=), not exact equality.
+    verify — so the sites cannot drift. The reconciliation counters bound:
+    agreed + disagreed + disagreed_inconclusive + needs_review +
+    error_count accounts for every findings_input finding except the
+    disagreed-but-still-vulnerable case, which increments only
+    confirmed_vulnerabilities (see core/verifier.py
+    _count_verification_outcomes) — the counters are therefore a bound
+    (<=), not exact equality. #509: ``disagreed_inconclusive`` is the
+    disagreement arm whose corrected finding is ``inconclusive`` — the
+    verifier could NOT confirm it, so it must never fold into ``safe``.
     """
     return {
         "findings_input": result.findings_input,
         "findings_verified": result.findings_verified,
         "agreed": result.agreed,
         "disagreed": result.disagreed,
+        "disagreed_inconclusive": result.disagreed_inconclusive,
         "confirmed_vulnerabilities": result.confirmed_vulnerabilities,
         "needs_review": result.needs_review,
         "error_count": result.error_count,
@@ -353,6 +357,12 @@ class VerifyResult:
     findings_verified: int = 0
     agreed: int = 0
     disagreed: int = 0
+    # #509: disagreements whose corrected finding is ``inconclusive`` —
+    # the verifier explicitly could NOT confirm the finding. Counted
+    # separately so the scanner threads them into ``inconclusive`` and
+    # they never fold into ``safe`` (the ->inconclusive arm of the
+    # #374/#381 family).
+    disagreed_inconclusive: int = 0
     confirmed_vulnerabilities: int = 0
     # PR #69 F5: findings whose Stage-2 verification could not COMPLETE
     # (degenerate path or adapter error). Counted separately so the scanner

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -133,6 +133,7 @@ def run_verification(
             findings_verified=0,
             agreed=0,
             disagreed=0,
+            disagreed_inconclusive=0,
             confirmed_vulnerabilities=0,
             # #302: the denominator survives the zero-findings early return —
             # a clean scan's scope statement is "adjudicated 0 of N", never
@@ -263,7 +264,8 @@ def run_verification(
     needs_review = _counts["needs_review"]
     error_count = _counts["error_count"]
 
-    print(f"\n[Verify] Results: {agreed} agreed, {disagreed} disagreed, "
+    print(f"\n[Verify] Results: {agreed} agreed, {disagreed} disagreed "
+          f"({_counts['disagreed_inconclusive']} to inconclusive), "
           f"{needs_review} need manual review, "
           f"{confirmed_vulnerabilities} confirmed vulnerabilities", file=sys.stderr)
     if error_count:
@@ -307,6 +309,7 @@ def run_verification(
         findings_verified=len(verified_results),
         agreed=agreed,
         disagreed=disagreed,
+        disagreed_inconclusive=_counts["disagreed_inconclusive"],
         confirmed_vulnerabilities=confirmed_vulnerabilities,
         needs_review=needs_review,
         error_count=error_count,
@@ -390,6 +393,9 @@ def _count_verification_outcomes(verified_results: list) -> dict:
     counts = {
         "agreed": 0,
         "disagreed": 0,
+        # #509: disagreements whose corrected finding is ``inconclusive`` —
+        # threaded to metrics.inconclusive, never folded into safe.
+        "disagreed_inconclusive": 0,
         "needs_review": 0,
         "confirmed_vulnerabilities": 0,
         "error_count": 0,
@@ -429,6 +435,14 @@ def _count_verification_outcomes(verified_results: list) -> dict:
             # safe — counting it as ``disagreed`` would under-report the vuln.
             if finding in ("vulnerable", "bypassable"):
                 counts["confirmed_vulnerabilities"] += 1
+            elif finding == "inconclusive":
+                # #509: the verifier disagreed AND could not confirm — the
+                # corrected finding is ``inconclusive``. NOT a safe verdict
+                # and NOT a generic disagreement: the scanner folds plain
+                # ``disagreed`` into ``safe`` (safe += disagreed), which
+                # would reclassify an explicitly-unconfirmable finding as
+                # safe in the aggregate metrics. Its own bucket.
+                counts["disagreed_inconclusive"] += 1
             else:
                 counts["disagreed"] += 1
         # #302: direction. `verdict` is the UN-overwritten Stage-1 original;

--- a/libs/openant-core/tests/test_famreport_disagreed_vuln_counted_safe.py
+++ b/libs/openant-core/tests/test_famreport_disagreed_vuln_counted_safe.py
@@ -78,3 +78,34 @@ def test_verdictonly_disagreed_still_vulnerable_is_confirmed():
         f"verdict-only disagreed-still-vulnerable must NOT fold into safe, "
         f"got disagreed={counts['disagreed']}"
     )
+
+
+def test_disagreed_corrected_to_inconclusive_is_not_safe():
+    """The ->inconclusive arm (#509): a disagreement whose corrected finding is
+    ``inconclusive`` is NOT a safe verdict — the verifier explicitly could not
+    confirm it. It must land in its own bucket (``disagreed_inconclusive``),
+    never in ``disagreed`` (which the scanner folds into ``safe``). The live
+    repro: two command-injection sinks reclassified to inconclusive read as
+    safe 6 / inconclusive 0 in scan.report.json while results_verified.json
+    carried safe 4 / inconclusive 2."""
+    verified_results = [
+        {  # Stage 2 disagreed and could NOT confirm -> inconclusive
+            "route_key": "s:1", "finding": "inconclusive",
+            "verification": {"agree": False, "correct_finding": "inconclusive",
+                             "incomplete": False},
+        },
+        {  # genuine downgrade to safe — still the only true "disagreed"
+            "route_key": "s:2", "finding": "safe",
+            "verification": {"agree": False, "correct_finding": "safe",
+                             "incomplete": False},
+        },
+    ]
+    counts = _count_verification_outcomes(verified_results)
+    assert counts["disagreed"] == 1, (
+        f"only the downgrade-to-safe may be 'disagreed' (safe-folding); "
+        f"got {counts['disagreed']}"
+    )
+    assert counts.get("disagreed_inconclusive") == 1, (
+        f"the corrected-to-inconclusive disagreement must land in its own "
+        f"bucket, got {counts}"
+    )


### PR DESCRIPTION
## The defect (live, from a glm-5.3 `--verify` e2e run)

Same run, three artifacts disagreeing:

- `results_verified.json` + `pipeline_output.json`: **safe 4, inconclusive 2** (two command-injection sinks Stage-2 reclassified to `inconclusive` — Stage 2's own words: "one caller away from being critical, remotely exploitable")
- `scan.report.json` metrics: **safe 6, inconclusive 0**, `stage2_disagreed: 2`

The aggregate folds explicitly-unconfirmable findings into `safe` — a false-clean on the CLI/envelope summary channel (anyone consuming only the summary sees a clean report). This is the **uncovered `->inconclusive` arm of the #374/#381 family**: `_count_verification_outcomes` bucketed every non-vulnerable corrected finding into `disagreed` (safe-folding via `scanner.py: safe += disagreed`); the vulnerable/bypassable arm was fixed and pinned (`test_famreport_disagreed_vuln_counted_safe`), this arm was not.

## The fix

- `verifier._count_verification_outcomes`: corrected-finding `inconclusive` → its own **`disagreed_inconclusive`** bucket (genuine downgrades-to-safe keep `disagreed`; still-vulnerable keeps `confirmed_vulnerabilities`)
- `VerifyResult.disagreed_inconclusive` — a deliberate schema surface (the counter must cross the verifier→scanner boundary); carried in `verify_step_summary`
- `scanner`: `inconclusive = analyze.metrics.inconclusive + verify_result.disagreed_inconclusive` (`safe += disagreed` unchanged — now covering only genuine safe-downgrades)
- the `[Verify]` stderr line surfaces the new bucket

## RED→GREEN (executed)

- **RED on pristine**: `test_disagreed_corrected_to_inconclusive_is_not_safe` FAILED (the arm landed in `disagreed` → safe-folding)
- **GREEN**: the famreport/#300/#302/#69 suites → **43 passed**; full suite **3592 passed / 0 failed**; ruff clean
- **E2E differential** (real glm-5.3 `--verify` rerun on the fix tree): cross-artifact consistency **PASS** (metrics safe 5 == results safe 5; the new field flows to the verify step summary; $0.288 recorded). Honest note: the `->inconclusive` arm did not fire in the rerun (Stage-2 verdicts are LLM-nondeterministic — that run confirmed one vuln and downgraded one to safe instead), so the durable mechanism proof is the RED→GREEN unit arm; the **pre-fix artifact** (safe 6/inconclusive 0 vs safe 4/inconclusive 2) is preserved as the #509 repro.

Closes #509.
