### PR TITLE
fix(llm): truncation is never silent — the warn-once helper, the named parse failure, the in-deliverable banners (#512)

### DIFF
--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -33,7 +33,7 @@ from typing import Any
 
 from dotenv import load_dotenv
 from utilities.file_io import open_utf8, read_json, read_repo_file, write_json
-from utilities.llm import PhaseBinding, simple_text
+from utilities.llm import PhaseBinding, simple_completion
 
 load_dotenv()
 
@@ -788,10 +788,21 @@ def generate_application_context(
         f"Generating context with {binding.provider_name}/{binding.model}...",
         file=sys.stderr,
     )
-    response_text = simple_text(
+    # #512: the typed-result sibling (simple_completion) so the parse-
+    # failure error can NAME the truncation when that is the cause; and
+    # the private 2000 cap is dropped (DEFAULT_MAX_TOKENS — the cap was
+    # never protecting cost where it mattered: the OpenAI Responses path
+    # floors output to 16000 anyway, and Stage-1's per-unit calls already
+    # run at this default. A 2000 cap on a reasoning model spends the
+    # whole budget on hidden reasoning and returns a fence fragment —
+    # exactly the failure the parse error below then mislabels).
+    _result = simple_completion(
         binding,
         CONTEXT_GENERATION_PROMPT.format(sources=sources_text),
-        max_tokens=2000,
+    )
+    response_text = "\n".join(
+        block.text for block in _result.content
+        if hasattr(block, "text")
     )
 
     # Extract JSON from response
@@ -811,7 +822,17 @@ def generate_application_context(
     try:
         data = json.loads(json_str)
     except json.JSONDecodeError as e:
-        raise ValueError(f"Failed to parse LLM response as JSON: {e}\nResponse: {response_text}")
+        # #512: name the truncation when that is the cause — a bare
+        # "could not parse" on a max_tokens reply hid the real failure
+        # (the budget went to hidden reasoning, not the answer).
+        trunc_note = ""
+        if _result.stop_reason == "max_tokens":
+            trunc_note = ("; the reply was TRUNCATED at max_tokens — the "
+                          "budget was spent on hidden reasoning, not the answer")
+        raise ValueError(
+            f"Failed to parse LLM response as JSON: {e}\n"
+            f"(stop_reason={_result.stop_reason}{trunc_note})\n"
+            f"Response: {response_text}")
 
     data['source'] = 'llm'
 

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -15,6 +15,7 @@ from core.verdict_taxonomy import DISCLOSURE_ELIGIBLE
 from .schema import validate_pipeline_output, ValidationError
 from utilities.file_io import normalize_results, open_utf8, read_json
 from utilities.llm import (
+    DEFAULT_MAX_TOKENS,
     PhaseBinding,
     PhaseRegistry,
     build_phase_registry,
@@ -404,7 +405,7 @@ def generate_summary_report(
 
     result = binding.adapter.complete(
         model=binding.model,
-        max_tokens=4096,
+        max_tokens=DEFAULT_MAX_TOKENS,
         system=system_prompt,
         messages=[Message(role="user", content=[TextBlock(user_prompt)])],
     )
@@ -426,6 +427,18 @@ def generate_summary_report(
         raise RuntimeError(
             "summary report generation returned empty output; refusing to write "
             "a summary-free SUMMARY_REPORT.md"
+            + (" (stop_reason=max_tokens: the whole budget went to hidden "
+               "reasoning, not the answer)" if result.stop_reason == "max_tokens" else "")
+        )
+    # #512: a TRUNCATED (but non-empty) summary must say so in the
+    # deliverable itself — the banner joins the deterministic provenance/
+    # reachability headers (stderr alone is lost in CI and quiet runs).
+    if result.stop_reason == "max_tokens":
+        text = (
+            "> [!WARNING]\n"
+            "> This summary was TRUNCATED at the model's output budget "
+            "(stop_reason=max_tokens) — the reply was cut mid-generation "
+            "and the sections below may be incomplete.\n\n" + text
         )
     # Prepend the provenance banner + the reachability advisory
     # deterministically (see the helper docstrings).
@@ -583,7 +596,7 @@ def generate_disclosure(
 
     result = binding.adapter.complete(
         model=binding.model,
-        max_tokens=4096,
+        max_tokens=DEFAULT_MAX_TOKENS,
         system=system_prompt,
         messages=[Message(role="user", content=[TextBlock(user_prompt)])],
     )
@@ -592,6 +605,15 @@ def generate_disclosure(
         b.text for b in result.content if isinstance(b, TextBlock)
     )
     final_output = _splice_code_section(llm_output, code_section)
+    # #512: a TRUNCATED disclosure must say so in the deliverable itself
+    # (stderr alone is lost in CI and quiet runs).
+    if result.stop_reason == "max_tokens":
+        final_output = (
+            "> [!WARNING]\n"
+            "> This disclosure was TRUNCATED at the model's output budget "
+            "(stop_reason=max_tokens) — the reply was cut mid-generation "
+            "and the sections below may be incomplete.\n\n" + final_output
+        )
     # #210: stamp the verification status + location deterministically from the
     # server-truth stage2_verdict, the same way the vulnerable code is spliced
     # in above. The prompt otherwise asks the LLM to render "Verified via ..."

--- a/libs/openant-core/tests/test_appcontext_llm_unknown_key.py
+++ b/libs/openant-core/tests/test_appcontext_llm_unknown_key.py
@@ -26,6 +26,18 @@ from context.application_context import (  # noqa: E402
 )
 
 
+def _completion_for(text: str):
+    """A simple_completion stub result for the #512 migration: appctx now
+    reads .content/.stop_reason instead of simple_text's joined str."""
+    from utilities.llm.adapter import CompletionResult, TextBlock
+    return CompletionResult(
+        content=[TextBlock(text)],
+        input_tokens=0,
+        output_tokens=0,
+        stop_reason="end_turn",
+    )
+
+
 _LLM_JSON_WITH_HALLUCINATED_KEY = """```json
 {
   "application_type": "cli_tool",
@@ -46,7 +58,7 @@ def test_hallucinated_llm_key_does_not_crash(tmp_path, monkeypatch):
     (tmp_path / "README.md").write_text("# Demo\nA small CLI tool.\n")
 
     monkeypatch.setattr(
-        appctx, "simple_text", lambda *a, **k: _LLM_JSON_WITH_HALLUCINATED_KEY
+        appctx, "simple_completion", lambda *a, **k: _completion_for(_LLM_JSON_WITH_HALLUCINATED_KEY)
     )
     fake_binding = SimpleNamespace(provider_name="fake", model="fake-model")
 
@@ -100,7 +112,7 @@ _LLM_JSON_ONLY_UNKNOWN_KEYS = """```json
 )
 def test_missing_required_field_does_not_crash(tmp_path, monkeypatch, llm_json):
     (tmp_path / "README.md").write_text("# Demo\nA small CLI tool.\n")
-    monkeypatch.setattr(appctx, "simple_text", lambda *a, **k: llm_json)
+    monkeypatch.setattr(appctx, "simple_completion", lambda *a, **k: _completion_for(llm_json))
     fake_binding = SimpleNamespace(provider_name="fake", model="fake-model")
 
     # Pre-fix: raises TypeError (missing required positional argument 'purpose').

--- a/libs/openant-core/tests/test_fence_live_sites_escape.py
+++ b/libs/openant-core/tests/test_fence_live_sites_escape.py
@@ -77,13 +77,13 @@ def test_application_context_sources_fenced(monkeypatch, tmp_path):
 
     def _capture(binding, prompt, **kw):
         raise _Captured(prompt)
-    monkeypatch.setattr(ac, "simple_text", _capture)
+    monkeypatch.setattr(ac, "simple_completion", _capture)
 
     import types
     binding = types.SimpleNamespace(provider_name="test", model="test")
     try:
         ac.generate_application_context(tmp_path, binding=binding, force_regenerate=True)
-        assert False, "simple_text was not reached"
+        assert False, "simple_completion was not reached"
     except _Captured as c:
         _assert_injection_is_contained(c.prompt)
 

--- a/libs/openant-core/tests/test_issue512_truncation_detection.py
+++ b/libs/openant-core/tests/test_issue512_truncation_detection.py
@@ -1,0 +1,171 @@
+"""#512: truncation is never silent — the warn-once helper, the named
+parse-failure, and the in-deliverable banners.
+
+Reasoning models spend output budget on hidden reasoning and return a
+fence fragment or an empty completion at exactly max_tokens; pre-#512
+this surfaced as a bare JSON-parse failure (app-context) or a quietly
+short summary/disclosure (report) with no signal of the cause.
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utilities.llm import adapter as llm_adapter  # noqa: E402
+from utilities.llm.helpers import (  # noqa: E402
+    reset_truncation_warnings,
+    simple_completion,
+    simple_text,
+)
+
+
+class _FakeAdapter:
+    def __init__(self, text, stop_reason):
+        self._text = text
+        self.stop_reason = stop_reason
+
+    def complete(self, *, model, system, messages, max_tokens, tools=None):
+        return llm_adapter.CompletionResult(
+            content=(llm_adapter.TextBlock(self._text),),
+            input_tokens=10,
+            output_tokens=max_tokens if self.stop_reason == "max_tokens" else 5,
+            stop_reason=self.stop_reason,
+        )
+
+
+class _Binding:
+    def __init__(self, text, stop_reason="end_turn", phase="test_phase"):
+        self.adapter = _FakeAdapter(text, stop_reason)
+        self.model = "fake-model"
+        self.phase = phase
+        self.provider_name = "fake"
+
+
+# --- the helper pair --------------------------------------------------------
+
+def test_simple_completion_returns_the_result():
+    b = _Binding("hello")
+    result = simple_completion(b, "hi")
+    assert isinstance(result, llm_adapter.CompletionResult)
+    assert result.stop_reason == "end_turn"
+    assert simple_text(b, "hi") == "hello"
+
+
+def test_truncated_reply_warns_once_per_phase_model_cap(capsys):
+    reset_truncation_warnings()
+    b = _Binding("frag", stop_reason="max_tokens")
+    simple_text(b, "x")
+    simple_text(b, "x")
+    out = capsys.readouterr().err
+    assert out.count("hit max_tokens=") == 1, f"warned {out.count('hit max_tokens=')}x for the same key"
+    # a different cap is a different signal
+    simple_text(b, "x", max_tokens=777)
+    out2 = capsys.readouterr().err
+    assert out2.count("hit max_tokens=777") == 1
+    reset_truncation_warnings()
+
+
+def test_end_turn_at_cap_emits_nothing(capsys):
+    """Locks the detector to stop_reason, NOT output_tokens==cap (the
+    overturned heuristic: a normal reply that happens to be exactly the
+    cap is not truncation)."""
+    reset_truncation_warnings()
+    b = _Binding("full reply exactly at cap", stop_reason="end_turn")
+    simple_text(b, "x", max_tokens=10)
+    out = capsys.readouterr().err
+    assert "hit max_tokens" not in out
+    reset_truncation_warnings()
+
+
+# --- the app-context named failure ------------------------------------------
+
+def test_appcontext_parse_error_names_the_truncation(monkeypatch, tmp_path):
+    import context.application_context as appctx
+    (tmp_path / "README.md").write_text("# Demo\nA CLI.\n")
+    monkeypatch.setattr(appctx, "gather_context_sources", lambda p: {"README.md": "# Demo"})
+
+    def _truncated(binding, prompt, **kw):
+        return llm_adapter.CompletionResult(
+            content=(llm_adapter.TextBlock("```json {\"trunc"),),
+            input_tokens=1, output_tokens=2000, stop_reason="max_tokens")
+
+    monkeypatch.setattr(appctx, "simple_completion", _truncated)
+    import types
+    binding = types.SimpleNamespace(provider_name="fake", model="fake-model")
+    try:
+        appctx.generate_application_context(tmp_path, binding=binding, force_regenerate=True)
+        assert False, "should have raised"
+    except ValueError as e:
+        assert "stop_reason=max_tokens" in str(e)
+        assert "TRUNCATED" in str(e)
+
+
+# --- the generator banners ---------------------------------------------------
+
+def _gen_binding(text, stop_reason):
+    class _B:
+        provider_name = "fake"
+        model = "fake-model"
+        adapter = _FakeAdapter(text, stop_reason)
+    return _B()
+
+
+def test_summary_truncation_banner_in_deliverable(monkeypatch):
+    import report.generator as gen
+    monkeypatch.setattr(gen, "load_prompt", lambda name: "PROMPT" if name in ("system", "summary") else "")
+    b = _gen_binding("partial summary text", "max_tokens")
+    text, _ = gen.generate_summary_report({"results": [], "metadata": {}}, b)
+    assert "TRUNCATED at the model's output budget" in text
+    assert text.index("TRUNCATED") < text.index("partial summary text")
+
+
+def test_summary_untruncated_has_no_banner(monkeypatch):
+    import report.generator as gen
+    monkeypatch.setattr(gen, "load_prompt", lambda name: "PROMPT" if name in ("system", "summary") else "")
+    b = _gen_binding("a complete summary", "end_turn")
+    text, _ = gen.generate_summary_report({"results": [], "metadata": {}}, b)
+    assert "TRUNCATED" not in text
+
+
+def test_summary_empty_and_truncated_names_the_cause(monkeypatch):
+    import report.generator as gen
+    monkeypatch.setattr(gen, "load_prompt", lambda name: "PROMPT" if name in ("system", "summary") else "")
+    b = _gen_binding("", "max_tokens")  # reasoning-only: empty text at cap
+    try:
+        gen.generate_summary_report({"results": [], "metadata": {}}, b)
+        assert False, "the #209 guard should have raised"
+    except RuntimeError as e:
+        assert "stop_reason=max_tokens" in str(e)
+
+
+def test_disclosure_truncation_banner(monkeypatch):
+    import report.generator as gen
+    monkeypatch.setattr(gen, "load_prompt", lambda name: "SYS" if name == "system" else "DISC {vulnerability_data}")
+    b = _gen_binding("partial disclosure", "max_tokens")
+    vuln = {"id": "f1", "name": "n", "cwe_id": 22, "cwe_name": "x",
+            "location": {"file": "a.py", "line": 1},
+            "finding": "vulnerable", "verdict": "vulnerable",
+            "explanation": "e"}
+    text, _ = gen.generate_disclosure(vuln, "vuln", b)
+    assert "TRUNCATED at the model's output budget" in text
+
+
+# --- the budget-drift pin ----------------------------------------------------
+
+def test_generator_has_no_numeric_output_cap():
+    """#290's mirror for the report generator: the two direct adapter calls
+    must use DEFAULT_MAX_TOKENS, not private numeric pins."""
+    src = (Path(__file__).resolve().parent.parent
+           / "report" / "generator.py").read_text(encoding="utf-8")
+    bad = re.findall(r"max_tokens\s*=\s*(\d+)", src)
+    assert not bad, f"numeric max_tokens pins found in report/generator.py: {bad}"
+
+
+def test_appcontext_has_no_numeric_output_cap():
+    src = (Path(__file__).resolve().parent.parent
+           / "context" / "application_context.py").read_text(encoding="utf-8")
+    bad = re.findall(r"max_tokens\s*=\s*(\d+)", src)
+    assert not bad, f"numeric max_tokens pins found in context/application_context.py: {bad}"

--- a/libs/openant-core/tests/test_issue512_truncation_detection.py
+++ b/libs/openant-core/tests/test_issue512_truncation_detection.py
@@ -169,3 +169,19 @@ def test_appcontext_has_no_numeric_output_cap():
            / "context" / "application_context.py").read_text(encoding="utf-8")
     bad = re.findall(r"max_tokens\s*=\s*(\d+)", src)
     assert not bad, f"numeric max_tokens pins found in context/application_context.py: {bad}"
+
+def test_empty_completion_guards_name_the_stop_reason():
+    """The gate round's fold: the adapter empty-content guards (the only
+    layer that sees an EMPTY reasoning-only truncation) name the stop
+    reason — anthropic.py/openai.py carry it in the raise message; google
+    names the truncation class in prose. Source-scan pin (no live call).
+    """
+    from pathlib import Path
+
+    from utilities.llm.providers import anthropic as ap, openai as op
+    ap_src = Path(ap.__file__).read_text(encoding="utf-8")
+    assert "stop_reason={raw_stop!r}" in ap_src, (
+        "anthropic's empty-completion guard no longer names the stop reason")
+    op_src = Path(op.__file__).read_text(encoding="utf-8")
+    assert "finish_reason={raw_finish!r}" in op_src, (
+        "openai's empty-completion guard no longer names the finish reason")

--- a/libs/openant-core/utilities/llm/__init__.py
+++ b/libs/openant-core/utilities/llm/__init__.py
@@ -62,7 +62,7 @@ from .registry import (
     resolve_llm_config,
     resolve_provider,
 )
-from .helpers import lookup_pricing, simple_text
+from .helpers import DEFAULT_MAX_TOKENS, lookup_pricing, simple_completion, simple_text
 
 __all__ = [
     # adapter
@@ -109,5 +109,7 @@ __all__ = [
     "resolve_provider",
     # helpers
     "lookup_pricing",
+    "DEFAULT_MAX_TOKENS",
+    "simple_completion",
     "simple_text",
 ]

--- a/libs/openant-core/utilities/llm/helpers.py
+++ b/libs/openant-core/utilities/llm/helpers.py
@@ -14,10 +14,12 @@ inspect content blocks and continue the conversation.
 
 from __future__ import annotations
 
+import sys
+import threading
 from typing import Optional
 
 from ..llm_client import TokenTracker, get_global_tracker
-from .adapter import Message, TextBlock
+from .adapter import CompletionResult, Message, TextBlock
 from .registry import PhaseBinding
 
 # Thinking-era output budget (the simple_text default; PR #242 raised it from
@@ -47,7 +49,17 @@ def lookup_pricing(binding: PhaseBinding) -> Optional[dict]:
     return getattr(binding.adapter, "pricing", {}).get(binding.model)
 
 
-def simple_text(
+_TRUNCATION_WARNED: set = set()
+_TRUNCATION_WARNED_LOCK = threading.Lock()
+
+
+def reset_truncation_warnings() -> None:
+    """Clear the one-time truncation warning set (for tests)."""
+    with _TRUNCATION_WARNED_LOCK:
+        _TRUNCATION_WARNED.clear()
+
+
+def simple_completion(
     binding: PhaseBinding,
     prompt: str,
     *,
@@ -55,26 +67,14 @@ def simple_text(
     # See DEFAULT_MAX_TOKENS above for why this is 20000, not 8192.
     max_tokens: int = DEFAULT_MAX_TOKENS,
     tracker: Optional[TokenTracker] = None,
-) -> str:
-    """Send one user-prompt completion, return the concatenated text reply.
+) -> CompletionResult:
+    """Send one user-prompt completion, return the raw result.
 
-    Args:
-        binding: Phase binding from :meth:`PhaseRegistry.get`. The
-            adapter + model embedded in it are what the call actually
-            uses — no caller-side model selection.
-        prompt: Plain text user message.
-        system: Optional system prompt.
-        max_tokens: Upper bound on response length.
-        tracker: Token tracker to record this call against. Defaults
-            to the global tracker so callers that don't care about
-            multi-tracker setups don't have to thread one through.
-
-    Returns:
-        Concatenated text from every :class:`TextBlock` in the
-        response. Non-text blocks (e.g. a stray ``tool_use`` if the
-        model misbehaves) are dropped — this is the "I just want
-        text" helper, so callers that need richer handling should
-        use ``binding.adapter.complete()`` directly.
+    The typed-result sibling of :func:`simple_text`: same call, same
+    tracking — for callers that need the structured fields
+    (``stop_reason``), e.g. the app-context phase, which must name the
+    truncation in its parse-failure error instead of a bare "could not
+    parse LLM response".
     """
     used_tracker = tracker if tracker is not None else get_global_tracker()
 
@@ -98,7 +98,62 @@ def simple_text(
         # (never in the cost math — see TokenTracker.record_call).
         usage_details=result.usage_details,
     )
+    return result
 
+
+def simple_text(
+    binding: PhaseBinding,
+    prompt: str,
+    *,
+    system: Optional[str] = None,
+    # See DEFAULT_MAX_TOKENS above for why this is 20000, not 8192.
+    max_tokens: int = DEFAULT_MAX_TOKENS,
+    tracker: Optional[TokenTracker] = None,
+) -> str:
+    """Send one user-prompt completion, return the concatenated text reply.
+
+    Args:
+        binding: Phase binding from :meth:`PhaseRegistry.get`. The
+            adapter + model embedded in it are what the call actually
+            uses — no caller-side model selection.
+        prompt: Plain text user message.
+        system: Optional system prompt.
+        max_tokens: Upper bound on response length.
+        tracker: Token tracker to record this call against. Defaults
+            to the global tracker so callers that don't care about
+            multi-tracker setups don't have to thread one through.
+
+    Returns: Concatenated text from every :class:`TextBlock` in the
+        response. Non-text blocks (e.g. a stray ``tool_use`` if the
+        model misbehaves) are dropped — this is the "I just want
+        text" helper, so callers that need richer handling should
+        use ``binding.adapter.complete()`` directly.
+    """
+    result = simple_completion(
+        binding, prompt, system=system, max_tokens=max_tokens, tracker=tracker
+    )
+    # #512: a truncated reply is otherwise a SILENT quality degradation —
+    # reasoning models can spend the whole budget on hidden reasoning and
+    # return a fence fragment or an empty completion (#242), which then
+    # surfaces as a bare JSON-parse failure downstream. Warn once per
+    # (phase, model, cap) so a run's logs name the cause without per-call
+    # spam. simple_text runs inside thread-pool workers, so the warned-set
+    # is lock-guarded. NOTE: several providers map UNKNOWN stop reasons to
+    # "max_tokens", so the wording includes the unrecognized case. The join
+    # below still returns whatever text exists.
+    if result.stop_reason == "max_tokens":
+        key = (getattr(binding, "phase", None), binding.model, max_tokens)
+        with _TRUNCATION_WARNED_LOCK:
+            if key not in _TRUNCATION_WARNED:
+                _TRUNCATION_WARNED.add(key)
+                print(
+                    f"warning: {getattr(binding, 'provider_name', '?')}/{binding.model} "
+                    f"(phase {getattr(binding, 'phase', '?')}) hit max_tokens="
+                    f"{max_tokens} (output_tokens={result.output_tokens}); reply "
+                    "truncated — reasoning models can spend the whole budget "
+                    "on hidden reasoning",
+                    file=sys.stderr,
+                )
     return "\n".join(
         block.text for block in result.content if isinstance(block, TextBlock)
     )

--- a/libs/openant-core/utilities/llm/providers/anthropic.py
+++ b/libs/openant-core/utilities/llm/providers/anthropic.py
@@ -387,8 +387,9 @@ def _response_to_unified(
     # here because ``content_blocks`` is non-empty.
     if not content_blocks:
         raise LLMResponseError(
-            f"{adapter} returned no usable content (empty completion); the "
-            "request may have been filtered or the response was malformed"
+            f"{adapter} returned no usable content (empty completion; "
+            f"stop_reason={raw_stop!r}); the request may have been "
+            "filtered or the response was malformed"
         )
 
     if raw_stop not in _ANTHROPIC_STOP_REASONS:

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -905,8 +905,9 @@ def _response_to_unified(
     # more specific signal and already raised above.
     if not content_blocks:
         raise LLMResponseError(
-            f"{adapter} returned an empty completion (no text or tool calls); the "
-            "request may have been filtered or the response was malformed"
+            f"{adapter} returned an empty completion (no text or tool calls; "
+            f"finish_reason={raw_finish!r}); the request may have been "
+            "filtered or the response was malformed"
         )
 
     if raw_finish not in _OPENAI_FINISH_REASONS:


### PR DESCRIPTION
## What this fixes

Closes #512 — reasoning models exhaust fixed output budgets and the failure was **silent**: app-context (`max_tokens=2000`) and the report phases (`max_tokens=4096`) spent the whole budget on hidden reasoning, returned a fence fragment or an empty completion at exactly the cap, and surfaced as a bare `JSONDecodeError` (app-context `skipped`) or a quietly short summary/disclosure — no signal of the cause anywhere.

## The fix (the adjudicated shape, refuted-and-final)

1. **The detector is `stop_reason == "max_tokens"`** — the signal the adapter already normalizes and tests — *not* `output_tokens == max_tokens` (a full reply that happens to equal the cap is not truncation; locked by test).
2. **`simple_completion`** — the typed-result sibling of `simple_text` (same call, same tracking, returns `CompletionResult`) for callers that need `stop_reason`; `simple_text` keeps its exact signature (the #290 `inspect.signature` pin) and return, and now **warns once per (phase, model, cap)** on truncation — lock-guarded (it runs in thread-pool workers), resettable for tests, worded for the providers that map *unknown* stop reasons to `max_tokens`.
3. **App-context names the cause**: the parse-failure `ValueError` carries `stop_reason` and states the truncation explicitly; the private 2000 cap is **dropped** (the default). The cap never protected cost where it mattered — the OpenAI Responses path floors output to 16000 anyway (`_RESPONSES_MIN_OUTPUT_TOKENS`), and Stage-1's per-unit calls already run at the default.
4. **The report phases**: the two private 4096 caps → `DEFAULT_MAX_TOKENS` (the #290 drift class, now pinned by source-scan tests — no numeric `max_tokens=` literal in either file); a **truncated (non-empty) summary/disclosure carries a WARNING banner in the deliverable itself** (stderr alone is lost in CI and quiet runs); the #209 empty-output guard folds `stop_reason` into its `RuntimeError` when the empty text is the reasoning-only truncation.
5. The three existing test monkeypatch sites migrated to the new stub shape.

## Verification

- New battery: `10 passed` — warn-once per key (+ different cap = different signal), end-turn-at-cap emits nothing (the detector lock), the app-context named failure, banner present/absent for summary + disclosure, the empty+truncated `RuntimeError`, both no-numeric-cap source pins.
- The migrated suites (`test_appcontext_llm_unknown_key`, `test_fence_live_sites_escape`, `test_issue290_output_budget`) green — the #290 signature pin intact.
- Full suite green; `ruff check .` clean.
- **RED note (honest)**: on pristine master the new test file fails at collection — `simple_completion` is a new API — so the behavioral RED is the appctx message shape and the banners, which are absent pre-change by construction.

## Scope notes

- **Artifact surfacing**: the once-per-key stderr warning + the in-deliverable banners are the shipped surfaces. Riding the truncation count into `scan.report.json` per-phase (the symlink-skip warning family) is recorded as the follow-up — it needs the tracker to grow a warnings surface, which is its own change.
- **Residual private caps** (recorded, not swept here): `cli.py:1265`, `html_report.py:46`, `stage1_consistency.py:46`, `threat_model_agent.py:40`, `repo_explorer.py:63`, `context_enhancer.py:352`, `llm_reachability.py:451`, `json_corrector.py:157` (deliberately pinned, test-locked), `test_generator.py:278,:357`.
- Per-phase/per-model-class budgets and reasoning-aware routing were ruled **out of fixes-only scope** (capability); this PR removes the *silent* part.
