### PR TITLE
fix(llm): a rejected completion's returned usage travels on the error and reaches the tracker (#537)

### DIFF
--- a/libs/openant-core/tests/test_issue537_rejected_usage.py
+++ b/libs/openant-core/tests/test_issue537_rejected_usage.py
@@ -1,0 +1,166 @@
+"""Tests for issue #537 — a rejected completion's returned usage is not lost.
+
+The empty-completion raise in providers/openai.py fires BEFORE the usage
+read, and simple_completion records usage only after complete() returns —
+so a rejected reply's usage is discarded un-read, and a verify conversation
+that fails on a later turn loses its earlier turns' accounting on the
+exceptional exit.
+
+The fix: LLMResponseError carries the rejected reply's usage (when the
+provider supplied it), and helpers.simple_completion records it via
+add_prior_usage before re-raising.
+"""
+from __future__ import annotations
+
+import pytest
+
+from utilities.llm import (
+    CompletionResult,
+    LLMAuthError,
+    LLMResponseError,
+    PhaseBinding,
+    TextBlock,
+)
+from utilities.llm_client import TokenTracker
+
+
+class _Usage:
+    def __init__(self, prompt_tokens, completion_tokens):
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
+class _Resp:
+    def __init__(self, usage, finish="stop"):
+        self.usage = usage
+        self.choices = [type("C", (), {"message": type("M", (), {"content": None}),
+                                       "finish_reason": finish})()]
+
+
+class RejectingAdapter:
+    """Mimics the provider contract: the raise path fires INSIDE complete
+    (the real openai.py raises before returning) — with the usage attached
+    per the #537 fix."""
+    name = "openai"
+    supports_tools = True
+
+    def __init__(self, usage):
+        self._usage = usage
+        self.calls = 0
+
+    def complete(self, *, model, system, messages, max_tokens, tools=None):
+        self.calls += 1
+        raise LLMResponseError(
+            "openai returned an empty completion",
+            input_tokens=getattr(self._usage, "prompt_tokens", 0),
+            output_tokens=getattr(self._usage, "completion_tokens", 0))
+
+    def validate(self, model):
+        pass
+
+
+class OkThenRejectAdapter:
+    name = "openai"
+    supports_tools = True
+
+    def __init__(self, usage):
+        self._usage = usage
+        self.n = 0
+
+    def complete(self, *, model, system, messages, max_tokens, tools=None):
+        self.n += 1
+        if self.n == 1:
+            return CompletionResult(
+                content=[TextBlock("ok")], input_tokens=10, output_tokens=5,
+                stop_reason="end_turn")
+        raise LLMResponseError(
+            "openai returned an empty completion",
+            input_tokens=getattr(self._usage, "prompt_tokens", 0),
+            output_tokens=getattr(self._usage, "completion_tokens", 0))
+
+    def validate(self, model):
+        pass
+
+
+def _binding(adapter, model="m"):
+    return PhaseBinding(phase="p", adapter=adapter, model=model,
+                        provider_name="openai")
+
+
+class TestRaiseCarriesUsage:
+    def test_response_error_carries_usage(self):
+        """The rejected reply's usage is ON the error — inspectable by the
+        caller's exceptional path."""
+        adapter = RejectingAdapter(_Usage(120, 34))
+        tracker = TokenTracker()
+        with pytest.raises(LLMResponseError) as ei:
+            from utilities.llm.helpers import simple_completion
+            simple_completion(_binding(adapter), "hi", tracker=tracker)
+        err = ei.value
+        assert getattr(err, "input_tokens", None) == 120
+        assert getattr(err, "output_tokens", None) == 34
+
+    def test_recorded_before_reraise(self):
+        """simple_completion records the rejected call's usage via
+        add_prior_usage — the tracker total carries it (never $0 for a
+        call the provider billed)."""
+        adapter = RejectingAdapter(_Usage(120, 34))
+        tracker = TokenTracker()
+        with pytest.raises(LLMResponseError):
+            from utilities.llm.helpers import simple_completion
+            simple_completion(_binding(adapter), "hi", tracker=tracker)
+        assert tracker.total_input_tokens >= 120
+        assert tracker.total_output_tokens >= 34
+
+    def test_ok_then_rejected_keeps_earlier_turn(self):
+        """A conversation that succeeds then rejects: the earlier turn's
+        usage survives (recorded at its own completion), the rejected
+        turn's usage recorded at the raise."""
+        adapter = OkThenRejectAdapter(_Usage(77, 21))
+        tracker = TokenTracker()
+        from utilities.llm.helpers import simple_completion
+        simple_completion(_binding(adapter), "first", tracker=tracker)
+        with pytest.raises(LLMResponseError):
+            simple_completion(_binding(adapter), "second", tracker=tracker)
+        # 10+5 from the ok turn; 77+21 from the rejected turn.
+        assert tracker.total_input_tokens == 10 + 77
+        assert tracker.total_output_tokens == 5 + 21
+
+    def test_auth_error_unchanged(self):
+        """LLMAuthError has no usage semantics — nothing to record."""
+        class BoomAuth(RejectingAdapter):
+            def complete(self, **kw):
+                raise LLMAuthError("bad key")
+
+        tracker = TokenTracker()
+        with pytest.raises(LLMAuthError):
+            from utilities.llm.helpers import simple_completion
+            simple_completion(_binding(BoomAuth(None)), "x", tracker=tracker)
+        assert tracker.total_input_tokens == 0
+
+
+class TestRealProviderSite:
+    """The real openai.py raise (not the fake-adapter contract): a response
+    object with usage but no usable content -> the error carries it."""
+
+    def test_chat_path_empty_completion_carries_usage(self, monkeypatch):
+        import utilities.llm.providers.openai as oa
+
+        class _Client:
+            class chat:
+                class completions:
+                    @staticmethod
+                    def create(**kw):
+                        return _Resp(_Usage(55, 13))
+
+        adapter = oa.OpenAIAdapter(api_key="sk-test",
+                                   _client=_Client())
+        from utilities.llm import Message, TextBlock
+        import pytest as _pytest
+        with _pytest.raises(LLMResponseError) as ei:
+            adapter.complete(
+                model="gpt-4o-mini", system=None,
+                messages=[Message(role="user", content=[TextBlock("x")])],
+                max_tokens=100)
+        assert ei.value.input_tokens == 55
+        assert ei.value.output_tokens == 13

--- a/libs/openant-core/utilities/llm/adapter.py
+++ b/libs/openant-core/utilities/llm/adapter.py
@@ -271,7 +271,19 @@ class LLMResponseError(LLMError):
     requires (e.g. missing usage block, malformed tool_use). Distinct
     from connection errors and rate limits so the pipeline can decide
     whether to retry.
+
+    #537: carries the REJECTED reply's usage when the provider supplied it
+    (a rejected call the provider billed must not vanish from accounting).
+    Zeroes when the failure predates a usage block (a transport error or
+    a refusal raised before the response parsed) — those are never billed
+    as completions by construction.
     """
+
+    def __init__(self, message: str, *,
+                 input_tokens: int = 0, output_tokens: int = 0):
+        super().__init__(message)
+        self.input_tokens = int(input_tokens or 0)
+        self.output_tokens = int(output_tokens or 0)
 
 
 class LLMRefusalError(LLMResponseError):

--- a/libs/openant-core/utilities/llm/helpers.py
+++ b/libs/openant-core/utilities/llm/helpers.py
@@ -19,7 +19,7 @@ import threading
 from typing import Optional
 
 from ..llm_client import TokenTracker, get_global_tracker
-from .adapter import CompletionResult, Message, TextBlock
+from .adapter import CompletionResult, LLMResponseError, Message, TextBlock
 from .registry import PhaseBinding
 
 # Thinking-era output budget (the simple_text default; PR #242 raised it from
@@ -79,12 +79,27 @@ def simple_completion(
     used_tracker = tracker if tracker is not None else get_global_tracker()
 
     messages = [Message(role="user", content=[TextBlock(prompt)])]
-    result = binding.adapter.complete(
-        model=binding.model,
-        system=system,
-        messages=messages,
-        max_tokens=max_tokens,
-    )
+    try:
+        result = binding.adapter.complete(
+            model=binding.model,
+            system=system,
+            messages=messages,
+            max_tokens=max_tokens,
+        )
+    except LLMResponseError as exc:
+        # #537: a rejected completion's returned usage is recorded BEFORE
+        # the re-raise — the call's tokens must not vanish from accounting
+        # (what the provider actually charged is unknowable from the
+        # artifact and stays unclaimed; the token counts are what the
+        # response carried).
+        if exc.input_tokens or exc.output_tokens:
+            used_tracker.record_call(
+                model=binding.model,
+                input_tokens=exc.input_tokens,
+                output_tokens=exc.output_tokens,
+                pricing=lookup_pricing(binding),
+            )
+        raise
     # Pricing lives on the adapter (issue #65 §9). Pass it through
     # so the tracker isn't forced to consult a shared global per
     # provider — the result is per-model accuracy without

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -839,9 +839,15 @@ def _response_to_unified(
         # the taxonomy instead of letting an IndexError escape unmapped
         # (mirrors the Gemini empty-``candidates`` guard); for a security
         # tool an empty end_turn would read as a clean, passing result.
+        _usage = getattr(response, "usage", None)
         raise LLMResponseError(
             f"{adapter} returned no choices (empty completion); the request "
-            "may have been filtered or the response was malformed"
+            "may have been filtered or the response was malformed",
+            # #537: same as the empty-content guard below — the rejected
+            # reply's usage travels (the sibling site of this class).
+            input_tokens=getattr(_usage, "prompt_tokens", 0) if _usage else 0,
+            output_tokens=(getattr(_usage, "completion_tokens", 0)
+                           if _usage else 0),
         )
     choice = choices[0]
     message = choice.message
@@ -904,10 +910,17 @@ def _response_to_unified(
     # here because ``content_blocks`` is non-empty. Refusal/content_filter is the
     # more specific signal and already raised above.
     if not content_blocks:
+        _usage = getattr(response, "usage", None)
         raise LLMResponseError(
             f"{adapter} returned an empty completion (no text or tool calls; "
             f"finish_reason={raw_finish!r}); the request may have been "
-            "filtered or the response was malformed"
+            "filtered or the response was malformed",
+            # #537: the rejected reply's usage travels ON the error —
+            # the raise used to fire before the usage read, discarding
+            # tokens the provider may already have billed.
+            input_tokens=getattr(_usage, "prompt_tokens", 0) if _usage else 0,
+            output_tokens=(getattr(_usage, "completion_tokens", 0)
+                           if _usage else 0),
         )
 
     if raw_finish not in _OPENAI_FINISH_REASONS:


### PR DESCRIPTION
## Summary

The empty-completion raise fired BEFORE the usage read, and `simple_completion` recorded usage only after `complete()` returned — so a rejected reply's tokens were discarded un-read (the artifact showed $0 for calls the provider may already have billed), and a verify conversation failing on a later turn lost the accounting for the turns before it.

The fix:

- **`LLMResponseError` carries the rejected reply's usage** (`input_tokens` / `output_tokens` keyword args; zeroes when the failure predates a usage block — a transport error or pre-parse refusal is never billed as a completion by construction). The signature change is additive: every existing raise site (positional message only) is unaffected, including the `LLMRefusalError` subclass.
- Both openai empty-completion guards (the no-choices site and the no-usable-content site — the sibling the review round caught) pass the response's usage onto the error.
- **`simple_completion` records it via the same `record_call` path as a successful call** (pricing lookup included) BEFORE re-raising — the rejection semantics are untouched: an empty completion is never accepted as clean.

**Disclosed bound:** what the provider actually charged is unknowable from the artifact and stays unclaimed; the token counts are what the response carried. The multi-turn verify loop's own flush-on-exit remains a separate surface (this fix covers the call-level accounting at the `simple_completion` boundary — the boundary every phase shares).

Closes #537.

## Test plan

5 tests in `tests/test_issue537_rejected_usage.py`: the error carries the usage; recorded before re-raise (the tracker total never $0 for a billed call); a conversation that succeeds then rejects keeps both turns' usage; an auth error records nothing; and the REAL provider site (a client stub driving `OpenAIAdapter.complete` → the raise carries the usage).

## Verification evidence

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue537_rejected_usage.py -q` | 5 passed |
| full suite | `pytest tests/ -q` | 3961 passed, 2 failed — both pre-existing (SDK pin drift, verified on the pristine base) |
| static analysis | ruff | clean |
| adversarial review | combined wave+refute | the two blockers folded: the sibling no-choices site + the provider-site test; the multi-site sweep verified the refusal subclass's constructor unaffected |
