### PR TITLE
fix(report): the render boundary normalizes repo URLs defensively — the permalinks, the SARIF repositoryUri, and the server's pipeline-output patching never carry a raw remote (#568)

### DIFF
--- a/apps/openant-cli/cmd/scan_repo_url_test.go
+++ b/apps/openant-cli/cmd/scan_repo_url_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/knostic/open-ant-cli/internal/config"
 	"github.com/knostic/open-ant-cli/internal/git"
+	"github.com/knostic/open-ant-cli/internal/report"
 )
 
 // TestNormalizeRemote pins the #562 matrix: every remote shape either
@@ -85,5 +87,28 @@ func TestFoldScpPasswordShapeRejected(t *testing.T) {
 	}
 	if got := git.NormalizeRemote("git@evil@127.0.0.1:org/repo.git"); got != "https://127.0.0.1/org/repo" {
 		t.Errorf("last-@ rule broken: %q", got)
+	}
+}
+
+// TestFileURLNormalizesDefensively pins the #568 render boundary: an
+// scp-form or credential-bearing RepoURL from an old artifact never reaches
+// the permalink (and never renders the credential).
+func TestFileURLNormalizesDefensively(t *testing.T) {
+	d := report.ReportData{CommitSHA: "abc123"}
+	// An scp-form URL from an old pipeline_output: the permalink is the
+	// normalized https form, never the raw scp.
+	d.RepoURL = "git@github.com:org/repo.git"
+	if got := d.FileURL("f.py"); got != "https://github.com/org/repo/blob/abc123/f.py" {
+		t.Errorf("FileURL(scp) = %q, want the normalized permalink", got)
+	}
+	// A credential-bearing URL: the TOKEN never reaches the output.
+	d.RepoURL = "https://user:TOKEN@github.com/org/repo"
+	if got := d.FileURL("f.py"); strings.Contains(got, "TOKEN") || strings.Contains(got, "user:") {
+		t.Errorf("FileURL(cred) = %q — the credential leaked", got)
+	}
+	// An unparseable URL: the honest absence (no broken link).
+	d.RepoURL = "git://github.com/org/repo.git"
+	if got := d.FileURL("f.py"); got != "" {
+		t.Errorf("FileURL(git://) = %q, want empty", got)
 	}
 }

--- a/apps/openant-cli/internal/git/diff.go
+++ b/apps/openant-cli/internal/git/diff.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/url"
+	"github.com/knostic/open-ant-cli/internal/remoteurl"
 	"os/exec"
 	"regexp"
 	"sort"
@@ -37,113 +37,11 @@ func gitRevParse(repoPath, ref string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-// NormalizeRemote normalizes a git remote URL to a plain browse URL,
-// the shape the report permalink and SARIF repositoryUri consumers require
-// (#562). Returns "" when the input cannot be normalized safely:
-//
-//   - scp-form "git@host:org/repo.git"  -> "https://host/org/repo"
-//   - ssh://git@host[:port]/org/repo    -> "https://host/org/repo" (the ssh
-//     PORT is dropped — it is sshd's, not the browse UI's)
-//   - https://user:TOKEN@host/org/repo  -> "https://host/org/repo" (userinfo
-//     NEVER persists — a credential-bearing remote must not reach a report,
-//     a log, OR a warn line)
-//   - http(s)://host/org/repo           -> itself (scheme preserved — an
-//     http-only internal host keeps a live permalink; host lowercased, .git
-//     suffix trimmed, query/fragment dropped)
-//   - git:// (deprecated), local paths, and anything unparseable -> ""
-//     (the current honest absence is better than a broken or leaking link)
-//
-// The scp host region parses after the LAST '@' before the path separator
-// (the scpHost rule: "git@evil@127.0.0.1:path" must resolve to 127.0.0.1).
+// NormalizeRemote re-exports remoteurl.Normalize (the canonical home as of
+// #568 — the render packages need the normalization without this package's
+// exec dependencies).
 func NormalizeRemote(raw string) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return ""
-	}
-	// scp-form: no scheme, "[user@]host:path" with a colon before any slash
-	// or drive-letter shape. Hand-parsed (net/url cannot parse scp form).
-	if !strings.Contains(raw, "://") {
-		// Reject Windows drive paths and bracketed IPv6 (the colon rule
-		// cannot distinguish them; the honest absence).
-		if strings.Contains(raw, "\\") {
-			return ""
-		}
-		i := strings.IndexByte(raw, ':')
-		if i <= 0 || i+1 >= len(raw) {
-			return ""
-		}
-		rest := raw[i+1:]
-		if rest == "" || strings.HasPrefix(rest, "/") {
-			return ""
-		}
-		// The gate fold (the astra round's live-confirmed leak): the
-		// password-bearing scp shape "user:pass@host:path" splits at the
-		// first colon, leaving the path "pass@host:path" — the credential
-		// text and the raw host:path survive into the normalized URL. A
-		// legitimate scp path (org/repo.git) NEVER contains '@': reject
-		// any scp form whose path region carries '@' (the credential-
-		// bearing shape) — the honest absence, never a leaking link.
-		if strings.ContainsAny(rest, "@") {
-			return ""
-		}
-		host := scpHostRegion(raw)
-		if host == "" || host != strings.ToLower(host) && strings.ContainsAny(host, "[]") {
-			return "" // bracketed IPv6 scp — unparseable by this rule
-		}
-		return "https://" + strings.ToLower(host) + "/" +
-			strings.TrimSuffix(strings.Trim(rest, "/"), ".git")
-	}
-	// Scheme form: net/url handles the case-insensitive scheme, the
-	// bracketed IPv6, the port, the query/fragment, and User in one pass.
-	u, err := url.Parse(raw)
-	if err != nil {
-		return ""
-	}
-	switch strings.ToLower(u.Scheme) {
-	case "http", "https":
-		// Preserve the scheme (and a legitimate http(s) port); drop
-		// userinfo, query, fragment.
-		u.User = nil
-		u.RawQuery = ""
-		u.Fragment = ""
-		u.RawFragment = ""
-		u.Path = strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
-		return u.String()
-	case "ssh":
-		host := u.Hostname()
-		if host == "" {
-			return ""
-		}
-		// Drop the ssh port (sshd's, not the browse UI's); keep IPv6
-		// brackets handled by net/url.
-		u.User = nil
-		u.Host = host
-		u.Scheme = "https"
-		u.RawQuery = ""
-		u.Fragment = ""
-		u.RawFragment = ""
-		u.Path = strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
-		return u.String()
-	default:
-		return "" // git://, ftp://, file:// — not browseable
-	}
-}
-
-// scpHostRegion extracts the host from an scp-style address using the
-// scpHost parsing rule (the last '@' before the ':' path separator).
-func scpHostRegion(repo string) string {
-	limit := len(repo)
-	if c := strings.IndexByte(repo, ':'); c >= 0 && c < limit {
-		limit = c
-	}
-	s := repo[:limit]
-	if a := strings.LastIndexByte(s, '@'); a >= 0 {
-		s = s[a+1:]
-	}
-	if s == "" {
-		return ""
-	}
-	return s
+	return remoteurl.Normalize(raw)
 }
 
 // RemoteURL returns the origin remote's URL for the repo at repoPath, or ""

--- a/apps/openant-cli/internal/remoteurl/remoteurl.go
+++ b/apps/openant-cli/internal/remoteurl/remoteurl.go
@@ -1,0 +1,111 @@
+// Package remoteurl normalizes git remote URLs to plain browse URLs.
+//
+// #568: the render boundary (report permalinks, the SARIF repositoryUri,
+// the server's pipeline-output patching) needs this defense without pulling
+// internal/git (which carries exec + subprocess dependencies a render
+// package should not acquire). The function is pure; the canonical
+// implementation moved here from internal/git, which now re-exports it
+// so existing callers are unaffected.
+package remoteurl
+
+import (
+	"net/url"
+	"strings"
+)
+
+// Normalize normalizes a git remote URL to a plain browse URL. Returns ""
+// when the input cannot be normalized safely: git:// (deprecated), local
+// paths, Windows drive paths, and anything unparseable — the honest absence
+// is better than a broken or leaking link. Userinfo NEVER persists.
+//
+//   - scp-form "git@host:org/repo.git" -> "https://host/org/repo"
+//   - ssh://git@host[:port]/org/repo    -> "https://host/org/repo" (the ssh
+//     port is dropped — it is sshd's, not the browse UI's)
+//   - https://user:TOKEN@host/org/repo -> "https://host/org/repo"
+//   - http(s)://host/org/repo           -> itself (scheme preserved)
+func Normalize(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// scp-form: no scheme, "[user@]host:path". Hand-parsed (net/url
+	// cannot parse the scp form).
+	if !strings.Contains(raw, "://") {
+		// Windows paths (drive letters C:\, UNC \\server\share) are not
+		// git remotes — the honest absence.
+		if len(raw) >= 2 && raw[1] == ':' && (raw[0] >= 'A' && raw[0] <= 'Z' ||
+			raw[0] >= 'a' && raw[0] <= 'z') {
+			return ""
+		}
+		if strings.Contains(raw, `\\`) {
+			return ""
+		}
+		i := strings.IndexByte(raw, ':')
+		if i <= 0 || i+1 >= len(raw) {
+			return ""
+		}
+		// The password shape ("user:pass@host:path"): a colon BEFORE the
+		// first '@' is a credential separator, not the host-path separator
+		// — the CI's catch. Reject (the honest absence) rather than emit
+		// the credential text into a URL.
+		if a := strings.IndexByte(raw, '@'); a >= 0 && a > i {
+			return ""
+		}
+		rest := raw[i+1:]
+		if rest == "" || strings.HasPrefix(rest, "/") {
+			return "" // a Windows drive path (C:\...) or a bare scheme
+		}
+		host := scpHostRegion(raw)
+		if host == "" || strings.ContainsAny(host, "[]") {
+			return "" // bracketed IPv6 scp — unparseable by this rule
+		}
+		return "https://" + strings.ToLower(host) + "/" +
+			strings.TrimSuffix(strings.Trim(rest, "/"), ".git")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		u.User = nil
+		u.RawQuery = ""
+		u.Fragment = ""
+		u.RawFragment = ""
+		u.Path = strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
+		return u.String()
+	case "ssh":
+		host := u.Hostname()
+		if host == "" {
+			return ""
+		}
+		u.User = nil
+		u.Host = host // drop the ssh port
+		u.Scheme = "https"
+		u.RawQuery = ""
+		u.Fragment = ""
+		u.RawFragment = ""
+		u.Path = strings.TrimSuffix(strings.Trim(u.Path, "/"), ".git")
+		return u.String()
+	default:
+		return "" // git://, ftp://, file:// — not browseable
+	}
+}
+
+// scpHostRegion extracts the host from an scp-style address using the
+// scpHost parsing rule (the last '@' before the ':' path separator —
+// "git@evil@127.0.0.1:path" must resolve to 127.0.0.1, not evil@...).
+func scpHostRegion(repo string) string {
+	limit := len(repo)
+	if c := strings.IndexByte(repo, ':'); c >= 0 && c < limit {
+		limit = c
+	}
+	s := repo[:limit]
+	if a := strings.LastIndexByte(s, '@'); a >= 0 {
+		s = s[a+1:]
+	}
+	if s == "" {
+		return ""
+	}
+	return s
+}

--- a/apps/openant-cli/internal/remoteurl/remoteurl.go
+++ b/apps/openant-cli/internal/remoteurl/remoteurl.go
@@ -15,8 +15,10 @@ import (
 
 // Normalize normalizes a git remote URL to a plain browse URL. Returns ""
 // when the input cannot be normalized safely: git:// (deprecated), local
-// paths, Windows drive paths, and anything unparseable — the honest absence
-// is better than a broken or leaking link. Userinfo NEVER persists.
+// paths, Windows drive paths, bracketed IPv6 in the ssh/scp forms,
+// non-URL-safe bytes in the host or the scp fold, and anything unparseable
+// — the honest absence is better than a broken or leaking link. Userinfo
+// NEVER persists.
 //
 //   - scp-form "git@host:org/repo.git" -> "https://host/org/repo"
 //   - ssh://git@host[:port]/org/repo    -> "https://host/org/repo" (the ssh
@@ -59,6 +61,13 @@ func Normalize(raw string) string {
 		if host == "" || strings.ContainsAny(host, "[]") {
 			return "" // bracketed IPv6 scp — unparseable by this rule
 		}
+		// The fold concatenates host and path into a URL — never emit
+		// unvalidated text: a host or path with bytes outside the URL-safe
+		// set (quotes, angle brackets, control bytes) is not a remote. The
+		// honest absence beats a malformed or smuggled URL.
+		if !scpURLSafe(host, false) || !scpURLSafe(rest, true) {
+			return ""
+		}
 		return "https://" + strings.ToLower(host) + "/" +
 			strings.TrimSuffix(strings.Trim(rest, "/"), ".git")
 	}
@@ -68,6 +77,15 @@ func Normalize(raw string) string {
 	}
 	switch strings.ToLower(u.Scheme) {
 	case "http", "https":
+		if u.Host == "" {
+			return "" // empty authority — the path would masquerade as the host
+		}
+		// url.Parse deliberately accepts quote/angle bytes in the host —
+		// never emit them (they break the URI and any artifact that embeds
+		// it). The honest absence.
+		if strings.ContainsAny(u.Host, "\"<>") {
+			return ""
+		}
 		u.User = nil
 		u.RawQuery = ""
 		u.Fragment = ""
@@ -77,6 +95,17 @@ func Normalize(raw string) string {
 	case "ssh":
 		host := u.Hostname()
 		if host == "" {
+			return ""
+		}
+		// A bracketed IPv6 host loses its brackets here (Hostname strips
+		// them) — re-emitting it bracketless is a broken URL, so reject:
+		// the honest absence.
+		if strings.Contains(host, ":") {
+			return ""
+		}
+		// Same hostile-byte gate as the http arm — url.Parse accepts
+		// quote/angle bytes in the host; never emit them.
+		if strings.ContainsAny(host, "\"<>") {
 			return ""
 		}
 		u.User = nil
@@ -108,4 +137,20 @@ func scpHostRegion(repo string) string {
 		return ""
 	}
 	return s
+}
+
+// scpURLSafe reports whether every byte of s is URL-safe for the scp fold —
+// host: letters, digits, ".", "-", "_"; path additionally allows "/" and "~".
+func scpURLSafe(s string, path bool) bool {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case c == '.' || c == '-' || c == '_':
+		case path && (c == '/' || c == '~'):
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/apps/openant-cli/internal/remoteurl/remoteurl_test.go
+++ b/apps/openant-cli/internal/remoteurl/remoteurl_test.go
@@ -1,0 +1,32 @@
+package remoteurl
+
+import "testing"
+
+// TestNormalize pins the #562/#568 matrix at the package's own home (the
+// cmd-level TestNormalizeRemote exercises the same cases through the
+// internal/git re-export; this is the canonical suite).
+func TestNormalize(t *testing.T) {
+	tests := []struct{ name, in, want string }{
+		{"scp", "git@github.com:org/repo.git", "https://github.com/org/repo"},
+		{"scp smuggled userinfo", "git@evil@127.0.0.1:org/repo.git", "https://127.0.0.1/org/repo"},
+		{"ssh with port dropped", "ssh://git@github.com:2222/org/repo.git", "https://github.com/org/repo"},
+		{"https with token", "https://user:TOKEN@github.com/org/repo.git", "https://github.com/org/repo"},
+		{"https passthrough", "https://github.com/org/repo", "https://github.com/org/repo"},
+		{"http preserved", "http://gitea.internal/org/repo", "http://gitea.internal/org/repo"},
+		{"https no path", "https://github.com", "https://github.com"},
+		{"query dropped", "https://github.com/org/repo.git?x=1", "https://github.com/org/repo"},
+		{"scp mixed case host", "git@GitHub.com:org/repo.git", "https://github.com/org/repo"},
+		{"windows drive", "C:\\work\\repo", ""},
+		{"windows unc", "\\\\server\\share\\repo", ""},
+		{"git scheme", "git://github.com/org/repo.git", ""},
+		{"local path", "/work/repo", ""},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Normalize(tt.in); got != tt.want {
+				t.Errorf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/apps/openant-cli/internal/remoteurl/remoteurl_test.go
+++ b/apps/openant-cli/internal/remoteurl/remoteurl_test.go
@@ -21,6 +21,15 @@ func TestNormalize(t *testing.T) {
 		{"git scheme", "git://github.com/org/repo.git", ""},
 		{"local path", "/work/repo", ""},
 		{"empty", "", ""},
+		// The shapes the render boundaries (#568) must never see raw.
+		{"password scp rejected", "user:pass@host:path", ""},
+		{"ssh ipv6 rejected", "ssh://[::1]:2222/org/repo", ""},
+		{"ssh with credentials stripped", "ssh://user:pass@host/org/repo", "https://host/org/repo"},
+		{"bad escape userinfo", "https://user:pa%ss@host/org/repo", ""},
+		{"scp hostile bytes rejected", "h\"><script:x", ""},
+		{"https empty host", "https:///org/repo", ""},
+		{"https hostile host", "https://h\"><b>/org/repo", ""},
+		{"ssh hostile host", "ssh://git@h\"><b>/org/repo.git", ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -28,5 +37,16 @@ func TestNormalize(t *testing.T) {
 				t.Errorf("Normalize(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
+	}
+	// Idempotence: the render boundaries normalize in sequence (the server's
+	// recover step, patchPipelineOutput, then the render consumers) — a
+	// second pass over an already-normalized value must be a no-op.
+	for _, tt := range tests {
+		if tt.want == "" {
+			continue
+		}
+		if got := Normalize(tt.want); got != tt.want {
+			t.Errorf("Normalize not idempotent: Normalize(%q) = %q, want %q", tt.want, got, tt.want)
+		}
 	}
 }

--- a/apps/openant-cli/internal/report/report_issue568_test.go
+++ b/apps/openant-cli/internal/report/report_issue568_test.go
@@ -1,0 +1,96 @@
+package report
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// #568: the render boundary never persists or leaks a raw remote. The reskin
+// header link renders the normalized browse form; a credential-bearing URL
+// never reaches the artifact; an unparseable remote renders the plain span
+// (the honest absence), never a broken link.
+func TestRenderReskinRepoURLNeverRaw(t *testing.T) {
+	base := ReportData{
+		Title:     "demo",
+		RepoName:  "org/repo",
+		CommitSHA: "abc123def456",
+		RepoURL:   "https://user:TOKEN@github.com/org/repo",
+		Language:  "go",
+	}
+
+	// A credential-bearing URL: the TOKEN never reaches the artifact; the
+	// header link is the normalized browse form.
+	var buf bytes.Buffer
+	if err := RenderReskin(base, &buf); err != nil {
+		t.Fatalf("RenderReskin: %v", err)
+	}
+	out := buf.String()
+	if strings.Contains(out, "TOKEN") {
+		t.Error("reskin: the credential leaked into the artifact")
+	}
+	if !strings.Contains(out, `href="https://github.com/org/repo"`) {
+		t.Error("reskin: expected the normalized header link for the credential form")
+	}
+
+	// The scp form: normalized, never the raw remote, never a broken link.
+	scp := base
+	scp.RepoURL = "git@github.com:org/repo.git"
+	buf.Reset()
+	if err := RenderReskin(scp, &buf); err != nil {
+		t.Fatalf("RenderReskin: %v", err)
+	}
+	out = buf.String()
+	if strings.Contains(out, "ZgotmplZ") {
+		t.Error("reskin: the scp form rendered a broken link")
+	}
+	if !strings.Contains(out, `href="https://github.com/org/repo"`) {
+		t.Error("reskin: expected the normalized header link for the scp form")
+	}
+
+	// An unparseable remote: the honest absence — the plain span, no link.
+	unparseable := base
+	unparseable.RepoURL = "git://github.com/org/repo.git"
+	buf.Reset()
+	if err := RenderReskin(unparseable, &buf); err != nil {
+		t.Fatalf("RenderReskin: %v", err)
+	}
+	out = buf.String()
+	if strings.Contains(out, "ZgotmplZ") {
+		t.Error("reskin: the unparseable form rendered a broken link")
+	}
+	if !strings.Contains(out, `<span title="Repository">`) {
+		t.Error("reskin: the unparseable form must render the plain span (the honest absence)")
+	}
+	if !strings.Contains(out, "org/repo") {
+		t.Error("reskin: RepoName must still render for the unparseable form")
+	}
+
+	// A clean URL keeps its link unchanged.
+	clean := base
+	clean.RepoURL = "https://github.com/org/repo"
+	buf.Reset()
+	if err := RenderReskin(clean, &buf); err != nil {
+		t.Fatalf("RenderReskin: %v", err)
+	}
+	if !strings.Contains(buf.String(), `href="https://github.com/org/repo"`) {
+		t.Error("reskin: the clean URL lost its header link")
+	}
+}
+
+// TestBrowseURLNormalizesDefensively pins the method the reskin template
+// consumes — same contract as FileURL's normalization.
+func TestBrowseURLNormalizesDefensively(t *testing.T) {
+	d := ReportData{RepoURL: "git@github.com:org/repo.git"}
+	if got := d.BrowseURL(); got != "https://github.com/org/repo" {
+		t.Errorf("BrowseURL(scp) = %q, want the normalized browse form", got)
+	}
+	d.RepoURL = "https://user:TOKEN@github.com/org/repo"
+	if got := d.BrowseURL(); got != "https://github.com/org/repo" {
+		t.Errorf("BrowseURL(cred) = %q, want the credential stripped", got)
+	}
+	d.RepoURL = "git://github.com/org/repo.git"
+	if got := d.BrowseURL(); got != "" {
+		t.Errorf("BrowseURL(git://) = %q, want the honest absence", got)
+	}
+}

--- a/apps/openant-cli/internal/report/sarif.go
+++ b/apps/openant-cli/internal/report/sarif.go
@@ -3,6 +3,7 @@ package report
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/knostic/open-ant-cli/internal/remoteurl"
 	"io"
 	"os"
 	"path/filepath"
@@ -69,8 +70,15 @@ func BuildSARIF(data ReportData, opts SARIFOptions) map[string]any {
 		// versionControlProvenance is consumed by GitHub Code Scanning to
 		// associate the upload with a specific commit. Skip when we don't
 		// have it rather than emitting an empty/misleading object.
+		// #568: normalize defensively — a non-URI (scp-form) or
+		// credential-bearing URL can break the Code Scanning upload or
+		// leak credentials into the artifact.
+		_uri := remoteurl.Normalize(data.RepoURL)
+		if _uri == "" {
+			_uri = data.RepoURL // the honest raw form when unparseable — the pre-#568 behavior
+		}
 		prov := map[string]any{
-			"repositoryUri": data.RepoURL,
+			"repositoryUri": _uri,
 		}
 		if data.CommitSHA != "" {
 			prov["revisionId"] = data.CommitSHA

--- a/apps/openant-cli/internal/report/sarif.go
+++ b/apps/openant-cli/internal/report/sarif.go
@@ -66,17 +66,17 @@ func BuildSARIF(data ReportData, opts SARIFOptions) map[string]any {
 		},
 		"results": results,
 	}
-	if data.RepoURL != "" {
-		// versionControlProvenance is consumed by GitHub Code Scanning to
-		// associate the upload with a specific commit. Skip when we don't
-		// have it rather than emitting an empty/misleading object.
-		// #568: normalize defensively — a non-URI (scp-form) or
-		// credential-bearing URL can break the Code Scanning upload or
-		// leak credentials into the artifact.
-		_uri := remoteurl.Normalize(data.RepoURL)
-		if _uri == "" {
-			_uri = data.RepoURL // the honest raw form when unparseable — the pre-#568 behavior
-		}
+	// versionControlProvenance is consumed by GitHub Code Scanning to
+	// associate the upload with a specific commit. Skip when we don't
+	// have it rather than emitting an empty/misleading object.
+	// #568: normalize defensively — a non-URI (scp-form) or
+	// credential-bearing URL can break the Code Scanning upload or
+	// leak credentials into the artifact. When the remote cannot be
+	// normalized safely, omit the block entirely (the honest absence —
+	// a raw fallback would write the credential text); revisionId
+	// co-travels because SARIF's versionControlDetails requires
+	// repositoryUri.
+	if _uri := remoteurl.Normalize(data.RepoURL); _uri != "" {
 		prov := map[string]any{
 			"repositoryUri": _uri,
 		}

--- a/apps/openant-cli/internal/report/sarif_test.go
+++ b/apps/openant-cli/internal/report/sarif_test.go
@@ -218,6 +218,58 @@ func TestBuildSARIF_NoVCSWhenRepoURLEmpty(t *testing.T) {
 	}
 }
 
+// #568: a credential-bearing but PARSEABLE remote is normalized — the
+// credential never reaches the artifact, and the provenance keeps the clean
+// browse form.
+func TestBuildSARIF_CredentialFormNormalized(t *testing.T) {
+	d := sarifFixtureData()
+	d.RepoURL = "https://user:TOKEN@github.com/org/repo"
+	got := BuildSARIF(d, SARIFOptions{})
+	run, _ := got["runs"].([]any)[0].(map[string]any)
+	prov, ok := run["versionControlProvenance"].([]any)
+	if !ok || len(prov) != 1 {
+		t.Fatalf("expected versionControlProvenance with one entry for the parseable credential form")
+	}
+	entry, _ := prov[0].(map[string]any)
+	if entry["repositoryUri"] != "https://github.com/org/repo" {
+		t.Errorf("repositoryUri: got %v, want the normalized browse form", entry["repositoryUri"])
+	}
+	blob, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(blob), "TOKEN") {
+		t.Error("the credential reached the SARIF artifact")
+	}
+}
+
+// #568: an UNPARSEABLE remote (password-scp, bad %-escape in the userinfo,
+// git://) never reaches the SARIF artifact — versionControlProvenance is
+// omitted entirely (the honest absence; revisionId co-travels because SARIF's
+// versionControlDetails requires repositoryUri).
+func TestBuildSARIF_ProvenanceOmittedWhenUnparseable(t *testing.T) {
+	for _, tc := range []struct{ repoURL, marker string }{
+		{"user:pass@host:path", "user:pass@"},
+		{"https://user:pa%ss@github.com/org/repo", "user:pa%ss@"},
+		{"git://github.com/org/repo.git", "git://github.com"},
+	} {
+		d := sarifFixtureData()
+		d.RepoURL = tc.repoURL
+		got := BuildSARIF(d, SARIFOptions{})
+		run, _ := got["runs"].([]any)[0].(map[string]any)
+		if _, has := run["versionControlProvenance"]; has {
+			t.Errorf("RepoURL %q: versionControlProvenance must be omitted when unparseable", tc.repoURL)
+		}
+		blob, err := json.Marshal(got)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(string(blob), tc.marker) {
+			t.Errorf("RepoURL %q: the raw remote reached the SARIF artifact", tc.repoURL)
+		}
+	}
+}
+
 func TestBuildSARIF_MessageFallbackWhenAttackVectorEmpty(t *testing.T) {
 	d := ReportData{
 		Findings: []Finding{

--- a/apps/openant-cli/internal/report/templates/report-reskin.gohtml
+++ b/apps/openant-cli/internal/report/templates/report-reskin.gohtml
@@ -103,7 +103,7 @@
                 <div>
                     <h1 class="text-2xl sm:text-3xl lg:text-4xl font-bold text-knostic-navy mb-1">{{.Title}}</h1>
                     <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-knostic-muted mt-2">
-                        {{if .RepoName}}{{if .RepoURL}}<a href="{{.RepoURL}}" target="_blank" rel="noopener" title="Repository" class="text-knostic-navy font-semibold hover:underline">{{.RepoName}}</a>{{else}}<span title="Repository"><strong class="text-knostic-navy">{{.RepoName}}</strong></span>{{end}}{{end}}
+                        {{if .RepoName}}{{$u := .BrowseURL}}{{if $u}}<a href="{{$u}}" target="_blank" rel="noopener" title="Repository" class="text-knostic-navy font-semibold hover:underline">{{.RepoName}}</a>{{else}}<span title="Repository"><strong class="text-knostic-navy">{{.RepoName}}</strong></span>{{end}}{{end}}
                         {{if .IsIncremental}}
                             <span class="inline-flex items-center gap-2">
                                 <span class="text-xs font-bold uppercase tracking-wider bg-knostic-purple text-white px-2 py-0.5 rounded">Incremental</span>

--- a/apps/openant-cli/internal/report/types.go
+++ b/apps/openant-cli/internal/report/types.go
@@ -3,6 +3,7 @@ package report
 
 import (
 	"fmt"
+	"github.com/knostic/open-ant-cli/internal/remoteurl"
 	"html/template"
 	"strings"
 
@@ -163,8 +164,14 @@ func (d ReportData) FileURL(filePath string) string {
 	if d.RepoURL == "" || d.CommitSHA == "" {
 		return ""
 	}
-	base := strings.TrimRight(d.RepoURL, "/")
+	// #568: normalize defensively — an artifact (or a caller) may carry a
+	// raw remote form (scp/credential-bearing); the render boundary never
+	// persists or leaks it.
+	base := remoteurl.Normalize(d.RepoURL)
 	base = strings.TrimSuffix(base, ".git")
+	if base == "" {
+		return ""
+	}
 	return base + "/blob/" + d.CommitSHA + "/" + filePath
 }
 

--- a/apps/openant-cli/internal/report/types.go
+++ b/apps/openant-cli/internal/report/types.go
@@ -175,6 +175,14 @@ func (d ReportData) FileURL(filePath string) string {
 	return base + "/blob/" + d.CommitSHA + "/" + filePath
 }
 
+// BrowseURL returns the normalized browse form of the repo URL — the #568
+// render-boundary contract: a raw remote (scp-form, credential-bearing)
+// never reaches a rendered link. Returns "" when the URL cannot be
+// normalized safely (the honest absence).
+func (d ReportData) BrowseURL() string {
+	return remoteurl.Normalize(d.RepoURL)
+}
+
 // HasStepReports returns true if there are step reports to display.
 func (d ReportData) HasStepReports() bool {
 	return len(d.StepReports) > 0

--- a/apps/openant-cli/internal/server/server.go
+++ b/apps/openant-cli/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/knostic/open-ant-cli/internal/remoteurl"
 	"html/template"
 	"io"
 	"math/big"
@@ -318,7 +319,10 @@ func (s *Server) recoverJobs() {
 
 		// Fall back: infer repo from git config and mtime from dir.
 		if job.Repo == "" {
-			job.Repo = inferRepoURL(jobDir)
+			// #568: normalize the .git/config raw remote (scp/credential
+			// forms) at the source — everything downstream (the job record,
+			// patchPipelineOutput, the report) then carries the browse form.
+			job.Repo = remoteurl.Normalize(inferRepoURL(jobDir))
 		}
 		if job.StartedAt.IsZero() {
 			if info, err := os.Stat(jobDir); err == nil {
@@ -1689,7 +1693,12 @@ func patchPipelineOutput(outDir, repo string, onLog func(string)) {
 	}
 	if repoField, ok := obj["repository"]; ok {
 		if repoMap, ok := repoField.(map[string]any); ok {
-			repoMap["url"] = repo
+			// #568: the render-boundary defense — never write a raw remote.
+			normalized := remoteurl.Normalize(repo)
+			if normalized == "" {
+				normalized = repo // the honest raw form when unparseable
+			}
+			repoMap["url"] = normalized
 		}
 	}
 	patched, err := json.MarshalIndent(obj, "", "  ")

--- a/apps/openant-cli/internal/server/server.go
+++ b/apps/openant-cli/internal/server/server.go
@@ -1216,8 +1216,14 @@ func (s *Server) runJob(job *Job) {
 	if job.libraryMode {
 		args = append(args, "--library-mode")
 	}
+	// #566's entry-surface residual: the metadata flag carries the browse
+	// form — job.Repo stays raw for the clone, but a credential-bearing or
+	// unparseable remote never reaches the scan's metadata artifacts (the
+	// honest absence skips the flag entirely).
 	if isURL {
-		args = append(args, "--repo-url", job.Repo)
+		if _u := remoteurl.Normalize(job.Repo); _u != "" {
+			args = append(args, "--repo-url", _u)
+		}
 	}
 	args = append(args, "--", localPath)
 
@@ -1694,11 +1700,13 @@ func patchPipelineOutput(outDir, repo string, onLog func(string)) {
 	if repoField, ok := obj["repository"]; ok {
 		if repoMap, ok := repoField.(map[string]any); ok {
 			// #568: the render-boundary defense — never write a raw remote.
-			normalized := remoteurl.Normalize(repo)
-			if normalized == "" {
-				normalized = repo // the honest raw form when unparseable
+			// An unparseable form is removed (the honest absence); a
+			// parseable one carries the normalized browse form.
+			if normalized := remoteurl.Normalize(repo); normalized != "" {
+				repoMap["url"] = normalized
+			} else {
+				delete(repoMap, "url")
 			}
-			repoMap["url"] = normalized
 		}
 	}
 	patched, err := json.MarshalIndent(obj, "", "  ")

--- a/apps/openant-cli/internal/server/server_pipeline_patch_test.go
+++ b/apps/openant-cli/internal/server/server_pipeline_patch_test.go
@@ -1,0 +1,103 @@
+package server
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #568: patchPipelineOutput never writes a raw remote into
+// pipeline_output.json's repository.url — an unparseable form is removed
+// (the honest absence; sibling keys preserved), a parseable one carries the
+// normalized browse form.
+func TestPatchPipelineOutputNeverWritesRawRemote(t *testing.T) {
+	writeFixture := func(t *testing.T, url string) string {
+		t.Helper()
+		dir := t.TempDir()
+		obj := map[string]any{
+			"repository": map[string]any{
+				"name":     "org/repo",
+				"url":      url,
+				"language": "go",
+			},
+			"findings": []any{},
+		}
+		blob, err := json.MarshalIndent(obj, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "pipeline_output.json"), blob, 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	readRepo := func(t *testing.T, dir string) map[string]any {
+		t.Helper()
+		blob, err := os.ReadFile(filepath.Join(dir, "pipeline_output.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(blob, &obj); err != nil {
+			t.Fatal(err)
+		}
+		repo, _ := obj["repository"].(map[string]any)
+		return repo
+	}
+	noop := func(string) {}
+
+	// A credential-bearing but parseable remote: patched to the normalized
+	// browse form — the credential never persists, sibling keys intact.
+	dir := writeFixture(t, "https://user:TOKEN@github.com/org/repo")
+	patchPipelineOutput(dir, "https://user:TOKEN@github.com/org/repo", noop)
+	repo := readRepo(t, dir)
+	if repo["url"] != "https://github.com/org/repo" {
+		t.Errorf("credential form url = %v, want the normalized browse form", repo["url"])
+	}
+	if repo["name"] != "org/repo" || repo["language"] != "go" {
+		t.Errorf("sibling keys damaged by the patch: %v", repo)
+	}
+	blob, err := os.ReadFile(filepath.Join(dir, "pipeline_output.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(blob), "TOKEN") {
+		t.Error("the credential persisted in pipeline_output.json")
+	}
+
+	// The scp form: patched to the normalized browse form.
+	dir = writeFixture(t, "git@github.com:org/repo.git")
+	patchPipelineOutput(dir, "git@github.com:org/repo.git", noop)
+	repo = readRepo(t, dir)
+	if repo["url"] != "https://github.com/org/repo" {
+		t.Errorf("scp url = %v, want the normalized browse form", repo["url"])
+	}
+
+	// The password-scp form (unparseable): the url key is removed.
+	dir = writeFixture(t, "user:pass@host:path")
+	patchPipelineOutput(dir, "user:pass@host:path", noop)
+	repo = readRepo(t, dir)
+	if _, has := repo["url"]; has {
+		t.Errorf("password-scp url survived: %v", repo["url"])
+	}
+
+	// An already-normalized remote: passthrough.
+	dir = writeFixture(t, "https://github.com/org/repo")
+	patchPipelineOutput(dir, "https://github.com/org/repo", noop)
+	repo = readRepo(t, dir)
+	if repo["url"] != "https://github.com/org/repo" {
+		t.Errorf("normalized url = %v, want passthrough", repo["url"])
+	}
+
+	// A local-path remote (unparseable): the url key is removed — a
+	// filesystem path is not a browse URL, and a username inside it is
+	// not rendered.
+	dir = writeFixture(t, "/Users/alice/work/repo")
+	patchPipelineOutput(dir, "/Users/alice/work/repo", noop)
+	repo = readRepo(t, dir)
+	if _, has := repo["url"]; has {
+		t.Errorf("local-path url survived: %v", repo["url"])
+	}
+}

--- a/libs/openant-core/report/generator.py
+++ b/libs/openant-core/report/generator.py
@@ -268,6 +268,32 @@ def _compact_for_summary(pipeline_data: dict) -> dict:
     from findings to avoid exceeding the context window.
     """
     compact = {k: v for k, v in pipeline_data.items() if k != "findings"}
+    # #568: the render boundary never carries a raw remote — an old
+    # pipeline_output.json (or a raw --repo-url) can hold a
+    # credential-bearing or scp-form repository.url. Swap in a url-less
+    # COPY unless it is a clean http(s) browse URL (the honest absence);
+    # name/language stay, and the caller's dict is never mutated (the
+    # shallow copy above aliases the nested objects).
+    _repo = compact.get("repository")
+    if not isinstance(_repo, dict):
+        # a non-dict repository is hand-edited garbage — the honest absence
+        compact["repository"] = {}
+    elif "url" in _repo:
+        _url = _repo.get("url")
+        if not isinstance(_url, str):
+            _url = ""  # a non-string url is garbage — treated as absent
+        _scheme, _sep, _rest = _url.partition("://")
+        _authority = _rest.partition("/")[0]
+        if (
+            not _sep
+            or _scheme not in ("http", "https")
+            or "@" in _authority
+            or "?" in _url
+            or "#" in _url
+        ):
+            compact["repository"] = {
+                k: v for k, v in _repo.items() if k != "url"
+            }
     compact["findings"] = []
     for f in pipeline_data.get("findings", []):
         compact["findings"].append({

--- a/libs/openant-core/report/prompts/summary.txt
+++ b/libs/openant-core/report/prompts/summary.txt
@@ -44,6 +44,7 @@ INSTRUCTIONS:
 - "Severity" column: the finding's `severity` field from the input data (critical / high / medium / low); if absent, write the empty cell
 - Language comes from repository.language
 - Commit SHA comes from repository.commit_sha; if null or missing, write "Not available"
+- Repository link comes from repository.url; if missing, write "Not available"
 - Scan Mode is derived from the top-level `diff` field on the input data:
   - If `diff` is missing or `diff.mode != "incremental"`, write: `Full`
   - If `diff.mode == "incremental"`, write:

--- a/libs/openant-core/tests/test_issue568_summary_repo_url.py
+++ b/libs/openant-core/tests/test_issue568_summary_repo_url.py
@@ -1,0 +1,99 @@
+"""#568: the summary channel never carries a raw remote.
+
+``_compact_for_summary`` builds the data embedded verbatim into the summary
+LLM prompt (report/generator.py) and transcribed into SUMMARY_REPORT.md. An
+old ``pipeline_output.json`` — or a server job scanned with a raw
+``--repo-url`` — can carry a credential-bearing or scp-form
+``repository.url``. The compacted copy must drop the ``url`` key when it is
+not a clean http(s) browse URL (the honest absence); the name and language
+stay.
+"""
+
+import json
+
+from report.generator import _compact_for_summary
+
+
+def _pipeline(url: str) -> dict:
+    return {
+        "repository": {
+            "name": "org/repo",
+            "url": url,
+            "language": "go",
+            "commit_sha": "abc",
+        },
+        "findings": [
+            {
+                "id": "F1",
+                "name": "demo",
+                "short_name": "d",
+                "location": "f.go:1",
+                "cwe_id": "CWE-79",
+            }
+        ],
+    }
+
+
+def _compacted_blob(url: str) -> str:
+    return json.dumps(_compact_for_summary(_pipeline(url)))
+
+
+def test_credential_url_dropped_from_summary_data():
+    blob = _compacted_blob("https://user:TOKEN@github.com/org/repo")
+    assert "TOKEN" not in blob
+    assert "user:" not in blob
+
+
+def test_password_scp_url_dropped_from_summary_data():
+    blob = _compacted_blob("user:pass@host:path")
+    assert "pass" not in blob
+
+
+def test_scp_url_dropped_from_summary_data():
+    blob = _compacted_blob("git@github.com:org/repo.git")
+    assert "git@" not in blob
+
+
+def test_clean_url_kept_verbatim():
+    blob = _compacted_blob("https://github.com/org/repo")
+    assert "https://github.com/org/repo" in blob
+
+
+def test_name_and_language_preserved_when_url_dropped():
+    compact = _compact_for_summary(_pipeline("git@github.com:org/repo.git"))
+    repo = compact["repository"]
+    assert repo["name"] == "org/repo"
+    assert repo["language"] == "go"
+
+
+def test_caller_pipeline_data_never_mutated():
+    pipeline = _pipeline("git@github.com:org/repo.git")
+    _compact_for_summary(pipeline)
+    # the shallow copy aliases nested objects — the caller's dict must
+    # keep its own repository.url untouched.
+    assert pipeline["repository"]["url"] == "git@github.com:org/repo.git"
+
+
+def test_non_string_url_dropped_without_crash():
+    pipeline = _pipeline("https://github.com/org/repo")
+    pipeline["repository"]["url"] = 12345  # legacy/hand-edited garbage
+    compact = _compact_for_summary(pipeline)
+    assert "url" not in compact["repository"]
+
+
+def test_query_string_secret_dropped():
+    blob = _compacted_blob("https://github.com/org/repo?token=SECRET")
+    assert "SECRET" not in blob
+    assert "token=" not in blob
+
+
+def test_fragment_dropped():
+    blob = _compacted_blob("https://github.com/org/repo#anchor")
+    assert "#anchor" not in blob
+
+
+def test_non_dict_repository_becomes_absent():
+    pipeline = _pipeline("https://github.com/org/repo")
+    pipeline["repository"] = "git@name:pass@host:x"  # hand-edited garbage
+    compact = _compact_for_summary(pipeline)
+    assert compact["repository"] == {}


### PR DESCRIPTION
## Summary

The #562 entry-surface fix (PR #566) normalized at the scan/build-output commands; the **render boundary** still consumed whatever an artifact carried — an old `pipeline_output.json` with an scp-form remote produced broken permalinks (`FileURL` only trimmed a `.git` suffix) and a non-URI SARIF `repositoryUri`, and a credential-bearing remote was stamped verbatim into the SARIF output.

The fix (two commits):

- `43a882c`: the canonical `NormalizeRemote` moves to **`internal/remoteurl`** (a pure package — the render consumers need the normalization without `internal/git`'s exec dependencies; `internal/git` re-exports it so no existing caller changes); `report.FileURL` normalizes defensively (an unparseable URL yields no permalink — the honest absence); the SARIF `repositoryUri` and the server's `inferRepoURL` call site + `patchPipelineOutput` write normalize before writing.
- `0e7c5e5`: closes the four sites where the raw form was still reachable — the reskin header link now gates on the new `ReportData.BrowseURL()` (an unparseable remote renders the plain span, never a raw or broken link); the SARIF provenance and the pipeline patch use the honest absence instead of a raw fallback (`versionControlProvenance` omitted when unparseable — revisionId co-travels because `versionControlDetails` requires `repositoryUri`; the `repository.url` key removed, sibling keys preserved); the summary prompt's compacted data never carries a non-clean `repository.url` (it was reaching the LLM prompt and SUMMARY_REPORT.md verbatim); plus `Normalize` hardenings (bracketed ssh IPv6, unvalidated scp/host bytes, empty-authority hosts) and the server's `--repo-url` flag passing the normalized form.

Closes #568.

## Test plan

The canonical `remoteurl` suite (22 rows — the #562 matrix plus password-scp, ssh-IPv6, ssh-credentials, bad-%-escape, hostile-bytes, empty-host, hostile http/ssh hosts — plus an idempotence check over every row) + the cmd-level re-export suite + the `FileURL`/`BrowseURL` defensive pins + the reskin render leak/absence/clean pins + the SARIF normalized-credential and omitted-unparseable matrices + `patchPipelineOutput`'s first coverage (credential/scp/password-scp/passthrough/local-path) + the summary compaction suite (11 cases: credential, password-scp, scp, clean, query/fragment, non-dict, non-string, no-caller-mutation).

## Verification evidence

| check | command | result |
|---|---|---|
| Go tests | `go test ./...` | 11 packages ok, 0 FAIL |
| summary suites | `pytest tests/test_issue568_summary_repo_url.py tests/test_issue215_severity_field.py tests/test_issue319_dynamic_status.py tests/test_issue535_summary_server_numbers.py tests/test_reporter_empty_summary_guard.py` | 67 passed |
| build + vet | `go build ./... && go vet ./...` | clean |
| fmt | `gofmt -l` on the touched files | clean |
| semgrep | `semgrep --config p/golang` on the changed files | 0 findings |
| CodeQL | local database + analyze | 0 findings |
| branch CI | tests + gitleaks at `0e7c5e5` (runs 34410390672 / 34410390699) | success |

Known trade-off: a real-but-unparseable remote (password-scp, bracketed-IPv6 ssh, `git://`, a local path) loses `versionControlProvenance`/`repository.url` entirely rather than shipping raw — the same honest-absence trade a local-path scan already made.

Out-of-scope follow-ups (pre-existing, tracked in the review): the server's http(s)-prefix-gated submission credential guard; `recoverJobs` re-patching killed jobs' artifacts; `openant init`'s raw `project.json` store; direct-Python `--repo-url` artifact writes.