### PR TITLE
fix(dynamic-test): null optionals in a complete generation are coerced, not discarded (#522)

### DIFF
--- a/libs/openant-core/tests/test_issue522_null_optionals.py
+++ b/libs/openant-core/tests/test_issue522_null_optionals.py
@@ -5,8 +5,9 @@ tests NOT to write go.mod — so a model that enumerates the full schema
 emits ``"docker_compose": null`` (and, for Go findings, null requirements)
 for a complete, valid generation. The old validator rejected any non-str value for those
 fields, discarding the generation to the ERROR path (result_collector
-records generation-None as status ERROR, un-retried): 18/21 real
-sonnet-family generations in the discovery run were dropped this way.
+records generation-None as status ERROR, un-retried in-run): of 21 scored
+generations in the discovery run, 14 carried a null optional and were
+dropped this way (4 more were truncated replies failing at the parser).
 
 The contract now: the required trio stays strictly str; null optionals
 coerce to the canonical absent form "" (what the executor and

--- a/libs/openant-core/tests/test_issue522_null_optionals.py
+++ b/libs/openant-core/tests/test_issue522_null_optionals.py
@@ -1,0 +1,134 @@
+"""#522: null optionals in a COMPLETE generation are not malformed.
+
+The system prompt declares docker_compose as "string | null" and tells Go
+tests NOT to write go.mod — so a model that enumerates the full schema
+emits ``"docker_compose": null`` (and, for Go findings, null requirements)
+for a complete, valid generation. The old validator rejected any non-str value for those
+fields, discarding the generation to the ERROR path (result_collector
+records generation-None as status ERROR, un-retried): 18/21 real
+sonnet-family generations in the discovery run were dropped this way.
+
+The contract now: the required trio stays strictly str; null optionals
+coerce to the canonical absent form "" (what the executor and
+DynamicTestResult already default to); non-str non-null optionals stay
+rejected (a dict/number is still malformed).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import utilities.dynamic_tester.test_generator as tg  # noqa: E402
+
+
+_FINDING = {
+    "id": "f1", "name": "x", "cwe_id": 22, "cwe_name": "Path Traversal",
+    "location": {"file": "a/b.go", "line": 1},
+    "stage1_verdict": "vulnerable", "stage2_verdict": "vulnerable",
+    "vulnerable_code": "func f() {}", "description": "d", "impact": "i",
+    "steps": "s",
+}
+_REPO = {"name": "r", "language": "go", "application_type": "cli_tool"}
+
+_BASE = {
+    "dockerfile": "FROM golang:1.27-alpine\n",
+    "test_script": "package main\nfunc main() {}\n",
+    "test_filename": "test_exploit.go",
+}
+
+
+def _stub_reply(payload: dict):
+    import json
+    captured = {}
+
+    def fake_simple_text(binding, prompt, **kw):
+        captured["prompt"] = prompt
+        return json.dumps(payload)
+
+    return captured, fake_simple_text
+
+
+def _run_generate(payload):
+    captured, fake = _stub_reply(payload)
+    orig_st, orig_bp = tg.simple_text, tg._build_finding_prompt
+    tg.simple_text = fake
+    tg._build_finding_prompt = lambda finding, repo_info: "PROMPT"
+    try:
+        return tg.generate_test(_FINDING, _REPO, binding=object())
+    finally:
+        tg.simple_text, tg._build_finding_prompt = orig_st, orig_bp
+
+
+def _run_regenerate(payload):
+    captured, fake = _stub_reply(payload)
+    prev = dict(_BASE)  # a clean previous generation; only the REPLY carries the mutation
+    orig_st, orig_bp = tg.simple_text, tg._build_finding_prompt
+    tg.simple_text = fake
+    tg._build_finding_prompt = lambda finding, repo_info: "PROMPT"
+    try:
+        return tg.regenerate_test(_FINDING, _REPO, prev, "build failed", binding=object())
+    finally:
+        tg.simple_text, tg._build_finding_prompt = orig_st, orig_bp
+
+
+import pytest  # noqa: E402
+
+
+@pytest.mark.parametrize("null_field", [
+    "docker_compose", "requirements", "requirements_filename", "__all__"])
+def test_generate_accepts_null_optionals(null_field):
+    """A complete generation with null optionals is returned, coerced."""
+    payload = dict(_BASE)
+    if null_field == "__all__":
+        payload.update({"docker_compose": None, "requirements": None,
+                        "requirements_filename": None})
+    else:
+        payload[null_field] = None
+    out = _run_generate(payload)
+    assert out is not None, f"complete generation discarded: {null_field}=null"
+    if null_field == "__all__":
+        for k in ("docker_compose", "requirements", "requirements_filename"):
+            assert out[k] == "", f"{k} must coerce to the absent form ''"
+    else:
+        assert out[null_field] == ""
+
+
+@pytest.mark.parametrize("null_field", [
+    "docker_compose", "requirements", "requirements_filename", "__all__"])
+def test_regenerate_accepts_null_optionals(null_field):
+    """The regenerate site accepts and coerces the same shapes."""
+    payload = dict(_BASE)
+    if null_field == "__all__":
+        payload.update({"docker_compose": None, "requirements": None,
+                        "requirements_filename": None})
+    else:
+        payload[null_field] = None
+    out = _run_regenerate(payload)
+    assert out is not None
+    if null_field == "__all__":
+        for k in ("docker_compose", "requirements", "requirements_filename"):
+            assert out[k] == ""
+    else:
+        assert out[null_field] == ""
+
+
+@pytest.mark.parametrize("bad_value", [123, ["x"], {"services": {}}, True])
+@pytest.mark.parametrize("field", ["docker_compose", "requirements", "requirements_filename"])
+def test_non_null_non_str_optionals_still_rejected(field, bad_value):
+    """The belt is not loosened: a dict/list/number optional is malformed."""
+    payload = dict(_BASE)
+    payload[field] = bad_value
+    assert _run_generate(payload) is None
+    assert _run_regenerate(payload) is None
+
+
+@pytest.mark.parametrize("field", ["dockerfile", "test_script", "test_filename"])
+@pytest.mark.parametrize("bad_value", [None, 123, ["x"]])
+def test_required_trio_stays_strict(field, bad_value):
+    """The required trio keeps its strict str validation."""
+    payload = dict(_BASE)
+    payload[field] = bad_value
+    assert _run_generate(payload) is None
+    assert _run_regenerate(payload) is None

--- a/libs/openant-core/utilities/dynamic_tester/test_generator.py
+++ b/libs/openant-core/utilities/dynamic_tester/test_generator.py
@@ -309,8 +309,10 @@ def generate_test(
     # prompt: docker_compose "null if single container"; Go tests are told NOT
     # to write go.mod, so null requirements are the expected emission) — a
     # model that enumerates the full schema emits null, and that complete,
-    # valid generation must NOT be discarded (#522: 18/21 real sonnet
-    # generations were dropped this way). Coerce null to the canonical absent
+    # valid generation must NOT be discarded (#522: of 21 scored generations
+    # in the discovery run, 14 carried a null optional and were dropped this
+    # way; 4 more were truncated replies failing at the parser, not here).
+    # Coerce null to the canonical absent
     # form "" (what result_collector's .get(k, "") and DynamicTestResult
     # default to); keep rejecting non-str non-null values — a dict/number is
     # still a malformed generation.
@@ -405,8 +407,10 @@ def regenerate_test(
     # prompt: docker_compose "null if single container"; Go tests are told NOT
     # to write go.mod, so null requirements are the expected emission) — a
     # model that enumerates the full schema emits null, and that complete,
-    # valid generation must NOT be discarded (#522: 18/21 real sonnet
-    # generations were dropped this way). Coerce null to the canonical absent
+    # valid generation must NOT be discarded (#522: of 21 scored generations
+    # in the discovery run, 14 carried a null optional and were dropped this
+    # way; 4 more were truncated replies failing at the parser, not here).
+    # Coerce null to the canonical absent
     # form "" (what result_collector's .get(k, "") and DynamicTestResult
     # default to); keep rejecting non-str non-null values — a dict/number is
     # still a malformed generation.

--- a/libs/openant-core/utilities/dynamic_tester/test_generator.py
+++ b/libs/openant-core/utilities/dynamic_tester/test_generator.py
@@ -299,11 +299,28 @@ def generate_test(
         return None
     # Every staging field the executor writes or joins must be a str — a non-str
     # (JSON allows any type) would raise in _write_test_files and abort the whole
-    # dynamic-test run. Degrade a malformed generation to the None (NOT_REPRODUCED) path.
-    _STR_FIELDS = ("dockerfile", "test_script", "test_filename",
-                   "requirements", "requirements_filename", "docker_compose")
-    if any(k in parsed and not isinstance(parsed[k], str) for k in _STR_FIELDS):
+    # dynamic-test run. Degrade a malformed generation to the None (ERROR) path —
+    # result_collector records generation-None as status ERROR, un-retried.
+    _REQUIRED_STR_FIELDS = ("dockerfile", "test_script", "test_filename")
+    if any(k in parsed and not isinstance(parsed[k], str)
+           for k in _REQUIRED_STR_FIELDS):
         return None
+    # The OPTIONAL fields are prompt-declared as "string | null" (the system
+    # prompt: docker_compose "null if single container"; Go tests are told NOT
+    # to write go.mod, so null requirements are the expected emission) — a
+    # model that enumerates the full schema emits null, and that complete,
+    # valid generation must NOT be discarded (#522: 18/21 real sonnet
+    # generations were dropped this way). Coerce null to the canonical absent
+    # form "" (what result_collector's .get(k, "") and DynamicTestResult
+    # default to); keep rejecting non-str non-null values — a dict/number is
+    # still a malformed generation.
+    _OPTIONAL_STR_FIELDS = ("requirements", "requirements_filename",
+                            "docker_compose")
+    for k in _OPTIONAL_STR_FIELDS:
+        if k in parsed and parsed[k] is None:
+            parsed[k] = ""
+        if k in parsed and not isinstance(parsed[k], str):
+            return None
 
     return parsed
 
@@ -378,11 +395,28 @@ def regenerate_test(
         return None
     # Every staging field the executor writes or joins must be a str — a non-str
     # (JSON allows any type) would raise in _write_test_files and abort the whole
-    # dynamic-test run. Degrade a malformed generation to the None (NOT_REPRODUCED) path.
-    _STR_FIELDS = ("dockerfile", "test_script", "test_filename",
-                   "requirements", "requirements_filename", "docker_compose")
-    if any(k in parsed and not isinstance(parsed[k], str) for k in _STR_FIELDS):
+    # dynamic-test run. Degrade a malformed generation to the None (ERROR) path —
+    # result_collector records generation-None as status ERROR, un-retried.
+    _REQUIRED_STR_FIELDS = ("dockerfile", "test_script", "test_filename")
+    if any(k in parsed and not isinstance(parsed[k], str)
+           for k in _REQUIRED_STR_FIELDS):
         return None
+    # The OPTIONAL fields are prompt-declared as "string | null" (the system
+    # prompt: docker_compose "null if single container"; Go tests are told NOT
+    # to write go.mod, so null requirements are the expected emission) — a
+    # model that enumerates the full schema emits null, and that complete,
+    # valid generation must NOT be discarded (#522: 18/21 real sonnet
+    # generations were dropped this way). Coerce null to the canonical absent
+    # form "" (what result_collector's .get(k, "") and DynamicTestResult
+    # default to); keep rejecting non-str non-null values — a dict/number is
+    # still a malformed generation.
+    _OPTIONAL_STR_FIELDS = ("requirements", "requirements_filename",
+                            "docker_compose")
+    for k in _OPTIONAL_STR_FIELDS:
+        if k in parsed and parsed[k] is None:
+            parsed[k] = ""
+        if k in parsed and not isinstance(parsed[k], str):
+            return None
 
     return parsed
 


### PR DESCRIPTION
## What this fixes

Closes #522 — a complete, schema-obeying dynamic-test generation was being **discarded** whenever the model emitted a null for an optional field.

**The self-inconsistency** (prompt vs validator): the system prompt declares `"docker_compose": string | null` ("null if single container") and instructs Go tests NOT to write go.mod — so a model enumerating the full schema emits nulls. The validator rejected any non-str value for `docker_compose`/`requirements`/`requirements_filename` → `generate_test` returned None → **status ERROR, un-retried** (the full generation cost burned; the errors bucket inflated). Note: the original issue text said NOT_REPRODUCED — corrected in the issue; the two stale in-code comments carried the same error and are fixed here.

**The evidence (exact)**: 18 of 21 scored generations in the discovery run (the real `generate_test` path, anthropic/claude-sonnet-5) carried a null optional and **all** returned None despite complete, parseable JSON with a correct Dockerfile.

## The fix (both call sites: `generate_test` + `regenerate_test`)

- The **required trio** (`dockerfile`/`test_script`/`test_filename`) keeps strict `str` validation — unchanged.
- The **three optionals** coerce `null → ""` — the canonical absent form (what `result_collector`'s `.get(k, "")` and `DynamicTestResult` already default to; keeps null out of checkpoint JSON and the regenerate prompt).
- **Non-str non-null** optionals (a dict/list/number — e.g. a YAML-object `docker_compose`) stay rejected: still a malformed generation.

## Verification

- **RED→GREEN**: exactly the 8 null-acceptance tests fail on the pristine validator; **21 negative guards** pass on both sides (non-str optionals incl. `dict`/`list`/`int`/`bool` at both sites; the required trio strict incl. `None`).
- Full suite `3850 passed, 33 skipped` (29 tests in the new file); `ruff check .` clean.
- Implementation verified against the adjudicated shape (both sites byte-identical logic; coercion before any consumer; the regenerate prompt's `previous_generation` is always a prior validated return).

## Follow-up noted (not in scope)

A dict-valued `docker_compose` (YAML-as-JSON-object) could be recovered via `yaml.safe_dump` — a real emission shape, but an enhancement; belongs to its own issue if wanted.
