### PR TITLE
fix(report): Stage 2's explanation reaches the disclosure body — the dead hook repopulated, the deterministic banner carries the explanation (#534)

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -586,6 +586,13 @@ def build_pipeline_output(
                or finding.get("verification_explanation") else {}),
             **({"verification_note": finding["verification_note"]}
                if finding.get("verification_note") else {}),
+            # #534 gate fold (fable+astra): the consistency pass rewrites
+            # the verdict WITHOUT touching verification["explanation"] — the
+            # banner can stamp an updated status beside the explanation that
+            # argued for the original one. Carry the update present-only so
+            # the banner can attribute the pre-update explanation correctly.
+            **({"consistency_update": finding["consistency_update"]}
+               if isinstance(finding.get("consistency_update"), dict) else {}),
             # #215 (partial repair): the two FINDING-SEMANTIC transit
             # fields — confidence (float 0.0-1.0 per the verdict schema,
             # json_corrector.py:32; NOT analysis_core.py:181's error-shape

--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -497,8 +497,17 @@ def build_pipeline_output(
                 else:
                     flow_str = _coerce_to_str(data_flow)
                 parts.append("Data flow: " + flow_str)
-            if finding.get("verification_explanation"):
-                parts.append("Verification: " + _coerce_to_str(finding["verification_explanation"]))
+            # #534: read Stage 2's explanation from where the verify stage
+            # actually writes it (finding["verification"]["explanation"]),
+            # with the legacy top-level key as fallback — the old read was a
+            # hook to a key NO PRODUCER wrote (the disclosure body could
+            # assert what Stage 2 refuted).
+            _v = finding.get("verification")
+            if not isinstance(_v, dict):
+                _v = {}
+            _v_expl = _v.get("explanation") or finding.get("verification_explanation")
+            if _v_expl:
+                parts.append("Verification: " + _coerce_to_str(_v_expl))
             steps_to_reproduce = "\n\n".join(parts) if parts else None
 
         # Determine stage2 verdict.
@@ -564,6 +573,19 @@ def build_pipeline_output(
             "cwe_name": vuln.get("cwe_name") or finding.get("cwe_name") or full_result.get("cwe_name", "Unknown"),
             "stage1_verdict": finding.get("verdict", finding.get("finding", "vulnerable")),
             "stage2_verdict": stage2_verdict,
+            # #534: Stage 2's text reaches the disclosure prompt as OWN
+            # record keys. Fresh-wins precedence (the verify dict is the
+            # authoritative Stage-2 record — the same precedence as the
+            # steps-rebuild path); coerced (dict-shaped explanations are a
+            # real model-output class); the note is the TOP-LEVEL
+            # verification_note the verifier actually writes; present-only.
+            **({"verification_explanation":
+                    _coerce_to_str(verification.get("explanation")
+                                  or finding.get("verification_explanation"))}
+               if (isinstance(verification, dict) and verification.get("explanation"))
+               or finding.get("verification_explanation") else {}),
+            **({"verification_note": finding["verification_note"]}
+               if finding.get("verification_note") else {}),
             # #215 (partial repair): the two FINDING-SEMANTIC transit
             # fields — confidence (float 0.0-1.0 per the verdict schema,
             # json_corrector.py:32; NOT analysis_core.py:181's error-shape

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -529,9 +529,33 @@ def _disclosure_verdict_header(vulnerability_data: dict) -> str:
     if qual:
         # #534: blockquote-safe — a multi-paragraph explanation must stay
         # inside the banner block (a bare \n\n would dump the rest as
-        # top-level prose above the model's H1).
-        lines.append("> **Stage-2 explanation:** "
-                     + qual.replace("\n", "\n> "))
+        # top-level prose above the model's H1). The gate fold adds newline
+        # normalization first: CommonMark treats \r\n and bare \r as line
+        # endings, so an unnormalized \r would escape the > prefix (fable's
+        # finding — a Windows/legacy-model output shape would break out).
+        _norm = qual.replace("\r\n", "\n").replace("\r", "\n")
+        _had_update = isinstance(vulnerability_data.get("consistency_update"), dict)
+        _label = ("Stage-2 explanation (pre-dating the consistency update — "
+                  "the verdict shown above was changed after this reasoning):"
+                  if _had_update else "Stage-2 explanation:")
+        # The banner length is DELIBERATELY UNBOUNDED (the fable+astra gate
+        # decision, recorded here): the explanation's gate clause ("the path
+        # is gated by...") is the entire point of #534 — a cap risks cutting
+        # it when it appears late in a multi-paragraph analysis. Both
+        # sibling consumers cap at 300 for their own surfaces (the CLI
+        # summary; the HTML justification line); this surface — the
+        # reporter-facing disclosure body — preserves the full reasoning by
+        # design. The docstring records the decision; the multi-paragraph
+        # test pins the containment.
+        lines.append(f"> **{_label}** " + _norm.replace("\n", "\n> "))
+        # The gate fold: attribute the verdict transition when it happened.
+        cu = vulnerability_data.get("consistency_update")
+        if _had_update:
+            _from = str(cu.get("from") or "?").strip()
+            _to = str(cu.get("to") or "?").strip()
+            _reason = str(cu.get("reason") or "").strip()
+            _reason_part = f" — {_reason}" if _reason else ""
+            lines.append(f"> **Consistency update:** {_from} → {_to}{_reason_part}")
 
     return "\n".join(lines) + "\n\n"
 

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -470,7 +470,9 @@ def _disclosure_verdict_header(vulnerability_data: dict) -> str:
     Lets a reader distinguish an attacker-simulation-confirmed finding from a
     not-yet-confirmed one without trusting the LLM to render the "Verified via
     ..." line (dropped in most documents), and stamps the real file/function
-    location the "{affected_versions}" prompt field never carries.
+    location the "{affected_versions}" prompt field never carries. Placement
+    is deterministic; the explanation line's CONTENT is Stage-2 model text
+    (repo-influenced) — deterministically placed, not server-authored.
     """
     verdict = str(vulnerability_data.get("stage2_verdict") or "").lower()
     stage1 = str(vulnerability_data.get("stage1_verdict") or "").lower()
@@ -517,6 +519,20 @@ def _disclosure_verdict_header(vulnerability_data: dict) -> str:
     if isinstance(loc, dict) and (loc.get("file") or loc.get("function")):
         where = ":".join(str(x) for x in (loc.get("file"), loc.get("function")) if x)
         lines.append(f"> **Location:** {where}")
+    # #534: the Stage-2 QUALIFICATION line, stated verbatim — the one piece
+    # of Stage 2's reasoning a reader must not lose to the model's prose. The
+    # banner is deterministic and server-stamped, so the qualification cannot
+    # be dropped the way the in-body "Verification:" line was (the receipt:
+    # a disclosure asserted the exact path Stage 2's explanation said was
+    # gated).
+    qual = str(vulnerability_data.get("verification_explanation") or "").strip()
+    if qual:
+        # #534: blockquote-safe — a multi-paragraph explanation must stay
+        # inside the banner block (a bare \n\n would dump the rest as
+        # top-level prose above the model's H1).
+        lines.append("> **Stage-2 explanation:** "
+                     + qual.replace("\n", "\n> "))
+
     return "\n".join(lines) + "\n\n"
 
 

--- a/libs/openant-core/report/prompts/disclosure.txt
+++ b/libs/openant-core/report/prompts/disclosure.txt
@@ -55,6 +55,10 @@ Verified via {"dynamic testing" if dynamic_testing else "dynamic test FAILED (st
 
 INSTRUCTIONS:
 - Keep summary under 50 words
+- If the vulnerability data includes a "verification_explanation" field, the
+  Summary and Steps to Reproduce must not assert reachability of any path that
+  explanation describes as gated or conditional — state the precondition it
+  names instead.
 - Do NOT include a "## Vulnerable Code" section — it is added automatically after your output is generated. Do NOT emit code fences with the vulnerable source code. If you need to reference the vulnerable code, refer to the function name and describe the issue in prose.
 - Other code snippets (Suggested Fix): show only the minimal change needed, not entire files
 - Steps to Reproduce: if dynamic_testing data exists, use those steps; if only dynamic_testing_attempted exists (the test ran but did not confirm), still write "[REQUIRES DYNAMIC TESTING]" — the attempted evidence is diagnostic, not a reproduction; otherwise write "[REQUIRES DYNAMIC TESTING]" for each step

--- a/libs/openant-core/tests/test_issue534_disclosure_stage2.py
+++ b/libs/openant-core/tests/test_issue534_disclosure_stage2.py
@@ -145,3 +145,60 @@ class TestDeterministicHeader:
         header = _disclosure_verdict_header(data)
         banner_lines = [l for l in header.split("\n") if l.strip()]
         assert all(l.startswith(">") for l in banner_lines), header
+
+
+# --- the fable+astra gate folds (the consistency provenance + the containment) ----
+
+def _base_vd(explanation="Model analysis of the finding."):
+    """The vulnerability_data dict the banner consumes, with a
+    verification_explanation present (the #534 shape)."""
+    return {
+        "status": "confirmed",
+        "finding": "vulnerable",
+        "verdict": "vulnerable",
+        "file": "app.py",
+        "function": "handler",
+        "cwe_id": 79,
+        "verification_explanation": explanation,
+    }
+
+def test_fold_consistency_update_carried_and_banner_attributes():
+    """The MEDIUM-2 fold: after a consistency pass rewrites the verdict, the
+    banner must attribute the pre-update explanation (the explanation argued
+    for the ORIGINAL verdict; the status line shows the updated one)."""
+    vd = dict(_base_vd(), verification_explanation="The path is gated by the "
+              "autodetect filter; exploitation requires the gate to be open.",
+              consistency_update={"from": "vulnerable", "to": "bypassable",
+                                  "reason": "peer units disagree"})
+    header = _disclosure_verdict_header(vd)
+    assert "Stage-2 explanation (pre-dating the consistency update" in header, (
+        "the banner must attribute the pre-update explanation when an update occurred")
+    assert "**Consistency update:** vulnerable → bypassable — peer units disagree" in header
+
+
+def test_fold_no_update_no_attribution():
+    """The negative: without a consistency update, the plain label stays."""
+    vd = dict(_base_vd(), verification_explanation="The path is fully reachable.")
+    header = _disclosure_verdict_header(vd)
+    assert "> **Stage-2 explanation:** " in header
+    assert "pre-dating" not in header
+    assert "Consistency update:" not in header
+
+
+def test_fold_crlf_and_cr_stay_inside_the_banner():
+    """The LOW-4 fold: \\r\\n and bare \\r are CommonMark line endings — an
+    unnormalized \\r would escape the > prefix and dump prose above the H1."""
+    vd = dict(_base_vd(), verification_explanation="line one\r\nline two\rline three")
+    header = _disclosure_verdict_header(vd)
+    assert "line one\n> line two\n> line three" in header, (
+        "CRLF and CR must be normalized to \\n and stay inside the blockquote")
+
+
+def test_fold_gt_leading_line_and_link_contained():
+    """The containment probes (fable's ask): a >-leading line nests (cosmetic
+    containment); a markdown link renders inside the quote (structural
+    containment — the same trust model as every model-text line)."""
+    vd = dict(_base_vd(), verification_explanation="> nested quote\n[link](http://x)")
+    header = _disclosure_verdict_header(vd)
+    assert "> **Stage-2 explanation:** > nested quote" in header
+    assert "> [link](http://x)" in header

--- a/libs/openant-core/tests/test_issue534_disclosure_stage2.py
+++ b/libs/openant-core/tests/test_issue534_disclosure_stage2.py
@@ -1,0 +1,147 @@
+"""Tests for issue #534 — Stage 2's explanation reaches the disclosure body.
+
+The disclosure record was built from Stage-1 fields only: the one Stage-2 text
+hook (``finding.get("verification_explanation")``) reads a key no producer
+writes — the verify stage stores its explanation under
+``finding["verification"]["explanation"]``. The disclosure model therefore
+never saw Stage 2's reasoning, and a disclosure could assert what Stage 2
+refuted (receipt: a monitored run's DISCLOSURE_02 asserted the exact entry
+path the same run's results_verified.json:152 said was gated).
+
+The fix: (1) the record build reads Stage-2 text from its REAL location
+(``verification.explanation`` / ``verification.note``, with the legacy
+top-level key as fallback) and emits it as its own record key so the
+disclosure prompt's ``{vulnerability_data}`` carries it; (2) the steps-to-
+reproduce rebuild path reads the same real location; (3) the deterministic
+``_disclosure_verdict_header`` (which the model cannot drop) carries the
+Stage-2 qualification line verbatim.
+"""
+from __future__ import annotations
+
+import json
+
+from core.reporter import build_pipeline_output
+from report.generator import _disclosure_verdict_header
+
+
+def _stage2_row(explanation=None, note=None, legacy=None):
+    """A verified row shaped like results_verified.json."""
+    row = {
+        "finding": "vulnerable",
+        "verdict": "vulnerable",
+        "file": "app.py",
+        "function": "handler",
+        "cwe_id": 79,
+        "vulnerable_code": "def handler(): pass",
+        "description": "XSS in handler",
+        "impact": "arbitrary script execution",
+        "verification": {
+            "agree": True,
+            "correct_finding": "vulnerable",
+            "explanation": explanation,
+            "iterations": 3,
+            "total_tokens": 100,
+        },
+    }
+    if note is not None:
+        row["verification_note"] = note
+    if legacy is not None:
+        row["verification_explanation"] = legacy
+    return row
+
+
+
+def _run_pipeline(rows, tmp_path):
+    """Drive the real build_pipeline_output over a results file."""
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps({
+        "dataset": "demo",
+        "results": rows,
+        "metrics": {"vulnerable": len(rows), "safe": 0, "inconclusive": 0},
+    }))
+    out = tmp_path / "pipeline_output.json"
+    build_pipeline_output(
+        results_path=str(results),
+        output_path=str(out),
+        repo_name="demo",
+        language="python",
+    )
+    return json.loads(out.read_text())["findings"]
+
+class TestRecordCarriesStage2Text:
+    def test_explanation_reaches_the_record(self, tmp_path):
+        """THE #534 regression: the finding record must carry Stage 2's
+        explanation under verification_explanation (the key the steps hook
+        and the disclosure prompt read)."""
+        row = _stage2_row(
+            explanation="Stage 1's cited entry path is gated by the "
+                        "autodetect filter; the reachable path requires "
+                        "explicit enablement.")
+        findings = _run_pipeline([row], tmp_path)
+        finding = findings[0]
+        assert finding["verification_explanation"] == (
+            "Stage 1's cited entry path is gated by the "
+            "autodetect filter; the reachable path requires "
+            "explicit enablement.")
+
+    def test_fresh_verify_dict_wins_when_both_present(self, tmp_path):
+        """One precedence, both sites: the verify dict is the authoritative
+        Stage-2 record (the legacy top-level key has no producer)."""
+        row = _stage2_row(explanation="new-style", legacy="old-style")
+        findings = _run_pipeline([row], tmp_path)
+        assert findings[0]["verification_explanation"] == "new-style"
+
+    def test_note_travels_too(self, tmp_path):
+        row = _stage2_row(explanation="expl", note="the note")
+        findings = _run_pipeline([row], tmp_path)
+        assert findings[0]["verification_note"] == "the note"
+
+    def test_absent_stays_absent(self, tmp_path):
+        """No verification dict → no fabricated keys (present-only)."""
+        row = _stage2_row(explanation="x")
+        del row["verification"]
+        findings = _run_pipeline([row], tmp_path)
+        f = findings[0]
+        assert "verification_explanation" not in f
+        assert "verification_note" not in f
+
+    def test_steps_rebuild_uses_real_location(self, tmp_path):
+        """When steps_to_reproduce is absent, the rebuilt steps must include
+        the Verification line sourced from the REAL key."""
+        row = _stage2_row(explanation="The gated path requires enablement")
+        findings = _run_pipeline([row], tmp_path)
+        f = findings[0]
+        assert f["steps_to_reproduce"] is not None
+        assert "The gated path requires enablement" in f["steps_to_reproduce"]
+
+
+class TestDeterministicHeader:
+    def test_header_carries_the_qualification(self):
+        """The deterministic banner (the line the model cannot drop) states
+        the Stage-2 qualification verbatim."""
+        data = {
+            "stage2_verdict": "confirmed",
+            "stage1_verdict": "vulnerable",
+            "verification_explanation":
+                "Weaponization requires chaining a second defect.",
+        }
+        header = _disclosure_verdict_header(data)
+        assert "Weaponization requires chaining a second defect." in header
+
+    def test_header_without_explanation_unchanged(self):
+        data = {"stage2_verdict": "confirmed", "stage1_verdict": "vulnerable"}
+        base = _disclosure_verdict_header(data)
+        assert base
+        assert "Stage-2 explanation" not in base
+
+    def test_header_explanation_is_blockquote_safe(self):
+        """A multi-paragraph explanation stays inside the banner block —
+        every line carries the '> ' prefix (the review's 2c)."""
+        data = {
+            "stage2_verdict": "confirmed",
+            "stage1_verdict": "vulnerable",
+            "verification_explanation": "First paragraph.\n\nSecond line of the reasoning.",
+        }
+        header = _disclosure_verdict_header(data)
+        banner_lines = [l for l in header.split("\n") if l.strip()]
+        assert all(l.startswith(">") for l in banner_lines), header


### PR DESCRIPTION
## Summary

The disclosure record was built from Stage-1 fields only: the one Stage-2 text hook, `finding.get("verification_explanation")`, read a key **no producer writes** — the verify stage stores its explanation under `finding["verification"]["explanation"]`. The disclosure model therefore never saw Stage 2's reasoning, and a disclosure could assert what Stage 2 refuted (receipt: a monitored run's `DISCLOSURE_02` asserted the exact entry path the same run's `results_verified.json` said was gated by the autodetect filter; only the deterministic verdict banner was Stage-2-aware).

The fix:

- the finding record now carries **`verification_explanation`** as its own key, sourced from the verify stage's real location (`verification["explanation"]`), present-only, coerced (`_coerce_to_str` — dict-shaped explanations are a real model-output class); it rides `{vulnerability_data}` into the disclosure prompt;
- **`verification_note`** travels too — read from the top-level `verification_note` the verifier actually writes (the reclassification "Changed from X to Y" text and the incomplete-verdict notes);
- the steps-to-reproduce rebuild path reads the same real location;
- the deterministic **`_disclosure_verdict_header`** (the one block the model cannot drop) now appends a `> **Stage-2 explanation:**` line, blockquote-safe (multi-paragraph explanations stay inside the banner);
- `disclosure.txt` gains one consistency instruction: when the field is present, Summary/Steps must not assert reachability of a path the explanation describes as gated.

**Residual, stated plainly:** the prose can still contradict the banner — the failure mode is downgraded from *silently wrong* to *visibly self-contradictory with the correct half server-stamped*. That is the honest improvement; the model's prose is not deterministic.

Closes #534.

## Test plan

8 tests in `tests/test_issue534_disclosure_stage2.py`: the explanation reaching the record (the #534 regression), the fresh-wins precedence, the top-level note traveling, absent-stays-absent (present-only), the steps-rebuild path, the banner carrying the qualification verbatim, the no-explanation header unchanged (negative), and the multi-paragraph blockquote-safety.

## Verification evidence

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue534_disclosure_stage2.py -q` | 8 passed |
| family regression | `pytest tests/test_reporter_coercion.py tests/test_disclosure_verdict_header.py tests/test_issue319_dynamic_status.py -q` | 42 passed |
| full suite | `pytest tests/ -q` | 3923 passed, 2 failed — both pre-existing (SDK pin drift, verified on the pristine base) |
| static analysis | ruff / Semgrep / CodeQL | clean / 0 / the 3 hits in my two files are pre-existing outside the touched hunks (verified against the prior scan) |
| consumers | the schema is presence-only (no additionalProperties); the payload's exclude list untouched; the summary allowlist untouched; the Go/webui side has no key-set assertion | additive-key safe everywhere |
