### PR TITLE
docs: the Python floor statements agree with the authority (3.11+, with a drift guard) (#515)

### DIFF
--- a/libs/openant-core/PIPELINE_MANUAL.md
+++ b/libs/openant-core/PIPELINE_MANUAL.md
@@ -49,7 +49,7 @@ OpenAnt is a vulnerability analysis tool using Claude. The name "two-stage" refe
 ### Required Software
 
 ```bash
-# Python 3.10+
+# Python 3.11+
 python3 --version
 
 # Node.js (for JavaScript parser)

--- a/libs/openant-core/README.md
+++ b/libs/openant-core/README.md
@@ -10,7 +10,7 @@ OpenAnt uses Claude to analyze code for security vulnerabilities through a two-s
 
 ### Prerequisites
 
-- Python 3.8+
+- Python 3.11+
 - Node.js 16+ (for JavaScript/TypeScript parsing)
 - Go 1.21+ (for Go parsing)
 - Docker (for dynamic testing)

--- a/libs/openant-core/report/README.md
+++ b/libs/openant-core/report/README.md
@@ -186,6 +186,6 @@ Uses Claude Opus 4.5 (`claude-opus-4-5-20250514`).
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.11+
 - `anthropic` package
 - `ANTHROPIC_API_KEY` in `.env` file (project root) or environment variable

--- a/libs/openant-core/tests/test_issue515_python_floor_docs.py
+++ b/libs/openant-core/tests/test_issue515_python_floor_docs.py
@@ -1,0 +1,53 @@
+"""#515: the Python-floor statements cannot drift again.
+
+Three docs stated two different Python floors (3.8+ / 3.10+) while the
+authority (pyproject requires-python) says >=3.11 — the doc-floor drift
+family found by the closed-renovate-PR audit. This guard derives the
+floor from the single source of truth and pins every prose statement
+plus the Go runtime's floor constant against it.
+"""
+from __future__ import annotations
+
+import re
+import tomllib
+from pathlib import Path
+
+_CORE = Path(__file__).resolve().parent.parent
+_REPO_ROOT = _CORE.parent.parent
+
+_DOC_FILES = [
+    _CORE / "README.md",
+    _CORE / "report" / "README.md",
+    _CORE / "PIPELINE_MANUAL.md",
+]
+_RUNTIME_GO = _REPO_ROOT / "apps" / "openant-cli" / "internal" / "python" / "runtime.go"
+
+
+def _pyproject_minor() -> int:
+    with (_CORE / "pyproject.toml").open("rb") as fh:
+        req = tomllib.load(fh)["project"]["requires-python"]
+    m = re.search(r">=\s*3\.(\d+)", req)
+    assert m, f"unparseable requires-python: {req!r}"
+    return int(m.group(1))
+
+
+def test_doc_floor_statements_agree_with_pyproject():
+    minor = _pyproject_minor()
+    for doc in _DOC_FILES:
+        text = doc.read_text(encoding="utf-8")
+        stated = re.findall(r"Python 3\.(\d+)\+", text)
+        assert stated, f"{doc.name}: no Python floor statement found (the guard expects one)"
+        for st in stated:
+            assert int(st) >= minor, (
+                f"{doc.name}: states Python 3.{st}+ — below the pyproject floor 3.{minor}+ "
+                "(the #515 doc-drift class)")
+
+
+def test_go_runtime_floor_matches_pyproject():
+    """The Go CLI's MinPythonMinor must equal the pyproject floor — the
+    managed-venv bootstrap refuses below it, so a mismatch breaks installs."""
+    src = _RUNTIME_GO.read_text(encoding="utf-8")
+    m = re.search(r"MinPythonMinor\s*=\s*(\d+)", src)
+    assert m, "runtime.go: MinPythonMinor constant not found"
+    assert int(m.group(1)) == _pyproject_minor(), (
+        f"runtime.go MinPythonMinor={m.group(1)} != pyproject floor 3.{_pyproject_minor()}")

--- a/libs/openant-core/tests/test_issue515_python_floor_docs.py
+++ b/libs/openant-core/tests/test_issue515_python_floor_docs.py
@@ -19,6 +19,9 @@ _DOC_FILES = [
     _CORE / "README.md",
     _CORE / "report" / "README.md",
     _CORE / "PIPELINE_MANUAL.md",
+    # the repo-root README also states the floor (README.md:143) — the
+    # census found it correct today, but it must not drift silently either
+    _REPO_ROOT / "README.md",
 ]
 _RUNTIME_GO = _REPO_ROOT / "apps" / "openant-cli" / "internal" / "python" / "runtime.go"
 


### PR DESCRIPTION
## What this fixes

Closes #515 — the doc-floor drift family: three prose statements carried **two different Python floors, both below the actual one** — `libs/openant-core/README.md` said 3.8+, `report/README.md` and `PIPELINE_MANUAL.md` said 3.10+ — while the authority says **`requires-python = ">=3.11"`** (and the Go runtime's `MinPythonMinor = 11` matches; CI runs 3.11–3.14).

## The change

- All three docs now state **Python 3.11+**.
- `tests/test_issue515_python_floor_docs.py` — the drift guard: derives the floor from `pyproject`'s `requires-python` (the single source of truth, parsed with `tomllib` — the same pattern as `test_issue428_floors_vs_pins.py`), asserts every prose `Python 3.x+` statement in the three docs matches, **and pins `runtime.go`'s `MinPythonMinor` to the same value** (no Go test covered that constant; the managed-venv bootstrap refuses below it). Mutation-smoked: reverting one doc to 3.8 trips the guard.

## Scope note

A 15-hit census of version statements across the repo found no other stale Python-floor prose (the `3.14`s are the CI matrix, `python:3.11-slim` is the attacker-sidecar base image, `openai==3.8.0` is a dependency pin) — the three sites are the complete family. Out of scope, noted for whoever touches these docs next: several files still reference `generate_report.py` (now `report/html_report.py`) — related to #502's surface.

## Verification

- Guard: `2 passed`; mutation smoke: reverting README to 3.8 → `1 failed` (the guard has teeth).
- Full suite green; `ruff check .` clean.
