### PR TITLE
fix(verify): the resume narration's 'already done' counts restored-complete rows, not the raw checkpoint store (#542)

### DIFF
--- a/libs/openant-core/tests/test_issue542_verify_narration.py
+++ b/libs/openant-core/tests/test_issue542_verify_narration.py
@@ -1,0 +1,123 @@
+"""Tests for issue #542 — the verify resume narration's "already done" is
+the raw checkpoint count.
+
+The Mode line printed ``({len(checkpointed)} already done)`` — the raw
+checkpoint store includes the ERROR rows being queued for retry, so a
+resumed run narrated "3 findings to verify (3 already done)" over a
+population of 4 (1 complete + 2 being retried). Exactly the pre-#472 shape
+PR #472 removed from analyze (the #435 family): done must derive from the
+restored-complete counts so done + remaining reconciles to the population.
+"""
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stderr
+from unittest.mock import patch
+
+from utilities.finding_verifier import FindingVerifier
+
+
+def _ckpt_row(kind, finding="vulnerable"):
+    """kind: 'ok' a restored-complete row; 'err' a retryable ERROR row
+    (the shape _cp_is_error detects: correct_finding == 'error')."""
+    if kind == "err":
+        return {"finding": "error",
+                "verification": {"agree": False, "correct_finding": "error",
+                                 "explanation": "boom", "iterations": 1,
+                                 "total_tokens": 10},
+                "error": "LLMResponseError: boom"}
+    return {"finding": finding,
+            "verification": {"agree": True, "correct_finding": finding,
+                              "explanation": "ok", "iterations": 1,
+                              "total_tokens": 10}}
+
+
+def _row(uid):
+    return {"unit_id": uid, "finding": "vulnerable", "verdict": "vulnerable"}
+
+
+class _FakeCheckpoint:
+    def __init__(self, store):
+        self._store = store
+        self.dir = "/tmp/fake"
+
+    @property
+    def exists(self):
+        return bool(self._store)
+
+    def load(self):
+        return self._store
+
+    def write_summary(self, *a, **kw):
+        pass
+
+    def sync_identity(self, fp, **kw):
+        return {"status": "match"}
+
+
+class TestModeLineNarration:
+    def test_done_derives_from_restored_not_store(self):
+        """THE #542 receipt: 4 findings, 1 complete, 2 errored, 1 new ->
+        the Mode line reads '3 findings to verify (1 already done)' —
+        never 3 already done (the raw store count)."""
+        orch = FindingVerifier.__new__(FindingVerifier)
+        orch.logger = None
+        orch._use_logger = False
+        orch.verbose = True
+        orch.tracker = type("T", (), {
+            "start_unit_tracking": lambda s: None,
+            "get_unit_usage": lambda s: {},
+            "add_prior_usage": lambda s, *a, **kw: None,
+            "record_call": lambda s, *a, **kw: None,
+            "get_unit_record": lambda s, *a, **kw: None})()
+        orch.binding = None
+        orch.checkpoint = _FakeCheckpoint({
+            "a:ok": _ckpt_row("ok"),
+            "b:err": _ckpt_row("err"),
+            "c:err": _ckpt_row("err"),
+        })
+        results = [_row("a:ok"), _row("b:err"), _row("c:err"), _row("d:new")]
+
+        captured = io.StringIO()
+        with redirect_stderr(captured):
+            with patch.object(orch, "_verify_batch_sequential",
+                              lambda *a, **kw: None):
+                orch.verify_batch(
+                    results, {}, workers=1,
+                    checkpoint=orch.checkpoint)
+        out = captured.getvalue()
+        # The Mode line: done + remaining reconcile to the population.
+        assert "3 findings to verify" in out, out
+        assert "(1 already done)" in out, (
+            f"the raw-store shape ('3 already done') must be gone: {out}")
+
+    def test_foreign_checkpoint_not_narrated_as_retry(self):
+        """The sibling (the review round): a stale checkpoint for a unit no
+        longer in results must not narrate as an 'errored retry'."""
+        orch = FindingVerifier.__new__(FindingVerifier)
+        orch.logger = None
+        orch._use_logger = False
+        orch.verbose = True
+        orch.tracker = type("T", (), {
+            "start_unit_tracking": lambda s: None,
+            "get_unit_usage": lambda s: {},
+            "add_prior_usage": lambda s, *a, **kw: None,
+            "record_call": lambda s, *a, **kw: None})()
+        orch.binding = None
+        orch.checkpoint = _FakeCheckpoint({
+            "a:ok": _ckpt_row("ok"),
+            "stale:gone": _ckpt_row("err"),   # a foreign row
+        })
+        results = [_row("a:ok"), _row("d:new")]
+        captured = io.StringIO()
+        with redirect_stderr(captured):
+            with patch.object(orch, "_verify_batch_sequential",
+                              lambda *a, **kw: None):
+                orch.verify_batch(results, {}, workers=1,
+                                  checkpoint=orch.checkpoint)
+        out = captured.getvalue()
+        assert "Retrying 0 previously errored" not in out or \
+            "Retrying 0" in out, out
+        # 1 restored + 1 new; the foreign row narrates nothing.
+        assert "1 findings to verify (1 already done)" in out, out
+        assert "stale" not in out

--- a/libs/openant-core/utilities/finding_verifier.py
+++ b/libs/openant-core/utilities/finding_verifier.py
@@ -728,6 +728,7 @@ class FindingVerifier:
         results_to_verify = []
         _restored_ok = 0
         _restored_incomplete = 0
+        _errored_retried = 0
         for r in results:
             key = r.get("unit_id") or r.get("route_key", "unknown")
             cp_data = checkpointed.get(key)
@@ -750,13 +751,15 @@ class FindingVerifier:
             else:
                 # Either no checkpoint, or an errored one — re-verify
                 results_to_verify.append(r)
+                if cp_data:
+                    _errored_retried += 1
 
         if _restored_ok or _restored_incomplete:
             print(f"[Verify] Restored {_restored_ok + _restored_incomplete} findings "
                   f"from checkpoints", file=sys.stderr, flush=True)
             if restored_callback:
                 restored_callback(_restored_ok + _restored_incomplete)
-        errored_retries = len(checkpointed) - _restored_ok - _restored_incomplete
+        errored_retries = _errored_retried
         if errored_retries:
             print(f"[Verify] Retrying {errored_retries} previously errored findings",
                   file=sys.stderr, flush=True)
@@ -832,9 +835,16 @@ class FindingVerifier:
                                          usage=_usage_dict(), incomplete=_summary_incomplete)
 
         remaining = len(results_to_verify)
+        # #542 (the #435 family, PR #472's verify sibling): "already done"
+        # derives from the RESTORED-COMPLETE counts, not the raw checkpoint
+        # store — the store includes the errored rows being re-queued, so
+        # the old line narrated "3 to verify (3 already done)" over a
+        # population of 4 (1 complete + 2 being retried). Done + remaining
+        # must reconcile to the findings population.
+        _done = _restored_ok + _restored_incomplete
         mode = "sequential" if workers <= 1 else f"parallel ({workers} workers)"
         print(f"[Verify] Mode: {mode}, {remaining} findings to verify "
-              f"({len(checkpointed)} already done)", file=sys.stderr, flush=True)
+              f"({_done} already done)", file=sys.stderr, flush=True)
 
         if workers <= 1:
             self._verify_batch_sequential(


### PR DESCRIPTION
## Summary

The verify resume narration's Mode line printed `len(checkpointed)` — the raw checkpoint store **including the ERROR rows being re-queued for retry** — so a resumed run narrated "3 findings to verify (3 already done)" over a population of 4 (1 complete + 2 being retried). Exactly the pre-#472 shape PR #472 removed from `analyze` (the `#435` family, its verify sibling).

The fix:

- **"already done"** derives from the restored-complete counts (`_restored_ok + _restored_incomplete`) so done + remaining reconciles to the findings population — the narration, the "Restored N" line, and the progress-reporter seed (2/4, 3/4…) now agree;
- **the sibling (the review round): "Retrying N previously errored"** is now loop-tracked (`_errored_retried` — the cp rows for units actually in results that were error-shaped) instead of the raw store minus restored — a stale/foreign checkpoint row no longer narrates as an "errored retry" that never runs.

Closes #542.

## Test plan

2 tests in `tests/test_issue542_verify_narration.py`: the receipt shape (1 complete + 2 errored + 1 new → "3 findings to verify (1 already done)", never 3 already done); the foreign-checkpoint row narrates no retry.

## Verification evidence

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue542_verify_narration.py -q` | 2 passed |
| full suite | `pytest tests/ -q` | 3958 passed, 2 failed — both pre-existing (SDK pin drift) |
| static analysis | ruff | clean |
| adversarial review | combined wave+refute | SHIP + the sibling raw-store count folded (loop-tracked) |
