### PR TITLE
fix(llm): the anthropic adapter's empty-completion raise carries the rejected reply's usage (#564)

### DIFF
--- a/libs/openant-core/tests/test_issue564_anthropic_usage.py
+++ b/libs/openant-core/tests/test_issue564_anthropic_usage.py
@@ -1,0 +1,80 @@
+"""Tests for issue #564 — the anthropic adapter's empty-completion raise
+carries the rejected reply's usage.
+
+The #537 usage carriage existed on the openai sites only; the anthropic
+guard raised before reading the usage the successful return reads two
+lines below (the same response object) — recording 0/0 for a call the
+provider may have billed.
+"""
+from __future__ import annotations
+
+import pytest
+
+from utilities.llm import LLMResponseError, Message, TextBlock
+from utilities.llm.providers.anthropic import AnthropicAdapter
+
+
+class _Usage:
+    def __init__(self, i=11, o=7):
+        self.input_tokens = i
+        self.output_tokens = o
+
+
+class _Resp:
+    def __init__(self, stop, usage):
+        self.stop_reason = stop
+        self.content = []
+        self.usage = usage
+
+
+def _make_client(resp):
+    """A client whose messages.create returns the canned response."""
+    class _messages:
+        @staticmethod
+        def create(**kw):
+            return resp
+    return type("C", (), {"messages": _messages})()
+
+
+def _adapter(resp):
+    return AnthropicAdapter(api_key="sk-test", _client=_make_client(resp))
+
+
+def _msg():
+    return [Message(role="user", content=[TextBlock("x")])]
+
+
+class TestAnthropicUsageCarriage:
+    def test_raise_carries_usage(self):
+        """THE #564 regression: the error carries the rejected reply's
+        tokens (the openai sites' #537 shape)."""
+        adapter = _adapter(_Resp("end_turn", _Usage(11, 7)))
+        with pytest.raises(LLMResponseError) as ei:
+            adapter.complete(model="claude-test", system=None,
+                             messages=_msg(), max_tokens=100)
+        assert ei.value.input_tokens == 11
+        assert ei.value.output_tokens == 7
+
+    def test_no_usage_defaults_zero(self):
+        adapter = _adapter(_Resp("end_turn", None))
+        with pytest.raises(LLMResponseError) as ei:
+            adapter.complete(model="claude-test", system=None,
+                             messages=_msg(), max_tokens=100)
+        assert ei.value.input_tokens == 0
+        assert ei.value.output_tokens == 0
+
+    def test_recorded_before_reraise(self):
+        """simple_completion records the rejected call's usage — the
+        tracker total carries it (the #537 contract, now on this adapter)."""
+        from utilities.llm.helpers import simple_completion
+        from utilities.llm import PhaseBinding
+        from utilities.llm_client import TokenTracker
+
+        adapter = _adapter(_Resp("end_turn", _Usage(30, 9)))
+        tracker = TokenTracker()
+        binding = PhaseBinding(phase="p", adapter=adapter, model="claude-test",
+                               provider_name="anthropic")
+        with pytest.raises(LLMResponseError):
+            simple_completion(binding, "hi", tracker=tracker)
+        assert tracker.total_input_tokens >= 30
+        assert tracker.total_output_tokens >= 9

--- a/libs/openant-core/utilities/llm/providers/anthropic.py
+++ b/libs/openant-core/utilities/llm/providers/anthropic.py
@@ -394,9 +394,16 @@ def _response_to_unified(
                   if raw_stop == "max_tokens"
                   else "the request may have been filtered or the response "
                        "was malformed")
+        # #564: the rejected reply's usage travels ON the error (the #537
+        # carriage the openai sites already have — the successful return
+        # below reads the same response object; the guard used to raise
+        # before the read, recording 0/0 for a call the provider may have
+        # billed).
         raise LLMResponseError(
             f"{adapter} returned no usable content (empty completion; "
-            f"stop_reason={raw_stop!r}); {_cause}"
+            f"stop_reason={raw_stop!r}); {_cause}",
+            input_tokens=getattr(usage, "input_tokens", 0) if usage else 0,
+            output_tokens=getattr(usage, "output_tokens", 0) if usage else 0,
         )
 
     if raw_stop not in _ANTHROPIC_STOP_REASONS:


### PR DESCRIPTION
## Summary

The #537 usage carriage existed on the openai sites only: the anthropic no-usable-content guard raised **before** reading the usage the successful return reads from the same response object two lines below — recording 0/0 for a call the provider may have billed (the same gap #537 fixed on the openai path, on the sibling adapter).

The fix: read the usage onto the error's `input_tokens`/`output_tokens` kwargs (the openai sites' two-line shape); zero defaults when the response carries no usage.

Closes #564.

## Test plan

3 tests: the raise carries the rejected reply's tokens (the #564 regression); no-usage defaults zero; `simple_completion` records it before re-raising (the tracker total carries it — the #537 contract, now on this adapter).

## Verification evidence

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue564_anthropic_usage.py -q` | 3 passed |
| full suite | `pytest tests/ -q` | 3999 passed, 2 failed — both pre-existing (SDK pin drift, verified on the pristine base) |
| static analysis | ruff / Semgrep | clean / 0 |
