### PR TITLE
fix(context+checkpoints): the deterministic-derivation identity enters the resume keys — source_sha256 stamped by all three context arms, folded into the gated phases' fingerprints (#546)

### DIFF
--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -151,8 +151,13 @@ class ApplicationContext:
     # file is handed to the pipeline — the precondition for comparing them.
     # Provenance of a repo-supplied threat model, for scan-artifact visibility.
     # Both are additive/defaulted so save_context(asdict)/load_context(**data)
-    # round-trip unchanged. sha256 is over the raw file bytes; permissive_warnings
-    # is warn_permissive_threat_model's output, which was previously discarded.
+    # round-trip unchanged. #546 generalizes source_sha256 to the
+    # DETERMINISTIC-DERIVATION identity of whichever arm produced the
+    # context: the threat-model file's raw bytes (that arm), the override
+    # file's content (the manual arm), or the gathered CONTEXT sources'
+    # digest (the LLM arm) — the checkpoint family's resume keys fold it;
+    # permissive_warnings is warn_permissive_threat_model's output, which
+    # was previously discarded.
     source_sha256: str | None = None
     permissive_warnings: list = None
     threat_model_version: int | None = None
@@ -389,6 +394,27 @@ def gather_context_sources(repo_path: Path) -> dict[str, str]:
     return sources
 
 
+def context_sources_digest(sources: dict[str, str]) -> str:
+    """#546: the deterministic-derivation identity over the gathered
+    CONTEXT sources — the fingerprint the checkpoint family folds into its
+    resume keys (via the artifact's source_sha256).
+
+    Hashes ONLY the repo-derived CONTEXT_FILES entries and the two
+    degradation markers — NOT ``[directory_structure]`` (it lists the
+    in-repo output dir, so hashing it would self-invalidate on every
+    resume that writes a new artifact) and NOT ``[detected_patterns]``
+    (an rglob-order, cap-windowed list — not canonical). Those two stay a
+    named residual: a rename that flips the LLM's classification without
+    touching the hashed sources does not invalidate.
+    """
+    import hashlib
+    entries = {k: v for k, v in sources.items()
+               if not k.startswith("[directory_structure]")
+               and not k.startswith("[detected_patterns]")}
+    payload = json.dumps(entries, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
 def get_directory_structure(repo_path: Path, max_depth: int = 2) -> str:
     """Get directory tree for pattern recognition.
 
@@ -580,6 +606,16 @@ def _application_context_from_override(data: Any, filename: str) -> ApplicationC
         )
     data["override_warnings"] = override_warnings
     data["override_filename"] = filename
+    # #546: the override arm's deterministic input IS the override file —
+    # sha over the raw content (the family folds it via the artifact).
+    if not data.get("source_sha256"):
+        import hashlib as _h
+        try:
+            _raw = json.dumps(data, sort_keys=True, separators=(",", ":"))
+            data["source_sha256"] = _h.sha256(
+                _raw.encode("utf-8")).hexdigest()
+        except (TypeError, ValueError):
+            data["source_sha256"] = None
     known = {f.name for f in fields(ApplicationContext)}
     unknown = [k for k in data if k not in known]
     if unknown:
@@ -835,6 +871,12 @@ def generate_application_context(
             f"Response: {response_text}")
 
     data['source'] = 'llm'
+    # #546: stamp the deterministic-derivation identity — the checkpoint
+    # family's resume keys fold this (via the artifact), so a repo edit
+    # that changes the context derivation invalidates the stale records
+    # while the LLM's own re-narration does not re-pay.
+    if 'source_sha256' not in data or not data.get('source_sha256'):
+        data['source_sha256'] = context_sources_digest(sources)
 
     # Allowlist-filter to dataclass fields: the LLM can hallucinate unknown/extra
     # keys, and a raw ApplicationContext(**data) would raise an uncaught TypeError

--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -608,14 +608,16 @@ def _application_context_from_override(data: Any, filename: str) -> ApplicationC
     data["override_filename"] = filename
     # #546: the override arm's deterministic input IS the override file —
     # sha over the raw content (the family folds it via the artifact).
-    if not data.get("source_sha256"):
-        import hashlib as _h
-        try:
-            _raw = json.dumps(data, sort_keys=True, separators=(",", ":"))
-            data["source_sha256"] = _h.sha256(
-                _raw.encode("utf-8")).hexdigest()
-        except (TypeError, ValueError):
-            data["source_sha256"] = None
+    # UNCONDITIONAL: the override data is repo-supplied; a supplied
+    # source_sha256 must never pin the resume identity (#546's review
+    # round — the identity is derived, never adopted).
+    import hashlib as _h
+    try:
+        _raw = json.dumps(data, sort_keys=True, separators=(",", ":"))
+        data["source_sha256"] = _h.sha256(
+            _raw.encode("utf-8")).hexdigest()
+    except (TypeError, ValueError):
+        data["source_sha256"] = None
     known = {f.name for f in fields(ApplicationContext)}
     unknown = [k for k in data if k not in known]
     if unknown:
@@ -874,9 +876,10 @@ def generate_application_context(
     # #546: stamp the deterministic-derivation identity — the checkpoint
     # family's resume keys fold this (via the artifact), so a repo edit
     # that changes the context derivation invalidates the stale records
-    # while the LLM's own re-narration does not re-pay.
-    if 'source_sha256' not in data or not data.get('source_sha256'):
-        data['source_sha256'] = context_sources_digest(sources)
+    # while the LLM's own re-narration does not re-pay. UNCONDITIONAL:
+    # model output is untrusted — a supplied source_sha256 (steered by
+    # the scanned repo's sources text) must never pin the identity.
+    data['source_sha256'] = context_sources_digest(sources)
 
     # Allowlist-filter to dataclass fields: the LLM can hallucinate unknown/extra
     # keys, and a raw ApplicationContext(**data) would raise an uncaught TypeError

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -449,7 +449,7 @@ def _count_verdicts(results):
     return counts
 
 
-def _analyze_fingerprint(binding) -> dict:
+def _analyze_fingerprint(binding, ctx_sha=None) -> dict:
     """Build the analyze-phase backend-identity fingerprint.
 
     The static system + user-analysis templates are rendered with
@@ -465,7 +465,14 @@ def _analyze_fingerprint(binding) -> dict:
         lambda: get_system_prompt(app_context=None),
         lambda: get_analysis_prompt(code="", language="code", app_context=None),
     ])
-    return fingerprint_for_binding(binding, texts)
+    # #546: the context's deterministic-derivation identity joins the KEY
+    # (the narration stays excluded — this is the SOURCES hash, not the
+    # text). None (no context / a pre-#546 artifact) leaves the key
+    # member absent-equivalent; a changed derivation archives the stale
+    # records and re-pays.
+    return fingerprint_for_binding(
+        binding, texts,
+        extra_key=({"ctx_sources_sha256": ctx_sha} if ctx_sha else None))
 
 
 def _archive_stale_results(output_dir: str, current_fp: str) -> None:
@@ -605,12 +612,22 @@ def run_analysis(
     binding = registry.get("analyze")
     print(f"[Analyze] Provider: {binding.provider_name}, Model: {binding.model}", file=sys.stderr)
 
+    # #546: the application context loads BEFORE the I2 fingerprint — the
+    # adopt gate folds the context's deterministic-derivation identity
+    # (source_sha256), so the prior order (fingerprint-then-load) would key
+    # on None forever.
+    app_context = None
+    if app_context_path and HAS_APP_CONTEXT and os.path.exists(app_context_path):
+        app_context = load_context(Path(app_context_path))
+        print(f"[Analyze] App context: {app_context.application_type}", file=sys.stderr)
+
     # I2 adopt gate: BEFORE loading any prior checkpoints, verify the backend
     # identity that produced them matches the current one. A changed model /
     # provider / adapter / static template archives the stale dir aside and
     # forces a re-run rather than silently adopting another backend's verdicts.
     # Run AFTER the checkpoint.dir override above.
-    analyze_fp = _analyze_fingerprint(binding)
+    analyze_fp = _analyze_fingerprint(
+        binding, ctx_sha=getattr(app_context, "source_sha256", None))
     checkpoint.sync_identity(analyze_fp)
     # Preserve a prior scan's final report before this run overwrites it.
     _archive_stale_results(output_dir, analyze_fp["key_digest"])
@@ -618,12 +635,6 @@ def run_analysis(
     # JSON corrector inherits the analyze binding so correction calls
     # route through the same provider+model.
     json_corrector = JSONCorrector(binding)
-
-    # Load application context if provided
-    app_context = None
-    if app_context_path and HAS_APP_CONTEXT and os.path.exists(app_context_path):
-        app_context = load_context(Path(app_context_path))
-        print(f"[Analyze] App context: {app_context.application_type}", file=sys.stderr)
 
     # Load dataset
     print(f"[Analyze] Loading dataset: {dataset_path}", file=sys.stderr)

--- a/libs/openant-core/core/backend_identity.py
+++ b/libs/openant-core/core/backend_identity.py
@@ -25,10 +25,16 @@ Deliberate exclusions (minimal by mandate):
   * NO endpoint DETECTION / drift_log / strict-mode — over-built, excluded.
   * NO credential-derived value (api_key). A credential-routing gateway (same
     URL + model, different key → different upstream) is a NAMED RESIDUAL.
-  * app_context / threat-model is LLM-generated and regenerates
+  * app_context / threat-model NARRATION is LLM-generated and regenerates
     non-deterministically every scan; callers MUST render templates with
     ``app_context=None`` so it never enters ``templates_sha`` (including it
     caused a VERIFIED ~17k-token spurious re-pay on a same-config resume).
+    #546 (scheme 2) amends the clause: the DETERMINISTIC-DERIVATION identity
+    of the context (the artifact's ``source_sha256`` — the threat-model
+    file's bytes, the override's content, or the gathered CONTEXT sources'
+    digest) DOES belong in the key via ``extra_key["ctx_sources_sha256"]`` —
+    the narration stays excluded; the derivation invalidates stale records
+    when the repo shape that produced the context changes.
   * Generation parameters (``max_tokens``, ``temperature``, etc.) are
     deliberately NOT global KEY members (#242: "this config-only change does
     not invalidate prior checkpoints. Rationale is FN-safe: pre-fix empty
@@ -74,7 +80,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 # Bump when the KEY definition below changes so pre-existing sidecars invalidate
 # cleanly (they will simply mismatch and trigger an archive-and-repay).
-FINGERPRINT_SCHEME_VERSION = 1
+FINGERPRINT_SCHEME_VERSION = 2
 
 # Sidecar filename written into each checkpoint dir. Excluded from every
 # checkpoint counter (see core/checkpoint.py and the Go DetectFallback).

--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -518,6 +518,8 @@ def analyze_reachability(
             # I2 adopt gate: BEFORE loading prior checkpoints, verify the backend
             # identity that produced them matches (a changed model/provider/
             # adapter/template archives the stale dir and forces a re-run).
+            _ctx_sha = ((app_context or {}).get("source_sha256")
+                        if isinstance(app_context, dict) else None)
             llr_fp = fingerprint_for_binding(
                 binding,
                 render_template_texts([
@@ -526,6 +528,12 @@ def analyze_reachability(
                         units_block="",
                     )
                 ]),
+                # #546: the context's deterministic-derivation identity —
+                # the per-prompt app-context block stays excluded (the
+                # narration non-determinism trap); the SOURCES hash
+                # invalidates the stale records when the derivation changes.
+                extra_key=({"ctx_sources_sha256": _ctx_sha}
+                          if _ctx_sha else None),
             )
             checkpoint.sync_identity(llr_fp)
             prior_records = checkpoint.load()

--- a/libs/openant-core/core/verifier.py
+++ b/libs/openant-core/core/verifier.py
@@ -195,6 +195,12 @@ def run_verification(
         verify_binding, _verify_texts,
         extra_key={
             "analyze_fingerprint": experiment.get("analyze_fingerprint"),
+            # #546: the context's deterministic-derivation identity — a
+            # standalone verify can be given a different --app-context than
+            # analyze used; the fold keeps the family's keys consistent.
+            **({"ctx_sources_sha256":
+                    getattr(app_context, "source_sha256", None)}
+               if getattr(app_context, "source_sha256", None) else {}),
             # #287: the verify phase's generation budget is part of its
             # checkpoint identity — a budget change invalidates verify
             # checkpoints specifically (no scheme bump; the extra_key

--- a/libs/openant-core/tests/test_issue293_three_state_counters.py
+++ b/libs/openant-core/tests/test_issue293_three_state_counters.py
@@ -295,7 +295,7 @@ def test_analyzer_run_analysis_three_bucket_summary(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyzer_mod, "_run_detection", fake_run_detection)
     monkeypatch.setattr(analyzer_mod, "_analyze_fingerprint",
-                        lambda binding: {"key_digest": "sha256:test"})
+                        lambda binding, ctx_sha=None: {"key_digest": "sha256:test"})
 
     from utilities.llm import PhaseBinding
 
@@ -358,7 +358,7 @@ def test_analyzer_restore_counts_inconclusive_completed(tmp_path, monkeypatch):
 
     monkeypatch.setattr(analyzer_mod, "_run_detection", fake_run_detection)
     monkeypatch.setattr(analyzer_mod, "_analyze_fingerprint",
-                        lambda binding: {"key_digest": "sha256:test"})
+                        lambda binding, ctx_sha=None: {"key_digest": "sha256:test"})
 
     from utilities.llm import PhaseBinding
 

--- a/libs/openant-core/tests/test_issue546_ctx_fingerprint.py
+++ b/libs/openant-core/tests/test_issue546_ctx_fingerprint.py
@@ -1,0 +1,182 @@
+"""Tests for issue #546 — the deterministic-context-sources fingerprint.
+
+The checkpoint family's resume keys excluded the app-context payload —
+correctly for the NARRATED text (the non-determinism trap), but the
+context is derived from deterministic repo sources; a repo edit that
+changes the derivation while leaving a unit's code identical replayed
+stale signals under the changed analysis context. The fix: the context
+ARTIFACT carries source_sha256 (the deterministic-derivation identity —
+each arm's own input: the threat-model file's bytes, the override's
+content, the LLM arm's gathered-sources digest), and the gated phases
+fold it into their identity keys via extra_key.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from context.application_context import (
+    context_sources_digest,
+    gather_context_sources,
+)
+
+
+class TestContextSourcesDigest:
+    def _repo(self, tmp_path: Path, files: dict) -> Path:
+        for name, content in files.items():
+            f = tmp_path / name
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(content)
+        return tmp_path
+
+    def test_same_files_same_digest(self, tmp_path):
+        a = context_sources_digest(gather_context_sources(
+            self._repo(Path(tmp_path), {"README.md": "x"})))
+        b = context_sources_digest(gather_context_sources(
+            self._repo(Path(tmp_path), {"README.md": "x"})))
+        assert a == b and a
+
+    def test_content_change_differs(self, tmp_path):
+        a = context_sources_digest(gather_context_sources(
+            self._repo(Path(tmp_path), {"README.md": "x"})))
+        (Path(tmp_path) / "README.md").write_text("changed")
+        b = context_sources_digest(gather_context_sources(Path(tmp_path)))
+        assert a != b
+
+    def test_new_context_file_differs(self, tmp_path):
+        a = context_sources_digest(gather_context_sources(
+            self._repo(Path(tmp_path), {"README.md": "x"})))
+        (Path(tmp_path) / "go.mod").write_text("module x")
+        b = context_sources_digest(gather_context_sources(Path(tmp_path)))
+        assert a != b
+
+    def test_output_dir_artifacts_do_not_invalidate(self, tmp_path):
+        """THE self-invalidation hazard: [directory_structure] lists the
+        in-repo output dir; the digest must exclude it — writing new
+        artifacts into results/ does NOT change the digest."""
+        self._repo(Path(tmp_path), {"README.md": "x"})
+        a = context_sources_digest(gather_context_sources(Path(tmp_path)))
+        (Path(tmp_path) / "results").mkdir()
+        (Path(tmp_path) / "results" / "analyze_checkpoints").mkdir()
+        (Path(tmp_path) / "results" / "scan.json").write_text("{}")
+        b = context_sources_digest(gather_context_sources(Path(tmp_path)))
+        assert a == b
+
+    def test_untracked_py_file_under_results_unchanged(self, tmp_path):
+        """[detected_patterns] rglobs *.py capped at 100 — an untracked
+        file under the output dir must not shift the digest (excluded)."""
+        self._repo(Path(tmp_path), {"README.md": "x"})
+        a = context_sources_digest(gather_context_sources(Path(tmp_path)))
+        (Path(tmp_path) / "results").mkdir()
+        (Path(tmp_path) / "results" / "new_thing.py").write_text("x=1")
+        b = context_sources_digest(gather_context_sources(Path(tmp_path)))
+        assert a == b
+
+
+class TestProducerStamps:
+    def _gen(self, tmp_path, monkeypatch, narrations):
+        from context import application_context as ac
+
+        (tmp_path / "README.md").write_text("stub repo")
+        calls = iter([json.dumps({"application_type": "cli_tool",
+                                  "purpose": n}) for n in narrations])
+
+        class _R:
+            stop_reason = "end_turn"
+            input_tokens = 1
+            output_tokens = 1
+            usage_details = None
+
+            def __init__(self, text):
+                self.content = [type("B", (), {"text": text})()]
+
+        def fake_sc(binding, prompt, system=None, max_tokens=0, tracker=None):
+            return _R(next(calls))
+
+        monkeypatch.setattr(ac, "simple_completion", fake_sc)
+        from utilities.llm import PhaseBinding
+
+        class _A:
+            name = "t"
+            supports_tools = True
+
+            def validate(self, model):
+                pass
+
+        b = PhaseBinding(phase="app_context", adapter=_A(), model="m",
+                         provider_name="p")
+        return (ac.generate_application_context(
+                    repo_path=Path(tmp_path), binding=b),
+                ac.generate_application_context(
+                    repo_path=Path(tmp_path), binding=b))
+
+    def test_llm_arm_stamps_the_digest(self, tmp_path, monkeypatch):
+        """A source landing BETWEEN the two calls → the stamps differ."""
+        from context import application_context as ac
+        (tmp_path / "README.md").write_text("stub repo")
+        narrations = iter(["one", "DIFFERENT"])
+
+        class _R:
+            stop_reason = "end_turn"
+            input_tokens = 1
+            output_tokens = 1
+            usage_details = None
+
+            def __init__(self, text):
+                self.content = [type("B", (), {"text": text})()]
+
+        def fake_sc(binding, prompt, system=None, max_tokens=0, tracker=None):
+            return _R(json.dumps({"application_type": "cli_tool",
+                                  "purpose": next(narrations)}))
+
+        monkeypatch.setattr(ac, "simple_completion", fake_sc)
+        from utilities.llm import PhaseBinding
+
+        class _A:
+            name = "t"
+            supports_tools = True
+
+            def validate(self, model):
+                pass
+
+        b = PhaseBinding(phase="app_context", adapter=_A(), model="m",
+                         provider_name="p")
+        ctx1 = ac.generate_application_context(
+            repo_path=Path(tmp_path), binding=b)
+        (tmp_path / "package.json").write_text("{}")  # the source lands
+        ctx2 = ac.generate_application_context(
+            repo_path=Path(tmp_path), binding=b)
+        assert ctx1.source_sha256 != ctx2.source_sha256
+
+    def test_llm_same_sources_same_stamp(self, tmp_path, monkeypatch):
+        """SAME sources, DIFFERENT narration → the same stamp."""
+        (ctx1, ctx2) = self._gen(Path(tmp_path), monkeypatch,
+                                  ["one", "DIFFERENT"])
+        assert ctx1.source_sha256 == ctx2.source_sha256
+
+
+class TestGateWiring:
+    def test_analyze_fingerprint_folds_the_sha(self):
+        from core.analyzer import _analyze_fingerprint
+
+        class _B:
+            phase = "analyze"
+            model = "m"
+            provider_name = "p"
+            base_url = None
+            adapter = type("A", (), {"name": "x"})()
+        fp_none = _analyze_fingerprint(_B())
+        fp_sha = _analyze_fingerprint(_B(), ctx_sha="abc")
+        assert "ctx_sources_sha256" not in fp_none.get("extra", {})
+        assert fp_sha["extra"]["ctx_sources_sha256"] == "abc"
+        assert fp_none["key_digest"] != fp_sha["key_digest"]
+
+    def test_pre_fix_artifact_yields_none(self, tmp_path):
+        """Backcompat: an old application_context.json without the field
+        loads and yields None (no crash, one-time archive on first run)."""
+        from context.application_context import load_context
+        f = tmp_path / "application_context.json"
+        f.write_text(json.dumps({"application_type": "cli_tool",
+                                "purpose": "x", "source": "llm"}))
+        ctx = load_context(f)
+        assert ctx.source_sha256 is None

--- a/libs/openant-core/tests/test_issue546_ctx_fingerprint.py
+++ b/libs/openant-core/tests/test_issue546_ctx_fingerprint.py
@@ -154,6 +154,61 @@ class TestProducerStamps:
                                   ["one", "DIFFERENT"])
         assert ctx1.source_sha256 == ctx2.source_sha256
 
+    def test_llm_arm_supplied_sha_is_overwritten(self, tmp_path, monkeypatch):
+        """A model-emitted source_sha256 (steerable by the scanned repo's
+        sources text) must never pin the identity — the stamp is DERIVED
+        (#546's review round: the identity is computed, never adopted)."""
+        from context import application_context as ac
+        (tmp_path / "README.md").write_text("stub repo")
+        supplied = iter(["0" * 64, "1" * 64])
+        narrated = iter(["p", "p"])
+
+        class _R:
+            stop_reason = "end_turn"
+            input_tokens = 1
+            output_tokens = 1
+            usage_details = None
+
+            def __init__(self, text):
+                self.content = [type("B", (), {"text": text})()]
+
+        def fake_sc(binding, prompt, system=None, max_tokens=0, tracker=None):
+            return _R(json.dumps({"application_type": "cli_tool",
+                                  "purpose": next(narrated),
+                                  "source_sha256": next(supplied)}))
+
+        monkeypatch.setattr(ac, "simple_completion", fake_sc)
+        from utilities.llm import PhaseBinding
+
+        class _A:
+            name = "t"
+            supports_tools = True
+
+            def validate(self, model):
+                pass
+
+        b = PhaseBinding(phase="app_context", adapter=_A(), model="m",
+                         provider_name="p")
+        ctx1 = ac.generate_application_context(
+            repo_path=Path(tmp_path), binding=b)
+        ctx2 = ac.generate_application_context(
+            repo_path=Path(tmp_path), binding=b)
+        # SAME sources → the same DERIVED digest — regardless of the two
+        # DIFFERENT supplied constants.
+        assert ctx1.source_sha256 == ctx2.source_sha256
+        assert ctx1.source_sha256 not in ("0" * 64, "1" * 64)
+
+    def test_override_arm_supplied_sha_is_overwritten(self):
+        """A repo-supplied OPENANT.json source_sha256 must never pin the
+        identity — the stamp is computed over the override content."""
+        from context.application_context import _application_context_from_override
+        ctx = _application_context_from_override(
+            {"application_type": "cli_tool", "purpose": "p",
+             "source_sha256": "0" * 64},
+            "OPENANT.json")
+        assert ctx.source_sha256 is not None
+        assert ctx.source_sha256 != "0" * 64
+
 
 class TestGateWiring:
     def test_analyze_fingerprint_folds_the_sha(self):


### PR DESCRIPTION
## Summary

The checkpoint family's resume keys excluded the app-context payload — correctly for the **narrated** text (the LLM non-determinism trap), but the context is derived from **deterministic repo sources**: a repo edit changing the derivation while leaving a unit's code identical replayed stale signals under the changed analysis context (they gate the re-filter — the FN-risk class the two-seat gate on PR #543 named).

The fix (the stamp-the-artifact architecture — no consumer re-derivation, no `repo_path` plumbing, no production/consumption race):

- **`context_sources_digest`**: the canonical sha over the gathered CONTEXT_FILES entries + the two degradation markers — deliberately **excluding** `[directory_structure]` (it lists the in-repo output dir; hashing it would self-invalidate on every resume that writes an artifact) and `[detected_patterns]` (rglob-order, cap-windowed — not canonical); those stay a named residual;
- **all three arms stamp `source_sha256` on the artifact**: the threat-model arm (the file's bytes — pre-existing), the manual-override arm (the override content), the LLM arm (the sources digest) — a **different narration over the same sources keeps the stamp** (no spurious re-pay);
- the gated phases fold it into their identity keys via `extra_key` (`ctx_sources_sha256`): **analyze** (the load-before-fingerprint reorder — the prior order computed the fingerprint before the context loaded, keying on `None` forever), **verify** (the standalone `--app-context` case), **llm-reach** (the dir-level fingerprint; the per-prompt narration stays excluded). A pre-fix artifact yields `None` → a one-time archive on first contact;
- `FINGERPRINT_SCHEME_VERSION` → **2** + the exclusion clause rewritten: the *narration* never enters; the *derivation identity* does.

Closes #546.

## Test plan

9 tests: the digest (same-files/same, content-change differs, new-context-file differs, **output-dir artifacts do not invalidate** — the self-invalidation hazard, untracked-py-under-results unchanged); the producer stamps (a source landing between calls differs; a different narration over the same sources keeps the stamp); the analyze fingerprint folds the sha (None vs sha differ; the pre-fix artifact loads yielding None).

## Verification evidence

| check | command | result |
|---|---|---|
| new tests | `pytest tests/test_issue546_ctx_fingerprint.py -q` | 9 passed |
| the family suites | `pytest tests/test_issue293_three_state_counters.py tests/test_issue532_llr_resume.py tests/test_llm_reachability.py tests/test_backend_identity.py -q` | 91 passed |
| full suite | `pytest tests/ -q` | 4026 passed, 2 failed — both pre-existing (SDK pin drift, verified on the pristine base) |
| static analysis | ruff / Semgrep | clean / 0 |
| adversarial design review | the fable need-check | the full-`gather_context_sources` hash rejected (the `[directory_structure]` self-invalidation + the `[detected_patterns]` order hazard); the consumer-side re-derivation rejected (the `repo_path` crux); the three-arm coverage gap (threat-model + manual-override arms never call `gather_context_sources`) closed by the stamp-the-artifact design |
