### PR TITLE
fix(llm-reach): resume parity — per-unit records under the backend-identity gate (#532)

### DIFF
--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -151,7 +151,13 @@ func runScan(cmd *cobra.Command, args []string) {
 
 	// Check for interrupted runs in the scan directory
 	if ctx != nil && scanOutput != "" {
-		steps := []string{"enhance", "analyze", "verify"}
+		// #532: llm_reach joins the probe list — its checkpoints are the most
+		// expensive per-pass ($10+ on a 5K-unit corpus), so a silent auto-adopt
+		// on an explicit fresh start would defeat the user's choice. Records
+		// classify as completed (no error arms match) and a missing/unknown
+		// _summary takes PromptResume's legacy arm — same lifecycle as the
+		// other phases.
+		steps := []string{"enhance", "analyze", "verify", "llm_reach"}
 		for _, step := range steps {
 			if cpInfo := checkpoint.DetectViaPython(rt.Path, scanOutput, step); cpInfo != nil {
 				if !checkpoint.PromptResume(cpInfo, step, quiet) {

--- a/libs/openant-core/core/checkpoint.py
+++ b/libs/openant-core/core/checkpoint.py
@@ -1,9 +1,9 @@
 """
 Shared checkpoint utilities for resumable pipeline steps.
 
-Each LLM-heavy step (enhance, analyze, verify) can save per-unit checkpoint
-files so interrupted runs resume where they left off. The checkpoint dir
-lives next to the output file:
+Each LLM-heavy step (enhance, analyze, verify, llm_reach) can save per-unit
+checkpoint files so interrupted runs resume where they left off. The
+checkpoint dir lives next to the output file:
 
     {scan_dir}/enhance_checkpoints/
     {scan_dir}/analyze_checkpoints/

--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -376,6 +376,8 @@ def analyze_reachability(
     max_units: Optional[int] = None,
     on_error: Optional[Callable[[str], None]] = None,
     stats: Optional[Dict[str, int]] = None,
+    checkpoint_path: Optional[str] = None,
+    tracker: Optional[Any] = None,
 ) -> List[ReachabilitySignal]:
     """Run the LLM reachability review stage over a parsed dataset.
 
@@ -428,14 +430,19 @@ def analyze_reachability(
         probe_registry_or_raise(registry)
         binding = registry.get("llm_reach")
 
-    valid_ids = {u.get("id") for u in units if u.get("id")}
-
     # Lazy import so this module stays usable when callers explicitly
     # provide a binding and never want the registry fallback above.
     from utilities.llm import LLMAuthError, simple_text
 
+    # #532 (review-wave fix): the usage machinery must be live in PRODUCTION —
+    # resolve the global tracker when the caller doesn't pass one (the family
+    # pattern; without this, records persist zero usage and the restored-cost
+    # contract is dead outside tests).
+    if tracker is None:
+        from utilities.llm_client import get_global_tracker
+        tracker = get_global_tracker()
+
     signals: List[ReachabilitySignal] = []
-    batches = _chunk(units, batch_size)
     # #294: count parse-level batch drops and the units they carried —
     # a dropped batch is a coverage gap in the most consequential direction
     # (this stage decides which units are analyzed at all), and previously
@@ -443,12 +450,153 @@ def analyze_reachability(
     # in which some units were never reviewed.
     dropped_batches = 0
     units_not_reviewed = 0
+
+    # ------------------------------------------------------------------
+    # #532: resume/adopt machinery — the checkpoint family's own pattern
+    # (analyzer.py's StepCheckpoint + backend-identity gate).
+    #   * per-unit records {"signals", "projection_sha", "usage"} — a
+    #     "reviewed, no signal" outcome IS a record (the majority case);
+    #   * the KEY is backend-identity only (model/provider/adapter/base_url/
+    #     static template rendered with app_context=None) — app-context
+    #     CONTENT is deliberately excluded (it regenerates non-determinis-
+    #     tically every scan; content-keying = a guaranteed re-pay — the
+    #     backend_identity ~17k-token lesson at LLR prices);
+    #   * projection_sha = unit_type + trimmed code: a body edit under the
+    #     same id re-runs (closes the family's path-only residual for the
+    #     phase where it is most FN-severe);
+    #   * dropped/exception batches leave NO records — absence IS the retry
+    #     marker (no frozen coverage gaps, no error records the #311
+    #     summary-vs-status drift class would miscount);
+    #   * adopted SIGNALS (not promotion outcomes) — apply_signals still
+    #     runs over them under the CURRENT promotion policy.
+    # ------------------------------------------------------------------
+    checkpoint = None
+    adopted: Dict[str, dict] = {}
+    units_to_run = units
+    if checkpoint_path is not None:
+        import hashlib
+        import os as _os
+
+        from core.backend_identity import (
+            fingerprint_for_binding,
+            render_template_texts,
+        )
+        from core.checkpoint import StepCheckpoint
+
+        def _projection_sha(unit: dict) -> str:
+            # Hash EXACTLY the bytes the prompt sends: the same
+            # _unit_for_prompt projection build_prompt uses (golden
+            # invariant by construction). is_entry_point / reachable are
+            # excluded because they are CONSTANT at this stage's input in
+            # the scanner path — parse runs at level "all" under
+            # --llm-reachability (parser_adapter.py:688-690 skips the
+            # filter), so the flags arrive False/None every run; the
+            # re-parsed dataset overwrites any mutation before the next
+            # pass reads it (scanner.py:391-399). A parser that stamped
+            # the flags itself would carry them across a flip — named
+            # residual. Null/non-str fields coerce to "" — a malformed
+            # unit must cost this hash one line, never the whole stage
+            # (deep-refute 2026-09-08: TypeError here skipped LLR).
+            p = _unit_for_prompt(unit, max_code_bytes=max_code_bytes)
+            body = str(p.get("unit_type") or "") + "\n" + str(p.get("code") or "")
+            return hashlib.sha256(body.encode("utf-8", "replace")).hexdigest()
+
+        try:
+            checkpoint = StepCheckpoint("llm_reach", _os.path.dirname(checkpoint_path))
+            checkpoint.dir = checkpoint_path
+            # I2 adopt gate: BEFORE loading prior checkpoints, verify the backend
+            # identity that produced them matches (a changed model/provider/
+            # adapter/template archives the stale dir and forces a re-run).
+            llr_fp = fingerprint_for_binding(
+                binding,
+                render_template_texts([
+                    lambda: PROMPT_TEMPLATE.format(
+                        app_context_block=_build_app_context_block(None),
+                        units_block="",
+                    )
+                ]),
+            )
+            checkpoint.sync_identity(llr_fp)
+            prior_records = checkpoint.load()
+        except OSError as exc:
+            # The save doctrine applies to the whole persistence block: an
+            # unwritable/absent checkpoint dir costs persistence, never the
+            # pass — run this stage without checkpointing rather than skip it.
+            if on_error:
+                on_error(f"llm_reach checkpoint init failed, running unpersisted: {exc}")
+            else:
+                print(f"[LLMReach] checkpoint init failed, running unpersisted: {exc}",
+                      file=sys.stderr)
+            checkpoint = None
+            prior_records = {}
+        if checkpoint is not None:
+            current_sha = {u.get("id"): _projection_sha(u) for u in units}
+            for uid, rec in prior_records.items():
+                if (uid not in current_sha or not isinstance(rec, dict)
+                        or rec.get("projection_sha") != current_sha[uid]):
+                    continue
+                try:
+                    rec_sigs = [ReachabilitySignal(**s)
+                                for s in (rec.get("signals") or [])]
+                except TypeError:
+                    # Malformed prior record — never adopt it; the unit re-runs.
+                    continue
+                adopted[uid] = rec
+                signals.extend(rec_sigs)
+            units_to_run = [u for u in units if u.get("id") not in adopted]
+            if stats is not None:
+                stats["units_adopted"] = len(adopted)
+            # Family lifecycle (deep-refute 2026-09-08): an in_progress
+            # summary at PASS START, exactly as analyzer.py:719-722 does —
+            # a run killed mid-loop after a prior completed pass must NOT
+            # leave a stale phase="done" summary behind (the Go resume
+            # sweep reads it and would suppress the fresh/resume prompt
+            # entirely, checkpoint.go:115-116).
+            try:
+                checkpoint.write_summary(
+                    total_units=len(units),
+                    completed=len(adopted),
+                    errors=0,
+                    error_breakdown={},
+                    phase="in_progress",
+                    usage=None,
+                    incomplete=max(0, len(units) - len(adopted)),
+                )
+            except OSError:
+                pass
+            # Restored cost lands as PRIOR usage — never zero, never this run's
+            # new spend (the #26/#26b kill-vs-complete asymmetry lessons).
+            if adopted and tracker is not None:
+                tot_in = sum(int((r.get("usage") or {}).get("input_tokens", 0) or 0)
+                             for r in adopted.values())
+                tot_out = sum(int((r.get("usage") or {}).get("output_tokens", 0) or 0)
+                              for r in adopted.values())
+                tot_cost = sum(float((r.get("usage") or {}).get("cost_usd", 0) or 0)
+                               for r in adopted.values())
+                unpriced: set = set()
+                for r in adopted.values():
+                    unpriced.update(
+                        (r.get("usage") or {}).get("unpriced_models") or [])
+                try:
+                    tracker.add_prior_usage(
+                        tot_in, tot_out, tot_cost,
+                        unpriced_models=sorted(unpriced) or None)
+                except Exception:  # noqa: BLE001 — accounting must never kill the pass
+                    pass
+
+    batches = _chunk(units_to_run, batch_size)
+    persisted = 0
     for i, batch in enumerate(batches):
         prompt = build_prompt(
             batch, app_context=app_context, max_code_bytes=max_code_bytes
         )
+        if tracker is not None:
+            try:
+                tracker.start_unit_tracking()
+            except Exception:  # noqa: BLE001
+                pass
         try:
-            text = simple_text(binding, prompt, max_tokens=4096)
+            text = simple_text(binding, prompt, max_tokens=4096, tracker=tracker)
         except LLMAuthError:
             # Auth failures are fatal and recur on every batch — surface
             # them instead of burying them as a per-batch "failed" line,
@@ -462,19 +610,101 @@ def analyze_reachability(
                 print(f"[LLMReach] {msg}", file=sys.stderr)
             continue
 
-        def _count_drop(batch=batch):
-            nonlocal dropped_batches, units_not_reviewed
-            dropped_batches += 1
-            units_not_reviewed += len(batch)
-
+        # #532 (disclosed behavior change): valid ids are PER-BATCH, so a
+        # signal for a unit outside the producing batch is ungrounded by
+        # construction — under persistence, adopted state must equal
+        # applied state (an out-of-batch signal would apply this run but
+        # never persist).
+        batch_ids = {u.get("id") for u in batch if u.get("id")}
         first = batch[0].get("id", "?") if batch else "?"
         last = batch[-1].get("id", "?") if batch else "?"
+        dropped_this_batch = False
+
+        def _count_drop_and_flag(batch=batch):
+            nonlocal dropped_batches, units_not_reviewed, dropped_this_batch
+            dropped_batches += 1
+            units_not_reviewed += len(batch)
+            dropped_this_batch = True
+
         parsed = parse_response(
-            text, valid_unit_ids=valid_ids, on_error=on_error,
+            text, valid_unit_ids=batch_ids, on_error=on_error,
             batch_label=f"batch {i + 1}/{len(batches)}, units {first}..{last}",
-            on_batch_drop=_count_drop,
+            on_batch_drop=_count_drop_and_flag,
         )
         signals.extend(parsed)
+
+        # Persist per-unit records ONLY for a batch that completed without a
+        # drop — dropped batches leave no records (absence = the retry
+        # marker on the next resume). Save failures cost persistence, not
+        # the pass (the stage's own advisory doctrine).
+        if checkpoint is not None and not dropped_this_batch:
+            batch_usage = {}
+            if tracker is not None:
+                try:
+                    batch_usage = tracker.get_unit_usage() or {}
+                except Exception:  # noqa: BLE001
+                    batch_usage = {}
+            n_units = max(len(batch), 1)
+
+            def _share(units_in_batch: int) -> dict:
+                share = {
+                    "input_tokens": int(batch_usage.get("input_tokens", 0) or 0) // units_in_batch,
+                    "output_tokens": int(batch_usage.get("output_tokens", 0) or 0) // units_in_batch,
+                    "cost_usd": round(float(batch_usage.get("cost_usd", 0.0) or 0.0) / units_in_batch, 6),
+                }
+                # #216: the incomplete-cost marker travels with the record so
+                # a resume restores it (the family's analyzer contract).
+                if batch_usage.get("unpriced_models"):
+                    share["cost_incomplete"] = True
+                    share["unpriced_models"] = sorted(
+                        set(batch_usage["unpriced_models"]))
+                return share
+
+            sig_by_unit: Dict[str, List[dict]] = {}
+            for s in parsed:
+                sig_by_unit.setdefault(s.unit_id, []).append({
+                    "unit_id": s.unit_id, "kind": s.kind,
+                    "confidence": s.confidence, "reason": s.reason,
+                })
+            for u in batch:
+                uid = u.get("id")
+                if not uid:
+                    continue
+                try:
+                    checkpoint.save(uid, {
+                        "signals": sig_by_unit.get(uid, []),
+                        "projection_sha": current_sha[uid],
+                        "usage": _share(n_units),
+                    })
+                    persisted += 1
+                except OSError as exc:
+                    if on_error:
+                        on_error(f"llm_reach checkpoint save failed for {uid}: {exc}")
+                    else:
+                        print(f"[LLMReach] checkpoint save failed for {uid}: {exc}",
+                              file=sys.stderr)
+
+    if checkpoint is not None:
+        try:
+            completed = len(adopted) + persisted
+            # #293 three-state invariant: completed + incomplete + errors ==
+            # total_units. Un-reviewed units (dropped/exception batches —
+            # absence IS their retry marker) are the `incomplete` bucket,
+            # NOT summary errors (#311 drift class); the phase stays
+            # "in_progress" until every unit has a record.
+            incomplete = max(0, len(units) - completed)
+            checkpoint.write_summary(
+                total_units=len(units),
+                completed=completed,
+                errors=0,
+                error_breakdown={},
+                phase="done" if completed == len(units) else "in_progress",
+                usage=None,
+                incomplete=incomplete,
+            )
+        except OSError as exc:
+            if on_error:
+                on_error(f"llm_reach checkpoint summary write failed: {exc}")
 
     if stats is not None:
         stats["batches_dropped"] = dropped_batches

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -28,6 +28,7 @@ from core.schemas import (
 )
 from core.step_report import step_context
 from core import tracking
+from utilities.llm_client import get_global_tracker
 from utilities.child_interp import resolved_core_path
 from utilities.file_io import read_json, write_json
 from utilities.llm.adapter import LLMAuthError
@@ -648,6 +649,13 @@ def scan_repository(
                         binding=llm_reach_binding,
                         max_code_bytes=llm_reachability_max_code_bytes,
                         stats=reach_stats,
+                        # #532: resume parity with the checkpointed stages —
+                        # per-unit records under the family's backend-identity
+                        # gate; a relaunch adopts matching units instead of
+                        # re-paying the whole pass.
+                        checkpoint_path=os.path.join(
+                            output_dir, "llm_reach_checkpoints"),
+                        tracker=get_global_tracker(),
                     )
                     summary = apply_signals(dataset, signals)
 
@@ -863,6 +871,10 @@ def scan_repository(
                     dataset_persisted = True
 
                     ctx.summary = {
+                        # Coverage semantics (#386 + #532): every unit whose
+                        # review state is ACCOUNTED this pass — adopted-
+                        # restored (see units_adopted) plus newly sent. For
+                        # "sent this run" only, subtract units_adopted.
                         "units_reviewed": pre_filter_count,
                         "signals_added": summary["signals_applied"],
                         "entry_points_promoted": summary["entry_points_promoted"],
@@ -872,6 +884,10 @@ def scan_repository(
                         # sets differ in promotions with byte-identical
                         # step reports otherwise.
                         "promote_set": summary.get("promote_set", []),
+                        # #532: adopted units are restored, not re-reviewed —
+                        # the resume provenance (they were reviewed; their
+                        # signals replay under THIS run's promote set).
+                        "units_adopted": reach_stats.get("units_adopted", 0),
                         "post_filter_units": post_filter_count,
                         "refilter_supported": refilter_supported,
                         # #294: the honest coverage numbers — units_reviewed

--- a/libs/openant-core/tests/test_issue532_llr_resume.py
+++ b/libs/openant-core/tests/test_issue532_llr_resume.py
@@ -1,0 +1,540 @@
+"""Tests for issue #532 — the llm-reachability resume/adopt contract.
+
+The stage gains the checkpoint family's resume machinery: per-unit records
+(signals + reviewed-ness + a code projection hash), backend-identity gated via
+the family's ``sync_identity``; dropped/exception batches leave NO records
+(absence IS the retry marker); adopted signals replay through
+``apply_signals`` under the CURRENT promotion policy (promote-only
+preserved); restored usage lands as prior usage, never as zero nor as new
+spend.
+
+Hermetic: the FakeAdapter pattern from test_llm_reachability.py — no network,
+no API key. The tracker is stubbed (the three surfaces this stage touches:
+start/get unit tracking + add_prior_usage).
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import List
+
+from core.llm_reachability import (
+    analyze_reachability,
+    apply_signals,
+)
+
+
+# ---------------------------------------------------------------------------
+# Harness (mirrors test_llm_reachability.py)
+# ---------------------------------------------------------------------------
+
+class FakeAdapter:
+    name = "anthropic"
+    supports_tools = True
+
+    def __init__(self, responses: List[str] | None = None):
+        self._responses = list(responses or [])
+        self.calls: List[dict] = []
+
+    def complete(self, *, model, system, messages, max_tokens, tools=None):
+        from utilities.llm import CompletionResult, TextBlock
+
+        prompt = messages[0].content[0].text
+        self.calls.append({"prompt": prompt, "max_tokens": max_tokens,
+                           "model": model})
+        if not self._responses:
+            text = '{"signals": []}'
+        else:
+            text = self._responses.pop(0)
+        return CompletionResult(
+            content=[TextBlock(text)],
+            input_tokens=10,
+            output_tokens=10,
+            stop_reason="end_turn",
+        )
+
+    def validate(self, model):
+        pass
+
+
+class FakeTracker:
+    """The three tracker surfaces this stage touches (llm_client.TokenTracker)."""
+
+    def __init__(self):
+        self.prior_calls: List[dict] = []
+        self._current = {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}
+
+    def record_call(self, *, model=None, input_tokens=0, output_tokens=0,
+                    pricing=None, usage_details=None):
+        self._current["input_tokens"] += input_tokens or 0
+        self._current["output_tokens"] += output_tokens or 0
+        self._current["cost_usd"] += 0.01  # deterministic per-call price
+
+    def start_unit_tracking(self):
+        self._current = {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}
+
+    def get_unit_usage(self):
+        return dict(self._current)
+
+    def add_prior_usage(self, input_tokens, output_tokens, cost_usd,
+                        unpriced_models=None):
+        self.prior_calls.append(
+            {"input_tokens": input_tokens, "output_tokens": output_tokens,
+             "cost_usd": cost_usd})
+
+
+def _binding(adapter):
+    from utilities.llm import PhaseBinding
+
+    return PhaseBinding(
+        phase="llm_reach",
+        adapter=adapter,
+        model="claude-test",
+        provider_name="anthropic",
+    )
+
+
+def _make_unit(unit_id: str, code: str = "pass", **kw) -> dict:
+    unit = {"id": unit_id, "unit_type": kw.pop("unit_type", "function"),
+            "code": {"primary_code": code}}
+    unit.update(kw)
+    return unit
+
+
+def _canned(*signals) -> str:
+    return json.dumps({"signals": list(signals)})
+
+
+def _sig(unit_id, kind="entry_point", confidence="high", reason="reads argv"):
+    return {"unit_id": unit_id, "kind": kind, "confidence": confidence,
+            "reason": reason}
+
+
+# ---------------------------------------------------------------------------
+# The resume/adopt contract
+# ---------------------------------------------------------------------------
+
+class TestAdopt:
+    def test_second_run_adopts_records_and_makes_no_new_calls(self, tmp_path):
+        """THE #532 regression: a relaunch with existing per-unit records must
+        not re-pay for units whose code projection is unchanged."""
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1"), _make_unit("b:f2")]}
+        canned = _canned(_sig("a:f1"), _sig("b:f2", kind="external_input"))
+
+        first = analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([canned])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        assert len(first) == 2
+
+        # Second run: a fresh adapter with NO canned responses would blow up
+        # (pop from empty) if any unit re-ran; with full adoption it is never
+        # called at all.
+        second = analyze_reachability(
+            dataset, binding=_binding(FakeAdapter()),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        assert {s.unit_id for s in second} == {"a:f1", "b:f2"}
+        assert {s.kind for s in second} == {"entry_point", "external_input"}
+
+    def test_edited_unit_reruns_only_itself(self, tmp_path):
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        u1, u2 = _make_unit("a:f1"), _make_unit("b:f2")
+        dataset = {"units": [u1, u2]}
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"), _sig("b:f2"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        # Edit one unit's code: its projection no longer matches the record.
+        u2["code"]["primary_code"] = "def changed(): return 2"
+        adapter = FakeAdapter([_canned(_sig("b:f2"))])
+        analyze_reachability(
+            dataset, binding=_binding(adapter), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        assert len(adapter.calls) == 1
+        assert "b:f2" in adapter.calls[0]["prompt"]
+
+    def test_new_unit_runs_foreign_record_ignored(self, tmp_path):
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        dataset = {"units": [_make_unit("a:f1"), _make_unit("c:f3")]}
+        adapter = FakeAdapter([_canned(_sig("c:f3"))])
+        analyze_reachability(
+            dataset, binding=_binding(adapter), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        assert len(adapter.calls) == 1
+
+    def test_removed_unit_record_not_adopted(self, tmp_path):
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1"), _make_unit("b:f2")]}
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"), _sig("b:f2"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        # b:f2 removed: its foreign record must not inject a signal.
+        dataset = {"units": [_make_unit("a:f1")]}
+        second = analyze_reachability(
+            dataset, binding=_binding(FakeAdapter()), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        assert {s.unit_id for s in second} == {"a:f1"}
+
+
+class TestRetryMarkers:
+    def test_dropped_batch_writes_no_records(self, tmp_path):
+        """A malformed batch must leave no records: absence IS the retry
+        marker (the #386 counter family + #532's 'must not freeze drops')."""
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1"), _make_unit("b:f2")]}
+        # Malformed JSON for the whole (single) batch.
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter(["not json {"])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        adapter = FakeAdapter([_canned(_sig("a:f1"), _sig("b:f2"))])
+        analyze_reachability(
+            dataset, binding=_binding(adapter), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        # Both units had no records -> both re-ran in one batch.
+        assert len(adapter.calls) == 1
+
+    def test_exception_batch_writes_no_records(self, tmp_path):
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+
+        class Boom(FakeAdapter):
+            def complete(self, **kw):
+                raise RuntimeError("provider exploded")
+
+        analyze_reachability(
+            dataset, binding=_binding(Boom()), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        adapter = FakeAdapter([_canned(_sig("a:f1"))])
+        analyze_reachability(
+            dataset, binding=_binding(adapter), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        assert len(adapter.calls) == 1
+
+    def test_save_oserror_surfaced_not_fatal(self, tmp_path, monkeypatch):
+        """The stage's own doctrine: advisory, never crash the pipeline. A
+        checkpoint write failure costs persistence, not the pass."""
+        from core import checkpoint as ckpt_mod
+
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        errors: List[str] = []
+
+        def flaky_save(self, unit_id, data):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(ckpt_mod.StepCheckpoint, "save", flaky_save)
+        signals = analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(), on_error=errors.append,
+        )
+        assert {s.unit_id for s in signals} == {"a:f1"}
+        assert any("disk full" in e for e in errors)
+
+
+class TestPromoteOnly:
+    def test_adopted_signal_replays_under_current_promote_set(self, tmp_path, monkeypatch):
+        """Adopted SIGNALS (not promotion outcomes): apply_signals runs fresh
+        under the CURRENT OPENANT_PROMOTE_ENTRY_POINT_AT — a medium signal
+        recorded under a strict set promotes under a widened one."""
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        # First run under a config that promotes nothing (record the medium).
+        monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", "high")
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter(
+                [_canned(_sig("a:f1", confidence="medium"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        # Second run, full adoption, medium not promotable.
+        signals = analyze_reachability(
+            dataset, binding=_binding(FakeAdapter()), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        summary = apply_signals({"units": [_make_unit("a:f1")]}, signals)
+        assert summary["entry_points_promoted"] == 0
+        # Widen the set on the SAME adopted record: the medium now promotes —
+        # the policy is read at APPLY time, never frozen in the record.
+        monkeypatch.setenv("OPENANT_PROMOTE_ENTRY_POINT_AT", "high,medium")
+        summary = apply_signals({"units": [_make_unit("a:f1")]}, signals)
+        assert summary["entry_points_promoted"] == 1
+
+    def test_adopted_signal_never_demotes(self, tmp_path):
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        kept = {"units": [_make_unit("a:f1", is_entry_point=True)]}
+        signals = analyze_reachability(
+            dataset, binding=_binding(FakeAdapter()), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        apply_signals(kept, signals)
+        assert kept["units"][0]["is_entry_point"] is True
+
+
+class TestBoundaries:
+    def test_backend_change_invalidates_records(self, tmp_path):
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        # A different model = a different backend identity: adopt nothing.
+        from utilities.llm import PhaseBinding
+        other = PhaseBinding(
+            phase="llm_reach", adapter=FakeAdapter([_canned(_sig("a:f1"))]),
+            model="claude-other", provider_name="anthropic",
+        )
+        adapter = other.adapter
+        analyze_reachability(dataset, binding=other, checkpoint_path=cp,
+                             tracker=FakeTracker())
+        assert len(adapter.calls) == 1
+
+    def test_out_of_batch_signal_not_carried(self, tmp_path):
+        """The disclosed behavior change: valid_unit_ids is per-batch, so a
+        signal for a unit outside the producing batch is ungrounded by
+        construction — adopted state must equal applied state."""
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        # Two units, batch size forces two batches (one unit each).
+        dataset = {"units": [_make_unit("a:f1"), _make_unit("b:f2")]}
+        canned = [_canned(_sig("a:f1"), _sig("b:f2")),  # batch 1: a:f1 (+ out-of-batch b:f2)
+                  _canned()]                             # batch 2: b:f2 (nothing)
+        signals = analyze_reachability(
+            dataset, binding=_binding(FakeAdapter(canned)), batch_size=1,
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        # b:f2's signal came from batch 1 (out of batch) — filtered there.
+        assert {s.unit_id for s in signals} == {"a:f1"}
+        # The out-of-batch signal must NOT have been persisted into b:f2's
+        # record (batch 2 reviewed it and found nothing — signals == []).
+        import json as _json
+        with open(os.path.join(cp, "b_f2.json")) as fh:
+            rec_b = _json.load(fh)
+        assert rec_b["signals"] == []
+        assert rec_b["projection_sha"]
+        # And a:f1's record carries only its own in-batch signal.
+        with open(os.path.join(cp, "a_f1.json")) as fh:
+            rec_a = _json.load(fh)
+        assert [s["unit_id"] for s in rec_a["signals"]] == ["a:f1"]
+
+
+class TestUsageAndSummary:
+    def test_adopted_usage_lands_as_prior_usage(self, tmp_path):
+        """Restored cost is PRIOR usage on the tracker — never zero, never
+        counted as this run's new spend (the #26/#26b lessons)."""
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        tracker = FakeTracker()
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter()), checkpoint_path=cp,
+            tracker=tracker,
+        )
+        assert tracker.prior_calls, "adopted records must inject prior usage"
+        assert tracker.prior_calls[0]["input_tokens"] > 0
+
+    def test_summary_shape(self, tmp_path):
+        """_summary.json: completed counts records (reviewed-ness incl. empty
+        signals), errors=0 (the #311 summary-vs-status drift class: status()
+        counts errors from FILES; dropped units live in the step report)."""
+        from core.checkpoint import StepCheckpoint
+
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1"), _make_unit("b:f2")]}
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        s = StepCheckpoint.read_summary(cp)
+        assert s["total_units"] == 2
+        assert s["completed"] == 2  # b:f2 reviewed with no signal
+        assert s["errors"] == 0
+        assert s["incomplete"] == 0
+        assert s["phase"] == "done"
+
+    def test_summary_incomplete_when_batches_dropped(self, tmp_path):
+        """#293 three-state invariant: un-reviewed units (a dropped batch)
+        land in `incomplete`, phase stays in_progress — never a clean-done
+        summary over a pass that did not complete (the review-wave finding)."""
+        from core.checkpoint import StepCheckpoint
+
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1"), _make_unit("b:f2")]}
+        # Malformed response drops the whole (single) batch.
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter(["not json {"])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        s = StepCheckpoint.read_summary(cp)
+        assert s["completed"] == 0
+        assert s["incomplete"] == 2
+        assert s["errors"] == 0  # absence is the retry marker, not an error
+        assert s["phase"] == "in_progress"
+
+
+class TestWaveFixes:
+    """The adversarial review round's (2026-09-08) findings, pinned."""
+
+    def test_tracker_fallback_resolves_global(self, tmp_path):
+        """The production shape: no tracker passed — the global tracker must
+        still make records carry nonzero usage (records with zeros would
+        restore zeros even after any later fix; the HIGH wave finding)."""
+        from core.llm_reachability import analyze_reachability as ar
+
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        ar(dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+           checkpoint_path=cp)  # NOTE: no tracker kwarg — production shape
+        import json as _json
+        with open(os.path.join(cp, "a_f1.json")) as fh:
+            rec = _json.load(fh)
+        assert rec["usage"]["input_tokens"] > 0
+        assert rec["usage"]["output_tokens"] > 0
+        # #216: the fake model is unpriced in config -> the incomplete-cost
+        # marker must travel into the record.
+        assert rec["usage"].get("cost_incomplete") is True
+        assert rec["usage"].get("unpriced_models") == ["claude-test"]
+
+    def test_projection_hashes_the_prompt_bytes(self, tmp_path):
+        """The golden invariant: projection_sha is over EXACTLY what the
+        prompt sends — a `source`-fallback unit and a str-code unit must hash
+        their real bytes, never crash, never hash empty (the wave finding:
+        _unit_for_prompt's extraction, not a private reimplementation)."""
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [
+            {"id": "s:f1", "unit_type": "function",
+             "code": {"source": "reads_env()"}},   # source fallback
+            {"id": "t:f1", "unit_type": "function",
+             "code": "raw_string_body"},            # str code
+        ]}
+        adapter = FakeAdapter([_canned(), _canned()])
+        analyze_reachability(
+            dataset, binding=_binding(adapter), batch_size=1,
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        # A str/source edit re-runs (the hashes captured real bytes).
+        dataset["units"][0]["code"]["source"] = "edited_body()"
+        dataset["units"][1]["code"] = "edited_str"
+        rerun = FakeAdapter([_canned(), _canned()])
+        analyze_reachability(
+            dataset, binding=_binding(rerun), batch_size=1,
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        assert len(rerun.calls) == 2  # both re-ran: neither hashed empty
+
+    def test_malformed_prior_record_not_adopted(self, tmp_path):
+        """A record whose signals are malformed must NOT adopt as reviewed —
+        the unit re-runs (the FN direction)."""
+        import json as _json
+
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        # Corrupt the record's signals in place.
+        p = os.path.join(cp, "a_f1.json")
+        with open(p) as fh:
+            rec = _json.load(fh)
+        rec["signals"] = [{"not": "a signal shape"}]
+        with open(p, "w") as fh:
+            _json.dump(rec, fh)
+        rerun = FakeAdapter([_canned(_sig("a:f1"))])
+        analyze_reachability(
+            dataset, binding=_binding(rerun), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        assert len(rerun.calls) == 1  # re-ran, not adopted
+
+    def test_checkpoint_init_oserror_runs_unpersisted(self, tmp_path, monkeypatch):
+        """An unwritable checkpoint dir costs persistence, never the pass —
+        the stage runs and returns signals."""
+        from core.checkpoint import StepCheckpoint
+
+        def boom(self, fingerprint, *, verbose=True):
+            raise OSError("EACCES")
+
+        monkeypatch.setattr(StepCheckpoint, "sync_identity", boom)
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1")]}
+        errors: List[str] = []
+        signals = analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(), on_error=errors.append,
+        )
+        assert {s.unit_id for s in signals} == {"a:f1"}
+        assert any("unpersisted" in e for e in errors)
+
+
+class TestDeepRefuteFixes:
+    """The final adversarial round (2026-09-08), pinned."""
+
+    def test_null_unit_type_coerces_not_crashes(self, tmp_path):
+        """A malformed unit (unit_type=None / code=None) costs the hash one
+        line, never the whole stage (the FN-direction deep-refute finding)."""
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [
+            {"id": "n:f1", "unit_type": None, "code": None},
+            _make_unit("a:f1"),
+        ]}
+        # batch 1 = n:f1 (malformed, empty reply); batch 2 = a:f1 (signal).
+        adapter = FakeAdapter([_canned(), _canned(_sig("a:f1"))])
+        signals = analyze_reachability(
+            dataset, binding=_binding(adapter), batch_size=1,
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        assert {s.unit_id for s in signals} == {"a:f1"}
+
+    def test_pass_start_writes_in_progress_summary(self, tmp_path):
+        """The stale-done hazard: a run killed mid-loop after a prior
+        completed pass must leave phase=in_progress (the Go sweep reads
+        phase=='done' && errors==0 as nothing-to-resume, checkpoint.go:115)."""
+        from core.checkpoint import StepCheckpoint
+
+        cp = str(tmp_path / "llm_reach_checkpoints")
+        dataset = {"units": [_make_unit("a:f1"), _make_unit("b:f2")]}
+        # A completed prior pass: summary says done.
+        analyze_reachability(
+            dataset, binding=_binding(FakeAdapter([_canned(_sig("a:f1"))])),
+            checkpoint_path=cp, tracker=FakeTracker(),
+        )
+        assert StepCheckpoint.read_summary(cp)["phase"] == "done"
+        # An interrupted re-run (one unit edited, killed before the loop can
+        # finish): simulate by checking the START summary of a fresh call —
+        # patch the adapter to raise mid-pass and verify the on-disk phase.
+        class KillMidPass(FakeAdapter):
+            def complete(self, **kw):
+                raise RuntimeError("killed")
+
+        # One unit edited: it re-runs, the pass dies mid-loop, and the
+        # START summary (in_progress) is what survives on disk.
+        dataset["units"][1]["code"]["primary_code"] = "def edited(): pass"
+        analyze_reachability(
+            dataset, binding=_binding(KillMidPass()), checkpoint_path=cp,
+            tracker=FakeTracker(),
+        )
+        s = StepCheckpoint.read_summary(cp)
+        assert s["phase"] == "in_progress"
+        assert s["incomplete"] >= 1


### PR DESCRIPTION
## Summary

A relaunch re-ran the whole llm-reachability pass (~$10 + ~70 min duplicated on a 5.4K-unit run) while every other LLM stage restored from checkpoints. The stage now uses the checkpoint family's own machinery:

- **per-unit records** `{signals, projection_sha, usage}` — a "reviewed, no signal" outcome IS a record (the majority case; signals alone cannot resume);
- the **backend-identity KEY** gates adoption (model/provider/adapter/base_url + the static template rendered with `app_context=None` — app-context content is excluded: it regenerates non-deterministically every scan, and content keying is the verified spurious-re-pay trap at LLR prices);
- **projection_sha hashes exactly the bytes the prompt sends** (`_unit_for_prompt`'s projection) — a body edit under the same id re-runs; null/non-str fields coerce rather than skip the stage;
- **dropped and exception batches leave no records** — absence IS the retry marker (no frozen coverage gaps, no error records the #311 drift class would miscount); the summary honors the #293 three-state invariant, with an `in_progress` phase written at pass start so the resume/fresh prompt sees a killed run correctly;
- **adopted signals (not promotion outcomes) replay** through `apply_signals` under the CURRENT promotion policy — promote-only semantics preserved (a `medium` recorded under a strict set promotes under a widened one);
- **restored usage lands as prior usage** (`add_prior_usage`; the #216 unpriced-model marker travels with per-record usage and restores across resume);
- `scan.go`'s fresh-start probe list gains `llm_reach` (the most expensive phase; an explicit fresh start can now discard it).

**Disclosed behavior change:** `valid_unit_ids` is per-batch — an out-of-batch signal was applied but never persisted, so adopted state now equals applied state; cross-batch ids were hallucination-only inputs that could wrongly seed the structural re-filter.

**Named residuals:** checkpoint records are forgeable by a directory writer — the same filesystem-bound residual the analyze/verify/enhance checkpoint family has always carried; an app-context change does not invalidate records (the KEY exclusion, same tier as analyze's).

Closes #532.

## Test plan

20 new tests in `tests/test_issue532_llr_resume.py`: adoption/no-repay, edited-unit re-run, foreign/removed records, dropped-batch and exception-batch retry, promote-set replay (recorded under `high`, promotes under `high,medium`), backend-change invalidation, out-of-batch signal isolation, prior-usage restore, the two summary shapes (done + interrupted), OSError tolerance (save + init), null-field coercion, the stale-done hazard, and the projection/prompt golden invariant (str and source-fallback code shapes).

## Verification evidence

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue532_llr_resume.py -q` | 20 passed |
| family regression | `pytest tests/test_llm_reachability.py -q` | 30 passed |
| full suite | `pytest tests/ -q` | 3933 passed, 2 failed — both pre-existing (SDK pin drift; verified failing on the pristine base by reverting this change and re-running) |
| static analysis | ruff / Semgrep / CodeQL | clean / 0 findings / 0 findings in this diff (one pre-existing `empty-except` in scanner.py outside the touched hunks) |
| Go side | `gofmt -l` / `go vet ./cmd/` / `go build ./...` | clean / clean / builds |

End-to-end, live binding (`e2e-raptor-20260907`, a 2-language corpus, base @ master vs this branch, freshly built binaries per side):
- fresh base-vs-fix, python (4 units): identical coverage and promotions (6 signals / 3 promoted / 0 dropped both sides); one signal's confidence differed — the model's own run-over-run variance, no coverage effect;
- fresh base-vs-fix, go (3 units): **byte-identical** signals, kinds, confidences, and the same promotion;
- resume (this branch, same output dir): `units_adopted: 4`, LLR duration **0.0s** with **no new LLM spend**, the prior pass's cost restored as prior usage, the same signals replayed and the same promotions — vs the pre-fix behavior of re-paying the full pass every relaunch.
