### PR TITLE
fix(dynamic-test): the runtime policy anchored — target-declared runtime first, stable fallback; the Go pin de-rotted (#412)

### DIFF
--- a/libs/openant-core/tests/test_issue412_runtime_anchor.py
+++ b/libs/openant-core/tests/test_issue412_runtime_anchor.py
@@ -55,6 +55,28 @@ def test_runtime_anchor_guidance_present():
     """The policy itself is pinned: target-declared runtime first, stable
     fallback only when nothing is declared."""
     src = (_DYNDIR / "test_generator.py").read_text(encoding="utf-8")
-    assert "BASE IMAGE RUNTIME POLICY" in src
-    assert "DECLARED runtime" in src
-    assert "fall back to the current stable" in src
+    assert "BASE IMAGE RUNTIME POLICY" in src, (
+        "the runtime-policy block was removed from the prompt — #412's "
+        "anchor is gone; restore it or update this pin consciously")
+    assert "DECLARED runtime" in src, (
+        "the target-declared-runtime-first clause is gone from the prompt")
+    assert "fall back to the current stable" in src, (
+        "the stable-fallback clause is gone from the prompt")
+
+
+def test_reference_doc_template_table_matches_the_templates():
+    """The reference doc's template table is a THIRD spelling of the
+    template facts — it drifted before (node:20 vs the template's 24) and
+    is bound here now (the #412 audit's find)."""
+    doc = (_DYNDIR / "DYNAMIC_TESTER_REFERENCE.md").read_text(encoding="utf-8")
+    for name in ("python", "node", "go"):
+        tmpl_first = (_DYNDIR / "docker_templates" / f"{name}.Dockerfile"
+                      ).read_text(encoding="utf-8").splitlines()[0]
+        import re as _re
+        m = _re.search(r"FROM\s+(\S+)", tmpl_first)
+        assert m, f"{name}.Dockerfile's FROM line is malformed: {tmpl_first!r}"
+        image = m.group(1)
+        assert f"`{image}`" in doc, (
+            f"DYNAMIC_TESTER_REFERENCE.md's template table does not name "
+            f"{image} (the {name}.Dockerfile base) — the table drifted "
+            "from the templates it describes (the #412 class)")

--- a/libs/openant-core/tests/test_issue412_runtime_anchor.py
+++ b/libs/openant-core/tests/test_issue412_runtime_anchor.py
@@ -1,0 +1,60 @@
+"""#412: the dynamic-test runtime anchors cannot silently drift again.
+
+The system prompt's Go fallback tag and the docker_templates/ reference
+Dockerfile are two spellings of one fact ("the current Go fallback").
+They drifted three ways once (prompt 1.25 / template 1.27 / doc 1.22)
+because nothing bound them. This test parses both at collection time and
+fails on any mismatch — a future pin bump must touch both (and this test's
+expected fallback list) in one conscious change.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_DYNDIR = Path(__file__).resolve().parent.parent / "utilities" / "dynamic_tester"
+
+# The fallback tag the prompt and the template must agree on. When bumping
+# the fallback, update ALL of: this list, the prompt's two mentions in
+# test_generator.py, and docker_templates/go.Dockerfile.
+_KNOWN_FALLBACKS = {"golang:1.27-alpine"}
+
+
+def _prompt_go_tags() -> set[str]:
+    src = (_DYNDIR / "test_generator.py").read_text(encoding="utf-8")
+    return set(re.findall(r"golang:\d+(?:\.\d+)?-alpine", src))
+
+
+def _template_go_tag() -> str:
+    first = (_DYNDIR / "docker_templates" / "go.Dockerfile").read_text(
+        encoding="utf-8").splitlines()[0]
+    m = re.search(r"golang:\d+(?:\.\d+)?-alpine", first)
+    assert m, "go.Dockerfile's FROM line no longer names a golang tag"
+    return m.group(0)
+
+
+def test_go_fallback_tag_is_known():
+    tags = _prompt_go_tags()
+    assert tags <= _KNOWN_FALLBACKS, (
+        f"the prompt's Go fallback tags {sorted(tags)} are not in the "
+        f"known-fallback set {sorted(_KNOWN_FALLBACKS)} — a pin bump must "
+        "update the prompt AND docker_templates/go.Dockerfile AND this "
+        "test's set together (the #412 drift guard)")
+
+
+def test_prompt_and_template_go_tags_match():
+    tags = _prompt_go_tags()
+    assert tags, "no golang tag found in the prompt at all"
+    template = _template_go_tag()
+    assert template in tags, (
+        f"the prompt's Go fallback {sorted(tags)} and the template's "
+        f"{template} disagree — the three-way drift #412 was filed for")
+
+
+def test_runtime_anchor_guidance_present():
+    """The policy itself is pinned: target-declared runtime first, stable
+    fallback only when nothing is declared."""
+    src = (_DYNDIR / "test_generator.py").read_text(encoding="utf-8")
+    assert "BASE IMAGE RUNTIME POLICY" in src
+    assert "DECLARED runtime" in src
+    assert "fall back to the current stable" in src

--- a/libs/openant-core/utilities/dynamic_tester/DYNAMIC_TESTER_REFERENCE.md
+++ b/libs/openant-core/utilities/dynamic_tester/DYNAMIC_TESTER_REFERENCE.md
@@ -30,7 +30,7 @@ State machine additions in `autopilot/state.py`:
 | `reporter.py` | Markdown report | `generate_report()` |
 | `docker_templates/python.Dockerfile` | Base Python image | `python:3.11-slim` |
 | `docker_templates/node.Dockerfile` | Base Node image | `node:20-slim` |
-| `docker_templates/go.Dockerfile` | Base Go image | `golang:1.22-alpine` |
+| `docker_templates/go.Dockerfile` | Base Go image | `golang:1.27-alpine` |
 | `docker_templates/attacker_server.py` | Capture server | Port 9999, endpoints: `/health`, `/capture`, `/logs`, `/logs/clear` |
 
 ## Modified Existing Files

--- a/libs/openant-core/utilities/dynamic_tester/DYNAMIC_TESTER_REFERENCE.md
+++ b/libs/openant-core/utilities/dynamic_tester/DYNAMIC_TESTER_REFERENCE.md
@@ -29,7 +29,7 @@ State machine additions in `autopilot/state.py`:
 | `result_collector.py` | Parse output | `collect_result()` |
 | `reporter.py` | Markdown report | `generate_report()` |
 | `docker_templates/python.Dockerfile` | Base Python image | `python:3.11-slim` |
-| `docker_templates/node.Dockerfile` | Base Node image | `node:20-slim` |
+| `docker_templates/node.Dockerfile` | Base Node image | `node:24-slim` |
 | `docker_templates/go.Dockerfile` | Base Go image | `golang:1.27-alpine` |
 | `docker_templates/attacker_server.py` | Capture server | Port 9999, endpoints: `/health`, `/capture`, `/logs`, `/logs/clear` |
 

--- a/libs/openant-core/utilities/dynamic_tester/test_generator.py
+++ b/libs/openant-core/utilities/dynamic_tester/test_generator.py
@@ -62,14 +62,25 @@ DEPENDENCY INSTALLATION:
 - For Node.js: put ALL dependencies in package.json.
 - For Go: do NOT write go.mod or go.sum yourself. Instead, the Dockerfile MUST initialize
   the module inside the container using `RUN go mod init <name> && go mod tidy`. This works
-  whether the test uses stdlib only or third-party packages. Use golang:1.25-alpine as the
-  base image to support modern k8s and cloud-native packages. Example Dockerfile for Go:
-      FROM golang:1.25-alpine
+  whether the test uses stdlib only or third-party packages. Use golang:1.27-alpine as the
+  base image (the fallback when the target's declared Go version is unknown — matches
+  docker_templates/go.Dockerfile) to support modern k8s and cloud-native packages.
+  Example Dockerfile for Go:
+      FROM golang:1.27-alpine
       WORKDIR /test
       COPY test_exploit.go .
       RUN go mod init openant-test && go mod tidy
       RUN go build -o test_exploit test_exploit.go
       CMD ["./test_exploit"]
+- BASE IMAGE RUNTIME POLICY (all languages): prefer a base image matching the
+  scanned target's DECLARED runtime — the `go` directive in go.mod, a
+  .python-version / pyproject requires-python, a package.json engines field,
+  a .tool-versions, or a language-version cue stated in the finding itself.
+  A wrong runtime can hide version-dependent exploit behavior or break the
+  repro outright (the exploit may not compile/run on a different major).
+  Only when no declaration is visible, fall back to the current stable
+  release of the language. The Go example above is that fallback, not an
+  override of a declared version.
 - The Dockerfile MUST install dependencies from the requirements/package file, NOT inline in RUN commands.
 - If a package has many transitive dependencies, only install the specific sub-package you need
   (e.g., `langchain-core` instead of `langchain`).


### PR DESCRIPTION
## What this fixes

Closes #412 with **option 2** (the adjudicated decide-and-close shape): the dynamic-test runtime policy is anchored, the Go pin is de-rotted, and a drift guard makes the rot structurally impossible to re-introduce silently.

**The state being fixed** (re-derived at the sites): the executed runtime Dockerfile is the LLM-generated `generation["dockerfile"]` per finding; the system prompt gave **Python no base-image guidance at all** while pinning Go to `golang:1.25-alpine` — and that pin had drifted **three ways**: prompt `1.25` / template `1.27` / reference doc `1.22`.

## The change

1. **The policy** (prompt, all languages): *"prefer a base image matching the scanned target's **declared** runtime"* — `go.mod`'s `go` directive, `.python-version` / `requires-python`, `engines`, `.tool-versions`, or a version cue stated in the finding — *"a wrong runtime can hide version-dependent exploit behavior or break the repro outright. Only when no declaration is visible, fall back to the current stable release."* The Go example in the prompt is that **fallback**, explicitly not an override of a declared version.
2. **The pin refresh**: `golang:1.27-alpine` everywhere the fallback is spelled — both prompt mentions, `docker_templates/go.Dockerfile`, and the reference doc.
3. **The drift guard** (`tests/test_issue412_runtime_anchor.py`, 3 tests, all RED on current master): the prompt's Go tags and the template's `FROM` tag must **match** and live in the test's known-fallback set — a future bump must touch prompt + template + the set in one conscious change; plus a pin on the policy text itself so it cannot be silently deleted.

## Notes for the reviewer

- `docker_templates/` remain **reference-only** (the issue's own finding: no executor reads them) — no executor change here; only the prompt, the doc, and the guard.
- The **config-key option (3) was ruled out**: config surface for a string the model rewrites per finding, with no consumer — real maintenance, no determinism gain.
- FN scope (bounded in the adjudication): a wrong runtime withholds the dynamic **proof** but does not shrink disclosure eligibility — the collector returns a result (ERROR/INCONCLUSIVE/NOT_REPRODUCED), and the report merge preserves `stage2_verdict`. This PR improves repro fidelity; it does not claim full dependency fidelity (the prompt's "don't pin exact versions unless version-specific" dependency rule still applies).

## Verification

- `pytest tests/test_issue412_runtime_anchor.py` → `3 passed` (RED on pristine master: `3 failed` — every test catches a pre-fix defect: the unknown tag, the prompt/template mismatch, the absent policy).
- Full suite green; `ruff check .` clean.
