### PR TITLE
feat(scan): a bare-path scan of a git checkout stamps the working-tree HEAD — the flag > project > git-detected metadata tier (#557)

### DIFF
--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -69,10 +69,18 @@ func init() {
 // scanCmd and by the thin diffCmd wrapper so that both surfaces accept the
 // same knobs.
 
-// resolveRepoMetadata merges the explicit CLI flags with the project
-// context (#539): the flag wins; the project context is the fallback; a
-// bare-path scan (nil context) uses the flags alone.
-func resolveRepoMetadata(name, url, sha string, ctx *projectContext) (string, string, string) {
+// resolveRepoMetadata merges the explicit CLI flags, the project context,
+// and the git-detected working-tree HEAD (#539 + #557): the flag wins; the
+// project context is the middle tier; a bare-path scan of a git checkout
+// falls to detection (a nil context is the #539 primary usage; a non-git
+// path detects empty and keeps whatever the earlier tiers supplied).
+// The returned warn is non-empty when the winning SHA disagrees with the
+// detected HEAD (an explicit flag in a CI synthetic-merge checkout is
+// legitimate; a stale project SHA is the footgun — the caller prints it).
+// The "nogit" sentinel (init records it for non-repo paths) is treated as
+// empty so it never flows into permalinks or SARIF revisionIds.
+func resolveRepoMetadata(name, url, sha string, ctx *projectContext, detectedSHA string) (string, string, string, string) {
+	flaggedSHA := sha != ""
 	if ctx != nil && ctx.Project != nil {
 		if name == "" && ctx.Project.Name != "" {
 			name = ctx.Project.Name
@@ -80,11 +88,27 @@ func resolveRepoMetadata(name, url, sha string, ctx *projectContext) (string, st
 		if url == "" && ctx.Project.RepoURL != "" {
 			url = ctx.Project.RepoURL
 		}
-		if sha == "" && ctx.Project.CommitSHA != "" {
+		if sha == "" && ctx.Project.CommitSHA != "" &&
+			ctx.Project.CommitSHA != "nogit" {
 			sha = ctx.Project.CommitSHA
 		}
 	}
-	return name, url, sha
+	if sha == "" && detectedSHA != "" {
+		sha = detectedSHA
+	}
+	warn := ""
+	if detectedSHA != "" && sha != detectedSHA {
+		warn = fmt.Sprintf(
+			"report will stamp commit %s but the working tree is at %s; "+
+				"the scan runs on the working tree, not the stamped commit",
+			sha, detectedSHA)
+		if !flaggedSHA {
+			// The project tier supplied a SHA init recorded — a moved tree,
+			// not a deliberate CI override. The remedy: re-run init.
+			warn += " (re-run `openant init` to refresh the project SHA)"
+		}
+	}
+	return name, url, sha, warn
 }
 
 func registerScanFlags(cmd *cobra.Command) {
@@ -256,8 +280,16 @@ func runScan(cmd *cobra.Command, args []string) {
 	// placeholders. #539: an explicit flag wins; the project context is the
 	// fallback (a bare-path scan has no project context — the flags are the
 	// only way in).
-	repoName, repoURL, commitSHA := resolveRepoMetadata(
-		scanRepoName, scanRepoURL, scanCommitSHA, ctx)
+	// #557: detection runs AFTER resolveScanMode (the --pr path checks
+	// out the PR head in mode.go's FetchPR — scan.go:178) — hoisting this
+	// above would stamp the pre-checkout SHA (the review round's ordering
+	// hazard).
+	detectedSHA := git.HeadSHA(repoPath)
+	repoName, repoURL, commitSHA, metadataWarn := resolveRepoMetadata(
+		scanRepoName, scanRepoURL, scanCommitSHA, ctx, detectedSHA)
+	if metadataWarn != "" {
+		output.PrintWarning(metadataWarn)
+	}
 	if repoName != "" {
 		pyArgs = append(pyArgs, "--repo-name", repoName)
 	}

--- a/apps/openant-cli/cmd/scan_repo_metadata_test.go
+++ b/apps/openant-cli/cmd/scan_repo_metadata_test.go
@@ -1,9 +1,14 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/knostic/open-ant-cli/internal/config"
+	"github.com/knostic/open-ant-cli/internal/git"
 )
 
 // TestScanRepoMetadataFlagsDefined locks the #539 flag-parity fix: the Go
@@ -23,10 +28,11 @@ func TestScanRepoMetadataFlagsDefined(t *testing.T) {
 // the explicit flags must flow through alone).
 func TestResolveRepoMetadata(t *testing.T) {
 	tests := []struct {
-		name                       string
-		flagName, flagURL, flagSHA string
-		ctx                        *projectContext
-		wantName, wantURL, wantSHA string
+		name                                   string
+		flagName, flagURL, flagSHA             string
+		ctx                                    *projectContext
+		detected                               string
+		wantName, wantURL, wantSHA, wantWarnIn string
 	}{
 		{
 			name:     "bare path (nil ctx): flags flow through alone",
@@ -39,6 +45,7 @@ func TestResolveRepoMetadata(t *testing.T) {
 			ctx: &projectContext{Project: &config.Project{
 				Name: "proj/app", RepoURL: "https://p", CommitSHA: "fff000",
 			}},
+			detected: "fff000",
 			wantName: "proj/app", wantURL: "https://p", wantSHA: "fff000",
 		},
 		{
@@ -46,8 +53,10 @@ func TestResolveRepoMetadata(t *testing.T) {
 			ctx: &projectContext{Project: &config.Project{
 				Name: "proj/app", RepoURL: "https://p", CommitSHA: "fff000",
 			}},
-			flagName: "acme/app", flagSHA: "abc123",
+			flagName: "acme/app", flagSHA: "abc123", detected: "fff000",
 			wantName: "acme/app", wantURL: "https://p", wantSHA: "abc123",
+			// The CI synthetic-merge shape: the flag differs from HEAD, warned.
+			wantWarnIn: "stamp commit abc123 but the working tree is at fff000",
 		},
 		{
 			name:     "nil Project inside a non-nil ctx",
@@ -55,14 +64,93 @@ func TestResolveRepoMetadata(t *testing.T) {
 			flagName: "acme/app",
 			wantName: "acme/app",
 		},
+		{
+			name:     "#557: bare-path git checkout falls to detection",
+			ctx:      nil,
+			detected: "abc123",
+			wantSHA:  "abc123",
+		},
+		{
+			name:     "#557: non-git path (empty detection) keeps empty",
+			ctx:      nil,
+			detected: "",
+			wantSHA:  "",
+		},
+		{
+			name: "#557: stale project SHA warns (the footgun)",
+			ctx: &projectContext{Project: &config.Project{
+				Name: "proj/app", CommitSHA: "old1111",
+			}},
+			detected: "new2222",
+			wantName: "proj/app", wantSHA: "old1111",
+			wantWarnIn: "stamp commit old1111 but the working tree is at new2222",
+		},
+		{
+			name:    "#557: bare-path CI flag vs detection warns (the legit case)",
+			ctx:     nil,
+			flagSHA: "abc123", detected: "fff000",
+			wantSHA:    "abc123",
+			wantWarnIn: "stamp commit abc123 but the working tree is at fff000",
+		},
+		{
+			name: "#557: the project-tier mismatch carries the remedy hint",
+			ctx: &projectContext{Project: &config.Project{
+				Name: "proj/app", CommitSHA: "old1111",
+			}},
+			detected: "new2222",
+			wantName: "proj/app", wantSHA: "old1111",
+			wantWarnIn: "re-run",
+		},
+		{
+			name: "#557: the nogit sentinel never reaches the SHA",
+			ctx: &projectContext{Project: &config.Project{
+				Name: "proj/app", CommitSHA: "nogit",
+			}},
+			detected: "abc123",
+			wantName: "proj/app", wantSHA: "abc123",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			n, u, s := resolveRepoMetadata(tt.flagName, tt.flagURL, tt.flagSHA, tt.ctx)
+			n, u, s, warn := resolveRepoMetadata(tt.flagName, tt.flagURL, tt.flagSHA, tt.ctx, tt.detected)
 			if n != tt.wantName || u != tt.wantURL || s != tt.wantSHA {
 				t.Errorf("resolveRepoMetadata = (%q, %q, %q), want (%q, %q, %q)",
 					n, u, s, tt.wantName, tt.wantURL, tt.wantSHA)
 			}
+			if tt.wantWarnIn != "" && !strings.Contains(warn, tt.wantWarnIn) {
+				t.Errorf("warn = %q, want to contain %q", warn, tt.wantWarnIn)
+			}
+			if tt.wantWarnIn == "" && warn != "" {
+				t.Errorf("unexpected warn %q", warn)
+			}
 		})
+	}
+}
+
+// TestHeadSHA pins the detection helper: a real temp repo resolves; a repo
+// SUBDIRECTORY resolves (init's os.Stat(.git) gate fails on subdirs —
+// detection must not); a non-git dir yields "".
+func TestHeadSHA(t *testing.T) {
+	repoDir, _, headSHA := initCommitTestRepo(t)
+	if got := git.HeadSHA(repoDir); got != headSHA {
+		t.Errorf("HeadSHA(repo) = %q, want the fixture HEAD %q", got, headSHA)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got := git.HeadSHA(filepath.Join(repoDir, "sub")); got != headSHA {
+		t.Errorf("HeadSHA(subdir) = %q, want %q (git -C resolves subdirs)", got, headSHA)
+	}
+	if got := git.HeadSHA(t.TempDir()); got != "" {
+		t.Errorf("HeadSHA(non-git) = %q, want empty", got)
+	}
+	// An unborn repo (a fresh init, no commits): rev-parse HEAD errors —
+	// the empty return is the proof (the review round's dead-guard catch).
+	unborn := t.TempDir()
+	if out, err := exec.Command("git", "-C", unborn, "init", "-q").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, out)
+	}
+	if got := git.HeadSHA(unborn); got != "" {
+		t.Errorf("HeadSHA(unborn) = %q, want empty (rev-parse HEAD must error)", got)
 	}
 }

--- a/apps/openant-cli/cmd/setup_test.go
+++ b/apps/openant-cli/cmd/setup_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-// withScriptedStdin redirects os.Stdin to the contents of ``script`` for
+// withScriptedStdin redirects os.Stdin to the contents of “script“ for
 // the duration of the test. Each line of the script answers one prompt.
 // Lines that are blank ("\n") accept the prompt's default.
 //
@@ -77,25 +77,25 @@ func TestSetupLLMWizard_HappyPath(t *testing.T) {
 	//   3-7. verify, llm_reach, enhance, report, dynamic_test, app_context: accept provider default + model default
 	//   8. Set as default_llm: y
 	script := strings.Join([]string{
-		"my-config",          // llm-config name
-		"",                   // analyze: provider (accept default "anthropic")
-		"",                   // analyze: provider type (accept default "anthropic")
-		"sk-test",            // analyze: API key
-		"",                   // analyze: base URL (blank)
-		"",                   // analyze: model (accept Opus default)
-		"",                   // verify: provider (re-use anthropic from session)
-		"",                   // verify: model (default Opus)
-		"",                   // llm_reach: provider
-		"",                   // llm_reach: model
-		"",                   // enhance: provider
-		"",                   // enhance: model (default Sonnet)
-		"",                   // report: provider
-		"",                   // report: model
-		"",                   // dynamic_test: provider
-		"",                   // dynamic_test: model
-		"",                   // app_context: provider
-		"",                   // app_context: model
-		"y",                  // Set as default_llm?
+		"my-config", // llm-config name
+		"",          // analyze: provider (accept default "anthropic")
+		"",          // analyze: provider type (accept default "anthropic")
+		"sk-test",   // analyze: API key
+		"",          // analyze: base URL (blank)
+		"",          // analyze: model (accept Opus default)
+		"",          // verify: provider (re-use anthropic from session)
+		"",          // verify: model (default Opus)
+		"",          // llm_reach: provider
+		"",          // llm_reach: model
+		"",          // enhance: provider
+		"",          // enhance: model (default Sonnet)
+		"",          // report: provider
+		"",          // report: model
+		"",          // dynamic_test: provider
+		"",          // dynamic_test: model
+		"",          // app_context: provider
+		"",          // app_context: model
+		"y",         // Set as default_llm?
 	}, "\n") + "\n"
 
 	withScriptedStdin(t, script)
@@ -207,14 +207,14 @@ func TestSetupLLMWizard_OpenAIProvider(t *testing.T) {
 		"openai",          // provider type
 		"sk-openai-test",  // API key
 		"",                // base URL
-		"gpt-4o-mini",       // model
-		"", "gpt-4o-mini",   // llm_reach: provider (default openai) + model
-		"", "gpt-4o-mini",   // enhance
-		"", "gpt-4o",        // analyze (heavier model)
-		"", "gpt-4o",        // verify
-		"", "gpt-4o-mini",   // dynamic_test
-		"", "gpt-4o-mini",   // report
-		"y",               // default_llm
+		"gpt-4o-mini",     // model
+		"", "gpt-4o-mini", // llm_reach: provider (default openai) + model
+		"", "gpt-4o-mini", // enhance
+		"", "gpt-4o", // analyze (heavier model)
+		"", "gpt-4o", // verify
+		"", "gpt-4o-mini", // dynamic_test
+		"", "gpt-4o-mini", // report
+		"y", // default_llm
 	}, "\n") + "\n"
 
 	withScriptedStdin(t, script)
@@ -254,20 +254,20 @@ func TestSetupLLMWizard_RefusesOpenantDefaultName(t *testing.T) {
 	// a valid name. The rest of the flow is the minimum-input happy
 	// path.
 	script := strings.Join([]string{
-		"openant-default",   // rejected — reserved
-		"my-config",         // accepted
-		"",                  // analyze: provider
-		"",                  // analyze: provider type
-		"sk-test",           // analyze: API key
-		"",                  // analyze: base URL
-		"",                  // analyze: model
-		"", "",              // verify
-		"", "",              // llm_reach
-		"", "",              // enhance
-		"", "",              // report
-		"", "",              // dynamic_test
-		"", "",              // app_context
-		"",                  // default_llm (accept Y default)
+		"openant-default", // rejected — reserved
+		"my-config",       // accepted
+		"",                // analyze: provider
+		"",                // analyze: provider type
+		"sk-test",         // analyze: API key
+		"",                // analyze: base URL
+		"",                // analyze: model
+		"", "",            // verify
+		"", "", // llm_reach
+		"", "", // enhance
+		"", "", // report
+		"", "", // dynamic_test
+		"", "", // app_context
+		"", // default_llm (accept Y default)
 	}, "\n") + "\n"
 
 	withScriptedStdin(t, script)

--- a/apps/openant-cli/internal/git/diff.go
+++ b/apps/openant-cli/internal/git/diff.go
@@ -36,6 +36,24 @@ func gitRevParse(repoPath, ref string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
+// HeadSHA returns the working-tree HEAD commit of the repo at repoPath, or
+// "" when the path is not inside a git work tree (a bare-path scan of a
+// non-repo directory is legal; the caller treats "" as "not detected").
+// It deliberately reads HEAD rather than any requested ref — #557's
+// metadata tier mirrors the incremental manifest's head_sha semantics
+// (the tree that will actually be scanned), never a checkout intent.
+func HeadSHA(repoPath string) string {
+	// An unborn repo (a fresh `git init`) errors here (rev-parse HEAD:
+	// ambiguous argument) — the empty return covers it; no zero-id is
+	// ever emitted, so no zero-guard is needed (the review round's catch:
+	// the earlier zero-id comment was a false claim about git).
+	out, err := exec.Command("git", "-C", repoPath, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 // CurrentBranch returns the name of the branch HEAD points at, or "" if
 // HEAD is detached. Callers treat the empty result as "no branch info" —
 // it is informational metadata, not load-bearing.

--- a/apps/openant-cli/internal/git/diff_test.go
+++ b/apps/openant-cli/internal/git/diff_test.go
@@ -405,9 +405,9 @@ func TestHunkHeaderRegex(t *testing.T) {
 		wantCount int // 0 = no match expected
 	}{
 		{"@@ -1,3 +1,5 @@", 1, 5},
-		{"@@ -10 +20 @@", 20, 1},          // implicit count=1
+		{"@@ -10 +20 @@", 20, 1}, // implicit count=1
 		{"@@ -5,0 +12,3 @@", 12, 3},
-		{"@@ -5,2 +0,0 @@", 0, 0},          // pure deletion — count=0
+		{"@@ -5,2 +0,0 @@", 0, 0}, // pure deletion — count=0
 		{"not a hunk header", 0, 0},
 	}
 	for _, c := range cases {

--- a/apps/openant-cli/internal/git/manifest.go
+++ b/apps/openant-cli/internal/git/manifest.go
@@ -29,12 +29,12 @@ func IsValidScope(s string) bool {
 // in Hunks is a slice of [start_line, end_line] pairs on the new side
 // (inclusive). Pure-deletion hunks are dropped at build time.
 type Manifest struct {
-	BaseRef      string          `json:"base_ref"`
-	BaseSHA      string          `json:"base_sha"`
-	HeadSHA      string          `json:"head_sha"`
-	Scope        string          `json:"scope"`
-	PRNumber     int             `json:"pr_number,omitempty"`
-	ChangedFiles []string        `json:"changed_files"`
+	BaseRef      string              `json:"base_ref"`
+	BaseSHA      string              `json:"base_sha"`
+	HeadSHA      string              `json:"head_sha"`
+	Scope        string              `json:"scope"`
+	PRNumber     int                 `json:"pr_number,omitempty"`
+	ChangedFiles []string            `json:"changed_files"`
 	Hunks        map[string][][2]int `json:"hunks,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

A bare-path scan of a git checkout (the #539 primary usage) still reported `commit_sha: null` — the user had to type the 40-char SHA by hand even though the target's HEAD is one `rev-parse` away (the receipt: a monitored scan of a pinned external clone, the SHA known to the caller throughout).

The fix:

- **`git.HeadSHA`** in `internal/git` (beside `CurrentBranch`; dedupes the private rev-parse copies; resolves **subdirectories** where init's `os.Stat(.git)` gate fails; an unborn repo errors at rev-parse — the empty return is the proof, no zero-guard needed);
- **`resolveRepoMetadata` gains the detected tier** (`flag > project > git-detected`) and a mismatch **warn** to stderr (the codebase's `PrintWarning` pattern): the legitimate CI case (an explicit `--commit-sha` in a synthetic-merge checkout — the #539 flag-wins contract unchanged) and the stale-project footgun are both surfaced, the latter with the remedy (`re-run openant init to refresh the project SHA`);
- **the `nogit` sentinel** never reaches the SHA (it was flowing into `/blob/nogit/…` permalinks and SARIF `revisionId`s via the project tier);
- **detection runs after `resolveScanMode`** (the `--pr` path checks out the PR head in `mode.go`'s `FetchPR` — hoisting detection above would stamp the pre-checkout SHA).

Scoped out (named): dirty-worktree warning (init does not do it either — a divergence would be the opposite of reuse); the URL/remote tier (scp-form remotes and credential-bearing URLs need normalization first); recording HEAD on a possibly-dirty tree is **not** a new assertion — the incremental manifest already stamps `rev-parse HEAD` as `diff.head_sha` with no dirty check.

Closes #557.

## Test plan

The 10-row `resolveRepoMetadata` table (the #539 rows + the detected tier: bare-path detection, non-git empty, the project/flag/CI mismatch warns, the remedy hint, `nogit`) + `TestHeadSHA` (a real repo, a subdirectory, a non-git dir, an unborn repo).

## Verification evidence

| check | command | result |
|---|---|---|
| Go tests | `go test ./cmd/ -run 'TestResolveRepoMetadata\|TestHeadSHA\|TestScanRepoMetadata' -v` | all pass |
| the cmd package | `go test ./cmd/` | ok |
| build + vet + fmt | `go build ./... && go vet ./cmd/` | clean |
| adversarial review | combined wave+refute | the 4 folds: the wrong checkout comment (mode.go, not prepareDiffManifest), the dead unborn guard deleted (rev-parse errors — the zero-id claim was false about git), the missing CI table row, the remedy hint |
