### PR TITLE
fix(ui,llm): the hygiene bundle — the dead target/rel allowance retired, the stale retry literal re-pinned, the typed Bedrock credential error mapped

### DIFF
--- a/apps/openant-cli/ui/disclosure.html
+++ b/apps/openant-cli/ui/disclosure.html
@@ -63,7 +63,7 @@ const MD_SANITIZE = {
   ALLOWED_TAGS: ['h1','h2','h3','h4','h5','h6','p','br','hr','blockquote',
     'ul','ol','li','pre','code','em','strong','del','a','span','div',
     'table','thead','tbody','tr','th','td','sup','sub','kbd'],
-  ALLOWED_ATTR: ['href','title','class','align','colspan','rowspan','target','rel'],
+  ALLOWED_ATTR: ['href','title','class','align','colspan','rowspan'],
   FORBID_TAGS: ['style','form','input','button','textarea','select','option',
     'img','picture','source','svg','math','iframe','object','embed','link','base','meta','script'],
   FORBID_ATTR: ['style','src','srcset','action','formaction','background','poster','loading'],

--- a/apps/openant-cli/ui/summary.html
+++ b/apps/openant-cli/ui/summary.html
@@ -57,7 +57,7 @@ const MD_SANITIZE = {
   ALLOWED_TAGS: ['h1','h2','h3','h4','h5','h6','p','br','hr','blockquote',
     'ul','ol','li','pre','code','em','strong','del','a','span','div',
     'table','thead','tbody','tr','th','td','sup','sub','kbd'],
-  ALLOWED_ATTR: ['href','title','class','align','colspan','rowspan','target','rel'],
+  ALLOWED_ATTR: ['href','title','class','align','colspan','rowspan'],
   FORBID_TAGS: ['style','form','input','button','textarea','select','option',
     'img','picture','source','svg','math','iframe','object','embed','link','base','meta','script'],
   FORBID_ATTR: ['style','src','srcset','action','formaction','background','poster','loading'],

--- a/apps/openant-cli/ui/vendor_test.go
+++ b/apps/openant-cli/ui/vendor_test.go
@@ -407,7 +407,7 @@ func TestMDSanitizeConfigPinnedAndUsed(t *testing.T) {
   ALLOWED_TAGS: ['h1','h2','h3','h4','h5','h6','p','br','hr','blockquote',
     'ul','ol','li','pre','code','em','strong','del','a','span','div',
     'table','thead','tbody','tr','th','td','sup','sub','kbd'],
-  ALLOWED_ATTR: ['href','title','class','align','colspan','rowspan','target','rel'],
+  ALLOWED_ATTR: ['href','title','class','align','colspan','rowspan'],
   FORBID_TAGS: ['style','form','input','button','textarea','select','option',
     'img','picture','source','svg','math','iframe','object','embed','link','base','meta','script'],
   FORBID_ATTR: ['style','src','srcset','action','formaction','background','poster','loading'],

--- a/libs/openant-core/tests/test_llm_bedrock_adapter.py
+++ b/libs/openant-core/tests/test_llm_bedrock_adapter.py
@@ -275,12 +275,23 @@ class TestErrorMapping:
         if cls is None:
             pytest.skip("the pinned anthropic predates CredentialsError (>=1.5.0)")
 
+        # The message deliberately does NOT carry _NO_CREDENTIALS_MARKER —
+        # a marker-carrying message would pass via the RuntimeError arm if
+        # the class ever subclassed RuntimeError, and this test must prove
+        # the TYPED arm did the mapping.
         def respond(**kw):
-            raise cls("could not resolve credentials from identity token file")
+            raise cls("identity token file is not readable")
 
         adapter, _ = _stub_adapter(respond)
         with pytest.raises(LLMAuthError) as exc_info:
             _complete(adapter)
+        assert "AWS_ACCESS_KEY_ID" in str(exc_info.value)
+
+        # The startup probe takes the same typed path (validate() is the
+        # first call a scan makes; the probe catches only LLMError).
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMAuthError) as exc_info:
+            adapter.validate(model="us.anthropic.claude-sonnet-4-6")
         assert "AWS_ACCESS_KEY_ID" in str(exc_info.value)
 
     def test_unrelated_runtime_error_propagates(self):

--- a/libs/openant-core/tests/test_llm_bedrock_adapter.py
+++ b/libs/openant-core/tests/test_llm_bedrock_adapter.py
@@ -265,6 +265,24 @@ class TestErrorMapping:
         with pytest.raises(LLMAuthError):
             adapter.validate(model="us.anthropic.claude-sonnet-4-6")
 
+    def test_typed_credentials_error_maps_to_auth_error(self):
+        """1.5.0 narrowed the identity-token/auth-profile raises to the typed
+        CredentialsError (an AnthropicError subclass the APIStatusError arm
+        never sees); it must surface typed like the bare-RuntimeError marker.
+        The except is getattr-guarded — on SDKs older than 1.5.0 the arm
+        matches nothing (the helper returns a never-raised class)."""
+        cls = getattr(anthropic, "CredentialsError", None)
+        if cls is None:
+            pytest.skip("the pinned anthropic predates CredentialsError (>=1.5.0)")
+
+        def respond(**kw):
+            raise cls("could not resolve credentials from identity token file")
+
+        adapter, _ = _stub_adapter(respond)
+        with pytest.raises(LLMAuthError) as exc_info:
+            _complete(adapter)
+        assert "AWS_ACCESS_KEY_ID" in str(exc_info.value)
+
     def test_unrelated_runtime_error_propagates(self):
         """Only the SDK's no-credentials RuntimeError is auth-shaped;
         anything else must not be swallowed into the taxonomy."""

--- a/libs/openant-core/tests/test_retry_empty_completion.py
+++ b/libs/openant-core/tests/test_retry_empty_completion.py
@@ -26,8 +26,11 @@ from utilities.rate_limiter import is_retryable_error  # noqa: E402
 
 # Verbatim adapter messages (str(e) of the raised exception is what reaches the
 # retry filter via core.analyzer._process_unit's except-branch error=str(e)).
-_EMPTY_ANTHROPIC = ("AnthropicAdapter returned no usable content (empty completion); "
-                    "the request may have been filtered or the response was malformed")
+# Post-#561 the anthropic producer embeds the raw stop in the parens and
+# branches the cause on it; the filtered arm is the retryable shape here.
+_EMPTY_ANTHROPIC = ("AnthropicAdapter returned no usable content (empty completion; "
+                    "stop_reason='end_turn'); the request may have been filtered "
+                    "or the response was malformed")
 # Post-#569 the google producer branches on the finish signal; the filtered
 # arm is the retryable shape tested here (the MAX_TOKENS arm carries the
 # budget marker and is pinned by test_issue569_budget_retry instead).
@@ -47,8 +50,12 @@ _EMPTY_OPENAI_RESPONSES_FILTERED = ("OpenAI Responses returned no usable content
 # translator) are silently not retried.
 _EMPTY_OPENAI_CHAT_NOCHOICES = ("OpenAIAdapter returned no choices (empty completion); "
                                 "the request may have been filtered or the response was malformed")
+# Post-#561/#569 the chat producer embeds the raw finish and branches the
+# cause; the filtered arm is the retryable shape here (the length arm
+# carries the budget marker, pinned by test_issue569_budget_retry).
 _EMPTY_OPENAI_CHAT_NOBLOCKS = ("OpenAIAdapter returned an empty completion (no text or tool "
-                               "calls); the request may have been filtered or malformed")
+                               "calls; finish_reason='stop'); the request may have been "
+                               "filtered or the response was malformed")
 _REFUSAL = ("AnthropicAdapter refused the request (stop_reason='refusal'); the model "
             "declined to answer for safety or policy reasons")
 

--- a/libs/openant-core/tests/test_retry_empty_completion.py
+++ b/libs/openant-core/tests/test_retry_empty_completion.py
@@ -28,8 +28,11 @@ from utilities.rate_limiter import is_retryable_error  # noqa: E402
 # retry filter via core.analyzer._process_unit's except-branch error=str(e)).
 _EMPTY_ANTHROPIC = ("AnthropicAdapter returned no usable content (empty completion); "
                     "the request may have been filtered or the response was malformed")
+# Post-#569 the google producer branches on the finish signal; the filtered
+# arm is the retryable shape tested here (the MAX_TOKENS arm carries the
+# budget marker and is pinned by test_issue569_budget_retry instead).
 _EMPTY_GEMINI = ("Gemini returned a candidate with no usable content (empty completion); "
-                 "the response may have been truncated (a thinking block)")
+                 "the response may have been filtered or malformed")
 # OpenAI Responses-API empty path: says "no usable content" but NOT
 # "empty completion" — the term must match the shared "no usable content"
 # phrase so this sibling is covered too. Both post-#569 producer arms (the
@@ -54,6 +57,7 @@ def test_empty_completion_is_retryable():
     assert is_retryable_error(_EMPTY_ANTHROPIC) is True
     assert is_retryable_error(_EMPTY_GEMINI) is True
     assert is_retryable_error(_EMPTY_OPENAI_RESPONSES) is True
+    assert is_retryable_error(_EMPTY_OPENAI_RESPONSES_FILTERED) is True
     assert is_retryable_error(_EMPTY_OPENAI_CHAT_NOCHOICES) is True
     assert is_retryable_error(_EMPTY_OPENAI_CHAT_NOBLOCKS) is True
 
@@ -98,6 +102,7 @@ def test_empty_completion_dict_is_retryable():
     assert is_retryable_error(_info(_EMPTY_ANTHROPIC)) is True
     assert is_retryable_error(_info(_EMPTY_GEMINI)) is True
     assert is_retryable_error(_info(_EMPTY_OPENAI_RESPONSES)) is True
+    assert is_retryable_error(_info(_EMPTY_OPENAI_RESPONSES_FILTERED)) is True
     assert is_retryable_error(_info(_EMPTY_OPENAI_CHAT_NOCHOICES)) is True
     assert is_retryable_error(_info(_EMPTY_OPENAI_CHAT_NOBLOCKS)) is True
 

--- a/libs/openant-core/utilities/llm/providers/bedrock.py
+++ b/libs/openant-core/utilities/llm/providers/bedrock.py
@@ -242,13 +242,17 @@ class BedrockAdapter:
                 raise LLMAuthError(_no_credentials_message(exc)) from redacted_cause_from(exc)
             raise
         except _typed_credentials_error() as exc:
-            # 1.5.0 narrowed the identity-token/auth-profile raises to the
-            # typed CredentialsError family (an AnthropicError subclass the
-            # APIStatusError arm above never sees). Map it to the same typed
-            # auth path as the bare-RuntimeError marker. getattr-guarded:
-            # the pyproject floor (anthropic>=0.40.0) predates the class —
-            # a bare `except anthropic.CredentialsError` would AttributeError
-            # on older SDKs at exactly the moment a real error propagates.
+            # Upgrade-defense (the review round's reachability correction):
+            # on the pinned 1.5.0 the BEDROCK signer still raises the bare
+            # RuntimeError the marker arm above already maps; the typed
+            # CredentialsError family is raised by the BASE client's
+            # auth-profile machinery, which AnthropicBedrock never invokes
+            # today — but an SDK narrowing (the direction 1.5.0 took the
+            # base-client raises) lands here first. Map it to the same typed
+            # auth path. getattr-guarded: the pyproject floor
+            # (anthropic>=0.40.0) predates the class — a bare
+            # `except anthropic.CredentialsError` would AttributeError on
+            # older SDKs at exactly the moment a real error propagates.
             raise LLMAuthError(_no_credentials_message(exc)) from redacted_cause_from(exc)
 
         return _response_to_unified(response, adapter="BedrockAdapter")
@@ -284,6 +288,12 @@ class BedrockAdapter:
             if _NO_CREDENTIALS_MARKER in str(exc):
                 raise LLMAuthError(_no_credentials_message(exc)) from redacted_cause_from(exc)
             raise
+        except _typed_credentials_error() as exc:
+            # Upgrade-defense, mirrored from complete() (validate() is the
+            # FIRST call a scan makes — registry.validate at startup — and
+            # probe_registry_or_raise catches only LLMError, so a typed
+            # credential failure here would surface raw and unredacted.
+            raise LLMAuthError(_no_credentials_message(exc)) from redacted_cause_from(exc)
 
 
 # ----------------------------------------------------------------------

--- a/libs/openant-core/utilities/llm/providers/bedrock.py
+++ b/libs/openant-core/utilities/llm/providers/bedrock.py
@@ -83,6 +83,16 @@ _MODEL_ACCESS_HINT = (
 
 _NO_CREDENTIALS_MARKER = "could not resolve credentials"
 
+
+def _typed_credentials_error() -> type[BaseException]:
+    """The SDK's typed credential-error class, or a never-matching fallback
+    when the pinned anthropic predates it (>=1.5.0 carries CredentialsError;
+    the pyproject floor is >=0.40.0). Returns BaseException-substituted so
+    the except clause is syntactically valid on every floor version while
+    matching nothing on the old SDKs."""
+    cls = getattr(anthropic, "CredentialsError", None)
+    return cls if cls is not None else type("_NeverRaised", (BaseException,), {})
+
 # One-time warning when a config sets api_key on a bedrock provider.
 # Silent-ignoring config a user explicitly wrote would violate the
 # no-silent-drops rule the other adapters follow.
@@ -231,6 +241,15 @@ class BedrockAdapter:
             if _NO_CREDENTIALS_MARKER in str(exc):
                 raise LLMAuthError(_no_credentials_message(exc)) from redacted_cause_from(exc)
             raise
+        except _typed_credentials_error() as exc:
+            # 1.5.0 narrowed the identity-token/auth-profile raises to the
+            # typed CredentialsError family (an AnthropicError subclass the
+            # APIStatusError arm above never sees). Map it to the same typed
+            # auth path as the bare-RuntimeError marker. getattr-guarded:
+            # the pyproject floor (anthropic>=0.40.0) predates the class —
+            # a bare `except anthropic.CredentialsError` would AttributeError
+            # on older SDKs at exactly the moment a real error propagates.
+            raise LLMAuthError(_no_credentials_message(exc)) from redacted_cause_from(exc)
 
         return _response_to_unified(response, adapter="BedrockAdapter")
 


### PR DESCRIPTION
## What

Three review-wave follow-ups, disjoint surfaces, one commit:

1. **MD_SANITIZE's dead `target`/`rel` allowance retired** — no producer since the #580 rewrite removal (marked's native autolink emits a plain `<a href>`); both pages + the vendor_test golden move together (the golden enforces the same-commit discipline). The app's own static `target="_blank"` links (index/scan) are outside the markdown path and unaffected.
2. **The stale `_EMPTY_GEMINI` literal re-pinned** — it no longer matched any current google producer wording (post-#569 the producer branches on the finish signal; the stale string passed only on shared substrings); re-pinned to the current filtered-arm wording. The defined-but-never-asserted `_EMPTY_OPENAI_RESPONSES_FILTERED` is now asserted in both the string-shape and dict-shape retryable tests.
3. **The typed Bedrock credential error mapped** — anthropic 1.5.0 narrowed the identity-token/auth-profile raises to the typed `CredentialsError` (an `AnthropicError` subclass the `APIStatusError` arm never sees); it now maps to the typed `LLMAuthError` path with the AWS env-var pointer. **getattr-guarded** because the pyproject floor (`anthropic>=0.40.0`) predates the class — a bare `except anthropic.CredentialsError` would `AttributeError` on older SDKs exactly when a real error propagates. Scoped to bedrock only (the direct anthropic adapter has no SigV4 path).

## Verification

- pytest: the bedrock + retry-empty-completion + issue569 slices — 43 passed; the full Python suite — 3921 passed, 0 FAIL.
- `go test ./ui/ ./internal/server/` — green (the vendor golden + pages moved together).
- The old-SDK fallback path proven live (a pre-1.5.0 environment resolves the never-raised class); the 1.5.0 environment resolves `CredentialsError` (both verified by execution).
