### PR TITLE
fix(dynamic-test): a failed compose build still tears down (#536)

### DIFF
--- a/libs/openant-core/tests/test_issue536_compose_teardown.py
+++ b/libs/openant-core/tests/test_issue536_compose_teardown.py
@@ -1,0 +1,92 @@
+"""Tests for issue #536 — the compose build-failure teardown gap.
+
+`_run_compose` returns early on a build failure (``code != 0 or timed_out``)
+BEFORE the ``try/finally`` that runs ``compose down --volumes
+--remove-orphans --rmi local`` — so a failed build leaks the images it
+partially built (per-run UUID names accumulate forever). The outer cleanup
+(``_cleanup_docker``) removes single-container names only
+(``openant-test-<run>-<id>`` + the network), not the compose project's
+``openant-<run>-<id>-<service>`` images.
+
+Receipt (the monitored run): a compose build failed for VULN-001; the
+post-run image ``openant-069b737a-vuln-001-attacker`` matched the compose
+naming shape exactly (project + the attacker service) — name-shape
+attribution (the docker event log carries no image names).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from utilities.dynamic_tester.docker_executor import _run_compose
+
+
+class _Recorder:
+    def __init__(self, results):
+        self._results = list(results)
+        self.calls: list[list[str]] = []
+
+    def __call__(self, cmd, timeout=None, cwd=None):
+        self.calls.append(list(cmd))
+        return self._results.pop(0)
+
+
+def _seq(*outcomes):
+    """Build the _run_command result sequence.
+
+    outcomes: tuples (stdout, stderr, code, timed_out) in call order.
+    """
+    return [o for o in outcomes]
+
+
+def test_build_failure_still_tears_down():
+    """THE #536 regression: a failed build must still run compose down
+    --rmi local (the images the partial build created must not leak)."""
+    # build fails, then (post-fix) the teardown runs.
+    rec = _Recorder([
+        ("", "failed to solve: exit 1", 1, False),   # docker compose build
+        ("", "", 0, False),                           # docker compose down (teardown)
+        ("", "", 0, False),                           # docker compose logs (defensive)
+    ])
+    with patch(
+        "utilities.dynamic_tester.docker_executor._run_command", rec
+    ):
+        result = _run_compose("/tmp/wd", "openant-abc12345-vuln-001", 60, 120)
+    assert result.build_error  # the build failure is reported
+    assert len(rec.calls) == 2, rec.calls  # build + teardown, nothing else
+    downs = [c for c in rec.calls
+             if "down" in c and "--rmi" in c and "local" in c]
+    assert len(downs) == 1, (
+        f"a failed build must tear down with --rmi local; calls: {rec.calls}")
+
+
+def test_build_timeout_still_tears_down():
+    rec = _Recorder([
+        ("", "", -1, True),                            # build times out
+        ("", "", 0, False),                           # teardown
+    ])
+    with patch(
+        "utilities.dynamic_tester.docker_executor._run_command", rec
+    ):
+        result = _run_compose("/tmp/wd", "p", 60, 120)
+    assert result.timed_out
+    assert len(rec.calls) == 2, rec.calls
+    downs = [c for c in rec.calls if "down" in c and "--rmi" in c]
+    assert len(downs) == 1
+
+
+def test_success_path_teardown_unchanged():
+    """The happy path tears down exactly once (in the existing finally)."""
+    rec = _Recorder([
+        ("", "", 0, False),   # build
+        ("", "", 0, False),   # up -d
+        ("log", "", 0, False),  # logs -f test
+        ("", "", 0, False),   # down (finally)
+    ])
+    with patch(
+        "utilities.dynamic_tester.docker_executor._run_command", rec
+    ):
+        result = _run_compose("/tmp/wd", "p", 60, 120)
+    assert result.exit_code == 0
+    assert not result.build_error
+    downs = [c for c in rec.calls if "down" in c and "--rmi" in c]
+    assert len(downs) == 1  # exactly one teardown — no double-down

--- a/libs/openant-core/utilities/dynamic_tester/docker_executor.py
+++ b/libs/openant-core/utilities/dynamic_tester/docker_executor.py
@@ -538,6 +538,19 @@ def _run_compose(
         result.build_error = stderr if not timed_out else "Compose build timed out"
         result.stderr = stderr
         result.timed_out = timed_out
+        # #536: a failed build still tears down. The finally below covers
+        # the success path only — an early return here used to leak the
+        # images the partial build had already created (per-run UUID names
+        # like openant-<run>-<id>-<service> accumulate forever: the receipt
+        # was a post-run image matching the compose naming shape exactly).
+        # --rmi local removes the images this project built; a build that
+        # failed before ANY service built is a no-op for it.
+        _run_command(
+            compose_base + ["down", "--volumes", "--remove-orphans",
+                            "--rmi", "local"],
+            timeout=30,
+            cwd=work_dir,
+        )
         return result
 
     # Start services


### PR DESCRIPTION
## Summary

A compose build failure (or timeout) returned early — before the `try/finally` that runs `compose down --volumes --remove-orphans --rmi local` — so the images the partial build had already created leaked (per-run UUID names like `openant-<run>-<id>-<service>` accumulate forever; the receipt was a post-run image matching the compose naming shape exactly). The outer cleanup (`_cleanup_docker`) removes single-container names only, not the compose project's images.

The teardown now runs on the build-failure branch too. `--rmi local` is a no-op for a build that failed before any service built; the success path's teardown is unchanged (exactly one `down`, no double-down — the failure branch returns before the `try`).

Closes #536.

## Test plan

3 tests in `tests/test_issue536_compose_teardown.py`: a failed build tears down with `--rmi local` (exactly 2 commands: build + teardown); a build timeout tears down; the success path tears down exactly once (no double-down).

## Verification evidence

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue536_compose_teardown.py -q` | 3 passed |
| full suite | `pytest tests/ -q` | 3959 passed, 2 failed — both pre-existing (SDK pin drift, verified on the pristine base) |
| static analysis | ruff / Semgrep | clean / 0 |
| adversarial review | the combined wave+refute | SHIP; the two test tightenings (exact call counts, the -1 timeout convention) folded |
