### PR TITLE
fix(scanner): a post-persist llm-reachability failure leaves units_count at the disk truth (#516)

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -604,6 +604,14 @@ def scan_repository(
             # and that one MUST still abort (bad credentials must not be
             # silently skipped into a "successful" degraded scan).
             pre_llmreach_units_count = result.units_count
+            # #516: whether the re-filtered dataset reached disk. write_json
+            # is ATOMIC (temp + fsync + os.replace) — after it returns, the
+            # disk IS the post-filter dataset and downstream consumes the
+            # DISK (enhance/analyze read active_dataset_path, never this
+            # local). A post-write bookkeeping failure must therefore leave
+            # units_count describing the post-filter state, not restore the
+            # pre-stage count over a persisted dataset.
+            dataset_persisted = False
             try:
                 if dataset is not None:
                     app_ctx_payload = None
@@ -852,6 +860,7 @@ def scan_repository(
                     # Persist final dataset so downstream stages see promoted
                     # entry points, per-unit signals, and the applied filter.
                     write_json(active_dataset_path, dataset, indent=2)
+                    dataset_persisted = True
 
                     ctx.summary = {
                         "units_reviewed": pre_filter_count,
@@ -894,13 +903,22 @@ def scan_repository(
                 # failure in that window left the count describing a dataset
                 # that never reached disk. Restore the pre-stage count so the
                 # result matches what downstream actually consumes.
-                result.units_count = pre_llmreach_units_count
+                # #516: that restore is correct ONLY when the persist never
+                # happened. write_json is atomic, so a persisted dataset IS
+                # the post-filter one downstream consumes — restoring the
+                # pre count there would describe a dataset that no longer
+                # exists on disk. Gate on the persist; record which state
+                # won so the step report never reads "no effects" while
+                # downstream consumes the re-filtered dataset.
+                if not dataset_persisted:
+                    result.units_count = pre_llmreach_units_count
                 print(
                     f"  WARNING: LLM reachability stage failed: {exc}",
                     file=sys.stderr,
                 )
                 ctx.status = "skipped"
-                ctx.summary = {"skipped": True, "reason": str(exc)}
+                ctx.summary = {"skipped": True, "reason": str(exc),
+                               "dataset_persisted": dataset_persisted}
                 # Record the crash so the degraded reachability pass is
                 # visible in the artifacts, matching the dataset-read guard.
                 _record_skip(result, "llm-reachability", "failed")

--- a/libs/openant-core/tests/test_issue516_units_count_persist.py
+++ b/libs/openant-core/tests/test_issue516_units_count_persist.py
@@ -1,0 +1,133 @@
+"""#516: a post-persist failure leaves units_count describing the DISK.
+
+The #268 handler restored the PRE-stage units_count unconditionally —
+correct when the dataset never reached disk, wrong when write_json had
+already landed the re-filtered dataset (it is ATOMIC: after it returns,
+the disk IS the post-filter state and downstream consumes the DISK, not
+the local). A failure in the post-write bookkeeping window (the ctx
+summary build) left the count describing a dataset that no longer
+exists. The fix: gate the restore on the persist; record which state
+won in the step report.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+import core.scanner as scanner_mod
+
+
+@pytest.fixture(autouse=True)
+def _offline(monkeypatch):
+    import utilities.llm as llm_mod
+    monkeypatch.setattr(llm_mod, "probe_registry_or_raise", lambda *a, **k: None)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    src = tmp_path / "repo"
+    (src / "web").mkdir(parents=True)
+    (src / "app.py").write_text("def handler():\n    pass\n")
+    (src / "web" / "app.js").write_text("function route() {}\n")
+    return src
+
+
+@pytest.fixture
+def fake_parsers(monkeypatch):
+    """python: 2 units, 1 entry point (post-filter keeps 1); js: 2 units, no
+    entry point (empty-seed net keeps both). Post-filter total = 3."""
+    graphs = {
+        "python": (["app.py:handler", "app.py:helper"], ["app.py:handler"]),
+        "javascript": (["web/app.js:route", "web/app.js:util"], []),
+    }
+
+    def fake_parser_for(language):
+        def _parse(repo_path, output_dir, processing_level, skip_tests=True,
+                   name=None, library_mode=False):
+            ids, entries = graphs[language]
+            d = Path(output_dir); d.mkdir(parents=True, exist_ok=True)
+            (d / "dataset.json").write_text(json.dumps({
+                "units": [{"id": i, "code": "x"} for i in ids],
+                "statistics": {}, "metadata": {},
+            }))
+            (d / "analyzer_output.json").write_text(json.dumps(
+                {"functions": {i: {} for i in ids}}))
+            (d / "call_graph.json").write_text(json.dumps({
+                "functions": {i: {"is_entry_point": i in entries} for i in ids},
+                "call_graph": {i: [] for i in ids},
+                "reverse_call_graph": {},
+            }))
+            from core.schemas import ParseResult
+            return ParseResult(
+                dataset_path=str(d / "dataset.json"),
+                analyzer_output_path=str(d / "analyzer_output.json"),
+                units_count=len(ids), language=language,
+                processing_level=processing_level,
+            )
+        return _parse
+
+    import core.parser_adapter as pa
+    monkeypatch.setattr(pa, "_parser_for", fake_parser_for)
+
+
+@pytest.fixture
+def post_write_failure(monkeypatch):
+    """The #516 window: the re-filtered dataset PERSISTS, then the post-write
+    bookkeeping raises — apply_signals returns a summary MISSING the
+    'signals_applied' key the ctx summary build indexes (a real KeyError
+    shape, injected genuinely AFTER the write by construction)."""
+    import core.llm_reachability as lr
+
+    monkeypatch.setattr(lr, "analyze_reachability", lambda *a, **k: [])
+
+    def fake_apply(dataset, signals):
+        for u in dataset.get("units", []):
+            if u.get("id") == "app.py:handler":
+                u["is_entry_point"] = True
+        # deliberately missing "signals_applied" -> KeyError at ctx.summary
+        return {"entry_points_promoted": 1, "units_touched": 1}
+
+    monkeypatch.setattr(lr, "apply_signals", fake_apply)
+    monkeypatch.setattr(lr, "signals_to_json", lambda s: [])
+
+
+def run(repo, out):
+    return scanner_mod.scan_repository(
+        repo_path=str(repo), output_dir=str(out),
+        languages=["python", "javascript"],
+        processing_level="reachable",
+        llm_reachability=True,
+        generate_context=False, generate_report=False,
+        enhance=False, verify=False,
+    )
+
+
+def test_post_persist_failure_leaves_count_at_disk_truth(
+        repo, tmp_path, fake_parsers, post_write_failure):
+    """THE #516 case: the dataset on disk is the POST-filter one (3 units);
+    a bookkeeping failure after the persist must leave units_count == 3.
+    Pre-fix: the unconditional restore reported 4 — a count for a dataset
+    that no longer exists."""
+    out = tmp_path / "out"
+    result = run(repo, out)
+
+    disk_units = len(json.loads(Path(result.dataset_path).read_text())["units"])
+    assert disk_units == 3, f"fixture drift: expected 3 disk units, got {disk_units}"
+    assert result.units_count == disk_units, (
+        f"units_count={result.units_count} describes a dataset that is not "
+        f"on disk (disk={disk_units}) — the #516 post-persist divergence")
+
+
+def test_step_report_records_which_state_won(
+        repo, tmp_path, fake_parsers, post_write_failure):
+    """The skip must not read as 'no effects' while downstream consumes the
+    re-filtered dataset: the step report carries dataset_persisted."""
+    out = tmp_path / "out"
+    run(repo, out)
+
+    step = json.loads((out / "llm-reachability.report.json").read_text())
+    assert step.get("summary", {}).get("dataset_persisted") is True, (
+        "the skipped step report does not record that the dataset persisted "
+        "— it reads as 'no effects' while downstream consumes the "
+        "re-filtered dataset")
+    assert step.get("status") == "skipped"


### PR DESCRIPTION
## What this fixes

Closes #516 — the narrow post-persist divergence window in the llm-reachability handler.

**The window** (re-derived at the fix site): between `write_json(active_dataset_path, dataset)` and the handler's `result.units_count = pre_llmreach_units_count` restore, the stage mutates the count mid-flow (post-re-filter). A failure in the post-write bookkeeping (the `ctx.summary` build indexes the applied-signals summary — a real `KeyError` shape) hit the #268 handler, which **restored the PRE-stage count over a dataset that had already persisted** — leaving `units_count` describing a dataset that no longer exists on disk, while downstream (enhance/analyze) consumes the **disk** (`active_dataset_path`, never the local).

## The fix

- A `dataset_persisted` flag: `False` before the try, set `True` immediately after the atomic write (`write_json` is temp+fsync+`os.replace` — after it returns, disk IS the post-filter state).
- The #268 restore is now **gated on the persist**: restore the pre count only when nothing persisted; leave the post-filter count (== the units on disk) when the dataset landed.
- The skipped step report records `dataset_persisted`, so a degraded-but-persisted stage never reads as "no effects" while downstream consumes the re-filtered dataset.

## Verification

- **RED→GREEN**: the discriminating test injects the failure genuinely *after* the persist (the applied-signals summary missing the key the ctx build indexes — a real `KeyError`, not a mock-side raise): pre-fix the count reported **4 against a 3-unit disk**; post-fix **3 == 3**.
- The #268 pre-write guard suite and the re-filter-loop suite unchanged (11 passed) — the pre-write restore path is pinned intact.
- Full suite green; `ruff check .` clean.
- `units_count` consumers enumerated (scan StepReport, `ScanResult.to_dict`, the CLI envelope's `total_units`) — nothing reads it between the stage and the report, and nothing else changed.
