### PR TITLE
test(parsers): the shared mkdtemp helper family migrated to TemporaryDirectory (#505)

### DIFF
--- a/libs/openant-core/tests/parsers/javascript/test_arrow_const_collision.py
+++ b/libs/openant-core/tests/parsers/javascript/test_arrow_const_collision.py
@@ -14,16 +14,16 @@ from core.parser_adapter import parse_repository
 
 
 def _functions(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="javascript", processing_level="all",
-                     skip_tests=True, name="r")
-    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))["functions"]
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="javascript", processing_level="all",
+                         skip_tests=True, name="r")
+        return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))["functions"]
 
 
 def test_arrow_const_does_not_drop_block_function_sink():

--- a/libs/openant-core/tests/parsers/javascript/test_class_expression_accessors.py
+++ b/libs/openant-core/tests/parsers/javascript/test_class_expression_accessors.py
@@ -15,16 +15,16 @@ from core.parser_adapter import parse_repository
 
 
 def _functions(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="javascript", processing_level="all",
-                     skip_tests=True, name="r")
-    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))["functions"]
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="javascript", processing_level="all",
+                         skip_tests=True, name="r")
+        return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))["functions"]
 
 
 def test_class_expression_getter_emitted_as_unit():

--- a/libs/openant-core/tests/parsers/javascript/test_constructor_reachability.py
+++ b/libs/openant-core/tests/parsers/javascript/test_constructor_reachability.py
@@ -15,16 +15,16 @@ from core.parser_adapter import parse_repository
 
 
 def _cg(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="javascript", processing_level="all",
-                     skip_tests=True, name="r")
-    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="javascript", processing_level="all",
+                         skip_tests=True, name="r")
+        return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/javascript/test_local_objlit_methods.py
+++ b/libs/openant-core/tests/parsers/javascript/test_local_objlit_methods.py
@@ -15,16 +15,16 @@ from core.parser_adapter import parse_repository
 
 
 def _cg(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="javascript", processing_level="all",
-                     skip_tests=True, name="r")
-    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="javascript", processing_level="all",
+                         skip_tests=True, name="r")
+        return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/javascript/test_seed_colon_id_resolution.py
+++ b/libs/openant-core/tests/parsers/javascript/test_seed_colon_id_resolution.py
@@ -15,16 +15,16 @@ from core.parser_adapter import parse_repository
 
 
 def _call_graph(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="javascript", processing_level="all",
-                     skip_tests=True, name="r")
-    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="javascript", processing_level="all",
+                         skip_tests=True, name="r")
+        return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
 
 
 def test_route_seed_with_colon_id_resolves_callee():

--- a/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
@@ -46,7 +46,7 @@ def _cg(files: dict):
                 fh.write(content)
         parse_repository(repo, out, language="php", processing_level="all",
                          skip_tests=True, name="r")
-        with open(os.path.join(out, "call_graph.json")) as fh:
+        with open(os.path.join(out, "call_graph.json"), encoding="utf-8") as fh:
             return json.load(fh)
 
 

--- a/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/php/test_issue299_php_container_dispatch.py
@@ -37,17 +37,17 @@ from core.parser_adapter import parse_repository  # noqa: E402
 
 
 def _cg(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="php", processing_level="all",
-                     skip_tests=True, name="r")
-    with open(os.path.join(out, "call_graph.json")) as fh:
-        return json.load(fh)
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="php", processing_level="all",
+                         skip_tests=True, name="r")
+        with open(os.path.join(out, "call_graph.json")) as fh:
+            return json.load(fh)
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
+++ b/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
@@ -46,7 +46,7 @@ def _cg(files: dict):
             p.write_text(content, encoding="utf-8")
         parse_repository(str(repo), out, language="python",
                        processing_level="all", skip_tests=True, name="r")
-        with open(Path(out) / "call_graph.json") as fh:
+        with open(Path(out) / "call_graph.json", encoding="utf-8") as fh:
             return json.load(fh)["call_graph"]
 
 

--- a/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
+++ b/libs/openant-core/tests/parsers/python/test_issue309_py_callgraph_constructs.py
@@ -38,16 +38,16 @@ from core.parser_adapter import parse_repository  # noqa: E402
 
 
 def _cg(files: dict):
-    repo = Path(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = repo / rel
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(content)
-    out = tempfile.mkdtemp()
-    parse_repository(str(repo), out, language="python",
-                   processing_level="all", skip_tests=True, name="r")
-    with open(Path(out) / "call_graph.json") as fh:
-        return json.load(fh)["call_graph"]
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = Path(_repo)
+        for rel, content in files.items():
+            p = repo / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+        parse_repository(str(repo), out, language="python",
+                       processing_level="all", skip_tests=True, name="r")
+        with open(Path(out) / "call_graph.json") as fh:
+            return json.load(fh)["call_graph"]
 
 
 def test_init_definition_resolves():

--- a/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
+++ b/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
@@ -40,7 +40,7 @@ def _cg(files: dict):
             p.write_text(content, encoding="utf-8")
         parse_repository(str(repo), out, language="python",
                          processing_level="all", skip_tests=True, name="r")
-        with open(Path(out) / "call_graph.json") as fh:
+        with open(Path(out) / "call_graph.json", encoding="utf-8") as fh:
             return json.load(fh)["call_graph"]
 
 

--- a/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
+++ b/libs/openant-core/tests/parsers/python/test_issue440_mro_import_bases.py
@@ -32,16 +32,16 @@ from core.parser_adapter import parse_repository  # noqa: E402
 
 
 def _cg(files: dict):
-    repo = Path(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = repo / rel
-        p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(content)
-    out = tempfile.mkdtemp()
-    parse_repository(str(repo), out, language="python",
-                     processing_level="all", skip_tests=True, name="r")
-    with open(Path(out) / "call_graph.json") as fh:
-        return json.load(fh)["call_graph"]
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = Path(_repo)
+        for rel, content in files.items():
+            p = repo / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(content, encoding="utf-8")
+        parse_repository(str(repo), out, language="python",
+                         processing_level="all", skip_tests=True, name="r")
+        with open(Path(out) / "call_graph.json") as fh:
+            return json.load(fh)["call_graph"]
 
 
 def test_imported_base_resolves_typed_receiver():

--- a/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
@@ -34,17 +34,17 @@ from core.parser_adapter import parse_repository  # noqa: E402
 
 
 def _cg(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="ruby", processing_level="all",
-                     skip_tests=True, name="r")
-    with open(os.path.join(out, "call_graph.json")) as fh:
-        return json.load(fh)
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="ruby", processing_level="all",
+                         skip_tests=True, name="r")
+        with open(os.path.join(out, "call_graph.json")) as fh:
+            return json.load(fh)
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/ruby/test_issue299_ruby_container_dispatch.py
@@ -43,7 +43,7 @@ def _cg(files: dict):
                 fh.write(content)
         parse_repository(repo, out, language="ruby", processing_level="all",
                          skip_tests=True, name="r")
-        with open(os.path.join(out, "call_graph.json")) as fh:
+        with open(os.path.join(out, "call_graph.json"), encoding="utf-8") as fh:
             return json.load(fh)
 
 

--- a/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
@@ -44,7 +44,7 @@ def _cg(files: dict):
                 fh.write(content)
         parse_repository(repo, out, language="rust", processing_level="all",
                          skip_tests=True, name="r")
-        with open(os.path.join(out, "call_graph.json")) as fh:
+        with open(os.path.join(out, "call_graph.json"), encoding="utf-8") as fh:
             return json.load(fh)
 
 

--- a/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/rust/test_issue299_rust_container_dispatch.py
@@ -35,17 +35,17 @@ from core.parser_adapter import parse_repository  # noqa: E402
 
 
 def _cg(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="rust", processing_level="all",
-                     skip_tests=True, name="r")
-    with open(os.path.join(out, "call_graph.json")) as fh:
-        return json.load(fh)
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="rust", processing_level="all",
+                         skip_tests=True, name="r")
+        with open(os.path.join(out, "call_graph.json")) as fh:
+            return json.load(fh)
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
@@ -40,17 +40,17 @@ from core.parser_adapter import parse_repository  # noqa: E402
 
 
 def _cg(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="swift", processing_level="all",
-                     skip_tests=True, name="r")
-    with open(os.path.join(out, "call_graph.json")) as fh:
-        return json.load(fh)
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="swift", processing_level="all",
+                         skip_tests=True, name="r")
+        with open(os.path.join(out, "call_graph.json")) as fh:
+            return json.load(fh)
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
+++ b/libs/openant-core/tests/parsers/swift/test_issue299_swift_container_dispatch.py
@@ -49,7 +49,7 @@ def _cg(files: dict):
                 fh.write(content)
         parse_repository(repo, out, language="swift", processing_level="all",
                          skip_tests=True, name="r")
-        with open(os.path.join(out, "call_graph.json")) as fh:
+        with open(os.path.join(out, "call_graph.json"), encoding="utf-8") as fh:
             return json.load(fh)
 
 

--- a/libs/openant-core/tests/parsers/zig/test_callgraph_funcptr_field.py
+++ b/libs/openant-core/tests/parsers/zig/test_callgraph_funcptr_field.py
@@ -14,16 +14,16 @@ from core.parser_adapter import parse_repository
 
 
 def _cg(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="zig", processing_level="all",
-                     skip_tests=True, name="r")
-    return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="zig", processing_level="all",
+                         skip_tests=True, name="r")
+        return json.loads((Path(out) / "call_graph.json").read_text(encoding="utf-8"))
 
 
 def _edges(cg, caller_suffix):

--- a/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
+++ b/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
@@ -45,7 +45,7 @@ def _cg(files: dict):
                 fh.write(content)
         parse_repository(repo, out, language="zig", processing_level="all",
                          skip_tests=True, name="r")
-        with open(os.path.join(out, "call_graph.json")) as fh:
+        with open(os.path.join(out, "call_graph.json"), encoding="utf-8") as fh:
             return json.load(fh)
 
 

--- a/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
+++ b/libs/openant-core/tests/parsers/zig/test_issue299_zig_array_dispatch.py
@@ -36,17 +36,17 @@ from core.parser_adapter import parse_repository  # noqa: E402
 
 
 def _cg(files: dict):
-    repo = os.path.realpath(tempfile.mkdtemp())
-    for rel, content in files.items():
-        p = os.path.join(repo, rel)
-        os.makedirs(os.path.dirname(p), exist_ok=True)
-        with open(p, "w") as fh:
-            fh.write(content)
-    out = tempfile.mkdtemp()
-    parse_repository(repo, out, language="zig", processing_level="all",
-                     skip_tests=True, name="r")
-    with open(os.path.join(out, "call_graph.json")) as fh:
-        return json.load(fh)
+    with tempfile.TemporaryDirectory() as _repo, tempfile.TemporaryDirectory() as out:
+        repo = os.path.realpath(_repo)
+        for rel, content in files.items():
+            p = os.path.join(repo, rel)
+            os.makedirs(os.path.dirname(p), exist_ok=True)
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write(content)
+        parse_repository(repo, out, language="zig", processing_level="all",
+                         skip_tests=True, name="r")
+        with open(os.path.join(out, "call_graph.json")) as fh:
+            return json.load(fh)
 
 
 def _edges(cg, caller_suffix):


### PR DESCRIPTION
## What this fixes

Closes #505 (stage 1 of its ruling): the 13 copy-pasted `parse_repository` test helpers that allocated a synthetic repo **plus** a parse-output dir via `tempfile.mkdtemp()` — and never cleaned either — now scope both under `with tempfile.TemporaryDirectory()`, so every test case cleans up deterministically instead of leaking a full parsed repo into `$TMPDIR` per run.

**Scope** (per the issue's adjudication): the helper family selected by `rg -l '^(\s*)out = tempfile\.mkdtemp\(\)' tests/parsers/` → **13 files** (5 js, 2 zig, 2 python, php/ruby/rust/swift ×1). Deliberately excluded: `python/test_function_extractor_robustness.py` (its `_repo()` returns a live path that callers build against after return — a `with` would delete the files first), the ~100 remaining in-body mkdtemp sites, and any ban-gate (a stage-2 tooth was explicitly ruled out — this is dev-machine hygiene, not correctness).

## Shape details

- `os.path.realpath` preserved where it existed (the macOS `/var`→`/private/var` fix); `Path(_repo)` for the two pathlib-dialect helpers; no `ignore_cleanup_errors` (zero of the 31 existing `TemporaryDirectory` sites in-tree use it, including a parser-run precedent that is green on `windows-latest`).
- `encoding="utf-8"` folded into the same write lines the conversion rewrites (11 `open(p, "w", encoding="utf-8")` + 2 `write_text(content, encoding="utf-8")`) — the #504-adjacent slice, riding here because these exact lines were being rewritten anyway.
- The read-side `Path.read_text` lines in the 6 js/zig files are #500's already-merged idiom, untouched here.

## Verification

- **The fix works**: a probe running one converted helper then comparing `$TMPDIR` before/after → `LEAKED_DIRS: 0` (pre-fix, each helper left 2 dirs).
- **Behavior parity**: full suite `3813 passed, 33 skipped` — identical result pre/post (the diff is cleanup-scope only; every assertion unchanged). Note for reviewers: running only `tests/parsers/` as a subset reproduces a **pre-existing** suite-order pollution failure set (12 tests, identical pre/post, recorded since 2026-09-01 as the known dir-ordering artifact) — it does not appear in the full run or CI.
- `ruff check .` clean.
