### PR TITLE
feat(llm-reach): the budget-exhaustion exception joins the split-and-retry — halves in LLR, not a same-cap resume coin flip (#569 x #558)

### DIFF
--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -53,6 +53,7 @@ from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from utilities.llm import PhaseBinding
+from utilities.rate_limiter import is_budget_exhausted_error
 
 
 # Maximum number of units to send in a single LLM call. Larger batches save
@@ -638,6 +639,33 @@ def analyze_reachability(
             # so the caller can stop and tell the user the key is bad.
             raise
         except Exception as exc:  # noqa: BLE001 — advisory stage; never crash pipeline
+            # #569 x #558 composition (the review follow-up): a DETERMINISTIC
+            # budget-exhausted empty surfaces HERE as an exception — the
+            # adapter raises on empty content before LLR's parse-path
+            # truncation gate ever sees a stop_reason — and under the #541
+            # classification it became batches_failed -> a same-cap resume
+            # re-roll: the exact billed coin flip #569 exists to kill, in the
+            # phase that decides what gets analyzed at all. Classify it as
+            # the TRUNCATED class with FULL deltas so #558's split-and-retry
+            # covers it: the counters + deltas match the parse-path
+            # truncated arm exactly, the split's subtraction stays exact,
+            # and the halves' own outcomes flow through the same arms. The
+            # split halves are smaller outputs (less likely to exhaust) AND
+            # a fresh roll — the #558 rationale, same-cap by design (LLR
+            # passes no raised cap; the raised-cap path is analyze-phase
+            # only, per #569).
+            if is_budget_exhausted_error(str(exc)):
+                dropped_batches += 1
+                batches_truncated += 1
+                units_not_reviewed += len(sub_batch)
+                msg = f"{label} truncated (budget exhausted: the model spent "
+                f"the output cap before emitting content): {exc}"
+                if on_error:
+                    on_error(msg)
+                else:
+                    print(f"[LLMReach] {msg}", file=sys.stderr)
+                return [], "truncated", {
+                    "dropped": 1, "units": len(sub_batch), "truncated": 1}
             # #541: a provider-exception batch is counted in the coverage
             # truth. A distinct counter (different failure class, different
             # remediation) + the same units_not_reviewed.

--- a/libs/openant-core/tests/test_issue532_llr_resume.py
+++ b/libs/openant-core/tests/test_issue532_llr_resume.py
@@ -762,6 +762,105 @@ class TestIssue558SplitRetry:
         assert stats["batches_dropped"] == 0  # the original revised
         assert stats["units_not_reviewed"] == 0  # the halves recovered
 
+    def test_budget_exhausted_exception_split_recovers(self):
+        """#569 x #558 composition: a DETERMINISTIC budget-exhausted empty
+        surfaces as an ADAPTER EXCEPTION (the empty-content raise) before
+        LLR's parse-path truncation gate can see a stop_reason. Under the
+        old #541 classification it became batches_failed -> a same-cap
+        resume re-roll (the coin flip #569 exists to kill). Now it is the
+        TRUNCATED class: the split re-issues halves, the recovery carries
+        provenance, and the failed counter never moves."""
+        stats: dict = {}
+        from utilities.llm.adapter import LLMResponseError
+
+        class BudgetRaisingAdapter(FakeAdapter):
+            """Raises the deterministic budget-exhaustion raise ONCE (the
+            original batch), then serves the halves OK."""
+
+            def __init__(self, responses):
+                super().__init__(responses)
+                self._raised = False
+
+            def complete(self, *, model, system, messages, max_tokens,
+                         tools=None):
+                if not self._raised:
+                    self._raised = True
+                    raise LLMResponseError(
+                        "OpenAIAdapter returned an empty completion (no text "
+                        "or tool calls; finish_reason='length'); the output "
+                        "budget was consumed before any visible content")
+                return super().complete(model=model, system=system,
+                                        messages=messages,
+                                        max_tokens=max_tokens, tools=tools)
+
+        adapter = BudgetRaisingAdapter([
+            _canned(_sig("a:f1")),
+            _canned(_sig("b:f2")),
+        ])
+        signals = analyze_reachability(
+            {"units": [_make_unit("a:f1"), _make_unit("b:f2")]},
+            binding=_binding(adapter), batch_size=2,
+            tracker=FakeTracker(), stats=stats)
+        assert {s.unit_id for s in signals} == {"a:f1", "b:f2"}
+        assert stats["batches_split_recovered"] == 1
+        assert stats["batches_dropped"] == 0  # the original revised
+        assert stats["units_not_reviewed"] == 0  # the halves recovered
+        assert stats["batches_failed"] == 0  # NOT the failed class anymore
+        assert stats.get("batches_truncated") == 0  # revised with the drop
+
+    def test_budget_exhausted_halves_stay_dropped(self):
+        """A budget-exhausted original whose halves ALSO budget-exhaust:
+        one split level, no recursion — the units re-run on the next resume
+        (absence-as-retry), the split-lost provenance counted."""
+        stats: dict = {}
+        from utilities.llm.adapter import LLMResponseError
+
+        class AlwaysBudgetAdapter(FakeAdapter):
+            def complete(self, *, model, system, messages, max_tokens,
+                         tools=None):
+                raise LLMResponseError(
+                    "OpenAIAdapter returned an empty completion (no text or "
+                    "tool calls; finish_reason='length'); the output budget "
+                    "was consumed before any visible content")
+
+        adapter = AlwaysBudgetAdapter()
+        signals = analyze_reachability(
+            {"units": [_make_unit("a:f1"), _make_unit("b:f2")]},
+            binding=_binding(adapter), batch_size=2,
+            tracker=FakeTracker(), stats=stats)
+        assert signals == []
+        assert stats["batches_split_lost"] == 1
+        # The original revised away; each half's own drop counted —
+        # never negative, never double beyond the two half attempts.
+        assert stats["batches_dropped"] == 2
+        assert stats["units_not_reviewed"] == 2
+        assert stats["batches_failed"] == 0
+        assert stats.get("batches_truncated") == 2
+
+    def test_odd_size_batch_splits_three_plus_two(self):
+        """mid = (len+1)//2 on an ODD batch: 5 units split 3+2 (the
+        untested arithmetic the #575 review named — pinned here)."""
+        stats: dict = {}
+        adapter = FakeAdapter([
+            "not json {",                       # the batch drops
+            _canned(_sig("u1"), _sig("u2"), _sig("u3")),   # half 1 (3)
+            _canned(_sig("u4"), _sig("u5")),                # half 2 (2)
+        ])
+        units = [_make_unit(f"u{i}") for i in range(1, 6)]
+        signals = analyze_reachability(
+            {"units": units}, binding=_binding(adapter), batch_size=5,
+            tracker=FakeTracker(), stats=stats)
+        assert {s.unit_id for s in signals} == {"u1", "u2", "u3", "u4", "u5"}
+        assert stats["batches_split_recovered"] == 1
+        assert stats["units_not_reviewed"] == 0
+        # The halves' unit counts prove the 3+2 split (the calls' prompts
+        # carry the unit ids — assert the grouping shape).
+        assert len(adapter.calls) == 3  # original + two halves
+        half1_ids = adapter.calls[1]["prompt"]
+        half2_ids = adapter.calls[2]["prompt"]
+        assert "u1" in half1_ids and "u3" in half1_ids and "u5" not in half1_ids
+        assert "u4" in half2_ids and "u5" in half2_ids and "u1" not in half2_ids
+
     def test_recovered_units_persist(self, tmp_path):
         """The recovered halves' units get checkpoint records (they were
         reviewed this pass — absence-as-retry only for the STILL-dropped)."""


### PR DESCRIPTION
## What

The #569 × #558 cross-PR composition: #569 fixed the budget-exhaustion raised-cap retry in the **analyze** phase only. In **LLR**, the same deterministic empty surfaces as an *adapter exception* (the empty-content raise fires before the parse-path truncation gate can see a stop_reason) and under the #541 classification became `batches_failed` → a **same-cap resume re-roll on every resume** — the exact billed coin flip #569 exists to kill, in the phase that decides what gets analyzed at all.

`_attempt`'s except arm now classifies `is_budget_exhausted_error` as the **truncated class with full deltas** (`{dropped: 1, units: len, truncated: 1}`) — matching the parse-path truncated arm exactly, so #558's split-and-retry covers it: the subtraction stays exact, the halves' own outcomes flow through the same arms, and `batches_failed` never moves (a length stop that surfaced as an exception, not a provider failure). The split halves are smaller outputs (less likely to exhaust) AND a fresh roll — the #558 rationale; same-cap by design (the raised-cap path is analyze-phase only).

## Verification

Counter semantics pinned both ways: a recovered budget-original ends `batches_failed == 0`, `batches_dropped == 0` (revised), `units_not_reviewed == 0`, `split_recovered == 1`; a both-halves-exhausted split stays dropped (absence-as-retry), `split_lost == 1`, the two half-attempts counted, never negative. Also pins the odd-size arithmetic the #575 review named: a 5-unit batch splits 3+2 (`mid = (len+1)//2`), asserted via the halves' prompt contents.

pytest: the LLR suites — 18 passed; the full Python suite — 4059 passed, 0 FAIL. The prior exception fixture (`RuntimeError("provider exploded")`) unaffected — no budget wording (verified before the change).
