### PR TITLE
fix(verify): an incomplete verification never vetoes a correction — and never drops out of disclosure (#296)

### DIFF
--- a/libs/openant-core/tests/test_issue296_conclusive_guards.py
+++ b/libs/openant-core/tests/test_issue296_conclusive_guards.py
@@ -1,21 +1,19 @@
-"""Regression tests for issue #296 — the conclusive-exploit-path guards
-test a free-text explanation string; the structured signal
-(``verification["incomplete"]``) sits unused on the same object.
-
-Scope of this change (the issue's lower-risk items, explicitly NOT the
-direction-aware behavior change the maintainer raised as an open question):
+"""Regression tests for issue #296 — the conclusive-path guards and the
+incomplete-verification signal, at the call site (the direction-aware fix,
+landed in this PR after the issue's own 2026-08-21 re-scoping):
 
 1. The matched marker is a NAMED constant (``INCOMPLETE_VERIFICATION_MARKER``)
-   with the match set UNCHANGED — widening it is the false-negative direction
-   for BOTH guards and must wait for the direction-awareness analysis.
-2. The ASYMMETRY is pinned (the issue's suggested test 3): an INCOMPLETE
-   verification carrying an INTACT exploit path must still leave
-   ``_has_conclusive_exploitable_path`` True — the downgrade into
-   DISCLOSURE_DROPPED stays BLOCKED. Whatever future fix makes the guards
-   signal-aware, it must not let an unfinished verification become the
-   reason a finding is downgraded out of disclosure.
-3. The guards' current behavior on the marker and on the constructed
-   defect input is characterized so any change forces a conscious decision.
+   — it stays as the legacy arm covering rows that predate the structured
+   flag.
+2. The raw helpers below are SHAPE-ONLY characterizations (both still
+   free-text/marker-driven by design — the incomplete-awareness lives at the
+   consistency CALL SITE, not in the helpers, so the #195/#243 mirror
+   contract is untouched).
+3. The call-site behavior: an INCOMPLETE verification never vetoes a
+   correction (arm 1) and never drops out of disclosure (arm 2 — a
+   correction into any DISCLOSURE_DROPPED verdict is blocked with an audit
+   record carrying ``incomplete: True``); the incomplete flag survives an
+   allowed correction (pinned).
 """
 
 from __future__ import annotations
@@ -83,19 +81,17 @@ def test_asymmetry_incomplete_intact_path_blocks_downgrade():
     assert _exploit_path(v) is False
 
 
-def test_characterization_incomplete_broken_path_is_the_open_defect():
-    """CHARACTERIZATION (the open defect, pinned so any change is a
-    conscious decision): incomplete:True + BROKEN path + model-authored
-    explanation reads as conclusive today, suppressing a consistency
-    correction. #296's traced constraint: the obvious tightening re-opens
-    the disclosure FN via the consistency update at :918 — the fix must be
-    direction-aware (skip only for non-downgrade updates). Changing this
-    assertion without that analysis is exactly what #296 warns against."""
+def test_characterization_incomplete_broken_path_helper_still_marker_driven():
+    """CHARACTERIZATION (the helper's shape contract, unchanged by the fix):
+    incomplete:True + BROKEN path + model-authored explanation still reads
+    as conclusive to the RAW helper — the incomplete-awareness lives at the
+    consistency call site (which skips the helper for incomplete rows), not
+    in the helper itself, so the #195/#243 mirror contract is untouched."""
     v = {"incomplete": True, "explanation": _MODEL_TEXT,
          "exploit_path": dict(_BROKEN)}
     assert _exploit_path(v) is True, (
-        "KNOWN DEFECT (see #296): an incomplete verification's broken path "
-        "currently suppresses corrections — fix requires direction-awareness")
+        "the raw helper must stay marker-driven (the #195/#243 contract); "
+        "incomplete-awareness belongs to the call site")
 
 
 def _verifier():

--- a/libs/openant-core/tests/test_issue296_conclusive_guards.py
+++ b/libs/openant-core/tests/test_issue296_conclusive_guards.py
@@ -129,3 +129,86 @@ def test_e2e_incomplete_intact_path_downgrade_still_blocked():
     got = next(r for r in out if r["route_key"] == rk)
     assert got.get("finding") == "vulnerable", "the downgrade was applied!"
     assert "consistency_downgrade_blocked" in got
+    assert got["consistency_downgrade_blocked"]["incomplete"] is True
+
+
+# ---------------------------------------------------------------------------
+# #296's direction-aware fix (adjudicated round 3): the finish-path window.
+# _parse_finish_result can mark a verification incomplete WHILE preserving a
+# populated exploit_path and model-authored explanation (agree-missing,
+# self-contradictory finishes) — the string-marker test passes and the
+# incomplete evidence vetoes a CORRECTION. The structured signal exists on
+# the same object: verification["incomplete"].
+# ---------------------------------------------------------------------------
+
+def test_finish_path_incomplete_with_populated_path_allows_correction():
+    """#296's fix: an agree-missing finish (incomplete=True, populated
+    BROKEN exploit_path, model text != the marker) must NOT count as a
+    conclusive exploit path — pre-fix it did (the broken-path conclusive
+    check vetoed), and the unfinished evidence suppressed the correction.
+    Route keys follow the *Msg grouping the pattern detector uses; the
+    proposal (vulnerable -> bypassable) stays inside DISCLOSURE_ELIGIBLE,
+    so the disclosure-drop guard is not the thing under test here. The
+    incomplete flag SURVIVES the correction: a consistency opinion is not
+    a completed verification."""
+    from utilities.finding_verifier import ConsistencyCheckResult
+    v = _verifier()
+    rk = "app/api/handler.go:serveMsg.json"
+    sibling = "app/api/handler.go:helperMsg.json"
+    v._resolve_inconsistency = lambda group, cbr: ConsistencyCheckResult(
+        "handler", "bypassable",
+        [{"route_key": rk, "should_be": "bypassable", "reason": "consistent"}], "x")
+    agree_missing_v = {
+        "incomplete": True,  # the structured signal the guard now reads
+        "correct_finding": "vulnerable",  # the group IS inconsistent (sibling says bypassable)
+        "explanation": _MODEL_TEXT,  # model text — not the marker
+        "exploit_path": dict(_BROKEN),  # populated, BROKEN — the finish-path shape
+    }
+    out = v._check_consistency([
+        {"route_key": rk, "finding": "vulnerable",
+         "verification": agree_missing_v},
+        {"route_key": sibling, "finding": "bypassable",
+         "verification": {"correct_finding": "bypassable"}}], {})
+    got = next(r for r in out if r["route_key"] == rk)
+    assert got.get("finding") == "bypassable", (
+        "the incomplete finish-path window still vetoed the correction "
+        "(the guard treats incomplete-but-populated evidence as "
+        "conclusive)")
+    assert got["verification"]["incomplete"] is True, (
+        "the correction must not clear the incomplete flag — a "
+        "consistency opinion is not a completed verification")
+
+
+def test_incomplete_correction_may_not_drop_disclosure():
+    """The astra-round guard: once the veto is lifted, a correction of an
+    INCOMPLETE verification into any DISCLOSURE_DROPPED verdict must be
+    blocked (mirroring the conclusive-exploitable block) — the mirror guard
+    alone cannot catch broken-path shapes (its return requires a reached
+    sink, attacker control, and no break). On pristine master the
+    broken-path conclusive check silently blocked the correction with NO
+    audit record; fix-(1)-alone would let it through — this guard is what
+    keeps the block, now with a record."""
+    from utilities.finding_verifier import ConsistencyCheckResult
+    v = _verifier()
+    rk = "app/api/admin.go:deleteMsg.json"
+    sibling = "app/api/admin.go:listMsg.json"
+    v._resolve_inconsistency = lambda group, cbr: ConsistencyCheckResult(
+        "admin handlers", "safe",
+        [{"route_key": rk, "should_be": "inconclusive", "reason": "pattern"}], "x")
+    incomplete_broken_v = {
+        "incomplete": True,
+        "correct_finding": "vulnerable",  # inconsistent with the sibling's safe
+        "explanation": _MODEL_TEXT,
+        "exploit_path": dict(_BROKEN),  # BROKEN — the mirror returns False on this shape
+    }
+    out = v._check_consistency([
+        {"route_key": rk, "finding": "vulnerable",
+         "verification": incomplete_broken_v},
+        {"route_key": sibling, "finding": "safe",
+         "verification": {"correct_finding": "safe"}}], {})
+    got = next(r for r in out if r["route_key"] == rk)
+    assert got.get("finding") == "vulnerable", (
+        "an incomplete verification was corrected into a disclosure-"
+        "dropping verdict (inconclusive is in DISCLOSURE_DROPPED) with no block")
+    assert "consistency_downgrade_blocked" in got
+    assert got["consistency_downgrade_blocked"]["incomplete"] is True

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -1194,9 +1194,45 @@ class FindingVerifier:
                     for result in results:
                         if result.get("route_key") == route_key:
                             # Check if this result has conclusive exploit path analysis
-                            if self._has_conclusive_exploit_path(result):
+                            # (#296's direction-aware fix: an INCOMPLETE
+                            # verification never counts as conclusive, even
+                            # with a populated exploit_path — the finish-path
+                            # shapes (agree-missing, self-contradictory)
+                            # preserve the path and model text while marking
+                            # the run incomplete, and that unfinished evidence
+                            # must not veto a correction. The marker check
+                            # below stays: it covers the same signal for
+                            # rows that predate the structured flag.)
+                            verification = result.get("verification", {})
+                            if verification.get("incomplete"):
+                                self._log("debug",
+                                          f"Skipping conclusive-path check for {route_key}: "
+                                          "verification is incomplete",
+                                          unit_id=route_key)
+                            elif self._has_conclusive_exploit_path(result):
                                 self._log("debug", f"Skipping {route_key}: has conclusive exploit path analysis",
                                           unit_id=route_key)
+                                continue
+
+                            # #296 + astra-round guard: a correction of an
+                            # INCOMPLETE verification into any DISCLOSURE_DROPPED
+                            # verdict is blocked (mirroring the conclusive-
+                            # exploitable block below). The mirror alone cannot
+                            # catch the broken-path shapes: its return requires
+                            # a reached sink, attacker control, and no break —
+                            # so an incomplete result with a broken path would
+                            # pass straight through into a disclosure drop.
+                            if (verification.get("incomplete")
+                                    and str(new_verdict or "").strip().lower() in DISCLOSURE_DROPPED):
+                                self._log("warning",
+                                          f"Blocked disclosure-dropping correction of incomplete {route_key} -> {new_verdict}",
+                                          unit_id=route_key)
+                                result["consistency_downgrade_blocked"] = {
+                                    "proposed": new_verdict,
+                                    "reason": finding_update.get("reason"),
+                                    "pattern": consistency_result.pattern_identified,
+                                    "incomplete": True,
+                                }
                                 continue
 
                             # F-KB-1b: a conclusively-exploitable finding must not be


### PR DESCRIPTION
## What this fixes

Closes #296 — the direction-aware fix the issue was re-scoped to by its own 2026-08-21 correction (**only the first helper changes**; the PR #195/#243 mirror guard stays untouched, per the issue's own constraint).

**The window** (re-derived at the fix site): `_parse_finish_result`'s finish paths — agree-missing and self-contradictory finishes — return `incomplete: True` **while preserving a populated `exploit_path` and a model-authored explanation**. The conclusive-path guard tested only the free-text marker string, so that unfinished evidence counted as a conclusive analysis and **vetoed verdict corrections** at the consistency call site. The structured signal (`verification["incomplete"]`) was already on the same object.

## The fix (two arms, per the adjudication)

1. **The veto lift**: an incomplete verification skips the conclusive-path check — unfinished evidence no longer suppresses corrections. The marker constant stays (it covers rows that predate the structured flag). A *complete* verification's conclusive broken path still vetoes, unchanged.
2. **The disclosure guard**: a correction of an **incomplete** verification into any `DISCLOSURE_DROPPED` verdict (`{safe, protected, inconclusive, rejected}` — the canonical set, imported) is blocked with a `consistency_downgrade_blocked` record carrying `incomplete: True`. Without this arm, lifting the veto alone would open the exact hole the adjudication found: the conclusively-exploitable mirror **cannot catch broken-path shapes** (its return requires a reached sink, attacker control, and no break), so an incomplete broken-path result would pass straight through into a disclosure drop.
3. The `incomplete` flag survives an allowed correction — a consistency opinion is not a completed verification (pinned by test).

## Verification

- **RED→GREEN on the true window** (incomplete + populated **broken** path + model text; route keys following the `*Msg` grouping the pattern detector actually uses):
  - test 1 (a `vulnerable→bypassable` correction, both disclosure-eligible) — RED on pristine master: the veto suppressed it. Green with the fix, and the `incomplete` flag survives (pinned).
  - test 2 (an `inconclusive` proposal, in `DISCLOSURE_DROPPED`) — RED on pristine master (silently blocked, **no audit record**) and RED on fix-arm-1-alone (the disclosure-drop hole). Green only with the full fix, and the block record carries `incomplete: True` (pinned).
- Full suite `3815 passed, 33 skipped` (includes the pre-existing characterization pins for both helpers and the e2e mirror-survival test); `ruff check .` clean.

## Notes for the reviewer

- The consistency apply-loop only fires on **non-conformant** model replies (the shipped prompt never requests `findings_to_update`) — this fix hardens that existing defense layer; it does not activate the unused prompt field.
- A characterization docstring in the test file was updated: it described this defect as open ("explicitly NOT the direction-aware behavior change"); post-fix the helpers are shape-only by design and the incomplete-awareness lives at the call site.
