### PR TITLE
feat(scan): the Go scan command exposes the repository metadata flags the Python CLI already accepts (#539)

### DIFF
--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -56,6 +56,9 @@ var (
 	scanLLMReachability             bool
 	scanLLMReachabilityMaxCodeBytes int
 	scanLibraryMode                 bool
+	scanRepoName                    string
+	scanRepoURL                     string
+	scanCommitSHA                   string
 )
 
 func init() {
@@ -65,6 +68,25 @@ func init() {
 // registerScanFlags wires the full scan-pipeline flag set onto cmd. Used by
 // scanCmd and by the thin diffCmd wrapper so that both surfaces accept the
 // same knobs.
+
+// resolveRepoMetadata merges the explicit CLI flags with the project
+// context (#539): the flag wins; the project context is the fallback; a
+// bare-path scan (nil context) uses the flags alone.
+func resolveRepoMetadata(name, url, sha string, ctx *projectContext) (string, string, string) {
+	if ctx != nil && ctx.Project != nil {
+		if name == "" && ctx.Project.Name != "" {
+			name = ctx.Project.Name
+		}
+		if url == "" && ctx.Project.RepoURL != "" {
+			url = ctx.Project.RepoURL
+		}
+		if sha == "" && ctx.Project.CommitSHA != "" {
+			sha = ctx.Project.CommitSHA
+		}
+	}
+	return name, url, sha
+}
+
 func registerScanFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&scanOutput, "output", "o", "", "Output directory (default: project scan dir or temp dir)")
 	cmd.Flags().StringVarP(&scanLanguage, "language", "l", "", languages.FlagHelp())
@@ -85,6 +107,13 @@ func registerScanFlags(cmd *cobra.Command) {
 	cmd.Flags().IntVar(&scanPR, "pr", 0, "Incremental mode against a GitHub PR number (requires gh; mutex with --diff-base)")
 	cmd.Flags().BoolVar(&scanStaged, "staged", false, "Incremental mode against the staged index vs HEAD (pre-commit hook usage; mutex with --diff-base/--pr)")
 	cmd.Flags().StringVar(&scanDiffScope, "diff-scope", "changed_functions", "Diff scope: changed_files, changed_functions, callers")
+	// #539: the repository metadata the Python CLI already accepts — a
+	// bare-path scan (the documented primary usage) resolves to a nil
+	// project context, so the metadata block below never fired and every
+	// report carried [NOT PROVIDED] with no CLI way to supply it.
+	cmd.Flags().StringVar(&scanRepoName, "repo-name", "", "Repository name (org/repo) — stamped into reports")
+	cmd.Flags().StringVar(&scanRepoURL, "repo-url", "", "Repository URL — stamped into reports")
+	cmd.Flags().StringVar(&scanCommitSHA, "commit-sha", "", "Commit SHA — stamped into reports")
 	cmd.Flags().BoolVar(&scanLLMReachability, "llm-reachability", false, "Enable the LLM reachability review stage (Opus). Surfaces entry points and external-input sites the structural pass would miss by reviewing the full codebase before the reachability filter is applied. Off by default — enabling this incurs cost proportional to total repo size, not the filtered unit count (~one Opus call per 25 units across the whole codebase).")
 	cmd.Flags().IntVar(&scanLLMReachabilityMaxCodeBytes, "llm-reachability-max-code-bytes", 1500, "Max code bytes per unit sent to the LLM reachability stage (default: 1500). Higher values (e.g. 4096, 8192) catch entry-point indicators past byte 1500 in long handlers / generated code, at proportional Opus cost increase. Only meaningful with --llm-reachability.")
 	cmd.Flags().BoolVar(&scanLibraryMode, "library-mode", false, "Seed the exported public API as reachability entry points, for a library whose public API is being dropped by the structural filter. Blunt: keeps most units — prefer letting fuzz/bin/route entry points seed reachability first.")
@@ -223,18 +252,20 @@ func runScan(cmd *cobra.Command, args []string) {
 		pyArgs = append(pyArgs, "--llm-reachability-max-code-bytes", fmt.Sprintf("%d", scanLLMReachabilityMaxCodeBytes))
 	}
 
-	// Pass repository metadata from project context so reports don't show
-	// [NOT PROVIDED] placeholders.
-	if ctx != nil && ctx.Project != nil {
-		if ctx.Project.Name != "" {
-			pyArgs = append(pyArgs, "--repo-name", ctx.Project.Name)
-		}
-		if ctx.Project.RepoURL != "" {
-			pyArgs = append(pyArgs, "--repo-url", ctx.Project.RepoURL)
-		}
-		if ctx.Project.CommitSHA != "" {
-			pyArgs = append(pyArgs, "--commit-sha", ctx.Project.CommitSHA)
-		}
+	// Pass repository metadata so reports don't show [NOT PROVIDED]
+	// placeholders. #539: an explicit flag wins; the project context is the
+	// fallback (a bare-path scan has no project context — the flags are the
+	// only way in).
+	repoName, repoURL, commitSHA := resolveRepoMetadata(
+		scanRepoName, scanRepoURL, scanCommitSHA, ctx)
+	if repoName != "" {
+		pyArgs = append(pyArgs, "--repo-name", repoName)
+	}
+	if repoURL != "" {
+		pyArgs = append(pyArgs, "--repo-url", repoURL)
+	}
+	if commitSHA != "" {
+		pyArgs = append(pyArgs, "--commit-sha", commitSHA)
 	}
 
 	result, err := python.Invoke(rt.Path, pyArgs, "", quiet, requireAPIKey())

--- a/apps/openant-cli/cmd/scan_repo_metadata_test.go
+++ b/apps/openant-cli/cmd/scan_repo_metadata_test.go
@@ -1,0 +1,68 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/knostic/open-ant-cli/internal/config"
+)
+
+// TestScanRepoMetadataFlagsDefined locks the #539 flag-parity fix: the Go
+// scan command exposes --repo-name/--repo-url/--commit-sha, mirroring the
+// Python backend (cli.py scan_p defines all three). A bare-path scan has no
+// project context, so the flags are the only way reports get metadata.
+func TestScanRepoMetadataFlagsDefined(t *testing.T) {
+	for _, name := range []string{"repo-name", "repo-url", "commit-sha"} {
+		if scanCmd.Flag(name) == nil {
+			t.Fatalf("scanCmd has no --%s (parity gap with the Python backend)", name)
+		}
+	}
+}
+
+// TestResolveRepoMetadata locks the precedence and the nil-context path
+// (the #539 defect itself: a bare-path scan resolves to a nil context —
+// the explicit flags must flow through alone).
+func TestResolveRepoMetadata(t *testing.T) {
+	tests := []struct {
+		name                       string
+		flagName, flagURL, flagSHA string
+		ctx                        *projectContext
+		wantName, wantURL, wantSHA string
+	}{
+		{
+			name:     "bare path (nil ctx): flags flow through alone",
+			ctx:      nil,
+			flagName: "acme/app", flagURL: "https://x", flagSHA: "abc123",
+			wantName: "acme/app", wantURL: "https://x", wantSHA: "abc123",
+		},
+		{
+			name: "project ctx fills empty flags",
+			ctx: &projectContext{Project: &config.Project{
+				Name: "proj/app", RepoURL: "https://p", CommitSHA: "fff000",
+			}},
+			wantName: "proj/app", wantURL: "https://p", wantSHA: "fff000",
+		},
+		{
+			name: "explicit flag wins over the project context",
+			ctx: &projectContext{Project: &config.Project{
+				Name: "proj/app", RepoURL: "https://p", CommitSHA: "fff000",
+			}},
+			flagName: "acme/app", flagSHA: "abc123",
+			wantName: "acme/app", wantURL: "https://p", wantSHA: "abc123",
+		},
+		{
+			name:     "nil Project inside a non-nil ctx",
+			ctx:      &projectContext{},
+			flagName: "acme/app",
+			wantName: "acme/app",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			n, u, s := resolveRepoMetadata(tt.flagName, tt.flagURL, tt.flagSHA, tt.ctx)
+			if n != tt.wantName || u != tt.wantURL || s != tt.wantSHA {
+				t.Errorf("resolveRepoMetadata = (%q, %q, %q), want (%q, %q, %q)",
+					n, u, s, tt.wantName, tt.wantURL, tt.wantSHA)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

A bare-path scan — the documented primary usage — resolves to a nil project context, so the repository-metadata pass-through block never fired: every report carried `[NOT PROVIDED]` url/commit with no CLI way to supply them (the receipt: a monitored scan of a pinned external clone with the SHA known to the caller the whole time; the Go scan command exposed none of the three flags the Python CLI already accepts).

The fix:

- `--repo-name` / `--repo-url` / `--commit-sha` on the Go `scan` command (and the `diff` wrapper, which shares the flag registration — the same repo, the same metadata semantics), forwarded to the Python flags that already exist;
- the precedence is explicit-flag-wins over the project context (the same shape `build-output` and `report` already use) — the context remains the fallback for project-mode invocations;
- the merge lives in a pure `resolveRepoMetadata` helper with a table test covering the four shapes, **including the nil-context path that is the reported defect**.

**Named follow-up (not this PR):** a bare-path scan of a git checkout still reports `commit_sha: null` unless the user passes the SHA — `init.go`'s `resolveLocalCommit` could supply a third-tier fallback (`flag > project > git rev-parse HEAD`).

Closes #539.

## Test plan

`TestScanRepoMetadataFlagsDefined` (the flag-parity pin, the analyze_flags precedent) + `TestResolveRepoMetadata` (4-row table: nil-ctx flags-through — the defect's own path; ctx-fills-empty; flag-wins; nil-Project-inside-ctx).

## Verification evidence

| check | command | result |
|---|---|---|
| Go tests | `go test ./cmd/ -run 'TestScanRepoMetadata\|TestResolveRepoMetadata' -v` | all pass |
| the cmd package | `go test ./cmd/` | ok |
| build + vet + fmt | `go build ./... && go vet ./cmd/ && gofmt -l cmd/` | clean |
| adversarial review | combined wave+refute | FIX-FIRST 1 (the source-grep test replaced by the extracted-helper table test — the nil-ctx regression now fails the suite); the diffCmd/build-output parity questions verified correct as-is |
