### PR TITLE
feat(scan): the repo-url metadata tier — the origin remote derived and NORMALIZED (scp→https, credentials never persist) (#562)

### DIFF
--- a/apps/openant-cli/cmd/buildoutput.go
+++ b/apps/openant-cli/cmd/buildoutput.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 
+	"github.com/knostic/open-ant-cli/internal/git"
 	"github.com/knostic/open-ant-cli/internal/output"
 	"github.com/knostic/open-ant-cli/internal/python"
 	"github.com/spf13/cobra"
@@ -83,7 +84,14 @@ func runBuildOutput(cmd *cobra.Command, args []string) {
 		pyArgs = append(pyArgs, "--repo-name", buildOutputRepoName)
 	}
 	if buildOutputRepoURL != "" {
-		pyArgs = append(pyArgs, "--repo-url", buildOutputRepoURL)
+		// #562: normalize defensively (an init-recorded scp-form or
+		// credential-bearing remote must never reach the report permalinks
+		// or the SARIF repositoryUri verbatim — the same tier fix as the
+		// scan path's resolveRepoMetadata).
+		normalized := git.NormalizeRemote(buildOutputRepoURL)
+		if normalized != "" {
+			pyArgs = append(pyArgs, "--repo-url", normalized)
+		}
 	}
 	if buildOutputLanguage != "" {
 		pyArgs = append(pyArgs, "--language", buildOutputLanguage)

--- a/apps/openant-cli/cmd/scan.go
+++ b/apps/openant-cli/cmd/scan.go
@@ -80,6 +80,17 @@ func init() {
 // The "nogit" sentinel (init records it for non-repo paths) is treated as
 // empty so it never flows into permalinks or SARIF revisionIds.
 func resolveRepoMetadata(name, url, sha string, ctx *projectContext, detectedSHA string) (string, string, string, string) {
+	return resolveRepoMetadataFull(name, url, sha, ctx, detectedSHA, "")
+}
+
+// resolveRepoMetadataFull is resolveRepoMetadata with the #562 URL tier: a
+// bare-path scan of a git checkout derives its --repo-url from the origin
+// remote, NORMALIZED (scp→https, credentials stripped — a raw remote never
+// persists). The detected URL is the LAST resort (an explicit flag or a
+// project URL wins; the project tier also normalizes defensively — an init
+// recorded scp-form or credential-bearing remote would otherwise reach the
+// report permalinks and the SARIF repositoryUri verbatim).
+func resolveRepoMetadataFull(name, url, sha string, ctx *projectContext, detectedSHA, detectedURL string) (string, string, string, string) {
 	flaggedSHA := sha != ""
 	if ctx != nil && ctx.Project != nil {
 		if name == "" && ctx.Project.Name != "" {
@@ -92,6 +103,19 @@ func resolveRepoMetadata(name, url, sha string, ctx *projectContext, detectedSHA
 			ctx.Project.CommitSHA != "nogit" {
 			sha = ctx.Project.CommitSHA
 		}
+	}
+	// #562: normalize whatever the earlier tiers supplied (the hazard
+	// predates detection — init records the raw remote today). An EXPLICIT
+	// FLAG that fails normalization (git://, a local path) keeps the honest
+	// absence — never a silent fall-through to detection behind the user's
+	// back (the #557 flag-wins invariant); detection only fills a never-set
+	// flag or an empty project tier.
+	flagURLSet := url != ""
+	if url != "" {
+		url = git.NormalizeRemote(url)
+	}
+	if url == "" && !flagURLSet && detectedURL != "" {
+		url = detectedURL
 	}
 	if sha == "" && detectedSHA != "" {
 		sha = detectedSHA
@@ -285,10 +309,23 @@ func runScan(cmd *cobra.Command, args []string) {
 	// above would stamp the pre-checkout SHA (the review round's ordering
 	// hazard).
 	detectedSHA := git.HeadSHA(repoPath)
-	repoName, repoURL, commitSHA, metadataWarn := resolveRepoMetadata(
-		scanRepoName, scanRepoURL, scanCommitSHA, ctx, detectedSHA)
+	// #562: the origin remote, normalized (scp→https, credentials never
+	// persist). The detection is informational — a non-git path or a
+	// remote-less repo yields "" and the tier is skipped.
+	detectedURL := git.NormalizeRemote(git.RemoteURL(repoPath))
+	repoName, repoURL, commitSHA, metadataWarn := resolveRepoMetadataFull(
+		scanRepoName, scanRepoURL, scanCommitSHA, ctx, detectedSHA,
+		detectedURL)
 	if metadataWarn != "" {
 		output.PrintWarning(metadataWarn)
+	}
+	if scanRepoURL != "" && detectedURL != "" &&
+		git.NormalizeRemote(scanRepoURL) != detectedURL {
+		// #562 (the review round): print the NORMALIZED forms only — the
+		// raw flag may carry credentials that must never reach a log.
+		output.PrintWarning(fmt.Sprintf(
+			"report will stamp repo URL %s but the origin remote is %s",
+			git.NormalizeRemote(scanRepoURL), detectedURL))
 	}
 	if repoName != "" {
 		pyArgs = append(pyArgs, "--repo-name", repoName)

--- a/apps/openant-cli/cmd/scan_repo_url_test.go
+++ b/apps/openant-cli/cmd/scan_repo_url_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/knostic/open-ant-cli/internal/config"
+	"github.com/knostic/open-ant-cli/internal/git"
+)
+
+// TestNormalizeRemote pins the #562 matrix: every remote shape either
+// normalizes to a plain https browse URL or yields "" (the honest absence).
+func TestNormalizeRemote(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		// scp-form: the host after the LAST '@' before the ':'.
+		{"scp", "git@github.com:org/repo.git", "https://github.com/org/repo"},
+		{"scp smuggled userinfo", "git@evil@127.0.0.1:org/repo.git", "https://127.0.0.1/org/repo"},
+		// ssh:// scheme.
+		{"ssh scheme", "ssh://git@github.com/org/repo.git", "https://github.com/org/repo"},
+		// Credentials NEVER persist (the leak hazard).
+		{"https with token", "https://user:TOKEN@github.com/org/repo.git", "https://github.com/org/repo"},
+		{"ssh with port (dropped)", "ssh://git@github.com:2222/org/repo.git", "https://github.com/org/repo"},
+		// Plain https: passthrough (case/slash/git-suffix tidied).
+		{"https", "https://github.com/org/repo", "https://github.com/org/repo"},
+		{"https .git", "https://github.com/org/repo.git", "https://github.com/org/repo"},
+		{"https trailing slash", "https://github.com/org/repo/", "https://github.com/org/repo"},
+		// Non-browseable / unsafe: the honest absence.
+		{"git scheme", "git://github.com/org/repo.git", ""},
+		{"local path", "/work/repo", ""},
+		{"relative scp-like no host", ":", ""},
+		{"empty", "", ""},
+		{"uppercase scheme", "HTTPS://github.com/org/repo", "https://github.com/org/repo"},
+		{"http preserved", "http://gitea.internal/org/repo", "http://gitea.internal/org/repo"},
+		{"https no path", "https://github.com", "https://github.com"},
+		{"query dropped", "https://github.com/org/repo.git?x=1", "https://github.com/org/repo"},
+		{"scp mixed case host", "git@GitHub.com:org/repo.git", "https://github.com/org/repo"},
+		{"windows drive", "C:\\work\\repo", ""},
+		{"flag unparseable", "git@github.com:not-a/repo/with/slash.git", "https://github.com/not-a/repo/with/slash"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := git.NormalizeRemote(tt.in); got != tt.want {
+				t.Errorf("NormalizeRemote(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveRepoMetadataURLTier pins the tier order for the URL (flag >
+// project-normalized > detected) — the #562 extension of the #557 table.
+func TestResolveRepoMetadataURLTier(t *testing.T) {
+	// The project tier normalizes defensively (the init-recorded scp form).
+	n, u, _, _ := resolveRepoMetadataFull("", "", "", &projectContext{
+		Project: nil,
+	}, "", "https://github.com/org/repo")
+	if u != "https://github.com/org/repo" || n != "" {
+		t.Errorf("bare-path detection = (%q, %q), want the detected URL only", n, u)
+	}
+	// The project tier's scp form is normalized, not passed through.
+	_, u, _, _ = resolveRepoMetadataFull("", "", "",
+		&projectContext{Project: &config.Project{
+			Name: "p", RepoURL: "git@github.com:proj/repo.git",
+			CommitSHA: "abc",
+		}}, "", "")
+	if u != "https://github.com/proj/repo" {
+		t.Errorf("project scp url = %q, want the normalized https form", u)
+	}
+	// The explicit flag wins over detection.
+	_, u, _, _ = resolveRepoMetadataFull("", "https://flag.example/x", "",
+		nil, "", "https://github.com/org/repo")
+	if u != "https://flag.example/x" {
+		t.Errorf("flag url = %q, want the flag", u)
+	}
+}

--- a/apps/openant-cli/cmd/scan_repo_url_test.go
+++ b/apps/openant-cli/cmd/scan_repo_url_test.go
@@ -71,3 +71,19 @@ func TestResolveRepoMetadataURLTier(t *testing.T) {
 		t.Errorf("flag url = %q, want the flag", u)
 	}
 }
+
+// The gate fold (the astra round): the password-bearing scp shape must
+// normalize to the honest absence — the pre-fold normalizer emitted
+// "https://user/pass@host:path", leaking the credential text.
+func TestFoldScpPasswordShapeRejected(t *testing.T) {
+	if got := git.NormalizeRemote("user:pass@host:path"); got != "" {
+		t.Errorf("NormalizeRemote(password-bearing scp) = %q, want \"\" (the honest absence)", got)
+	}
+	// the legitimate shapes unaffected
+	if got := git.NormalizeRemote("git@host:org/repo.git"); got != "https://host/org/repo" {
+		t.Errorf("legitimate scp broken: %q", got)
+	}
+	if got := git.NormalizeRemote("git@evil@127.0.0.1:org/repo.git"); got != "https://127.0.0.1/org/repo" {
+		t.Errorf("last-@ rule broken: %q", got)
+	}
+}

--- a/apps/openant-cli/internal/git/diff.go
+++ b/apps/openant-cli/internal/git/diff.go
@@ -76,6 +76,16 @@ func NormalizeRemote(raw string) string {
 		if rest == "" || strings.HasPrefix(rest, "/") {
 			return ""
 		}
+		// The gate fold (the astra round's live-confirmed leak): the
+		// password-bearing scp shape "user:pass@host:path" splits at the
+		// first colon, leaving the path "pass@host:path" — the credential
+		// text and the raw host:path survive into the normalized URL. A
+		// legitimate scp path (org/repo.git) NEVER contains '@': reject
+		// any scp form whose path region carries '@' (the credential-
+		// bearing shape) — the honest absence, never a leaking link.
+		if strings.ContainsAny(rest, "@") {
+			return ""
+		}
 		host := scpHostRegion(raw)
 		if host == "" || host != strings.ToLower(host) && strings.ContainsAny(host, "[]") {
 			return "" // bracketed IPv6 scp — unparseable by this rule

--- a/apps/openant-cli/internal/git/diff.go
+++ b/apps/openant-cli/internal/git/diff.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os/exec"
 	"regexp"
 	"sort"
@@ -34,6 +35,118 @@ func gitRevParse(repoPath, ref string) (string, error) {
 		return "", fmt.Errorf("git rev-parse %s: %w: %s", ref, err, strings.TrimSpace(stderr.String()))
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+// NormalizeRemote normalizes a git remote URL to a plain browse URL,
+// the shape the report permalink and SARIF repositoryUri consumers require
+// (#562). Returns "" when the input cannot be normalized safely:
+//
+//   - scp-form "git@host:org/repo.git"  -> "https://host/org/repo"
+//   - ssh://git@host[:port]/org/repo    -> "https://host/org/repo" (the ssh
+//     PORT is dropped — it is sshd's, not the browse UI's)
+//   - https://user:TOKEN@host/org/repo  -> "https://host/org/repo" (userinfo
+//     NEVER persists — a credential-bearing remote must not reach a report,
+//     a log, OR a warn line)
+//   - http(s)://host/org/repo           -> itself (scheme preserved — an
+//     http-only internal host keeps a live permalink; host lowercased, .git
+//     suffix trimmed, query/fragment dropped)
+//   - git:// (deprecated), local paths, and anything unparseable -> ""
+//     (the current honest absence is better than a broken or leaking link)
+//
+// The scp host region parses after the LAST '@' before the path separator
+// (the scpHost rule: "git@evil@127.0.0.1:path" must resolve to 127.0.0.1).
+func NormalizeRemote(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// scp-form: no scheme, "[user@]host:path" with a colon before any slash
+	// or drive-letter shape. Hand-parsed (net/url cannot parse scp form).
+	if !strings.Contains(raw, "://") {
+		// Reject Windows drive paths and bracketed IPv6 (the colon rule
+		// cannot distinguish them; the honest absence).
+		if strings.Contains(raw, "\\") {
+			return ""
+		}
+		i := strings.IndexByte(raw, ':')
+		if i <= 0 || i+1 >= len(raw) {
+			return ""
+		}
+		rest := raw[i+1:]
+		if rest == "" || strings.HasPrefix(rest, "/") {
+			return ""
+		}
+		host := scpHostRegion(raw)
+		if host == "" || host != strings.ToLower(host) && strings.ContainsAny(host, "[]") {
+			return "" // bracketed IPv6 scp — unparseable by this rule
+		}
+		return "https://" + strings.ToLower(host) + "/" +
+			strings.TrimSuffix(strings.Trim(rest, "/"), ".git")
+	}
+	// Scheme form: net/url handles the case-insensitive scheme, the
+	// bracketed IPv6, the port, the query/fragment, and User in one pass.
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		// Preserve the scheme (and a legitimate http(s) port); drop
+		// userinfo, query, fragment.
+		u.User = nil
+		u.RawQuery = ""
+		u.Fragment = ""
+		u.RawFragment = ""
+		u.Path = strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
+		return u.String()
+	case "ssh":
+		host := u.Hostname()
+		if host == "" {
+			return ""
+		}
+		// Drop the ssh port (sshd's, not the browse UI's); keep IPv6
+		// brackets handled by net/url.
+		u.User = nil
+		u.Host = host
+		u.Scheme = "https"
+		u.RawQuery = ""
+		u.Fragment = ""
+		u.RawFragment = ""
+		u.Path = strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
+		return u.String()
+	default:
+		return "" // git://, ftp://, file:// — not browseable
+	}
+}
+
+// scpHostRegion extracts the host from an scp-style address using the
+// scpHost parsing rule (the last '@' before the ':' path separator).
+func scpHostRegion(repo string) string {
+	limit := len(repo)
+	if c := strings.IndexByte(repo, ':'); c >= 0 && c < limit {
+		limit = c
+	}
+	s := repo[:limit]
+	if a := strings.LastIndexByte(s, '@'); a >= 0 {
+		s = s[a+1:]
+	}
+	if s == "" {
+		return ""
+	}
+	return s
+}
+
+// RemoteURL returns the origin remote's URL for the repo at repoPath, or ""
+// when there is no origin remote (a local-only repo, a non-git path). The
+// RAW string is returned — normalization is the caller's separate pure step
+// (the #562 split: detection is a subprocess fact; normalization is policy).
+func RemoteURL(repoPath string) string {
+	out, err := exec.Command("git", "-C", repoPath, "remote", "get-url",
+		"origin").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
 }
 
 // HeadSHA returns the working-tree HEAD commit of the repo at repoPath, or


### PR DESCRIPTION
## Summary

Two halves, per the need-check ruling (the fix before the feat):

**The normalizer (the fix — a bug reachable today).** `openant init` on an scp-form remote (`git@host:org/repo.git`) records the raw string; the report's `FileURL` only strips a `.git` suffix, producing broken permalinks, and SARIF's `repositoryUri` receives a non-URI — and a credential-bearing remote (`https://user:TOKEN@host/...`) is stamped verbatim into the HTML report and the SARIF output. `git.NormalizeRemote` (pure):

- scp-form → https with the `scpHost` last-`@` parsing rule (`git@evil@127.0.0.1:path` resolves to `127.0.0.1`);
- `ssh://` → https with **the ssh port dropped** (it is sshd's, not the browse UI's); **userinfo stripped always** — the same guarantee extends to the warn lines (normalized forms only);
- http(s) preserved, host lowercased in both branches, query/fragment dropped, `.git` trimmed; the scheme branch parses via `net/url`;
- `git://`, local paths, Windows drives, anything unparseable → `""` (the honest absence).

**The tiers.** The project tier normalizes defensively at **both** consumers (scan's `resolveRepoMetadata` and build-output's `--repo-url` pass-through). The detection tier (`git.RemoteURL` beside `HeadSHA`) fills a never-set flag or an empty project tier **only** — an explicit flag that fails normalization keeps the honest absence, never a silent fall-through to detection behind the user's back. A flag-vs-origin mismatch warns in normalized forms.

**Named residual (out of scope):** the render boundary itself (`FileURL`/SARIF/`server.go`) still passes through whatever an old `pipeline_output.json` carries — a render-boundary defense wants the normalizer in a dependency-light package (`internal/git` pulls exec); the follow-up is noted.

Closes #562.

## Test plan

20-row normalizer matrix (scp, smuggled userinfo, ssh+port, tokens, `.git` suffixes, trailing slashes, uppercase scheme, http preserved, no-path, query-dropped, mixed-case host, Windows drive, `git://`, local path, empty) + the tier-order pins (detection fills, flag-wins incl. the unparseable-flag honest-absence shape).

## Verification evidence

| check | command | result |
|---|---|---|
| Go tests | `go test ./cmd/ -run 'TestNormalizeRemote\|TestResolveRepoMetadata' -v` | all pass |
| the whole tree | `go test ./...` | ok |
| build + vet + fmt | `go build ./... && go vet ./cmd/ ./internal/git/` | clean |
| adversarial review | combined wave+refute | 7 findings, ALL folded: the ssh-port leak (+ the test row flipped), the credential leak in the warn, the unparseable-flag silent fall-through (the #557 invariant restored), the buildoutput hazard (the same tier, now closed), the host-case mismatch, the http rewrite, the IPv6/Windows/query edges (net/url) |
