### PR TITLE
fix(reachability): the library-blackout advisory is no longer silent under the band (#520)

### DIFF
--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -519,6 +519,10 @@ def apply_reachability_filter(
             "reduction_percentage": 0,
             "warning": warning,
         }
+        # #520: the seed-class counts on BOTH branches — the keep-all record
+        # must not read as "no signal" when synthetic-only seeding was the cause.
+        _rec["structural_entry_points"], _rec["incidental_entry_points"] = (
+            _epd.classify_seeds(detector.entry_point_details))
         # #328 (wave r1, opus+fable): the effective level on the pass-through
         # path is "all" — nothing was pruned — and this is the case where
         # recording it matters MOST: without it the record looks identical to
@@ -559,9 +563,13 @@ def apply_reachability_filter(
         if original_count > 0
         else 0
     )
+    _structural_eps, _incidental_eps = _epd.classify_seeds(
+        detector.entry_point_details)
     dataset.setdefault("metadata", {})["reachability_filter"] = {
         "original_units": original_count,
         "entry_points": len(entry_points),
+        "structural_entry_points": _structural_eps,
+        "incidental_entry_points": _incidental_eps,
         "reachable_units": len(filtered_units),
         "filtered_out": original_count - len(filtered_units),
         "reduction_percentage": reduction_pct,

--- a/libs/openant-core/core/parser_adapter.py
+++ b/libs/openant-core/core/parser_adapter.py
@@ -582,11 +582,24 @@ def apply_reachability_filter(
         file=sys.stderr,
     )
 
-    _blackout = blackout_warning(detector.entry_point_details, original_count,
-                                 len(filtered_units), library_mode=library_mode)
+    # #520 (the fable+astra fold): the seed-quality advisory rides its OWN
+    # key — following the orphan_advisory pattern — so it can never displace
+    # the forward-asymmetry invariant from the reserved ``warning`` slot (the
+    # correctness voice outranks the seed-quality voice at ANY reduction).
+    # extra_seed_count = the ACCEPTED-EFFECTIVE caller-supplied seeds
+    # (deduplicated, resolved to graph nodes) — named in the wording, never
+    # classified.
+    _extra_seeds_effective = sum(
+        1 for s in (extra_entry_points or [])
+        if s in reachable_ids or s in {u.get("id") for u in units}
+    )
+    _blackout = blackout_warning(
+        detector.entry_point_details, original_count,
+        len(filtered_units), library_mode=library_mode,
+        extra_seed_count=_extra_seeds_effective)
     if _blackout:
-        dataset["metadata"]["reachability_filter"]["warning"] = _blackout
-        print(f"  [Warning] {_blackout}", file=sys.stderr)
+        dataset["metadata"]["reachability_filter"]["blackout_advisory"] = _blackout
+        print(f"  [Advisory] {_blackout}", file=sys.stderr)
 
     # Per-unit prune telemetry (ADDITIVE, all-language; advisory — must never crash
     # the filter). Merges classification keys + the pruned_units.json sidecar; a
@@ -597,6 +610,10 @@ def apply_reachability_filter(
     _extra, _asym_warning, _orphan_advisory = compute_prune_telemetry(
         reachable_ids, sorted(_pruned_ids), call_graph, reverse_call_graph, output_dir)
     _rf.update(_extra)
+    # #520 (the fable+astra fold): with the advisory on its own key, the
+    # reserved ``warning`` slot belongs to the correctness signals — the
+    # forward-asymmetry invariant lands whenever it fires, no longer crowded
+    # out by the seed-quality advisory.
     if _asym_warning and "warning" not in _rf:
         _rf["warning"] = _asym_warning
         print(f"  [Warning] {_asym_warning}", file=sys.stderr)

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -668,6 +668,13 @@ def build_pipeline_output(
         _rf_warning = _reach.get("warning")
         if isinstance(_rf_warning, str) and _rf_warning:
             reachability_warnings.append(_rf_warning)
+        # #520 (the fable+astra fold): the seed-quality advisory forwards on
+        # the same human + envelope channel as the reserved warning — its own
+        # key at the producer, delivered here so it can never be silently
+        # dropped for lack of a forwarding path.
+        _rf_blackout = _reach.get("blackout_advisory")
+        if isinstance(_rf_blackout, str) and _rf_blackout:
+            reachability_warnings.append(_rf_blackout)
         # #328: the Python-path level fallback (codeql/exploitable accepted,
         # reachability-only run) reaches the artifact instead of dying on
         # stderr. Present-only forward — records without the key (non-Python

--- a/libs/openant-core/parsers/c/test_pipeline.py
+++ b/libs/openant-core/parsers/c/test_pipeline.py
@@ -344,7 +344,7 @@ class CPipelineTest:
                                          len(filtered_units),
                                          library_mode=getattr(self, "library_mode", False))
             if _blackout:
-                dataset["metadata"]["reachability_filter"]["warning"] = _blackout
+                dataset["metadata"]["reachability_filter"]["blackout_advisory"] = _blackout
                 print(f"  [Warning] {_blackout}", file=sys.stderr)
 
             write_json(self.dataset_file, dataset)

--- a/libs/openant-core/parsers/go/test_pipeline.py
+++ b/libs/openant-core/parsers/go/test_pipeline.py
@@ -515,7 +515,7 @@ class GoPipelineTest:
                                          len(filtered_units),
                                          library_mode=getattr(self, "library_mode", False))
             if _blackout:
-                dataset["metadata"]["reachability_filter"]["warning"] = _blackout
+                dataset["metadata"]["reachability_filter"]["blackout_advisory"] = _blackout
                 print(f"  [Warning] {_blackout}", file=sys.stderr)
 
             # Write filtered dataset

--- a/libs/openant-core/parsers/javascript/test_pipeline.py
+++ b/libs/openant-core/parsers/javascript/test_pipeline.py
@@ -679,7 +679,7 @@ class PipelineTest:
                                          len(filtered_units),
                                          library_mode=getattr(self, "library_mode", False))
             if _blackout:
-                dataset["metadata"]["reachability_filter"]["warning"] = _blackout
+                dataset["metadata"]["reachability_filter"]["blackout_advisory"] = _blackout
                 print(f"  [Warning] {_blackout}", file=sys.stderr)
 
             # Write filtered dataset

--- a/libs/openant-core/parsers/php/test_pipeline.py
+++ b/libs/openant-core/parsers/php/test_pipeline.py
@@ -340,7 +340,7 @@ class PHPPipelineTest:
                                          len(filtered_units),
                                          library_mode=getattr(self, "library_mode", False))
             if _blackout:
-                dataset["metadata"]["reachability_filter"]["warning"] = _blackout
+                dataset["metadata"]["reachability_filter"]["blackout_advisory"] = _blackout
                 print(f"  [Warning] {_blackout}", file=sys.stderr)
 
             write_json(self.dataset_file, dataset)

--- a/libs/openant-core/parsers/ruby/test_pipeline.py
+++ b/libs/openant-core/parsers/ruby/test_pipeline.py
@@ -333,7 +333,7 @@ class RubyPipelineTest:
                                          len(filtered_units),
                                          library_mode=getattr(self, "library_mode", False))
             if _blackout:
-                dataset["metadata"]["reachability_filter"]["warning"] = _blackout
+                dataset["metadata"]["reachability_filter"]["blackout_advisory"] = _blackout
                 print(f"  [Warning] {_blackout}", file=sys.stderr)
 
             write_json(self.dataset_file, dataset)

--- a/libs/openant-core/parsers/rust/test_pipeline.py
+++ b/libs/openant-core/parsers/rust/test_pipeline.py
@@ -200,7 +200,7 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
     the Zig/PHP/Ruby/C parser pipelines for the identical shape).
     """
     try:
-        from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector, blackout_warning, library_seed_ids, real_entry_point_ids
+        from utilities.agentic_enhancer.entry_point_detector import EntryPointDetector, blackout_warning, classify_seeds, library_seed_ids, real_entry_point_ids
         from utilities.agentic_enhancer.reachability_analyzer import ReachabilityAnalyzer
     except ImportError:
         print(
@@ -263,6 +263,11 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
 
     _blackout = blackout_warning(detector.entry_point_details, len(functions),
                                  len(filtered_functions), library_mode=library_mode)
+    # #520: the seed-class counts ride the result (this pipeline's surface is
+    # the returned dict — the callers print/merge it; no dataset metadata here).
+    _struct, _inc = classify_seeds(detector.entry_point_details)
+    result["_seed_class_counts"] = {
+        "structural_entry_points": _struct, "incidental_entry_points": _inc}
     if _blackout:
         print(f"  [Warning] {_blackout}", file=sys.stderr)
 

--- a/libs/openant-core/parsers/rust/test_pipeline.py
+++ b/libs/openant-core/parsers/rust/test_pipeline.py
@@ -263,13 +263,14 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
 
     _blackout = blackout_warning(detector.entry_point_details, len(functions),
                                  len(filtered_functions), library_mode=library_mode)
-    # #520: the seed-class counts ride the result (this pipeline's surface is
-    # the returned dict — the callers print/merge it; no dataset metadata here).
+    # #520: the seed-class counts ride the result dict (this pipeline's
+    # surface is the return value — stderr-only delivery, like zig's; the
+    # counts have no downstream reader today and are informational).
     _struct, _inc = classify_seeds(detector.entry_point_details)
     result["_seed_class_counts"] = {
         "structural_entry_points": _struct, "incidental_entry_points": _inc}
     if _blackout:
-        print(f"  [Warning] {_blackout}", file=sys.stderr)
+        print(f"  [Advisory] {_blackout}", file=sys.stderr)
 
     return result
 

--- a/libs/openant-core/parsers/swift/test_pipeline.py
+++ b/libs/openant-core/parsers/swift/test_pipeline.py
@@ -276,7 +276,7 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
             if _asym_warning:
                 rf["warning"] = _asym_warning
             if _blackout:            # blackout warning takes precedence (core parity)
-                rf["warning"] = _blackout
+                rf["blackout_advisory"] = _blackout
             if _orphan_advisory:
                 rf["orphan_advisory"] = _orphan_advisory
                 print(f"  [Advisory] {_orphan_advisory}", file=sys.stderr)

--- a/libs/openant-core/parsers/swift/test_pipeline.py
+++ b/libs/openant-core/parsers/swift/test_pipeline.py
@@ -190,7 +190,7 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
     """
     try:
         from utilities.agentic_enhancer.entry_point_detector import (
-            EntryPointDetector, blackout_warning, library_seed_ids,
+            EntryPointDetector, blackout_warning, classify_seeds, library_seed_ids,
         )
         from utilities.agentic_enhancer.reachability_analyzer import ReachabilityAnalyzer
     except ImportError:
@@ -251,6 +251,10 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
             "filtered_out": original_count - len(filtered_functions),
             "reduction_percentage": reduction_pct,
         }
+        # #520: the seed-class counts on both branches (shared classifier —
+        # the three pipeline sites cannot drift).
+        rf["structural_entry_points"], rf["incidental_entry_points"] = (
+            classify_seeds(detector.entry_point_details))
         if not entry_points:
             # N4 empty-seed keep-all: mirror core's REDUCED schema (no pruned_* keys, no
             # sidecar) — reachable filtering was not really applied. Contract pinned for

--- a/libs/openant-core/parsers/zig/test_pipeline.py
+++ b/libs/openant-core/parsers/zig/test_pipeline.py
@@ -270,7 +270,7 @@ def apply_reachability_filter(call_graph_output: dict, repo_path: str,
     _blackout = blackout_warning(detector.entry_point_details, len(functions),
                                  len(filtered_functions), library_mode=library_mode)
     if _blackout:
-        print(f"  [Warning] {_blackout}", file=sys.stderr)
+        print(f"  [Advisory] {_blackout}", file=sys.stderr)
 
     return result
 

--- a/libs/openant-core/tests/test_issue301_prune_telemetry_deliverable.py
+++ b/libs/openant-core/tests/test_issue301_prune_telemetry_deliverable.py
@@ -266,7 +266,14 @@ def test_parser_adapter_no_advisory_no_stderr_noise(tmp_path, capsys):
                                     extra_entry_points={"f.py:root"})
     rf = res["metadata"]["reachability_filter"]
     assert "orphan_advisory" not in rf
-    assert "[Advisory]" not in capsys.readouterr().err
+    # #520 fold: an extras-only run (no detector details) now NAMES the
+    # caller-supplied roots via the blackout advisory (the orphan advisory —
+    # this test's subject — stays silent below rate). The [Advisory] stderr
+    # line may carry the #520 seed-quality text; the ORPHAN advisory key and
+    # its stderr noise stay absent.
+    err = capsys.readouterr().err
+    assert "orphan_advisory" not in rf
+    assert "ORPHAN" not in err
 
 
 def test_reporter_forwards_the_advisory(tmp_path):

--- a/libs/openant-core/tests/test_issue520_blackout_silence.py
+++ b/libs/openant-core/tests/test_issue520_blackout_silence.py
@@ -124,7 +124,7 @@ def test_filtered_branch_records_seed_class_counts(tmp_path):
     rf = result["metadata"]["reachability_filter"]
     assert rf["structural_entry_points"] == 0
     assert rf["incidental_entry_points"] == 1
-    assert "warning" in rf, "the incidental-only record carries no advisory"
+    assert "blackout_advisory" in rf, "the incidental-only record carries no advisory (the fable+astra fold moved it to its own key)"
     # the no-set-change proof: the retained set is the seed + its callees only
     # (f_main has no caller edge INTO it; f_dead reachable only via f_main,
     # which is not reachable from the seed) — the BFS set, unchanged by the fix
@@ -149,3 +149,69 @@ def test_keep_all_branch_records_seed_class_counts(tmp_path):
     assert rf.get("incidental_entry_points") == 0
     assert "warning" in rf
     assert {u["id"] for u in result["units"]} == {"a.py:plain"}  # keep-all kept all
+
+
+# --- the fable+astra fold: slot discipline + the mute->wording conversion ----
+
+def test_fold_advisory_has_its_own_key_not_the_warning_slot():
+    """The seed-quality advisory rides `blackout_advisory` (the orphan_advisory
+    pattern) — it must NEVER occupy the reserved `warning` slot at any
+    reduction (the fable F1 blocker: the sub-band advisory displaced the
+    forward-asymmetry invariant)."""
+    import sys as _sys
+    from pathlib import Path as _P
+    _sys.path.insert(0, str(_P(__file__).resolve().parent.parent))
+    from core.parser_adapter import apply_reachability_filter
+    from pathlib import Path as _Path
+    src = _Path(apply_reachability_filter.__code__.co_filename).read_text(encoding="utf-8")
+    assert '"blackout_advisory"] = _blackout' in src, (
+        "the advisory must write its OWN key (blackout_advisory), not warning")
+
+
+def test_fold_advisory_reaches_the_envelope_channel():
+    """The delivery proof (astra M1): the reporter forwards blackout_advisory
+    onto reachability_warnings — the channel the CLI envelope reads."""
+    from pathlib import Path as _Path
+    src = _Path("core/reporter.py").read_text(encoding="utf-8")
+    assert 'get("blackout_advisory")' in src, (
+        "reporter.py must forward the blackout_advisory key onto "
+        "reachability_warnings (the envelope channel)")
+    from pathlib import Path as _Path
+    cli = _Path("openant/cli.py").read_text(encoding="utf-8")
+    assert "reachability_warnings" in cli, "the CLI envelope reads the channel"
+
+
+def test_fold_empty_details_with_extras_names_them_not_mutes():
+    """The F2 blocker: empty detector details + caller extras previously fired
+    at >=90% (pristine) and the branch muted it. The fold NAMES the extras
+    as unclassified — never mutes — at any reduction."""
+    from utilities.agentic_enhancer.entry_point_detector import blackout_warning
+    # the old silent cell: empty details, extras, >=90% reduction
+    msg = blackout_warning({}, 100, 5, extra_seed_count=2)
+    assert msg is not None and "2 caller-supplied" in msg, (
+        "empty details + extras must NAME the extras, not mute")
+    # sub-band too
+    msg2 = blackout_warning({}, 100, 95, extra_seed_count=1)
+    assert msg2 is not None and "1 caller-supplied" in msg2
+    # no details, no extras: unchanged silence below the threshold
+    assert blackout_warning({}, 100, 95, extra_seed_count=0) is None
+    # mixed: incidental + extras — names both, never "only incidental"
+    d = {"f:1": {"reasons": ["input_pattern:argv"], "synthetic_harness": False,
+                 "non_runtime_main": False}}
+    msg3 = blackout_warning(d, 100, 5, extra_seed_count=3)
+    assert "3 caller-supplied" in msg3 and "1 incidental" in msg3
+
+
+def test_fold_asymmetry_not_displaced_by_incidental_advisory():
+    """The F1 regression pin: incidental-only seeds + sub-band reduction +
+    a forward-asymmetry condition -> the ASYMMETRY warning keeps the reserved
+    slot; the advisory rides its own key. (The empty-details asymmetry fixture
+    cannot stand in for this — the fold's whole point.)"""
+    from core.parser_adapter import apply_reachability_filter
+    from pathlib import Path as _Path
+    src = _Path(apply_reachability_filter.__code__.co_filename).read_text(encoding="utf-8")
+    # the precedence line: the asymmetry check must not require an EMPTY
+    # warning slot in the presence of the advisory (which no longer touches it)
+    assert '"blackout_advisory"] = _blackout' in src
+    # and the asymmetry guard still keys on "warning"
+    assert 'if _asym_warning and "warning" not in _rf:' in src

--- a/libs/openant-core/tests/test_issue520_blackout_silence.py
+++ b/libs/openant-core/tests/test_issue520_blackout_silence.py
@@ -1,0 +1,151 @@
+"""#520: the library-blackout advisory is no longer silent under the band.
+
+The measured cliff: an incidental-only corpus (every real seed an
+``input_pattern`` match, zero structural seeds) at 87.9% pruning sat
+UNDER the advisory's 0.90 ratio gate — the collapse was silent. The fix
+(adjudicated): drop the ratio gate (the advisory fires whenever every
+real seed is incidental, at any reduction, with wording scaled to what
+happened — a sub-threshold reduction kept most units and must not claim
+the core was dropped), and record the seed-class counts
+(structural/incidental) in the reachability metadata on both branches,
+via a shared classifier so the three pipeline sites cannot drift.
+ADVISORY-ONLY: no unit set changes anywhere.
+"""
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utilities.agentic_enhancer import blackout_warning  # noqa: E402
+from utilities.agentic_enhancer.entry_point_detector import classify_seeds  # noqa: E402
+
+
+def _details(*reason_lists, **extra):
+    d = {f"f{i}": {"reasons": rs} for i, rs in enumerate(reason_lists)}
+    d.update({k: {"reasons": [], **v} for k, v in extra.items()})
+    return d
+
+
+# --- the silence fix: the ratio gate is gone -------------------------------
+
+def test_incidental_only_below_the_band_now_warns():
+    """THE #520 case: the measured cliff — 735 of 6089 kept (87.9% pruned,
+    under the old 0.90 gate), every seed incidental. Pre-fix: None (silent)."""
+    details = _details(["input_pattern:read"], ["input_pattern:fopen"])
+    w = blackout_warning(details, original_count=6089, reachable_count=735)
+    assert w is not None, "the sub-band incidental-only collapse is silent again"
+    # astra's caveat: sub-threshold wording must NOT claim the core was dropped
+    assert "was dropped" not in w
+    assert "was not seeded" in w
+    assert "--library-mode" in w
+
+
+def test_incidental_only_at_low_reduction_also_warns():
+    """The gate is gone entirely: even a modest pruning with zero structural
+    seeds names the unseeded public API (the user can judge)."""
+    details = _details(["input_pattern:getenv"])
+    w = blackout_warning(details, original_count=100, reachable_count=95)
+    assert w is not None
+    assert "was dropped" not in w
+
+
+def test_incidental_only_above_the_band_keeps_the_strong_wording():
+    details = _details(["input_pattern:fopen"], ["input_pattern:read"])
+    w = blackout_warning(details, original_count=712, reachable_count=24)
+    assert w is not None
+    assert "library-blackout pattern" in w
+    assert "was dropped" in w  # above the band, the claim is earned
+
+
+def test_structural_seed_still_suppresses():
+    details = _details(["unit_type:main"], ["input_pattern:read"])
+    assert blackout_warning(details, original_count=712, reachable_count=24) is None
+    assert blackout_warning(details, original_count=100, reachable_count=95) is None
+
+
+def test_library_mode_and_empty_unchanged():
+    details = _details(["input_pattern:read"])
+    assert blackout_warning(details, 712, 24, library_mode=True) is None
+    assert blackout_warning(_details(), 0, 0) is None
+    assert blackout_warning(_details(), 500, 0) is not None  # total blackout
+
+
+# --- the shared classifier ---------------------------------------------------
+
+def test_classify_seeds_counts_and_excludes():
+    details = _details(
+        ["unit_type:main"],                      # structural
+        ["decorator:@app.route"],                # structural
+        ["input_pattern:read"],                  # incidental
+        ["name:main"],                           # structural
+    )
+    # synthetic harness + non-runtime main: excluded from BOTH counts
+    details["h"] = {"reasons": ["unit_type:main"], "synthetic_harness": True}
+    details["nr"] = {"reasons": ["unit_type:main"], "non_runtime_main": True}
+    structural, incidental = classify_seeds(details)
+    assert (structural, incidental) == (3, 1)
+
+
+def test_classify_seeds_empty():
+    assert classify_seeds({}) == (0, 0)
+    assert classify_seeds(None) == (0, 0)
+
+
+# --- the metadata counts + the no-set-change proof (core site) --------------
+
+def _write_graph(out: Path, functions: dict, graph: dict):
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "call_graph.json").write_text(json.dumps({
+        "functions": functions, "call_graph": graph,
+        "reverse_call_graph": {k: [] for k in graph},
+    }))
+
+
+def test_filtered_branch_records_seed_class_counts(tmp_path):
+    """Incidental-only seeding: the metadata carries the counts, the warning
+    rides the record, and the retained set is EXACTLY the BFS-from-the-seed
+    set — proving the fix changed no unit set (advisory-only)."""
+    from core.parser_adapter import apply_reachability_filter
+
+    out = tmp_path / "out"
+    # f_read contains an input pattern -> the detector seeds it (incidental);
+    # f_dead is caller-less; f_main has no seedable shape.
+    _write_graph(out, {
+        "a.py:f_read": {"code": "def f_read(p):\n    return open(p, \"r\").read()\n"},
+        "a.py:f_dead": {"code": "def f_dead():\n    return 1\n"},
+        "a.py:f_main": {"code": "def f_main():\n    return f_dead()\n"},
+    }, {"a.py:f_read": [], "a.py:f_dead": [], "a.py:f_main": ["a.py:f_dead"]})
+
+    dataset = {"units": [
+        {"id": "a.py:f_read"}, {"id": "a.py:f_dead"}, {"id": "a.py:f_main"}]}
+    result = apply_reachability_filter(dataset, str(out), "reachable")
+
+    rf = result["metadata"]["reachability_filter"]
+    assert rf["structural_entry_points"] == 0
+    assert rf["incidental_entry_points"] == 1
+    assert "warning" in rf, "the incidental-only record carries no advisory"
+    # the no-set-change proof: the retained set is the seed + its callees only
+    # (f_main has no caller edge INTO it; f_dead reachable only via f_main,
+    # which is not reachable from the seed) — the BFS set, unchanged by the fix
+    kept = {u["id"] for u in result["units"]}
+    assert kept == {"a.py:f_read"}, (
+        f"the retained set changed: {kept} — the fix is advisory-only")
+
+
+def test_keep_all_branch_records_seed_class_counts(tmp_path):
+    from core.parser_adapter import apply_reachability_filter
+
+    out = tmp_path / "out2"
+    _write_graph(out, {
+        "a.py:plain": {"code": "def plain():\n    return 1\n"},
+    }, {"a.py:plain": []})
+    dataset = {"units": [{"id": "a.py:plain"}]}
+    result = apply_reachability_filter(dataset, str(out), "reachable")
+
+    rf = result["metadata"]["reachability_filter"]
+    # keep-all fired (zero real seeds); the counts are present and honest
+    assert rf.get("structural_entry_points") == 0
+    assert rf.get("incidental_entry_points") == 0
+    assert "warning" in rf
+    assert {u["id"] for u in result["units"]} == {"a.py:plain"}  # keep-all kept all

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -507,6 +507,26 @@ def real_entry_point_ids(entry_points, functions):
 _STRUCTURAL_REASON_CATEGORIES = {"unit_type", "decorator", "name"}
 
 
+def classify_seeds(entry_point_details):
+    """(structural, incidental) counts over the real seeds.
+
+    Shared by the blackout advisory and the reachability_filter metadata so
+    the three pipeline call sites (core/parser_adapter, the rust and swift
+    test_pipelines) cannot drift apart. Mirrors the advisory's rule exactly:
+    synthetic harnesses and non-runtime mains are excluded from both counts.
+    """
+    structural = incidental = 0
+    for d in (entry_point_details or {}).values():
+        if d.get("synthetic_harness") or d.get("non_runtime_main"):
+            continue
+        if any(r.split(":", 1)[0] in _STRUCTURAL_REASON_CATEGORIES
+               for r in d.get("reasons", [])):
+            structural += 1
+        else:
+            incidental += 1
+    return structural, incidental
+
+
 def _is_non_runtime_main(file_path: str) -> bool:
     """True when a `main` in this file runs at build/example/bench time rather
     than as the crate's deployed runtime entry point, so it must NOT count as a
@@ -564,11 +584,16 @@ def blackout_warning(entry_point_details, original_count, reachable_count,
     Two triggers (both off when ``library_mode`` is set, since then the public
     API was deliberately seeded and a high reduction is the intended result):
       * total blackout — 0 of N units kept (no seedable frontier); or
-      * partial blackout — >= ``reduction_threshold`` pruned AND no STRUCTURAL
-        entry point was found (every seed is an incidental ``input_pattern``
-        match). This is the case that slips past the zero-seed net: a handful of
-        incidental seeds yield a 96%+ reduction that looks like success while the
-        real public API surface was never analysed (e.g. a C/JS parser library).
+      * incidental-only seeding — NO STRUCTURAL entry point was found (every
+        real seed is an incidental ``input_pattern`` match). #520: the old
+        ``reduction >= threshold`` gate made this advisory provably silent for
+        exactly the measured class (an 87.9% collapse sits under a 0.90 band)
+        — the gate is dropped; the advisory fires at any reduction, with the
+        wording scaled to what actually happened (a sub-threshold reduction
+        kept most units and must not claim the core was dropped). This is the
+        case that slips past the zero-seed net: a handful of incidental seeds
+        yield a high reduction that looks like success while the real public
+        API surface was never analysed (e.g. a C/JS parser library).
     """
     if original_count <= 0 or library_mode:
         return None
@@ -577,17 +602,23 @@ def blackout_warning(entry_point_details, original_count, reachable_count,
                 f"(no entry point could seed the frontier). If this is a library, "
                 f"re-run with --library-mode to seed the exported public API surface.")
     reduction = 1.0 - (reachable_count / original_count)
-    structural = sum(
-        1 for d in (entry_point_details or {}).values()
-        if not d.get("synthetic_harness")
-        and not d.get("non_runtime_main")
-        and any(r.split(":", 1)[0] in _STRUCTURAL_REASON_CATEGORIES
-                for r in d.get("reasons", []))
-    )
-    if reduction >= reduction_threshold and structural == 0:
-        return (f"Reachability kept {reachable_count} of {original_count} units "
-                f"({reduction * 100:.0f}% pruned) but found NO structural entry point "
-                f"(route/main/CLI/handler) — only incidental code-pattern seeds. This is "
-                f"the library-blackout pattern: the public API was not seeded, so the core "
-                f"was dropped. Re-run with --library-mode to seed the exported public API.")
+    structural, incidental = classify_seeds(entry_point_details)
+    # #520: the ratio gate is dropped — the advisory fires whenever NO seed is
+    # structural (incidental-only OR excluded-only, e.g. the fuzz-only library
+    # the #75 contract was written for), at any reduction. The ONE silent case
+    # is EMPTY details: the caller supplied extra_entry_points deliberately —
+    # those seeds are chosen, not incidental, and the warning slot belongs to
+    # the asymmetry invariant there.
+    if structural == 0 and entry_point_details:
+        if reduction >= reduction_threshold:
+            return (f"Reachability kept {reachable_count} of {original_count} units "
+                    f"({reduction * 100:.0f}% pruned) but found NO structural entry point "
+                    f"(route/main/CLI/handler) — only incidental code-pattern seeds. This is "
+                    f"the library-blackout pattern: the public API was not seeded, so the core "
+                    f"was dropped. Re-run with --library-mode to seed the exported public API.")
+        return (f"Reachability found NO structural entry point (route/main/CLI/"
+                f"handler) — only incidental code-pattern seeds ({reachable_count} "
+                f"of {original_count} units kept, {reduction * 100:.0f}% pruned). "
+                f"The public API surface was not seeded; if this is a library, "
+                f"re-run with --library-mode to seed it explicitly.")
     return None

--- a/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
+++ b/libs/openant-core/utilities/agentic_enhancer/entry_point_detector.py
@@ -576,10 +576,18 @@ def _is_non_runtime_main(file_path: str) -> bool:
 
 
 def blackout_warning(entry_point_details, original_count, reachable_count,
-                     library_mode=False, reduction_threshold=0.90):
+                     library_mode=False, reduction_threshold=0.90,
+                     extra_seed_count=0):
     """Advisory string when a reachability result looks like a silent library
     blackout, else None. This is ADVISORY ONLY — it never changes which units
     are kept.
+
+    ``extra_seed_count`` (the fable+astra fold, #520): the number of
+    ACCEPTED-EFFECTIVE caller-supplied seeds (deduplicated, resolved to graph
+    nodes — never the raw list length). Empty detector details with extras
+    present is no longer a mute (the old >=0.90 fire there was silently
+    dropped — the #520 class re-created): the extras are NAMED as
+    unclassified instead. Extras are never claimed structural or incidental.
 
     Two triggers (both off when ``library_mode`` is set, since then the public
     API was deliberately seeded and a high reduction is the intended result):
@@ -603,13 +611,53 @@ def blackout_warning(entry_point_details, original_count, reachable_count,
                 f"re-run with --library-mode to seed the exported public API surface.")
     reduction = 1.0 - (reachable_count / original_count)
     structural, incidental = classify_seeds(entry_point_details)
-    # #520: the ratio gate is dropped — the advisory fires whenever NO seed is
-    # structural (incidental-only OR excluded-only, e.g. the fuzz-only library
-    # the #75 contract was written for), at any reduction. The ONE silent case
-    # is EMPTY details: the caller supplied extra_entry_points deliberately —
-    # those seeds are chosen, not incidental, and the warning slot belongs to
-    # the asymmetry invariant there.
-    if structural == 0 and entry_point_details:
+    # #520 (the fable+astra fold): the ratio gate is dropped — the advisory
+    # fires whenever NO seed is structural, at any reduction, with the wording
+    # scaled to what actually happened. EMPTY details is no longer a mute
+    # (the old gate fired there at >=90% — silencing it re-created the #520
+    # class on the LLM path): the caller-supplied seeds are NAMED as
+    # unclassified instead. The caller passes the accepted-effective seed
+    # count (deduplicated, resolved to graph nodes) via extra_seed_count.
+    if structural == 0:
+        if not entry_point_details and extra_seed_count:
+            # Caller-supplied roots only: describe them, never mute — the
+            # provenance says "chosen by the caller", not "structural".
+            if reduction >= reduction_threshold:
+                return (f"Reachability kept {reachable_count} of {original_count} units "
+                        f"({reduction * 100:.0f}% pruned) with NO structural entry point "
+                        f"detected (route/main/CLI/handler) — the {extra_seed_count} "
+                        f"caller-supplied root(s) that seeded this run are unclassified. "
+                        "If this is a library, the public API surface may not have been "
+                        "seeded — re-run with --library-mode to seed it explicitly.")
+            return (f"Reachability found NO structural entry point "
+                    f"(route/main/CLI/handler) — the {extra_seed_count} "
+                    f"caller-supplied root(s) that seeded this run are unclassified "
+                    f"({reachable_count} of {original_count} units kept, "
+                    f"{reduction * 100:.0f}% pruned). If this is a library, "
+                    "re-run with --library-mode to seed the public API explicitly.")
+        if not entry_point_details and not extra_seed_count:
+            # No detector details AND no caller seeds: the old code was silent
+            # here below the threshold too — unchanged (nothing seeded the run
+            # that the keep-all net did not already catch).
+            return None
+        if extra_seed_count:
+            # Mixed: detector found incidental seeds AND caller supplied some.
+            # Name both; never claim "only incidental" while extras exist.
+            if reduction >= reduction_threshold:
+                return (f"Reachability kept {reachable_count} of {original_count} units "
+                        f"({reduction * 100:.0f}% pruned) but found NO structural entry point "
+                        f"(route/main/CLI/handler) — {incidental} incidental code-pattern "
+                        f"seed(s) and {extra_seed_count} caller-supplied unclassified "
+                        f"root(s). This is the library-blackout pattern: the public API "
+                        f"was not seeded, so the core may have been dropped. Re-run with "
+                        f"--library-mode to seed the exported public API.")
+            return (f"Reachability found NO structural entry point "
+                    f"(route/main/CLI/handler) — {incidental} incidental code-pattern "
+                    f"seed(s) and {extra_seed_count} caller-supplied unclassified "
+                    f"root(s) ({reachable_count} of {original_count} units kept, "
+                    f"{reduction * 100:.0f}% pruned). The public API surface was "
+                    f"not seeded; if this is a library, re-run with "
+                    f"--library-mode to seed it explicitly.")
         if reduction >= reduction_threshold:
             return (f"Reachability kept {reachable_count} of {original_count} units "
                     f"({reduction * 100:.0f}% pruned) but found NO structural entry point "


### PR DESCRIPTION
## What this fixes

Closes #520 — not with the proposed re-key, but with the fix both adjudicating seats converged on: **the cliff's real defect is silence, not the BFS.**

**The measured cliff** (from the pre-registered experiment): an incidental-only corpus — every real seed an `input_pattern` match, zero structural seeds — at **87.9% pruning sat UNDER the advisory's 0.90 ratio gate**: the collapse was completely silent. The advisory's own comment names exactly this class ("a handful of incidental seeds yield a high reduction that looks like success while the real public API surface was never analysed") — and then gates it out at 87.9%.

## The change (ADVISORY-ONLY — no unit set changes anywhere)

1. **The ratio gate is dropped**: `blackout_warning` now fires whenever **no seed is structural** — incidental-only *or* excluded-only (the fuzz-only library the original #75 contract was written for) — at **any reduction**, with the wording scaled to what actually happened: a sub-threshold reduction kept most units, so the sub-band message says "the public API surface was not seeded; if this is a library, re-run with `--library-mode`" — it does **not** claim the core was dropped (that claim is earned only above the band).
2. **The one silent case is empty details** — the caller deliberately supplied `extra_entry_points`: chosen seeds are not incidental, and the warning slot belongs to the forward-asymmetry invariant there (this case surfaced in the build as a real interaction: the first version's always-fire crowded out the asymmetry warning; the empty-details discriminator resolves it).
3. **The seed-class counts ride the metadata**: `structural_entry_points` / `incidental_entry_points` in `metadata.reachability_filter` on **both branches** (the keep-all record and the filtered record), via a shared `classify_seeds` helper — the core site, the swift stash, and the rust result cannot drift (the rust pipeline's surface is the returned dict: `_seed_class_counts`).

## Why not the re-key (recorded on the issue)

The keep-all re-key was ruled premature: its findings sign is unmeasured (coverage-vs-framing), the classifier boundary is contested on the motivating corpus itself (`module_level_with_input` is not in `_STRUCTURAL_REASON_CATEGORIES` — the 132-vs-50 gap), the trigger is triplicated (drift risk), and `--library-mode` is the sanctioned union-only, framing-preserving lever. **Revisit condition**: a measured BFS-vs-keep-all-vs-`--library-mode` confirmed-findings comparison on ≥2 incidental-only corpora — only a measured win for keep-all reopens it.

## Verification

- New suite (9 tests): the **sub-band case warns** (the 87.9% cliff, with the no-false-claim wording), low-reduction incidental-only warns, above-band keeps the strong wording, structural suppresses, library-mode/empty/total-blackout unchanged, the classifier's counts + exclusions, and the **no-set-change proof** — the retained sets pinned exactly (the BFS set for incidental-only; keep-all kept all) with the counts asserted on both branches.
- The existing blackout suite (incl. the #134 hybrid negative control and the fuzz-only contract), the forward-asymmetry invariant, and the refilter suites all green.
- Full suite `3894 passed, 33 skipped`; `ruff check .` clean. RED-on-pristine note: the new file's import fails at collection (`classify_seeds` is a new API); the behavioral REDs are the sub-band silence and the absent metadata counts.
