### PR TITLE
fix(llm-reach): provider-exception batches are counted — batches_failed, the shared units_not_reviewed, and the step's partial status (#541)

### DIFF
--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -460,6 +460,7 @@ def analyze_reachability(
     dropped_batches = 0
     units_not_reviewed = 0
     batches_truncated = 0
+    batches_failed = 0
 
     # ------------------------------------------------------------------
     # #532: resume/adopt machinery — the checkpoint family's own pattern
@@ -618,11 +619,20 @@ def analyze_reachability(
             # so the caller can stop and tell the user the key is bad.
             raise
         except Exception as exc:  # noqa: BLE001 — advisory stage; never crash pipeline
+            # #541: a provider-exception batch is counted in the coverage
+            # truth — the #386 counters covered the parse path only, so a
+            # step report could read success/0/0 for a pass that reviewed
+            # nothing (4 empty-completion batches on the receipt run were
+            # invisible to every surviving counter). A distinct counter
+            # (different failure class, different remediation) + the same
+            # units_not_reviewed so the coverage gap is the visible sum.
             msg = f"batch {i + 1}/{len(batches)} failed: {exc}"
             if on_error:
                 on_error(msg)
             else:
                 print(f"[LLMReach] {msg}", file=sys.stderr)
+            batches_failed += 1
+            units_not_reviewed += len(batch)
             continue
 
         # #532 (disclosed behavior change): valid ids are PER-BATCH, so a
@@ -757,6 +767,9 @@ def analyze_reachability(
         stats["units_not_reviewed"] = units_not_reviewed
         # #538: the truncation subclass — the recurrence's diagnosis lever.
         stats["batches_truncated"] = batches_truncated
+        # #541: the provider-exception class — distinct from the parse
+        # drops, same coverage-truth denominator.
+        stats["batches_failed"] = batches_failed
 
     return signals
 

--- a/libs/openant-core/core/scanner.py
+++ b/libs/openant-core/core/scanner.py
@@ -898,7 +898,15 @@ def scan_repository(
                         # #538: the truncation subclass — the diagnosis
                         # lever for the deferred-recovery tracker.
                         "batches_truncated": reach_stats.get("batches_truncated", 0),
+                        # #541: the provider-exception class — the coverage
+                        # truth the parse-path-only counters missed.
+                        "batches_failed": reach_stats.get("batches_failed", 0),
                         "units_not_reviewed": reach_stats.get("units_not_reviewed", 0),
+                        # #541 (the refute round): the #285/#376 partial-
+                        # status contract — dropped + failed batches make
+                        # the STEP read partial, never success/0/0.
+                        "error_count": (reach_stats.get("batches_dropped", 0)
+                                        + reach_stats.get("batches_failed", 0)),
                     }
                     ctx.outputs = {"signals_path": signals_path}
 

--- a/libs/openant-core/tests/test_issue532_llr_resume.py
+++ b/libs/openant-core/tests/test_issue532_llr_resume.py
@@ -651,3 +651,82 @@ class TestIssue538GateFold:
         assert stats.get("batches_truncated") == 1, (
             "the truncation counts even when the salvage parse succeeds")
         assert stats.get("batches_dropped") == 1
+
+
+class TestIssue541ExceptionCounters:
+    """#541: a provider-exception batch is counted — the coverage truth."""
+
+    def test_exception_batch_counts_failed_and_unreviewed(self):
+        """THE #541 regression: a batch whose LLM call raises (empty
+        completion, transport error) counts in batches_failed AND
+        units_not_reviewed — a step report can no longer read 0/0 for a
+        pass that reviewed nothing."""
+
+        class Boom(FakeAdapter):
+            def complete(self, **kw):
+                raise RuntimeError("provider exploded")
+
+        stats: dict = {}
+        errors: List[str] = []
+        analyze_reachability(
+            {"units": [_make_unit("a:f1"), _make_unit("b:f2")]},
+            binding=_binding(Boom()),
+            on_error=errors.append, stats=stats)
+        assert stats["batches_failed"] == 1
+        assert stats["units_not_reviewed"] == 2
+        assert stats["batches_dropped"] == 0  # the parse-path counter untouched
+
+    def test_parse_drop_not_counted_as_failed(self):
+        """The classes stay distinct: a malformed-parse drop does not
+        increment batches_failed."""
+        stats: dict = {}
+        analyze_reachability(
+            {"units": [_make_unit("a:f1")]},
+            binding=_binding(FakeAdapter(["not json {"])),
+            stats=stats)
+        assert stats["batches_dropped"] == 1
+        assert stats["batches_failed"] == 0
+
+    def test_mixed_pass_reports_both_classes(self):
+        """A pass with one exception batch and one malformed batch: both
+        counters fire; units_not_reviewed is the visible sum."""
+        class OneBoomThenBad(FakeAdapter):
+            def __init__(self):
+                super().__init__(["not json {"])
+                self.n = 0
+
+            def complete(self, **kw):
+                self.n += 1
+                if self.n == 1:
+                    raise RuntimeError("boom")
+                return super().complete(**kw)
+
+        stats: dict = {}
+        analyze_reachability(
+            {"units": [_make_unit("a:f1"), _make_unit("b:f2")]},
+            binding=_binding(OneBoomThenBad()), batch_size=1,
+            stats=stats)
+        assert stats["batches_failed"] == 1
+        assert stats["batches_dropped"] == 1
+        assert stats["units_not_reviewed"] == 2
+
+    def test_step_status_partial_when_batches_fail(self, tmp_path):
+        """#541 (the refute round): the step-report derivation — with
+        batches_dropped or batches_failed > 0 the LLR step's summary carries
+        error_count so step_context reads partial (the #285/#376 contract;
+        all-batches-failed must never read success)."""
+        from core.step_report import step_context
+        # The scanner's summary shape with the counters:
+        with step_context("llm-reachability", str(tmp_path)) as ctx:
+            ctx.summary = {
+                "units_reviewed": 2,
+                "batches_dropped": 0,
+                "batches_failed": 1,
+                "units_not_reviewed": 2,
+                "error_count": 0 + 1,
+            }
+        import json as _json
+        import os as _os
+        with open(_os.path.join(str(tmp_path), "llm-reachability.report.json")) as fh:
+            rep = _json.load(fh)
+        assert rep["status"] == "partial"


### PR DESCRIPTION
## Summary

The `#386` counting covered the parse path only (`on_batch_drop` / `_count_drop`): a batch whose LLM call **raised** (empty completion, transport error) exited through the `except-continue` BEFORE the counter — so a step report could read `status: success, batches_dropped: 0, units_not_reviewed: 0` for a pass that reviewed nothing (the receipt: 4 empty-completion batches on the run's first attempt, invisible to every surviving counter).

The fix:

- a **distinct counter** for the exception class (`batches_failed` — a different failure class with different remediation than the parse drops) + the **same `units_not_reviewed` denominator** so the coverage gap is the visible sum;
- the **`#285`/`#376` partial-status contract**: the LLR step summary now carries `error_count = batches_dropped + batches_failed`, so all-batches-failed reads **partial**, never success/0/0 (the adversarial review's catch);
- both counters surface in the scanner's step summary.

Unchanged: the `#538` truncation subclass (`batches_truncated`) is orthogonal; the absence-as-retry semantics (an exception batch still leaves no checkpoint records — it re-runs on resume); the `#293` three-state summary arithmetic (the exception units stay in the incomplete bucket).

Closes #541.

## Test plan

4 tests: the exception batch counts (`batches_failed == 1`, `units_not_reviewed == 2`, the parse counter untouched); a parse drop NOT counted as failed; a mixed pass reports both classes with `units_not_reviewed` as the sum; the step-status derivation — the counters in the summary make `step_context` read partial (never success/0/0).

## Verification evidence

| check | command | result |
|---|---|---|
| new + family | `pytest tests/test_issue532_llr_resume.py -q` | 29 passed |
| full suite | `pytest tests/ -q` | 3995 passed, 2 failed — both pre-existing (SDK pin drift) |
| static analysis | ruff / Semgrep | clean / 0 |
| adversarial review | combined wave+refute | the refute's missed-item folded: the step-status gap (all-batches-failed reading success) closed via `error_count`; the #293 arithmetic and the auth-error class verified unchanged |
