### PR TITLE
fix(llm): the Responses budget wording gates on the raw incomplete-reason, not the derived stop_reason

### DIFF
--- a/libs/openant-core/tests/test_llm_openai_adapter.py
+++ b/libs/openant-core/tests/test_llm_openai_adapter.py
@@ -484,6 +484,20 @@ def test_empty_output_max_tokens_stop_carries_budget_wording():
         adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
 
 
+def test_empty_output_unknown_incomplete_reason_has_no_budget_wording():
+    # #569 follow-up (2c): the unknown-reason relabel sets stop_reason =
+    # "max_tokens" (the honest not-a-clean-finish signal for PARTIAL
+    # content), but an EMPTY response under that exotic shape must NOT
+    # carry the budget marker — the raised-cap retry class stays precise
+    # (raw status+reason only); the old derived-stop_reason gate keyed the
+    # marker on shapes that never exhausted a budget.
+    adapter, _ = _stub_resp(lambda **kw: _resp(status="incomplete", incomplete_reason="future_reason",
+                                               output=[_reasoning()]))
+    with pytest.raises(LLMResponseError) as ei:
+        adapter.complete(model=G5, system=None, messages=_hi(), max_tokens=8)
+    assert "consumed the budget" not in str(ei.value)
+
+
 def test_empty_output_filtered_shape_has_no_budget_wording():
     # #569 producer-side pin: a filtered empty output keeps the #292
     # same-cap rationale — its raise must NOT carry the budget marker.

--- a/libs/openant-core/utilities/llm/providers/openai.py
+++ b/libs/openant-core/utilities/llm/providers/openai.py
@@ -808,11 +808,15 @@ def _responses_to_unified(response: Any) -> CompletionResult:
         stop_reason = "tool_use"
 
     if not content_blocks:
-        # #569: the budget wording is DETERMINISTIC-CLASS-ONLY — a
-        # max_tokens stop (the incomplete/max_output_tokens shape) is the
-        # budget-exhaustion class; a filtered/failed response keeps the
-        # #292 same-cap rationale and must not carry the marker.
-        if stop_reason == "max_tokens":
+        # #569: the budget wording is DETERMINISTIC-CLASS-ONLY. Gated on
+        # the RAW signal — status incomplete with reason max_output_tokens —
+        # NOT the derived stop_reason: the unknown-reason and unknown-status
+        # relabels above also set stop_reason = "max_tokens" (the honest
+        # "not a clean finish" signal for PARTIAL content), and an empty
+        # response under those exotic shapes must not carry the budget
+        # marker as a false causal statement (the raised-cap retry class is
+        # precise; those shapes keep the #292 same-cap rationale).
+        if status == "incomplete" and reason == "max_output_tokens":
             raise LLMResponseError(
                 f"OpenAI Responses returned no usable content (status={status!r}); "
                 "the request was truncated — reasoning consumed the budget"


### PR DESCRIPTION
## What

The Responses empty-content guard's budget wording gated on the **derived** `stop_reason == "max_tokens"` — but the unknown-incomplete-reason and unknown-status relabels (the honest not-a-clean-finish signals for *partial* content) also set `max_tokens`. An **empty** response under those exotic shapes carried "reasoning consumed the budget" as a false causal statement and took the raised-cap retry on a class that never exhausted a budget.

The gate is now the **raw signal** — `status == "incomplete" and reason == "max_output_tokens"` — matching the raw-signal keying of the three sibling arms (anthropic `raw_finish`, google `raw_finish`, openai-chat `raw_finish`).

## Verification

A producer-side negative pin added: an unknown `incomplete_reason` with empty output raises WITHOUT the budget marker (the derived-stop_reason gate's exact false-positive shape). The existing positive pin (incomplete + max_output_tokens carries the marker) and the filtered-shape negative pin unchanged and green.

pytest: the openai-adapter + issue569 + retry-empty-completion slices — 100 passed.
