### PR TITLE
fix(config): encode the tailwind artifact-space ceiling (packageRules cap) + the CDN's HTTP-200 trap in SOURCES.txt

### DIFF
--- a/apps/openant-cli/internal/report/vendor/SOURCES.txt
+++ b/apps/openant-cli/internal/report/vendor/SOURCES.txt
@@ -24,8 +24,11 @@
 #         releases past 3.4.17, so renovate's npm-datasource notifier will
 #         propose versions with NO published Play-CDN artifact — those
 #         branches are read-before-acting: verify the CDN actually serves
-#         the version before attempting this recipe. The verification will
-#         fail for EVERY version past 3.4.17 — this vendored blob is frozen
+#         the version before attempting this recipe. TRAP: the CDN answers
+#         unknown versions with HTTP 200 + a console.error stub (~730 bytes,
+#         'Unknown Tailwind version: ...') — a status-code check reads as
+#         success; MATCH ON CONTENT (a ~400KB script) or the stub wins. The
+#         verification will fail for EVERY version past 3.4.17 — this vendored blob is frozen
 #         on this channel (including for future security fixes; the npm
 #         dist carries no play-cdn script — verified by tarball listing, so
 #         there is no second source to dual-verify against either). A

--- a/renovate.json
+++ b/renovate.json
@@ -50,5 +50,14 @@
       "datasourceTemplate": "npm",
       "packageNameTemplate": "chartjs-plugin-datalabels"
     }
+  ],
+  "packageRules": [
+    {
+      "description": "#497's artifact-space ceiling, ENCODED: cdn.tailwindcss.com (the Play-CDN's only publisher) serves the 3.x build up to 3.4.17 ONLY \u2014 3.4.18+ and v4 have no published artifact (verified 2026-09-05; the npm datasource's version space outruns the artifact space). Cap the notifier at what is actually vendorable; keep the notifier alive for any genuine 3.4.x<=3.4.17 fix (there is none as of the cap date) instead of proposing unactionable branches. NOTE: closing the v4 renovate branch (#495) already put renovate into ignore-tailwindcss-4.x state (its own comment: 'You will not get PRs for any future 4.x releases') \u2014 this rule encodes the ceiling in-repo rather than leaving it in renovate's PR memory.",
+      "matchPackageNames": [
+        "tailwindcss"
+      ],
+      "allowedVersions": "<=3.4.17"
+    }
   ]
 }


### PR DESCRIPTION
From this window's opus/fable/sol re-review: the ceiling lived only in documentation, while closing #495 put renovate into ignore-tailwindcss-4.x state (its own comment: no future 4.x PRs) — a dead notifier with its reality in renovate's PR memory. This encodes it in-repo: `allowedVersions: "<=3.4.17"` on `packageRules`, matching the verified artifact space (the CDN serves the 3.x Play-CDN build up to 3.4.17 only; 3.4.18+/v4 return stubs — verified 2026-09-05). Also records the trap in SOURCES.txt: the CDN answers unknown versions with **HTTP 200 + a ~730-byte console.error stub** — a status-code check reads as success; match on content (~400KB). Validator strict-pass; doc/config-only.