### PR TITLE
fix(dynamic-test): counted errors make the step partial — the #285/#376 status contract honored via a shared summary helper (#533)

### DIFF
--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 from core.schemas import (
     ScanResult, AnalysisMetrics, StepReport, verify_step_summary,
+    dynamic_test_step_summary,
 )
 from core.step_report import step_context
 from core import tracking
@@ -1246,14 +1247,7 @@ def scan_repository(
                         repo_path=repo_path,
                     )
 
-                    ctx.summary = {
-                        "findings_tested": dt_result.findings_tested,
-                        "confirmed": dt_result.confirmed,
-                        "not_reproduced": dt_result.not_reproduced,
-                        "blocked": dt_result.blocked,
-                        "inconclusive": dt_result.inconclusive,
-                        "errors": dt_result.errors,
-                    }
+                    ctx.summary = dynamic_test_step_summary(dt_result)
                     ctx.outputs = {
                         "results_json_path": dt_result.results_json_path,
                         "results_md_path": dt_result.results_md_path,

--- a/libs/openant-core/core/schemas.py
+++ b/libs/openant-core/core/schemas.py
@@ -421,6 +421,38 @@ class DynamicTestStepResult:
     def to_dict(self) -> dict:
         return asdict(self)
 
+    def step_summary(self) -> dict:
+        return dynamic_test_step_summary(self)
+
+
+def dynamic_test_step_summary(result: "DynamicTestStepResult") -> dict:
+    """The dynamic-test step-report summary (#533; the #300 verify pattern).
+
+    Shared by every construction site — core/scanner.py (the pipeline) and
+    openant/cli.py's standalone ``openant dynamic-test`` — so the sites
+    cannot drift. ``error_count`` is the #285/#376 partial-status contract's
+    well-typed int (``step_report.py`` derives ``partial`` from it and from
+    the ctx error list, never from ``summary["errors"]``); the ``errors``
+    key is retained as the persisted display contract (an int count here —
+    do NOT widen the status contract to read it: the same word is a list of
+    strings one level up on StepReport itself).
+
+    Reconciliation bound (the verify precedent): ``confirmed + not_reproduced
+    + blocked + inconclusive + errors <= findings_tested`` — the gap is the
+    language-SKIPPED rows (and any restored row whose persisted status falls
+    outside the five counted words); restored checkpoints ARE counted into
+    their buckets, and SKIPPED rows are deliberately not counted as errors.
+    """
+    return {
+        "findings_tested": result.findings_tested,
+        "confirmed": result.confirmed,
+        "not_reproduced": result.not_reproduced,
+        "blocked": result.blocked,
+        "inconclusive": result.inconclusive,
+        "errors": result.errors,
+        "error_count": result.errors,
+    }
+
 
 # ---------------------------------------------------------------------------
 # Step Report — written as {step}.report.json by every pipeline step

--- a/libs/openant-core/openant/cli.py
+++ b/libs/openant-core/openant/cli.py
@@ -779,7 +779,7 @@ def cmd_build_output(args):
 def cmd_dynamic_test(args):
     """Run Docker-isolated dynamic exploit testing."""
     from core.dynamic_tester import run_tests
-    from core.schemas import success, error
+    from core.schemas import success, error, dynamic_test_step_summary
     from core.step_report import step_context
     from core import tracking
 
@@ -800,14 +800,7 @@ def cmd_dynamic_test(args):
                 llm_config_name=args.llm_config,
             )
 
-            ctx.summary = {
-                "findings_tested": result.findings_tested,
-                "confirmed": result.confirmed,
-                "not_reproduced": result.not_reproduced,
-                "blocked": result.blocked,
-                "inconclusive": result.inconclusive,
-                "errors": result.errors,
-            }
+            ctx.summary = dynamic_test_step_summary(result)
             ctx.outputs = {
                 "results_json_path": result.results_json_path,
                 "results_md_path": result.results_md_path,

--- a/libs/openant-core/tests/test_issue533_dt_status_contract.py
+++ b/libs/openant-core/tests/test_issue533_dt_status_contract.py
@@ -1,0 +1,141 @@
+"""Tests for issue #533 — the dynamic-test step status contract.
+
+The dynamic-test producer wrote its counted failures under ``summary["errors"]``
+(an int), but the #285/#376 partial-status contract reads
+``summary["error_count"]`` (the well-typed int) or the ctx error list — so a
+dynamic-test run with counted generation/build failures reported
+``status: "success"`` (the receipt: a monitored run's
+``dynamic-test.report.json`` carried ``"status": "success"`` beside
+``"errors": 1``).
+
+The fix: a shared ``dynamic_test_step_summary()`` helper in core/schemas.py
+(the #300 verify_step_summary precedent — one construction shape so the
+pipeline and the standalone CLI cannot drift), adding ``error_count`` beside
+the retained ``errors`` key. Both call sites (core/scanner.py, openant/cli.py)
+use it.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+
+from core.schemas import (
+    DynamicTestStepResult,
+    ScanResult,
+    dynamic_test_step_summary,
+)
+from core.step_report import step_context
+
+
+def _dt_result(errors=1, confirmed=0):
+    return DynamicTestStepResult(
+        findings_tested=2, confirmed=confirmed, not_reproduced=0, blocked=0,
+        inconclusive=0, errors=errors,
+        results_json_path="/x.json", results_md_path="/x.md",
+    )
+
+
+class TestStatusContract:
+    def test_counted_errors_make_status_partial(self, tmp_path):
+        """THE #533 regression: a dynamic-test step with a counted failure
+        must report partial, never success."""
+        out = str(tmp_path)
+        # The FIXED producer shape (the shared helper — what both call
+        # sites now write): a counted error must read partial. On the
+        # pristine base the helper does not exist (the machinery RED).
+        with step_context("dynamic-test", out) as ctx:
+            ctx.summary = dynamic_test_step_summary(_dt_result(errors=1))
+        with open(os.path.join(out, "dynamic-test.report.json")) as fh:
+            report = json.load(fh)
+        assert report["status"] == "partial", (
+            f"a counted dynamic-test failure must not read success; got "
+            f"{report['status']!r} — summary: {report.get('summary')}")
+        assert report["summary"]["error_count"] == 1
+        # The errors key is a persisted contract — retained, not dropped.
+        assert report["summary"]["errors"] == 1
+
+    def test_zero_errors_stay_success(self, tmp_path):
+        out = str(tmp_path)
+        with step_context("dynamic-test", out) as ctx:
+            ctx.summary = dynamic_test_step_summary(_dt_result(errors=0))
+        with open(os.path.join(out, "dynamic-test.report.json")) as fh:
+            report = json.load(fh)
+        assert report["status"] == "success"
+        assert report["summary"]["error_count"] == 0
+
+    def test_helper_is_the_shared_shape(self):
+        """The #300 pattern: ONE construction site for the summary dict."""
+        helper = getattr(sys.modules['core.schemas'], 'dynamic_test_step_summary', None)
+        assert helper is not None, "dynamic_test_step_summary must exist in core/schemas.py"
+        result = DynamicTestStepResult(
+            findings_tested=2, confirmed=1, not_reproduced=0, blocked=0,
+            inconclusive=0, errors=1,
+            results_json_path="/x.json", results_md_path="/x.md",
+        )
+        s = helper(result)
+        assert s["error_count"] == 1
+        assert s["errors"] == 1        # the display key retained
+        assert s["confirmed"] == 1
+        assert set(s) == {
+            "findings_tested", "confirmed", "not_reproduced", "blocked",
+            "inconclusive", "errors", "error_count",
+        }
+
+    def test_both_call_sites_use_the_helper(self):
+        """Both producers route through the shared shape — the standalone
+        CLI site (openant/cli.py) must not drift from the pipeline site
+        (core/scanner.py); the need-check round found the second site."""
+        repo = os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__)))))
+        with open(os.path.join(repo, "libs", "openant-core",
+                            "core", "scanner.py")) as fh:
+            scanner_src = fh.read()
+        with open(os.path.join(repo, "libs", "openant-core",
+                                "openant", "cli.py")) as fh:
+            cli_src = fh.read()
+        assert "dynamic_test_step_summary(" in scanner_src
+        assert "dynamic_test_step_summary(" in cli_src
+        # Exclusivity (the review round): no THIRD inline construction site
+        # may appear in either file — the helper is the only shape.
+        assert '"findings_tested":' not in scanner_src
+        assert '"findings_tested":' not in cli_src
+
+    def test_aggregate_inherits_partial(self, tmp_path):
+        """The aggregate walk: clean steps + one partial dynamic-test ⇒
+        the scan report's status is partial (an otherwise-clean aggregate
+        must not stay green over a failed dynamic test)."""
+        from core.scanner import _write_scan_report
+
+        clean = {"status": "success", "cost_usd": 0.0, "duration_seconds": 1.0,
+                 "token_usage": {}}
+        partial = {"status": "partial", "cost_usd": 0.01, "duration_seconds": 2.0,
+                   "token_usage": {}, "summary": {"error_count": 1}}
+        result = ScanResult(
+            output_dir=str(tmp_path), language="python",
+            units_count=2, languages=["python"],
+        )
+        p = _write_scan_report(str(tmp_path), result, [clean, partial])
+        with open(p) as fh:
+            agg = json.load(fh)
+        assert agg["status"] == "partial"
+
+    def test_scanner_block_orders_helper_before_degrade(self):
+        """The wiring-order tripwire (the review round): the helper assignment
+        sits INSIDE the dynamic-test step_context body BEFORE the degrade
+        except (a regression moving it after the catch would erase the
+        counted-failure evidence with the skip dict)."""
+        repo = os.path.dirname(os.path.dirname(os.path.dirname(
+            os.path.dirname(os.path.abspath(__file__)))))
+        with open(os.path.join(repo, "libs", "openant-core",
+                               "core", "scanner.py")) as fh:
+            src = fh.read()
+        block = src[src.index('step_context("dynamic-test"'):]
+        block = block[:block.index("with step_context", 10) if "with step_context" in block[10:] else len(block)]
+        i_helper = block.index("dynamic_test_step_summary(")
+        i_degrade = block.index('ctx.summary = {"skipped": True')
+        assert i_helper < i_degrade, (
+            "the summary assignment must precede the degrade except; "
+            f"helper at {i_helper}, degrade at {i_degrade}")


### PR DESCRIPTION
## Summary

The dynamic-test producer wrote its counted failures under `summary["errors"]` (an int), but the `#285`/`#376` partial-status contract reads `summary["error_count"]` (the well-typed int) or the ctx error list — so a dynamic-test run with counted generation/build failures reported `status: "success"` (receipt: a monitored run's `dynamic-test.report.json` carried `"status": "success"` beside `"errors": 1` with a build failure in `error_breakdown`).

The fix, following the `#300` `verify_step_summary` pattern:

- **`dynamic_test_step_summary()`** in `core/schemas.py` is the ONE construction shape — the pipeline site (`core/scanner.py`) and the standalone `openant dynamic-test` site (`openant/cli.py`, the site the issue text missed) both route through it, so the sites cannot drift;
- it adds **`error_count`** beside the retained **`errors`** display key — the status contract is *not* widened to read `summary["errors"]`: the same word is a list of strings one level up on `StepReport`, and keeping one type per level is deliberate;
- a counted-failure step now reads **`partial`**; an otherwise-clean aggregate inherits it through the `_STATUS_RANK` walk; the Go SARIF `stepReportIsFailure` consumer flips `executionSuccessful` on the `error_count` it could already read (the CI-gate effect `#285` exists to deliver);
- the exception/degrade path is unchanged: a propagating error still reads `error`/`skipped` (the derivation's precedence at `core/step_report.py` is untouched).

**Disclosed residual (out of scope, named):** the standalone command's envelope still says `success(...)` and exits 0 on counted errors (only `confirmed > 0` sets exit 1) — the step report and the envelope now disagree where both previously lied success. This is the same envelope shape `verify` and `enhance` already have, tracked as a separate exit-code question. The reconciliation bound is documented on the helper (the `verify` precedent: the counters are a `<=`, the gap being language-SKIPPED rows).

Closes #533.

## Test plan

6 tests in `tests/test_issue533_dt_status_contract.py`:
- the RED case: a counted error through the real `step_context` → on-disk `partial` with `error_count == 1` and `errors` retained;
- zero errors stay `success`;
- the helper's exact key set (the seven-key contract);
- both call sites route through the helper (source tripwire) **and** no third inline construction site exists in either file (exclusivity grep);
- the helper call precedes the degrade `except` in the scanner block (the wiring-order tripwire);
- the aggregate `_write_scan_report` walk: clean steps + a partial dynamic-test ⇒ scan `partial`.

## Verification evidence

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue533_dt_status_contract.py -q` | 6 passed |
| family regression | `pytest tests/test_issue285_scan_report_status.py tests/test_issue311_dynamic_test_counters.py tests/test_issue431_dyntest_raise_accounting.py tests/test_artifact_serialization_contract.py -q` | 30 passed |
| full suite | `pytest tests/ -q` | 3920 passed, 2 failed — both pre-existing (SDK pin drift, verified on the pristine base by reverting this change) |
| static analysis | ruff / Semgrep / CodeQL | clean / 0 / 0 in this diff (the one new CodeQL hit — a test import style — normalized) |
| domain safety (stage 8) | structural parse base-vs-fix on a real corpus, `OPENANT_CORE_PATH` per tree | `dataset.json` units **byte-identical** (3/3, flags + entry-point reasons), `call_graph.json` identical — the deterministic pipeline core untouched |
| consumer trace | the hand-traced end-to-end (producer → step report → aggregate → sarif) | the only changes: step status success→partial on counted errors, the aggregate inheriting it, SARIF `executionSuccessful` flipping — every other consumer byte-identical |
