### PR TITLE
fix(llm-reach): the deferred-truncation tracker — the stop reason on every drop line, the private cap retired, the truncation gate (#538)

### DIFF
--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -282,6 +282,7 @@ def parse_response(
     on_error: Optional[Callable[[str], None]] = None,
     batch_label: Optional[str] = None,
     on_batch_drop: Optional[Callable[[], None]] = None,
+    stop_reason: Optional[str] = None,
 ) -> List[ReachabilitySignal]:
     """Parse a single LLM response into validated ``ReachabilitySignal``s.
 
@@ -304,9 +305,16 @@ def parse_response(
     data = _extract_json(response_text)
     if not isinstance(data, dict):
         shape = _classify_malformed(response_text)
+        # #538: the stop reason upgrades the brace heuristic to evidence —
+        # "truncated at max_tokens" (the model hit the cap) vs "unbalanced
+        # JSON (not truncated)" (end_turn + broken braces = a shape error).
+        truncated = (stop_reason == "max_tokens" and
+                     shape == "truncated or unbalanced JSON")
+        if truncated:
+            shape = "truncated at max_tokens"
         log(f"malformed response: {shape} — skipping batch{label};{snippet}")
         if on_batch_drop is not None:
-            on_batch_drop()
+            on_batch_drop(truncated=truncated)
         return []
 
     raw_signals = data.get("signals")
@@ -314,7 +322,7 @@ def parse_response(
         log(f"malformed response: 'signals' missing or not a list "
             f"(got {type(raw_signals).__name__}) — skipping batch{label};{snippet}")
         if on_batch_drop is not None:
-            on_batch_drop()
+            on_batch_drop(truncated=False)
         return []
 
     out: List[ReachabilitySignal] = []
@@ -432,7 +440,8 @@ def analyze_reachability(
 
     # Lazy import so this module stays usable when callers explicitly
     # provide a binding and never want the registry fallback above.
-    from utilities.llm import LLMAuthError, simple_text
+    from utilities.llm import (LLMAuthError, TextBlock, simple_completion,
+                            DEFAULT_MAX_TOKENS)
 
     # #532 (review-wave fix): the usage machinery must be live in PRODUCTION —
     # resolve the global tracker when the caller doesn't pass one (the family
@@ -450,6 +459,7 @@ def analyze_reachability(
     # in which some units were never reviewed.
     dropped_batches = 0
     units_not_reviewed = 0
+    batches_truncated = 0
 
     # ------------------------------------------------------------------
     # #532: resume/adopt machinery — the checkpoint family's own pattern
@@ -596,7 +606,12 @@ def analyze_reachability(
             except Exception:  # noqa: BLE001
                 pass
         try:
-            text = simple_text(binding, prompt, max_tokens=4096, tracker=tracker)
+            result = simple_completion(binding, prompt,
+                                       max_tokens=DEFAULT_MAX_TOKENS,
+                                       tracker=tracker)
+            text = "\n".join(
+                b.text for b in result.content
+                if isinstance(b, TextBlock))
         except LLMAuthError:
             # Auth failures are fatal and recur on every batch — surface
             # them instead of burying them as a per-batch "failed" line,
@@ -620,16 +635,20 @@ def analyze_reachability(
         last = batch[-1].get("id", "?") if batch else "?"
         dropped_this_batch = False
 
-        def _count_drop_and_flag(batch=batch):
-            nonlocal dropped_batches, units_not_reviewed, dropped_this_batch
+        def _count_drop_and_flag(batch=batch, truncated=False):
+            nonlocal dropped_batches, units_not_reviewed, \
+                dropped_this_batch, batches_truncated
             dropped_batches += 1
             units_not_reviewed += len(batch)
             dropped_this_batch = True
+            if truncated:
+                batches_truncated += 1
 
         parsed = parse_response(
             text, valid_unit_ids=batch_ids, on_error=on_error,
             batch_label=f"batch {i + 1}/{len(batches)}, units {first}..{last}",
             on_batch_drop=_count_drop_and_flag,
+            stop_reason=result.stop_reason,
         )
         signals.extend(parsed)
 
@@ -637,7 +656,12 @@ def analyze_reachability(
         # drop — dropped batches leave no records (absence = the retry
         # marker on the next resume). Save failures cost persistence, not
         # the pass (the stage's own advisory doctrine).
-        if checkpoint is not None and not dropped_this_batch:
+        # #538 (4)-primitive: a max_tokens reply is NEVER persisted even
+        # when the salvage parse succeeds — a truncated batch's prefix
+        # signals must not freeze the tail units as "reviewed, no signal".
+        truncated_reply = (result.stop_reason == "max_tokens")
+        if (checkpoint is not None and not dropped_this_batch
+                and not truncated_reply):
             batch_usage = {}
             if tracker is not None:
                 try:
@@ -709,6 +733,8 @@ def analyze_reachability(
     if stats is not None:
         stats["batches_dropped"] = dropped_batches
         stats["units_not_reviewed"] = units_not_reviewed
+        # #538: the truncation subclass — the recurrence's diagnosis lever.
+        stats["batches_truncated"] = batches_truncated
 
     return signals
 

--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -650,18 +650,40 @@ def analyze_reachability(
             on_batch_drop=_count_drop_and_flag,
             stop_reason=result.stop_reason,
         )
+        # #538 gate fold (fable+astra — the salvage-success gap): a
+        # max_tokens reply drops the batch WHOLE — the parsed prefix
+        # signals are NOT applied (the applied==adopted invariant: the
+        # signals gated the re-filter this run but were absent from the
+        # checkpoint, so a resume silently re-filtered on un-replayed
+        # state), and batches_truncated counts the truncation
+        # INDEPENDENTLY of the parse outcome (the salvage parse may
+        # succeed without the on_batch_drop callback ever firing — the
+        # counter was blind to exactly the case the gate acts on).
+        # Deduplicated: when the salvage parse DID drop (the callback
+        # fired), its counters already stand — the fold only adds the
+        # counts the callback never made.
+        _truncated = (result.stop_reason == "max_tokens")
+        if _truncated:
+            if not dropped_this_batch:
+                batches_truncated += 1
+                dropped_batches += 1
+                units_not_reviewed += len(batch)
+                print(f"[LLMReach] batch {i + 1}/{len(batches)} truncated at "
+                      f"max_tokens — dropping whole (salvage prefix discarded); "
+                      f"{len(batch)} units re-run on the next pass",
+                      file=sys.stderr)
+            continue
         signals.extend(parsed)
 
         # Persist per-unit records ONLY for a batch that completed without a
         # drop — dropped batches leave no records (absence = the retry
         # marker on the next resume). Save failures cost persistence, not
         # the pass (the stage's own advisory doctrine).
-        # #538 (4)-primitive: a max_tokens reply is NEVER persisted even
-        # when the salvage parse succeeds — a truncated batch's prefix
-        # signals must not freeze the tail units as "reviewed, no signal".
-        truncated_reply = (result.stop_reason == "max_tokens")
-        if (checkpoint is not None and not dropped_this_batch
-                and not truncated_reply):
+        # #538 (4)-primitive: a max_tokens reply NEVER reaches this block —
+        # the fold's `continue` above drops the whole batch BEFORE the
+        # persist (the applied==adopted invariant; the salvage prefix
+        # discarded). dropped_this_batch stays the parse-drop marker.
+        if (checkpoint is not None and not dropped_this_batch):
             batch_usage = {}
             if tracker is not None:
                 try:

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -895,6 +895,9 @@ def scan_repository(
                         # counts what was SENT for review, not what was
                         # actually reviewed.
                         "batches_dropped": reach_stats.get("batches_dropped", 0),
+                        # #538: the truncation subclass — the diagnosis
+                        # lever for the deferred-recovery tracker.
+                        "batches_truncated": reach_stats.get("batches_truncated", 0),
                         "units_not_reviewed": reach_stats.get("units_not_reviewed", 0),
                     }
                     ctx.outputs = {"signals_path": signals_path}

--- a/libs/openant-core/tests/test_issue294_reach_batch_diagnostics.py
+++ b/libs/openant-core/tests/test_issue294_reach_batch_diagnostics.py
@@ -107,7 +107,7 @@ def test_signals_missing_branch_names_type_and_counts_drop():
         '{"signals": "nope"}',
         on_error=got.append,
         batch_label="batch 1/1",
-        on_batch_drop=lambda: drops.append(1),
+        on_batch_drop=lambda truncated=False: drops.append(1),
     )
     assert "'signals' missing or not a list (got str)" in got[0]
     assert drops == [1]
@@ -119,7 +119,7 @@ def test_valid_response_does_not_fire_drop_callback():
         '{"signals": [{"unit_id": "a.py:f", "kind": "entry_point", '
         '"confidence": "high", "reason": "r"}]}',
         valid_unit_ids={"a.py:f"},
-        on_batch_drop=lambda: drops.append(1),
+        on_batch_drop=lambda truncated=False: drops.append(1),
     )
     assert len(out) == 1
     assert drops == []
@@ -136,12 +136,28 @@ def _dataset(n_units: int) -> dict:
 
 
 class _ScriptedBinding:
-    """simple_text is monkeypatched at module level; binding is opaque."""
+    """#538 migration: the call path is simple_completion now — the binding
+    carries a FakeAdapter (the test_issue532 pattern) that replays the
+    scripted responses through the real path (stop_reason included)."""
 
-    def __init__(self):  # pragma: no cover - opaque to analyze_reachability
-        self.model = "m"
-        self.adapter = None
-        self.provider_name = "anthropic"
+    def __init__(self, responses):
+        from utilities.llm import PhaseBinding
+        from tests.test_issue532_llr_resume import FakeAdapter
+        self._b = PhaseBinding(
+            phase="llm_reach", adapter=FakeAdapter(list(responses)),
+            model="m", provider_name="anthropic")
+
+    @property
+    def adapter(self):
+        return self._b.adapter
+
+    @property
+    def model(self):
+        return self._b.model
+
+    @property
+    def provider_name(self):
+        return self._b.provider_name
 
 
 def test_analyze_reachability_counts_dropped_units(tmp_path, monkeypatch):
@@ -156,13 +172,10 @@ def test_analyze_reachability_counts_dropped_units(tmp_path, monkeypatch):
     ])
     errs: list[str] = []
 
-    import utilities.llm as llm_mod
-    monkeypatch.setattr(llm_mod, "simple_text",
-                        lambda binding, prompt, **kw: next(responses))
 
     stats: dict = {}
     signals = analyze_reachability(
-        dataset, binding=_ScriptedBinding(), batch_size=2,
+        dataset, binding=_ScriptedBinding(responses), batch_size=2,
         on_error=errs.append, stats=stats)
 
     # batch 1's signal survived the drop of batch 2
@@ -173,15 +186,14 @@ def test_analyze_reachability_counts_dropped_units(tmp_path, monkeypatch):
     assert any("batch 2/2" in e and "prose/refusal" in e for e in errs), errs
 
 
-def test_analyze_reachability_stats_absent_means_uncounted(tmp_path, monkeypatch):
+def test_analyze_reachability_stats_absent_means_uncounted():
     """No stats dict → no counting (backwards-compatible call shape)."""
 
     dataset = _dataset(2)
-    import utilities.llm as llm_mod
-    monkeypatch.setattr(llm_mod, "simple_text",
-                        lambda binding, prompt, **kw: "not json at all")
-    signals = analyze_reachability(dataset, binding=_ScriptedBinding(),
-                                   batch_size=2)
+    signals = analyze_reachability(
+        dataset,
+        binding=_ScriptedBinding(["not json at all"]),
+        batch_size=2)
     assert signals == []
 
 

--- a/libs/openant-core/tests/test_issue532_llr_resume.py
+++ b/libs/openant-core/tests/test_issue532_llr_resume.py
@@ -538,3 +538,81 @@ class TestDeepRefuteFixes:
         s = StepCheckpoint.read_summary(cp)
         assert s["phase"] == "in_progress"
         assert s["incomplete"] >= 1
+
+
+class TestIssue538Tracker:
+    """#538: the stop-reason evidence, the cap lift, the truncation gate."""
+
+    def test_truncated_batch_evidence_and_stats(self):
+        """A max_tokens reply: the drop line names the cause; the
+        truncation counter fires; NO records persist for the batch."""
+
+        class TruncAdapter(FakeAdapter):
+            def complete(self, *, model, system, messages, max_tokens,
+                         tools=None):
+                from utilities.llm import CompletionResult, TextBlock
+                self.calls.append({"max_tokens": max_tokens})
+                return CompletionResult(
+                    content=[TextBlock('{"signals": [{"unit_id"')],
+                    input_tokens=5, output_tokens=5,
+                    stop_reason="max_tokens")
+
+        errors: List[str] = []
+        stats: dict = {}
+        analyze_reachability(
+            {"units": [_make_unit("a:f1")]},
+            binding=_binding(TruncAdapter()),
+            on_error=errors.append, stats=stats)
+        assert stats["batches_truncated"] == 1
+        assert stats["batches_dropped"] == 1
+        assert any("max_tokens" in e for e in errors)
+
+    def test_end_turn_unbalanced_not_truncated(self):
+        from utilities.llm import CompletionResult, TextBlock
+
+        class Unbalanced(FakeAdapter):
+            def complete(self, **kw):
+                return CompletionResult(
+                    content=[TextBlock('{"signals": [{"unit_id"')],
+                    input_tokens=5, output_tokens=5,
+                    stop_reason="end_turn")
+
+        stats: dict = {}
+        errors: List[str] = []
+        analyze_reachability(
+            {"units": [_make_unit("a:f1")]}, binding=_binding(Unbalanced()),
+            on_error=errors.append, stats=stats)
+        assert stats["batches_truncated"] == 0
+        assert stats["batches_dropped"] == 1
+        assert any("unbalanced" in e for e in errors)
+
+    def test_cap_is_default_not_4096(self):
+        """The private 4096 retired — the phase shares the floor cap."""
+        from utilities.llm.helpers import DEFAULT_MAX_TOKENS
+        adapter = FakeAdapter([_canned(_sig("a:f1"))])
+        analyze_reachability(
+            {"units": [_make_unit("a:f1")]}, binding=_binding(adapter))
+        assert adapter.calls[0]["max_tokens"] == DEFAULT_MAX_TOKENS
+
+    def test_truncated_reply_never_persists(self, tmp_path):
+        """(4)-primitive: even when the salvage parse SUCCEEDS on a
+        max_tokens reply, no records are written (the tail units must not
+        freeze as reviewed-no-signal)."""
+        from utilities.llm import CompletionResult, TextBlock
+
+        class TruncButValid(FakeAdapter):
+            def complete(self, **kw):
+                return CompletionResult(
+                    content=[TextBlock(_canned(_sig("a:f1")))],
+                    input_tokens=5, output_tokens=5,
+                    stop_reason="max_tokens")
+
+        cp = str(tmp_path / "llr_reach_checkpoints")
+        analyze_reachability(
+            {"units": [_make_unit("a:f1")]},
+            binding=_binding(TruncButValid()),
+            checkpoint_path=cp, tracker=FakeTracker())
+        import os
+        recs = [f for f in os.listdir(cp)
+                if f.endswith(".json") and not f.startswith("_")]
+        assert recs == [], f"a truncated reply must not persist: {recs}"

--- a/libs/openant-core/tests/test_issue532_llr_resume.py
+++ b/libs/openant-core/tests/test_issue532_llr_resume.py
@@ -616,3 +616,38 @@ class TestIssue538Tracker:
         recs = [f for f in os.listdir(cp)
                 if f.endswith(".json") and not f.startswith("_")]
         assert recs == [], f"a truncated reply must not persist: {recs}"
+
+
+class TestIssue538GateFold:
+    """The fable+astra fold: the salvage-success invariant — a truncated
+    reply's PARSED-PREFIX signals are never applied (applied==adopted), and
+    the truncation counts even when the salvage parse succeeds (the callback
+    never fires)."""
+
+    def test_fold_salvage_success_signals_not_applied(self):
+        """A max_tokens reply whose salvage parse WOULD succeed: the parsed
+        prefix signals must NOT reach the applied set (the applied==adopted
+        invariant — they were never persisted)."""
+        from utilities.llm import CompletionResult, TextBlock
+
+        class SalvageAdapter(FakeAdapter):
+            def complete(self, **kw):
+                # a WELL-FORMED reply (the salvage parse succeeds) but
+                # truncated per the stop reason — the fold's exact case
+                return CompletionResult(
+                    content=[TextBlock('{"signals": [{"unit_id": "a:f1", '
+                                       '"signal_kind": "input_pattern", '
+                                       '"confidence": 0.9}]}')],
+                    input_tokens=5, output_tokens=5,
+                    stop_reason="max_tokens")
+
+        stats: dict = {}
+        sigs = analyze_reachability(
+            {"units": [_make_unit("a:f1")]},
+            binding=_binding(SalvageAdapter()), stats=stats)
+        assert sigs == [], (
+            "a truncated reply's salvage-parsed signals must NOT apply "
+            "(applied==adopted)")
+        assert stats.get("batches_truncated") == 1, (
+            "the truncation counts even when the salvage parse succeeds")
+        assert stats.get("batches_dropped") == 1


### PR DESCRIPTION
## Summary

This tracker follows two documented deferrals to their levers (the #386 malformed-recovery deferral and #527's recorded private-cap residual), both of which recurred on the next target.

**(1) The stop reason is evidence.** The malformed path swaps to `simple_completion` (the `#512` `application_context` precedent — `simple_text` discards the result after joining), threads `result.stop_reason` into `parse_response`, and the classifier's brace heuristic becomes evidence-based: a `max_tokens` reply logs **"truncated at max_tokens"** (the diagnosis the recurrence receipts lacked); an `end_turn` reply with broken braces logs **"unbalanced JSON (not truncated)"**. `batches_truncated` counts the subclass and surfaces in the step summary beside `batches_dropped`. The `#512` one-time truncation warning stops firing for LLR — the per-batch drop line carries the same information.

**(2) The private 4096 cap retired.** The phase shares `DEFAULT_MAX_TOKENS` (the cap-not-floor contract: expected cost unchanged for healthy replies, which stop at `end_turn`; the OpenAI Responses path already floored to 16000). The checkpoint fingerprint is unaffected (`max_tokens` is not a KEY member) — records from batches that succeeded under 4096 stay valid.

**(4)-primitive.** A `max_tokens` reply **never persists records** — even when the salvage parse succeeds on a truncated prefix, the batch drops whole: the tail units must not freeze as "reviewed, no signal" in the checkpoint (the applied==adopted invariant from the resume machinery).

**(3) — the in-pass recovery — named as the measured follow-up:** split-and-retry is preferred over a JSON corrector (a corrector on a truncated reply would persist a partial batch as reviewed, defeating absence-as-retry). The resume machinery (the merged #543) covers relaunch-retry; deterministic in-run truncation is what the cap lift addresses.

Closes #538.

## Test plan

4 new tests (the #538 tracker class in `tests/test_issue532_llr_resume.py`): the truncated drop line + `batches_truncated == 1`; end-turn unbalanced not counted as truncated; the cap is `DEFAULT_MAX_TOKENS` (the fake records the kwarg); a truncated-but-salvageable reply persists nothing. The two `#294` tests migrated off the opaque-binding monkeypatch to the real call path.

## Verification evidence

| check | command | result |
|---|---|---|
| new + family | `pytest tests/test_issue532_llr_resume.py tests/test_issue294_reach_batch_diagnostics.py tests/test_llm_reachability.py -q` | 63 passed |
| full suite | `pytest tests/ -q` | 3959 passed, 2 failed — both pre-existing (SDK pin drift) |
| static analysis | ruff / Semgrep | clean / 0 |
| resume-safety | the checkpoint fingerprint unchanged (the cap is not a KEY member) — all 20 #543-era tests pass unchanged |
