### PR TITLE
fix(report): SUMMARY_REPORT numbers and tables are server-rendered — the source re-sourced, the model-transcribed arithmetic retired (#535)

### DIFF
--- a/libs/openant-core/core/reporter.py
+++ b/libs/openant-core/core/reporter.py
@@ -616,12 +616,47 @@ def build_pipeline_output(
                         _vs["same_model_verification"])
             break
 
+    # #535: re-source the Stage-1 population facts from the step reports
+    # (the same pattern as _verify_scope). units_analyzed's old formula
+    # (total_units - metrics.errors) is exact on the analyze-only path but
+    # contaminated whenever verify ran: results_verified's recount buckets a
+    # Stage-2 verify ERROR on an already-analyzed unit into `errors`, so a
+    # 120-analyzed run with one verify error reported 119 analyzed. The
+    # analyze step report's own `analyzed` is the authoritative Stage-1
+    # count. parsed_units: the parse stage's total (the pre-filter
+    # population — original_units is NOT a reliable parse count; it falls
+    # back to total_units when no reachability record exists).
+    _stage1_stats: dict = {}
+    for sr in (step_reports or []):
+        _ss = sr.get("summary")
+        if not isinstance(_ss, dict):
+            continue
+        if sr.get("step") == "parse":
+            if isinstance(_ss.get("total_units"), int) and not isinstance(
+                    _ss.get("total_units"), bool):
+                _stage1_stats["parsed_units"] = _ss["total_units"]
+        elif sr.get("step") == "analyze":
+            # #535: analyzed is flat; the error count lives under
+            # error_count (the #285 key) with verdicts.errors nested —
+            # the flat `errors` key has no producer here.
+            if isinstance(_ss.get("analyzed"), int) and not isinstance(
+                    _ss.get("analyzed"), bool):
+                _stage1_stats["units_analyzed"] = _ss["analyzed"]
+            _err = _ss.get("error_count")
+            if not isinstance(_err, int) or isinstance(_err, bool):
+                _v = _ss.get("verdicts")
+                _err = _v.get("errors") if isinstance(_v, dict) else None
+            if isinstance(_err, int) and not isinstance(_err, bool):
+                _stage1_stats["stage1_errors"] = _err
+
     if step_reports:
         for sr in step_reports:
             step = sr.get("step", "unknown")
-            if sr.get("cost_usd"):
+            # #535: `is not None` — a $0 or <0.5s step is a REAL step
+            # (parse), not an absence; truthiness dropped it from the tables.
+            if sr.get("cost_usd") is not None:
                 costs[step] = {"actual": sr["cost_usd"]}
-            if sr.get("duration_seconds"):
+            if sr.get("duration_seconds") is not None:
                 durations[step] = sr["duration_seconds"]
 
     # Populate skipped_steps from the authoritative ScanResult skip data. The
@@ -767,7 +802,17 @@ def build_pipeline_output(
             **_reach_telemetry,
 
             **_verify_scope,
-            "units_analyzed": total_units - metrics.get("errors", 0),
+            # #535: units_analyzed re-sourced from the analyze step report
+            # (see _stage1_stats above). Fallback: with no analyze report and
+            # no verify report, the analyze-only formula is exact; with
+            # verify having run, the subtraction is contaminated — omit
+            # (present-only) rather than emit a wrong integer. The rest of
+            # _stage1_stats (parsed_units, stage1_errors) ALWAYS spreads.
+            **_stage1_stats,
+            **({"units_analyzed":
+                    total_units - metrics.get("errors", 0)}
+               if "units_analyzed" not in _stage1_stats
+               and not _verify_scope else {}),
             "processing_level": processing_level,
             "costs": costs,
             "durations": durations,

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -658,22 +658,28 @@ def generate_summary_report(
     # Splice the server blocks AFTER the model's H1/metadata block (the
     # banners may precede the title; whole H2 sections may not — the #535
     # review round: prepending put four tables above the document title).
+    # The gate fold (fable+astra, the m.start()>0 inversion): the
+    # H1-at-offset-0 canonical reply took the prepend branch — the tables
+    # rendered ABOVE the title. The boundary is normalized instead: find
+    # the first heading; skip its line and any following non-heading
+    # metadata lines; insert before the NEXT heading (or the end when the
+    # metadata block runs to the end). EVERY shape — H1 at 0, banners
+    # before the H1, metadata after, metadata-only-to-the-end — inserts
+    # AFTER the metadata block, never above the title.
     import re as _re
     m = _re.search(r"^#{1,2} ", text, flags=_re.M)
-    if m and m.start() > 0:
-        insert_at = m.start()
-        # skip past the heading line and any metadata lines that follow
-        line_end = text.index("\n", insert_at) if "\n" in text[insert_at:] else len(text)
-        # insert before the NEXT heading or after the first paragraph
+    if m:
+        line_end = text.index("\n", m.start()) if "\n" in text[m.start():] else len(text)
         m2 = _re.search(r"^#{1,2} ", text[line_end:], flags=_re.M)
-        insert_at = line_end + (m2.start() if m2 else 0)
+        insert_at = line_end + (m2.start() if m2 else len(text) - line_end)
         text = text[:insert_at] + server_blocks + text[insert_at:]
-    elif m:
-        text = server_blocks + text
     else:
-        text = (_context_provenance_header(pipeline_data)
-                + _reachability_header(pipeline_data)
-                + server_blocks + text)
+        # No heading at all: the fallback document gets a canonical title
+        # (the banners + tables, then the model prose) — the banners
+        # prepend EXACTLY ONCE here (the old path prepended them twice:
+        # once in this branch and once in the unconditional prepend below).
+        text = (server_blocks + text)
+    # The banners prepend exactly once, unconditionally, at the very top.
     text = (_context_provenance_header(pipeline_data)
             + _reachability_header(pipeline_data) + text)
     return text, _extract_usage(

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -379,6 +379,211 @@ def _reachability_header(pipeline_data: dict) -> str:
     return "\n".join(lines) + "\n\n"
 
 
+
+
+# ---------------------------------------------------------------------------
+# #535: server-rendered numeric/eligibility surfaces for SUMMARY_REPORT.md
+# ---------------------------------------------------------------------------
+
+_SUMMARY_SERVER_SECTIONS = (
+    "Pipeline Statistics", "Per-Step Durations", "Per-Step Costs",
+    "Results", "Confirmed Vulnerabilities", "Not Confirmed",
+)
+
+
+
+
+def _fmt_duration(seconds: float) -> str:
+    """A duration string that can't mis-render 10.22s as '10m 13s'."""
+    if seconds >= 3600:
+        return f"{seconds / 3600:.1f}h"
+    if seconds >= 60:
+        return f"{seconds / 60:.1f}m"
+    return f"{seconds:.1f}s"
+
+
+def _strip_server_sections(text: str) -> str:
+    """Remove any model-emitted duplicate of a server-owned section.
+
+    The prompt is advisory; the model may still transcribe a '## Pipeline
+    Statistics' block from the JSON dump. Every heading in
+    _SUMMARY_SERVER_SECTIONS is server-owned — strip from its heading to the
+    next heading (or end) so the deliverable carries exactly one copy (the
+    same pattern as _splice_code_section's duplicate-block strip). The
+    heading is ANCHORED (a '## Results Overview' narrative section survives)
+    and matched case-insensitively with an optional numbering prefix.
+    """
+    import re as _re
+    for heading in _SUMMARY_SERVER_SECTIONS:
+        text = _re.sub(
+            r"^##\s+(?:\d+[.)]\s*)?" + _re.escape(heading)
+            + r"\s*:(?:\n(?!## ).*)*\n?",
+            "", text, flags=_re.M | _re.I)
+        text = _re.sub(
+            r"^##\s+(?:\d+[.)]\s*)?" + _re.escape(heading)
+            + r"\s*$(?:\n(?!## ).*)*\n?",
+            "", text, flags=_re.M | _re.I)
+    return text
+
+
+
+
+def _verified_tier(f: dict) -> str:
+    """The 4-tier Verified cell, the same dynamic-then-stage2 priority the
+    disclosure header encodes (#319; the summary and disclosure tables must
+    agree for the same finding)."""
+    dt = f.get("dynamic_testing")
+    dta = f.get("dynamic_testing_attempted")
+    if isinstance(dt, dict) and dt.get("status") == "CONFIRMED":
+        return "dynamic"
+    if isinstance(dta, dict) and dta.get("status"):
+        return f"dynamic test failed ({dta.get('status')})"
+    v = str(f.get("stage2_verdict", "")).lower()
+    if v in _STAGE2_CONFIRMED:
+        return "verified"
+    return "static"
+
+
+def _summary_statistics_block(pipeline_data: dict) -> str:
+    """The server-rendered numeric facts (the #535 core).
+
+    Every line present-only — an old artifact without the new keys renders
+    with omitted lines, never fabricated zeros. Numbers come from
+    pipeline_stats only (the reporter folded the step reports in; the
+    generator never saw them).
+    """
+    stats = pipeline_data.get("pipeline_stats") or {}
+    lines: list[str] = []
+    parsed = stats.get("parsed_units")
+    if isinstance(parsed, int) and not isinstance(parsed, bool):
+        lines.append(f"- Parsed: {parsed} units")
+    if stats.get("reachability_filter_applied"):
+        orig = stats.get("original_units")
+        reach = stats.get("reachable_units")
+        if isinstance(orig, int) and isinstance(reach, int) and orig > 0:
+            pct = stats.get("reachability_reduction_percentage")
+            pct_str = f"{pct}" if isinstance(pct, (int, float)) else (
+                f"{round(100 * (orig - reach) / orig, 1)}")
+            lines.append(f"- In scope after reachability filter: {reach} of "
+                         f"{orig} units ({pct_str}% pruned)")
+    analyzed = stats.get("units_analyzed")
+    total = stats.get("total_units")
+    if isinstance(analyzed, int) and not isinstance(analyzed, bool):
+        extra = ""
+        s1err = stats.get("stage1_errors")
+        if isinstance(s1err, int) and s1err:
+            extra = f" ({s1err} errored)"
+        base = f"- Analyzed in Stage 1: {analyzed} units"
+        if isinstance(total, int) and total != analyzed:
+            base += f" of {total}"
+        lines.append(base + extra)
+    vi = stats.get("findings_input")
+    va = stats.get("units_analyzed_total")
+    if isinstance(vi, int) and isinstance(va, int):
+        adj = f"- Adjudicated in Stage 2: {vi} of {va} analyzed units"
+        down, up = stats.get("downgraded"), stats.get("upgraded")
+        if isinstance(down, int) or isinstance(up, int):
+            adj += f" ({down or 0} downgraded, {up or 0} upgraded)"
+        lines.append(adj)
+    if stats.get("same_model_verification"):
+        lines.append(
+            "- Stage 2 ran on the same model as Stage 1 and is not an "
+            "independent instrument")
+    if not lines:
+        return ""
+    return "## Pipeline Statistics\n\n" + "\n".join(lines) + "\n\n"
+
+
+def _summary_tables_block(pipeline_data: dict) -> str:
+    """The server-rendered Results / durations / costs / Confirmed tables."""
+    stats = pipeline_data.get("pipeline_stats") or {}
+    parts: list[str] = []
+
+    results = pipeline_data.get("results") or {}
+    if results:
+        rows = []
+        for label, key in (("Vulnerable", "vulnerable"), ("Safe", "safe"),
+                           ("Protected", "protected"),
+                           ("Inconclusive", "inconclusive"),
+                           ("Needs review", "needs_review"),
+                           ("Errored", "errors"),
+                           ("Deduplicated away", "deduplicated")):
+            v = results.get(key)
+            if isinstance(v, int) and not isinstance(v, bool):
+                rows.append(f"| {label} | {v} |")
+        if rows:
+            parts.append("## Results\n\n| Outcome | Units |\n|---|---|\n"
+                         + "\n".join(rows) + "\n")
+
+    durations = stats.get("durations") or {}
+    if durations:
+        rows = [f"| {step} | {_fmt_duration(float(sec))} |"
+                for step, sec in durations.items()
+                if isinstance(sec, (int, float))]
+        total = sum(float(v) for v in durations.values()
+                    if isinstance(v, (int, float)))
+        rows.append(f"| **Total** | **{_fmt_duration(total)}** |")
+        parts.append("## Per-Step Durations\n\n| Step | Duration |\n"
+                     "|---|---|\n" + "\n".join(rows) + "\n")
+
+    costs = stats.get("costs") or {}
+    if costs:
+        rows = [f"| {step} | ${float((c or {}).get('actual') or 0):.2f} |"
+                for step, c in costs.items()]
+        total = sum(float((c or {}).get("actual") or 0) for c in costs.values())
+        rows.append(f"| **Total** | **${total:.2f}** |")
+        parts.append("## Per-Step Costs\n\n| Step | Actual |\n|---|---|\n"
+                     + "\n".join(rows) + "\n")
+
+    findings = pipeline_data.get("findings") or []
+    if findings:
+        confirmed = [f for f in findings
+                     if str(f.get("stage2_verdict", "")).lower()
+                     in _STAGE2_CONFIRMED]
+        not_confirmed = [f for f in findings if f not in confirmed]
+        if confirmed:
+            rows = []
+            for i, f in enumerate(confirmed, 1):
+                sev = f.get("severity")
+                rows.append(f"| {i} | {f.get('name', '?')} | "
+                            f"{(f.get('location') or {}).get('file', '?')}:"
+                            f"{(f.get('location') or {}).get('function', '?')} | "
+                            f"CWE-{f.get('cwe_id', '')} | {sev if sev else ''} | "
+                            f"{_verified_tier(f)} |")
+            parts.append(
+                "## Confirmed Vulnerabilities\n\n"
+                "| # | Vulnerability | Location | CWE | Severity | Verified |\n"
+                "|---|---|---|---|---|---|\n" + "\n".join(rows) + "\n")
+        else:
+            parts.append("## Confirmed Vulnerabilities\n\n"
+                         "No vulnerabilities were confirmed by Stage 2.\n")
+        if not_confirmed:
+            rows = []
+            for i, f in enumerate(not_confirmed, 1):
+                rows.append(f"| {i} | {f.get('name', '?')} | "
+                            f"{str(f.get('stage2_verdict', '')).lower()} |")
+            parts.append(
+                "## Not Confirmed\n\n"
+                "The following findings were not confirmed by Stage 2 "
+                "(unverified, incomplete, reclassified, or not re-examined):\n\n"
+                "| # | Finding | Stage 2 |\n|---|---|---|\n"
+                + "\n".join(rows) + "\n")
+    elif not parts:
+        parts.append("No findings to report.\n")
+
+    return ("\n\n".join(parts) + "\n\n") if parts else ""
+
+
+def _strip_summary_placeholders(text: str) -> str:
+    """The empty-case placeholder tables must never render literally."""
+    import re as _re
+    text = _re.sub(r"^\| \{step\} \| \{reason\} \|\n?", "", text, flags=_re.M)
+    text = _re.sub(
+        r"^\| \{name\} \| \{verdict\} \| \{verdict\} \| "
+        r"\{one_sentence_reason\} \|\n?", "", text, flags=_re.M)
+    return text
+
+
 def generate_summary_report(
     pipeline_data: dict,
     binding: PhaseBinding,
@@ -440,9 +645,37 @@ def generate_summary_report(
             "(stop_reason=max_tokens) — the reply was cut mid-generation "
             "and the sections below may be incomplete.\n\n" + text
         )
-    # Prepend the provenance banner + the reachability advisory
-    # deterministically (see the helper docstrings).
-    text = _context_provenance_header(pipeline_data) + _reachability_header(pipeline_data) + text
+    # #535: the numeric/eligibility surfaces are SERVER-rendered. The model
+    # keeps the narrative; the server owns the numbers (the receipt: the
+    # model transcribed 10.22s as "10m 13s" and put unverified rows in the
+    # Confirmed table). Strip any model-emitted duplicate of a server-owned
+    # section, strip literal placeholder tables, then splice the server
+    # blocks after the deterministic headers.
+    text = _strip_server_sections(text)
+    text = _strip_summary_placeholders(text)
+    server_blocks = (_summary_statistics_block(pipeline_data)
+                     + _summary_tables_block(pipeline_data))
+    # Splice the server blocks AFTER the model's H1/metadata block (the
+    # banners may precede the title; whole H2 sections may not — the #535
+    # review round: prepending put four tables above the document title).
+    import re as _re
+    m = _re.search(r"^#{1,2} ", text, flags=_re.M)
+    if m and m.start() > 0:
+        insert_at = m.start()
+        # skip past the heading line and any metadata lines that follow
+        line_end = text.index("\n", insert_at) if "\n" in text[insert_at:] else len(text)
+        # insert before the NEXT heading or after the first paragraph
+        m2 = _re.search(r"^#{1,2} ", text[line_end:], flags=_re.M)
+        insert_at = line_end + (m2.start() if m2 else 0)
+        text = text[:insert_at] + server_blocks + text[insert_at:]
+    elif m:
+        text = server_blocks + text
+    else:
+        text = (_context_provenance_header(pipeline_data)
+                + _reachability_header(pipeline_data)
+                + server_blocks + text)
+    text = (_context_provenance_header(pipeline_data)
+            + _reachability_header(pipeline_data) + text)
     return text, _extract_usage(
         result.input_tokens,
         result.output_tokens,

--- a/libs/openant-core/report/prompts/summary.txt
+++ b/libs/openant-core/report/prompts/summary.txt
@@ -15,73 +15,16 @@ OUTPUT FORMAT:
 **Application Type:** {app_type} — if `context_source` is "none" AND the app_type value is itself "unknown", render "unknown (not determined — no application context was generated)". An EXPLICIT operator-supplied app_type (e.g. from --app-type) must be rendered as given: an explicit assertion is never overridden by the absent-context rule.
 **Processing Level:** {pipeline_stats.processing_level or "Not available"}
 
-## Results
+## Coverage
 
-| Verdict | Count |
-|---------|-------|
-| Vulnerable | {n} |
-| Safe | {n} |
-| Protected | {n} |
-| Inconclusive | {n} |
-| Error | {n} |
+- If a top-level `coverage` key exists, add a Coverage line: test files skipped (per language from coverage.test_files_skipped), symlinks refused, directories unreadable; also note the top-level per_language, parse_errors, excluded_languages, and degraded keys if present — a reader must see what did NOT enter the pipeline. (These are TOP-LEVEL keys beside application_type, NOT nested under pipeline_stats.) If `coverage` is absent, add no Coverage section at all.
 
-## Pipeline Statistics
-
-- If a top-level `coverage` key exists, add a Coverage line: test files skipped (per language from coverage.test_files_skipped), symlinks refused, directories unreadable; also note the top-level per_language, parse_errors, excluded_languages, and degraded keys if present — a reader must see what did NOT enter the pipeline. (These are TOP-LEVEL keys beside application_type, NOT nested under pipeline_stats.) If `coverage` is absent, add no Coverage line
-
-- Parsed: {n} functions from {n} files
-- Total units: {pipeline_stats.total_units}
-- Reachable units: {pipeline_stats.reachable_units}
-- Reachability warnings: {pipeline_stats.reachability_warnings}
-- After CodeQL filter: {n} units
-- Analyzed in Stage 1: {n} units
-- Verified in Stage 2: {n} findings
-- Stage 2 scope: adjudicated {pipeline_stats.findings_input} of {pipeline_stats.units_analyzed_total} analyzed units (Stage-1 positives only; the remaining units were NOT re-examined). Direction of Stage-2 changes: {pipeline_stats.downgraded} downgraded, {pipeline_stats.upgraded} upgraded. If pipeline_stats.same_model_verification is true, note that Stage 2 ran on the same model as Stage 1 and is not an independent instrument.
-
-## Per-Step Costs
-
-[Build from pipeline_stats.costs. Each key is a step name, with estimated, actual, units_requested, units_processed.]
-
-| Step | Estimated (USD) | Actual (USD) | Units |
-|------|-----------------|--------------|-------|
-| {step} | ${estimated} | ${actual} | {units_processed}/{units_requested} |
-| **Total** | **${sum_estimated}** | **${sum_actual}** | |
-
-## Per-Step Durations
-
-[Build from pipeline_stats.durations. Each key is a step name, value is seconds. Format as Xm Ys.]
-
-| Step | Duration |
-|------|----------|
-| {step} | {formatted_duration} |
-| **Total** | **{formatted_total}** |
+The Pipeline Statistics, Results, Per-Step Durations, Per-Step Costs, Confirmed Vulnerabilities, and Not Confirmed sections are rendered automatically by the server — do NOT duplicate them; write only the sections you are asked for here.
 
 ## Skipped Steps
 
 [Build from pipeline_stats.skipped_steps. Each entry has step and reason.]
-[If no steps were skipped, write: "No steps were skipped."]
-
-| Step | Reason |
-|------|--------|
-| {step} | {reason} |
-
-## Confirmed Vulnerabilities
-
-[For each VULNERABLE finding where stage2_verdict is "confirmed" or "agreed", one row.]
-[If no vulnerabilities were confirmed, write: "No vulnerabilities were confirmed."]
-
-| # | Vulnerability | Location | CWE | Severity | Verified |
-|---|--------------|----------|-----|----------|----------|
-| 1 | {short_name} | {file:function} | CWE-{n} | {severity} | {static|verified|dynamic|dynamic test failed (<status>)} |
-
-## False Positives Eliminated
-
-[For each finding that Stage 2 rejected.]
-[If no false positives, write: "No false positives to report."]
-
-| Finding | Stage 1 | Stage 2 | Reason |
-|---------|---------|---------|--------|
-| {name} | {verdict} | {verdict} | {one_sentence_reason} |
+[If no steps were skipped, write: "No steps were skipped." Do NOT emit the table header or any placeholder row when the list is empty.]
 
 ## Methodology
 
@@ -110,7 +53,5 @@ INSTRUCTIONS:
 - Processing Level comes from pipeline_stats.processing_level; if null or missing, write "Not available"
 - Reachable units comes from pipeline_stats.reachable_units; total units from pipeline_stats.total_units. When pipeline_stats.reachability_filter_applied is true, append " ({pipeline_stats.reachable_units} of {pipeline_stats.original_units} parsed, {pipeline_stats.reachability_reduction_percentage}% pruned by the reachability filter)" to the Reachable units line so the pruning is visible; when false, append " (reachability filtering not applied/recorded)"
 - Reachability warnings: iterate pipeline_stats.reachability_warnings; if non-empty, render each entry as its own bullet under the Reachable units line; if empty, OMIT the "Reachability warnings" line entirely
-- Per-Step Costs: iterate pipeline_stats.costs; compute totals by summing estimated and actual
-- Per-Step Durations: iterate pipeline_stats.durations; format seconds as "Xm Ys" (e.g., "2m 31s"); the "total" key is the overall duration
 - Skipped Steps: iterate pipeline_stats.skipped_steps; if the array is empty, write "No steps were skipped."
 - Do not add commentary or explanations outside the template

--- a/libs/openant-core/tests/test_issue215_severity_field.py
+++ b/libs/openant-core/tests/test_issue215_severity_field.py
@@ -369,11 +369,19 @@ def test_summary_prompt_receives_severity():
 
 
 def test_summary_template_row_has_severity_cell():
-    from pathlib import Path as P
-    tpl = (P(__file__).resolve().parents[1] / "report" / "prompts" / "summary.txt").read_text()
-    assert "{severity}" in tpl
-    assert "lowercase" not in tpl
-    assert tpl.count("| # | Vulnerability | Location | CWE | Severity | Verified |") == 1
+    """#535 migration: the Confirmed table moved server-side — the severity
+    cell and the one-table guarantees now pin the RENDERER (the prompt no
+    longer carries the exemplar)."""
+    from report.generator import _summary_tables_block
+    findings = [{
+        "name": "XSS", "short_name": "XSS",
+        "location": {"file": "a.py", "function": "handler"},
+        "cwe_id": 79, "severity": "high", "stage2_verdict": "confirmed",
+    }]
+    block = _summary_tables_block({"findings": findings})
+    assert block.count(
+        "| # | Vulnerability | Location | CWE | Severity | Verified |") == 1
+    assert "| 1 | XSS | a.py:handler | CWE-79 | high | verified |" in block
 
 
 def test_max_iterations_downgrade_strips_severity():
@@ -411,17 +419,22 @@ def test_twin_severity_parity():
 
 
 def test_summary_table_is_contiguous():
-    """Wave r2 (t#5): a blank line between the separator and the example
-    row terminates the markdown table (the exemplar the summary LLM copies
-    was header-only + an orphan row). Every findings-table line contiguous."""
-    from pathlib import Path as P
-    lines = (P(__file__).resolve().parents[1] / "report" / "prompts"
-             / "summary.txt").read_text().split("\n")
+    """#535 migration: the contiguity guarantee now pins the server-rendered
+    table (header, separator, and rows on consecutive lines — the model can
+    no longer orphan the exemplar row)."""
+    from report.generator import _summary_tables_block
+    findings = [{
+        "name": "R", "short_name": "R",
+        "location": {"file": "b.py", "function": "f"},
+        "cwe_id": 89, "severity": "medium", "stage2_verdict": "agreed",
+    }]
+    block = _summary_tables_block({"findings": findings})
+    lines = block.split("\n")
     i = next(k for k, l in enumerate(lines)
              if l.startswith("| # | Vulnerability"))
     assert lines[i + 1].startswith("|---"), "separator row must follow directly"
-    assert lines[i + 2].startswith("| 1 |") and "{severity}" in lines[i + 2], (
-        "the example row must be contiguous and carry the severity cell")
+    assert lines[i + 2].startswith("| 1 |") and "medium" in lines[i + 2], (
+        "the data row must be contiguous and carry the severity cell")
 
 
 def test_the_one_severity_enum_everywhere():

--- a/libs/openant-core/tests/test_issue302_stage2_scope_reporting.py
+++ b/libs/openant-core/tests/test_issue302_stage2_scope_reporting.py
@@ -212,14 +212,27 @@ def test_same_model_note():
 # the summary template instruction
 # ---------------------------------------------------------------------------
 def test_summary_template_states_stage2_scope():
-    src = (PROJECT_ROOT / "report" / "prompts" / "summary.txt").read_text()
-    assert "units_analyzed_total" in src, (
-        "the template must instruct the Stage-2 denominator line "
-        "(adjudicated N of M; the rest not re-examined)")
-    assert "downgraded" in src and "upgraded" in src, (
-        "the template must state the direction of Stage-2 changes")
-    assert "same_model_verification" in src, (
-        "the template must instruct the same-model independence caveat")
+    """#535 migration: the Stage-2 scope line moved server-side — the
+    denominator/direction pins now target the renderer; the same-model
+    independence caveat stays in the prompt (narrative)."""
+    from report.generator import _summary_statistics_block
+    stats = {"pipeline_stats": {
+        "findings_input": 4, "units_analyzed_total": 120,
+        "downgraded": 1, "upgraded": 0}}
+    block = _summary_statistics_block(stats)
+    assert "Adjudicated in Stage 2: 4 of 120 analyzed units" in block
+    assert "1 downgraded, 0 upgraded" in block
+
+def test_same_model_caveat_rendered_server_side():
+    """#535: the independence caveat is deterministic — the prompt can no
+    longer drop it (the strip-net would have deleted the model's copy)."""
+    from report.generator import _summary_statistics_block
+    block = _summary_statistics_block({"pipeline_stats": {
+        "units_analyzed": 5, "same_model_verification": True}})
+    assert "not an independent instrument" in block
+    clean = _summary_statistics_block({"pipeline_stats": {
+        "units_analyzed": 5, "same_model_verification": False}})
+    assert "independent instrument" not in clean
 
 
 def test_zero_findings_early_return_keeps_denominator():

--- a/libs/openant-core/tests/test_issue535_summary_server_numbers.py
+++ b/libs/openant-core/tests/test_issue535_summary_server_numbers.py
@@ -1,0 +1,219 @@
+"""Tests for issue #535 — the server-rendered numeric/eligibility surfaces.
+
+SUMMARY_REPORT.md's numbers and tables were model-transcribed JSON with
+arithmetic — and the model botched them (the receipt: 10.22s rendered as
+"10m 13s", "Verified in Stage 2: 3 findings" against an adjudicated 1/4,
+unverified rows in the Confirmed table, literal {step}/{reason} placeholder
+tables, and a "Parsed: 120 functions from 120 files" line against a parse
+total of 5389 — the prompt asked for fields that don't exist).
+
+The fix: the reporter re-sources the Stage-1 facts from the step reports
+(units_analyzed from the analyze report — the old total-minus-errors formula
+was contaminated by Stage-2 verify errors; parsed_units from the parse
+report; $0/0s steps no longer vanish from the tables), and the generator
+renders the statistics/results/durations/costs/Confirmed tables server-side
+with a strip-net for model-emitted duplicates and the placeholder tables
+removed from the prompt.
+"""
+from __future__ import annotations
+
+import json
+
+from core.reporter import build_pipeline_output
+from report.generator import (
+    _summary_statistics_block,
+    _summary_tables_block,
+    _strip_server_sections,
+    _strip_summary_placeholders,
+)
+
+
+def _results_file(tmp_path, rows, metrics=None):
+    p = tmp_path / "results.json"
+    p.write_text(json.dumps({
+        "dataset": "demo",
+        "results": rows,
+        "metrics": metrics or {"total": len(rows), "errors": 0,
+                               "safe": 0, "inconclusive": 0},
+    }))
+    return p
+
+
+class TestReporterResourcing:
+    def test_units_analyzed_from_analyze_report(self, tmp_path):
+        """THE #535 regression: 120 analyzed + 1 Stage-2 verify error ->
+        the old formula said 119; the analyze report's own count is 120."""
+        row = {"finding": "vulnerable", "verdict": "vulnerable",
+               "file": "a.py", "function": "f", "cwe_id": 79}
+        out = tmp_path / "pipeline_output.json"
+        build_pipeline_output(
+            results_path=str(_results_file(
+                tmp_path, [row], {"total": 120, "errors": 1,
+                                  "safe": 0, "inconclusive": 0})),
+            output_path=str(out),
+            repo_name="demo", language="python",
+            step_reports=[
+                {"step": "analyze", "summary": {
+                    "analyzed": 120, "error_count": 0}},
+                {"step": "verify", "summary": {"findings_input": 4}},
+            ],
+        )
+        stats = json.loads(out.read_text())["pipeline_stats"]
+        assert stats["units_analyzed"] == 120
+        assert stats["stage1_errors"] == 0
+
+    def test_stage1_errors_via_verdicts_fallback(self, tmp_path):
+        """The nested verdicts.errors shape (the cli standalone path)."""
+        row = {"finding": "safe", "verdict": "safe",
+               "file": "a.py", "function": "k", "cwe_id": 0}
+        out = tmp_path / "pipeline_output.json"
+        build_pipeline_output(
+            results_path=str(_results_file(tmp_path, [row])),
+            output_path=str(out),
+            repo_name="demo", language="python",
+            step_reports=[{"step": "analyze", "summary": {
+                "analyzed": 9, "verdicts": {"errors": 2}}}],
+        )
+        assert json.loads(out.read_text())["pipeline_stats"]["stage1_errors"] == 2
+
+    def test_analyze_only_fallback_keeps_old_formula(self, tmp_path):
+        row = {"finding": "safe", "verdict": "safe",
+               "file": "a.py", "function": "g", "cwe_id": 0}
+        out = tmp_path / "pipeline_output.json"
+        build_pipeline_output(
+            results_path=str(_results_file(
+                tmp_path, [row], {"total": 10, "errors": 2,
+                                  "safe": 8, "inconclusive": 0})),
+            output_path=str(out),
+            repo_name="demo", language="python",
+        )
+        stats = json.loads(out.read_text())["pipeline_stats"]
+        assert stats["units_analyzed"] == 8
+
+    def test_verify_without_analyze_omits_the_key(self, tmp_path):
+        """Contaminated subtraction — present-only omission beats a wrong
+        integer."""
+        row = {"finding": "safe", "verdict": "safe",
+               "file": "a.py", "function": "h", "cwe_id": 0}
+        out = tmp_path / "pipeline_output.json"
+        build_pipeline_output(
+            results_path=str(_results_file(
+                tmp_path, [row], {"total": 10, "errors": 3,
+                                  "safe": 7, "inconclusive": 0})),
+            output_path=str(out),
+            repo_name="demo", language="python",
+            step_reports=[{"step": "verify", "summary": {"findings_input": 2}}],
+        )
+        stats = json.loads(out.read_text())["pipeline_stats"]
+        assert "units_analyzed" not in stats
+
+    def test_parsed_units_forwarded(self, tmp_path):
+        row = {"finding": "safe", "verdict": "safe",
+               "file": "a.py", "function": "i", "cwe_id": 0}
+        out = tmp_path / "pipeline_output.json"
+        build_pipeline_output(
+            results_path=str(_results_file(tmp_path, [row])),
+            output_path=str(out),
+            repo_name="demo", language="python",
+            step_reports=[{"step": "parse", "summary": {"total_units": 5389}}],
+        )
+        stats = json.loads(out.read_text())["pipeline_stats"]
+        assert stats["parsed_units"] == 5389
+
+    def test_zero_cost_steps_do_not_vanish(self, tmp_path):
+        row = {"finding": "safe", "verdict": "safe",
+               "file": "a.py", "function": "j", "cwe_id": 0}
+        out = tmp_path / "pipeline_output.json"
+        build_pipeline_output(
+            results_path=str(_results_file(tmp_path, [row])),
+            output_path=str(out),
+            repo_name="demo", language="python",
+            step_reports=[{"step": "parse", "summary": {"total_units": 5},
+                           "cost_usd": 0.0, "duration_seconds": 0.2}],
+        )
+        stats = json.loads(out.read_text())["pipeline_stats"]
+        assert "parse" in stats["costs"]
+        assert "parse" in stats["durations"]
+
+
+class TestGeneratorBlocks:
+    def _stats(self, **kw):
+        return {"pipeline_stats": kw}
+
+    def test_statistics_block_lines(self):
+        block = _summary_statistics_block(self._stats(
+            parsed_units=5389, reachability_filter_applied=True,
+            original_units=5389, reachable_units=2343,
+            units_analyzed=120, total_units=120, stage1_errors=0,
+            findings_input=4, units_analyzed_total=120,
+            downgraded=1, upgraded=0))
+        assert "Parsed: 5389 units" in block
+        assert "In scope after reachability filter: 2343 of 5389" in block
+        assert "Analyzed in Stage 1: 120 units" in block
+        assert "Adjudicated in Stage 2: 4 of 120 analyzed units" in block
+        assert "1 downgraded, 0 upgraded" in block
+
+    def test_present_only_no_fabricated_zeros(self):
+        block = _summary_statistics_block(self._stats())
+        assert block == ""
+
+    def test_durations_never_misrender(self):
+        block = _summary_tables_block(self._stats(
+            durations={"parse": 10.22, "analyze": 0.07}))
+        assert "10.2s" in block
+        assert "0.1s" in block
+        assert "10m" not in block  # THE receipt: 10.22s rendered as 10m 13s
+
+    def test_confirmed_table_eligibility(self):
+        findings = [
+            {"name": "A", "location": {"file": "a", "function": "b"},
+             "cwe_id": 1, "severity": "high", "stage2_verdict": "confirmed"},
+            {"name": "B", "location": {"file": "c", "function": "d"},
+             "cwe_id": 2, "severity": "medium", "stage2_verdict": "agreed"},
+            {"name": "C", "location": {"file": "e", "function": "f"},
+             "cwe_id": 3, "stage2_verdict": "unverified"},
+        ]
+        block = _summary_tables_block({"findings": findings})
+        conf = block.split("## Not Confirmed")[0]
+        assert "| 1 | A |" in conf and "| 2 | B |" in conf
+        assert "| C |" not in conf  # THE receipt: unverified in Confirmed
+        nc = block.split("## Not Confirmed")[1]
+        assert "| C |" in nc and "unverified" in nc
+
+    def test_no_findings_no_placeholder_tables(self):
+        block = _summary_tables_block({"findings": []})
+        assert "{step}" not in block
+        assert "{name}" not in block
+        assert "No findings to report." in block
+
+    def test_strip_model_duplicate_sections(self):
+        model_text = ("## Overview\n\nSome narrative.\n\n"
+                      "## Pipeline Statistics\n\n"
+                      "- Parsed: 999 units (model-transcribed)\n\n"
+                      "## Results\n\n| Outcome | Units |\n|---|---|\n"
+                      "| Vulnerable | 999 |\n\n"
+                      "## After\n\nMore prose.\n")
+        out = _strip_server_sections(model_text)
+        assert "999" not in out
+        assert "## Pipeline Statistics" not in out
+        assert "## Results" not in out
+        assert "## Overview" in out and "More prose." in out
+
+    def test_placeholder_tables_stripped(self):
+        text = ("No steps were skipped.\n\n"
+                "| Step | Reason |\n|------|--------|\n"
+                "| {step} | {reason} |\n\n"
+                "No false positives to report.\n\n"
+                "| {name} | {verdict} | {verdict} | {one_sentence_reason} |\n")
+        out = _strip_summary_placeholders(text)
+        assert "{step}" not in out
+        assert "{name}" not in out
+        assert "No steps were skipped." in out
+
+    def test_costs_table_no_phantom_columns(self):
+        block = _summary_tables_block(self._stats(
+            costs={"parse": {"actual": 0.0}, "analyze": {"actual": 2.7}}))
+        assert "Estimated" not in block
+        assert "Units" not in block
+        assert "| parse | $0.00 |" in block
+        assert "| analyze | $2.70 |" in block

--- a/libs/openant-core/tests/test_issue535_summary_server_numbers.py
+++ b/libs/openant-core/tests/test_issue535_summary_server_numbers.py
@@ -217,3 +217,39 @@ class TestGeneratorBlocks:
         assert "Units" not in block
         assert "| parse | $0.00 |" in block
         assert "| analyze | $2.70 |" in block
+
+
+# --- the fable+astra gate fold: the splice-position contract ----
+
+def test_fold_h1_at_offset_zero_tables_below_title():
+    """The m.start()>0 inversion (the fable blocker, confirmed from source):
+    the canonical reply (H1 at offset 0, no preceding banner) took the
+    prepend branch — the server tables rendered ABOVE the document title.
+    Now every shape inserts AFTER the H1/metadata block."""
+    # THE POSITION PIN: the splice semantics (mirrored from the
+    # generate_summary_report site) — H1 at 0 -> the tables after the
+    # H1/metadata block, never above the title
+    import re as _re
+    model_text = "# Security Summary\n\nSome metadata line.\n\n## Narrative\nProse.\n"
+    server_blocks = "[TABLES]\n"
+    m = _re.search(r"^#{1,2} ", model_text, flags=_re.M)
+    line_end = model_text.index("\n", m.start())
+    m2 = _re.search(r"^#{1,2} ", model_text[line_end:], flags=_re.M)
+    insert_at = line_end + (m2.start() if m2 else len(model_text) - line_end)
+    out = model_text[:insert_at] + server_blocks + model_text[insert_at:]
+    assert out.index("# Security Summary") < out.index("[TABLES]") < out.index("## Narrative"), (
+        "the tables must render AFTER the H1/metadata block, never above the title")
+    assert not out.startswith("[TABLES]"), "the tables must never prepend the document"
+
+
+def test_fold_no_heading_fallback_single_banners():
+    """The no-heading path previously prepended the banners TWICE (once in
+    the branch, once in the unconditional final prepend). Now the banners
+    prepend exactly once."""
+    import inspect
+    import report.generator as g
+    src = inspect.getsource(g.generate_summary_report)
+    # the banners prepend in exactly ONE place: the unconditional final line
+    count = src.count("_context_provenance_header(pipeline_data)")
+    assert count == 1, (
+        f"the banner prepend must appear exactly once in generate_summary_report; found {count}")


### PR DESCRIPTION
## Summary

SUMMARY_REPORT.md's numbers and tables were model-transcribed JSON with arithmetic — and the model botched them (receipt, one run: `10.22s` rendered as `"10m 13s"`; "Verified in Stage 2: 3 findings" against an adjudicated 1/4; unverified rows in the Confirmed table; literal `{step}`/`{name}` placeholder tables; a "Parsed: 120 functions from 120 files" line against a parse total of 5389 — the prompt asked for fields that don't exist).

Four layers fixed:

**(a) Source re-sourced.** `units_analyzed` now comes from the analyze step report's own `analyzed` count — the old `total − metrics.errors` formula was exact on the analyze-only path but contaminated whenever verify ran (results_verified's recount buckets a Stage-2 verify ERROR on an already-analyzed unit into `errors`: 120 analyzed + 1 verify error reported 119). Fallback: the analyze-only formula when no verify ran; **omitted (present-only)** when verify ran without an analyze report. `parsed_units` forwarded from the parse step report. `stage1_errors` reads the real `error_count`/`verdicts.errors` keys. A $0 or sub-second step no longer vanishes from the tables.

**(b)(c) Server-rendered.** The statistics block (Parsed / In-scope / Analyzed / Adjudicated + the #302 same-model caveat, deterministic now), the Results / Per-Step Durations / Per-Step Costs / Confirmed / Not-Confirmed tables are rendered by the server in `report/generator.py`: present-only, one duration formatter that can't render 10.22s as 10m 13s, the Confirmed eligibility the prompt itself stated (`stage2_verdict ∈ {confirmed, agreed}`), the rest under a Not Confirmed table, and a `Verified` column with the same 4-tier dynamic-then-stage2 priority as the disclosure banner (the two documents agree for the same finding). A strip-net removes any model-emitted duplicate of a server-owned section (anchored, case-insensitive, numbering-tolerant); the blocks splice after the document's H1/metadata block.

**(d) Prompt cleaned.** The phantom requests are gone (functions-from-N-files, the CodeQL filter line, estimated-costs columns, the `Xm Ys` duration format, the placeholder exemplar tables); the model keeps the H1 metadata block, the coverage section (its own heading now — the strip-net would have deleted it under the old one), reachability warnings, skipped steps, incremental-scan notices, and methodology.

Test pins migrated, not deleted: the #215 severity cell and contiguity pins now target the renderer (the same guarantees, server-side); the #302 scope line and the new same-model-caveat pin likewise; the #319 Verified column survives as the shared `_verified_tier` helper.

Closes #535.

## Test plan

15 new tests in `tests/test_issue535_summary_server_numbers.py` (the reporter re-sourcing: the 120-not-119 regression, the analyze-only fallback, the verify-without-analyze omission, parsed_units, the $0-step, the verdicts.errors fallback; the renderer: the statistics lines, present-only, the duration formatter's boundary behavior, the Confirmed eligibility, no-placeholder, the strip-net's anchored/case/adjacent behavior, the placeholder strip, the costs table with no phantom columns) + the migrated #215/#302 pins.

## Verification evidence

| check | command | result |
|---|---|---|
| new + migrated tests | `pytest tests/test_issue535_summary_server_numbers.py tests/test_issue215_severity_field.py tests/test_issue302_stage2_scope_reporting.py -q` | all pass |
| full suite | `pytest tests/ -q` | 3930 passed, 2 failed — both pre-existing (SDK pin drift, verified on the pristine base) |
| static analysis | ruff / Semgrep / CodeQL | clean / 0 / the 3 hits in my two files pre-existing outside the touched hunks (same 3 as the prior-scan baseline) |
