### PR TITLE
feat(analyze): the budget-retry cap is per-model — the registry's max_output_tokens ceiling honored (#569 follow-up)

### DIFF
--- a/config/models.json
+++ b/config/models.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment \u2014 see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
+  "_comment": "Provider-model registry: the single source of truth for model IDs and pricing, read by BOTH the Python engine (core/model_registry.py) and the Go CLI (internal/models). status is OpenAnt's shipped claim; source+retrieved are its provenance. price is null for any model that must not be auto-dispatched (retired/unknown) so it never resolves to a silent $0 in cost accounting. Prices are OpenAnt's shipped rates and are NOT verified against live provider pricing in the build environment — see each record's source. Recency of `retrieved` is an operational/CI concern, not asserted in the unit tests. INVARIANT (test_models_price_cross_check.py): records for the same model family across providers must agree on price unless the diverging record carries an explicit `price_diverges` reason string (#344).",
   "schema_version": 1,
   "models": [
     {
@@ -10,7 +10,7 @@
         "input": 5.0,
         "output": 25.0
       },
-      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) \u2014 both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
+      "source": "verified against live Anthropic pricing (Claude Opus 4.8 = $5/$25 per MTok, platform.claude.com/docs/en/about-claude/pricing, 2026-09-01) and the live OpenRouter catalogue (anthropic/claude-opus-4.8 = $5.00/$25.00 per 1M, openrouter.ai/api/v1/models, 2026-09-01) — both live sources agree; the prior 15.00/75.00 was the retired Opus 4.1-era shipped-table rate, never re-verified (#344)",
       "retrieved": "2026-09-01"
     },
     {
@@ -69,7 +69,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-opus-4-8",
@@ -92,7 +92,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-sonnet-4-6",
@@ -115,7 +115,7 @@
       },
       "source": "regional Bedrock inference profile; liveness via list-inference-profiles (us-east-1, status ACTIVE) on 2026-07-31; price = the direct Anthropic rate x1.1 (the regional-endpoint premium Anthropic's pricing page documents for Claude 4.5+ models), re-derived 2026-09-01",
       "retrieved": "2026-07-31",
-      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models \u2014 this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
+      "price_diverges": "Bedrock REGIONAL endpoint premium: Anthropic's pricing page states regional/multi-region endpoints carry +10% over global for Claude 4.5+ models — this is the direct rate x1.1, derived 2026-09-01 from that live page; the global.anthropic sibling carries the standard rate."
     },
     {
       "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -159,7 +159,8 @@
         "output": 8.0
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 32768
     },
     {
       "id": "gpt-4.1-mini",
@@ -170,7 +171,8 @@
         "output": 1.6
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 32768
     },
     {
       "id": "gpt-4.1-nano",
@@ -181,7 +183,8 @@
         "output": 0.4
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 32768
     },
     {
       "id": "o1",
@@ -192,7 +195,8 @@
         "output": 60.0
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 100000
     },
     {
       "id": "o3",
@@ -203,7 +207,8 @@
         "output": 8.0
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 100000
     },
     {
       "id": "o3-mini",
@@ -214,7 +219,8 @@
         "output": 4.4
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 100000
     },
     {
       "id": "o4-mini",
@@ -225,7 +231,8 @@
         "output": 4.4
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live OpenAI pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 100000
     },
     {
       "id": "gemini-2.5-pro",
@@ -236,7 +243,8 @@
         "output": 10.0
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 65536
     },
     {
       "id": "gemini-2.5-flash",
@@ -247,7 +255,8 @@
         "output": 2.5
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 65536
     },
     {
       "id": "gemini-2.5-flash-lite",
@@ -258,7 +267,8 @@
         "output": 0.4
       },
       "source": "openant shipped pricing table (utilities/model_config.py); not re-verified against live Google pricing",
-      "retrieved": "2026-07-23"
+      "retrieved": "2026-07-23",
+      "max_output_tokens": 65536
     },
     {
       "id": "gemini-2.0-flash",
@@ -368,7 +378,8 @@
         "output": 8.0
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 32768
     },
     {
       "id": "openai/gpt-4.1-mini",
@@ -379,7 +390,8 @@
         "output": 1.6
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 32768
     },
     {
       "id": "openai/gpt-4.1-nano",
@@ -390,7 +402,8 @@
         "output": 0.4
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 32768
     },
     {
       "id": "openai/o1",
@@ -401,7 +414,8 @@
         "output": 60.0
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 100000
     },
     {
       "id": "openai/o3",
@@ -412,7 +426,8 @@
         "output": 8.0
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 100000
     },
     {
       "id": "openai/o3-mini",
@@ -423,7 +438,8 @@
         "output": 4.4
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 100000
     },
     {
       "id": "openai/o4-mini",
@@ -434,7 +450,8 @@
         "output": 4.4
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 100000
     },
     {
       "id": "google/gemini-2.5-pro",
@@ -445,7 +462,8 @@
         "output": 10.0
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 65536
     },
     {
       "id": "google/gemini-2.5-flash",
@@ -456,7 +474,8 @@
         "output": 2.5
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 65536
     },
     {
       "id": "google/gemini-2.5-flash-lite",
@@ -467,7 +486,8 @@
         "output": 0.4
       },
       "source": "verified against the live OpenRouter catalogue (GET https://openrouter.ai/api/v1/models), per-token rates converted to per-1M; OpenRouter's rate, which may differ from the direct provider's",
-      "retrieved": "2026-08-01"
+      "retrieved": "2026-08-01",
+      "max_output_tokens": 65536
     },
     {
       "id": "anthropic/claude-opus-5",
@@ -510,7 +530,7 @@
         "input": 0.75,
         "output": 3.75
       },
-      "source": "verified against Google's own pricing page (ai.google.dev/gemini-api/docs/pricing: gemini-3.7-flash $0.75/$3.75 per 1M, 2026-09-01 \u2014 the page documents a scheduled step to $1.50/$7.50 on 2027-01-01; revisit then) and the live OpenRouter catalogue (google/gemini-3.7-flash $0.75/$3.75) \u2014 both live sources agree (#434's stale-family gap)",
+      "source": "verified against Google's own pricing page (ai.google.dev/gemini-api/docs/pricing: gemini-3.7-flash $0.75/$3.75 per 1M, 2026-09-01 — the page documents a scheduled step to $1.50/$7.50 on 2027-01-01; revisit then) and the live OpenRouter catalogue (google/gemini-3.7-flash $0.75/$3.75) — both live sources agree (#434's stale-family gap)",
       "retrieved": "2026-09-01"
     },
     {
@@ -532,7 +552,7 @@
         "input": 0.0,
         "output": 0.0
       },
-      "source": "verified on ollama.com/library/qwen3.8 (18GB, 256K ctx); local inference is free \u2014 $0 by definition, not an unverified vendor price",
+      "source": "verified on ollama.com/library/qwen3.8 (18GB, 256K ctx); local inference is free — $0 by definition, not an unverified vendor price",
       "retrieved": "2026-08-27"
     },
     {
@@ -543,7 +563,7 @@
         "input": 0.0,
         "output": 0.0
       },
-      "source": "modest-hardware alternative; verified on ollama.com/library/qwen3.5 (6.6GB); local inference is free \u2014 $0 by definition",
+      "source": "modest-hardware alternative; verified on ollama.com/library/qwen3.5 (6.6GB); local inference is free — $0 by definition",
       "retrieved": "2026-08-27"
     },
     {
@@ -554,7 +574,7 @@
         "input": 0.0,
         "output": 0.0
       },
-      "source": "verified live end-to-end: planted-vuln scan, both CWE-89 findings detected (2026-08-25); local inference is free \u2014 $0 by definition",
+      "source": "verified live end-to-end: planted-vuln scan, both CWE-89 findings detected (2026-08-25); local inference is free — $0 by definition",
       "retrieved": "2026-08-27"
     },
     {

--- a/libs/openant-core/core/analyzer.py
+++ b/libs/openant-core/core/analyzer.py
@@ -48,12 +48,34 @@ from utilities.rate_limiter import (
 # >~21,333 with "Streaming is required" — see helpers.py:29-31; the
 # adapters call non-streaming). The deterministic length-empty class gets
 # ONE retry that attacks the cause (the budget) within that envelope.
+# #569 follow-up (2b): the envelope is PER-MODEL where the registry knows
+# the ceiling (config/models.json max_output_tokens) — the review round's
+# granularity fix: a per-ADAPTER number over-raises for small-output
+# models, and a 400 on the retry would be an un-retried error, strictly
+# worse than the coin flip. Unlisted models keep this default-derived cap.
 BUDGET_RETRY_MAX_TOKENS = min(DEFAULT_MAX_TOKENS * 2, 21000)
 
-def budget_retry_cap(index: int, budget_set: set) -> int | None:
+def budget_retry_cap(index: int, budget_set: set, binding=None) -> int | None:
     """#569: the per-index retry cap — the raised cap for the budget class,
-    None (the unchanged default) for every other retryable."""
-    return BUDGET_RETRY_MAX_TOKENS if index in budget_set else None
+    None (the unchanged default) for every other retryable. With a binding,
+    the cap honors the model's documented max-output ceiling
+    (model_registry.max_output_tokens): a listed model gets
+    min(2x default, ceiling); an unlisted model keeps the default-derived
+    BUDGET_RETRY_MAX_TOKENS. A ceiling that admits no raise (<= the
+    default) returns None — a same-cap retry beats a guaranteed 400."""
+    if index not in budget_set:
+        return None
+    if binding is None:
+        return BUDGET_RETRY_MAX_TOKENS
+    from core import model_registry
+    ceiling = model_registry.max_output_tokens(
+        binding.provider_name, binding.model)
+    if ceiling is None:
+        return BUDGET_RETRY_MAX_TOKENS
+    cap = min(DEFAULT_MAX_TOKENS * 2, ceiling)
+    if cap <= DEFAULT_MAX_TOKENS:
+        return None
+    return cap
 
 
 # These live in core/ because core is shipped and experiment.py is not: importing
@@ -801,16 +823,25 @@ def run_analysis(
                   f"(waiting {backoff:.0f}s for rate limit to clear)...", file=sys.stderr)
             rate_limiter.wait_if_needed()
         else:
-            _extra = (f" ({len(budget_retry_indices)} at a raised output "
-                      f"cap {BUDGET_RETRY_MAX_TOKENS} — budget exhaustion)"
-                      if budget_retry_indices else "")
+            _cap_desc = ""
+            if budget_retry_indices:
+                _caps = sorted({c for c in (budget_retry_cap(
+                    i, _budget_set, binding) for i in budget_retry_indices)
+                    if c is not None})
+                if _caps:
+                    _cap_desc = (f" ({len(budget_retry_indices)} at a raised "
+                                 f"output cap {_caps} — budget exhaustion)")
+                else:
+                    _cap_desc = (f" ({len(budget_retry_indices)} budget-"
+                                 f"exhausted; no ceiling admits a raise — "
+                                 f"same-cap retry)")
             print(f"[Analyze] Retrying {len(retryable_indices)} failed units "
-                  f"(transient errors){_extra}...", file=sys.stderr)
+                  f"(transient errors){_cap_desc}...", file=sys.stderr)
 
         # Retry sequentially to avoid re-triggering rate limit
         for i in retryable_indices:
             unit = units[i]
-            _cap = budget_retry_cap(i, _budget_set)
+            _cap = budget_retry_cap(i, _budget_set, binding)
             out = _process_unit(binding, unit, i, json_corrector, app_context,
                                 max_tokens=_cap)
             results[i] = out["result"]

--- a/libs/openant-core/core/model_registry.py
+++ b/libs/openant-core/core/model_registry.py
@@ -172,6 +172,33 @@ def pricing_map(provider: str) -> dict[str, dict[str, float]]:
     return out
 
 
+def max_output_tokens(provider: str, model: str) -> int | None:
+    """The model's documented max-output ceiling, or ``None`` when unknown.
+
+    Feeds the #569 budget-retry cap (the review-round granularity fix: a
+    PER-ADAPTER number over-raises for small-output models — a 400 on the
+    retry would be an un-retried error, strictly worse than the coin flip).
+    The retry honors a ceiling only when it EXCEEDS the default-derived cap;
+    a smaller ceiling changes nothing (such a model would already 400 at the
+    default). Alias-tolerant like pricing_map: bare, vendor-prefixed, dotted
+    and dashed spellings resolve to the same record. Missing config raises
+    via require_models (fail-loud, same contract as pricing).
+    """
+    recs = [rec for rec in require_models()
+            if rec.get("provider") == provider]
+    by_id = {rec["id"]: rec for rec in recs}
+    rec = by_id.get(model)
+    if rec is None:
+        for rec_ in recs:  # alias pass
+            if model in _alias_spellings(rec_["id"]):
+                rec = rec_
+                break
+    if rec is None:
+        return None
+    cap = rec.get("max_output_tokens")
+    return int(cap) if cap else None
+
+
 def _alias_spellings(model_id: str) -> list[str]:
     """The conventional alternate spellings of a model id (#434's enumerated
     set): a vendor slug prefix may be present or absent, an Anthropic

--- a/libs/openant-core/tests/test_issue569_budget_retry.py
+++ b/libs/openant-core/tests/test_issue569_budget_retry.py
@@ -138,6 +138,89 @@ class TestCapThreaded:
             "budget-class unit's call")
 
 
+class TestRegistryCeilingInvariants:
+    """The registry discipline the per-model cap depends on (the review
+    round's conformance asks): the anthropic/bedrock exclusion is enforced
+    by TEST, not prose — a future max_output_tokens >= ~21,334 on those
+    records would push the retry past the SDK non-streaming ceiling (the
+    exact class the 21000 default exists to prevent); and same-family
+    records agree on their ceilings (the #344 price precedent, extended)."""
+
+    def test_anthropic_and_bedrock_carry_no_ceiling(self):
+        from core import model_registry
+        for rec in model_registry.load_models():
+            if rec.get("provider") in ("anthropic", "bedrock"):
+                assert not rec.get("max_output_tokens"), (
+                    f"{rec['provider']}/{rec['id']} carries max_output_tokens "
+                    f"{rec['max_output_tokens']!r} — the retry cap would "
+                    f"exceed the SDK non-streaming ~21,333 ceiling; the "
+                    f"exclusion is load-bearing (see analyzer.py)")
+
+    def test_same_family_agrees_on_ceiling(self):
+        from core import model_registry
+        import re
+        fam = {}
+        for rec in model_registry.load_models():
+            cap = rec.get("max_output_tokens")
+            if not cap:
+                continue
+            # family = the base model id (strip vendor prefix + date stamps)
+            base = rec["id"].split("/")[-1]
+            base = re.sub(r"-\d{8}.*$", "", base)
+            fam.setdefault(base, set()).add(cap)
+        for base, caps in fam.items():
+            assert len(caps) == 1, (
+                f"family {base!r} disagrees on max_output_tokens: {caps} — "
+                f"an alias landing on a sibling record must be ceiling-safe "
+                f"(the #344 same-family price precedent)")
+
+
+class TestPerModelCeiling:
+    """#569 follow-up (2b): the retry cap honors the model's documented
+    max-output ceiling (config/models.json max_output_tokens) — a listed
+    model gets min(2x default, ceiling); an unlisted model keeps the
+    default-derived cap; a ceiling that admits no raise gets None (a
+    same-cap retry beats a guaranteed 400)."""
+
+    class _Binding:
+        def __init__(self, provider, model):
+            self.provider_name = provider
+            self.model = model
+
+    def test_listed_model_gets_ceiling_capped_raise(self):
+        from core.analyzer import budget_retry_cap
+        from utilities.llm.helpers import DEFAULT_MAX_TOKENS
+        # gpt-4.1 carries max_output_tokens 32768: min(40000, 32768).
+        assert budget_retry_cap(0, {0}, self._Binding("openai", "gpt-4.1")) == 32768
+        # gemini-2.5-pro carries 65536: the 2x-default term binds.
+        assert budget_retry_cap(0, {0}, self._Binding("google", "gemini-2.5-pro")) == DEFAULT_MAX_TOKENS * 2
+
+    def test_alias_spelling_resolves_to_the_record(self):
+        from core.analyzer import budget_retry_cap
+        # The openrouter mirror spells it bare; the alias pass resolves it.
+        assert budget_retry_cap(0, {0}, self._Binding("openrouter", "gpt-4.1")) == 32768
+
+    def test_unlisted_model_keeps_default_cap(self):
+        from core.analyzer import budget_retry_cap, BUDGET_RETRY_MAX_TOKENS
+        assert budget_retry_cap(0, {0}, self._Binding("openai", "gpt-4o")) == BUDGET_RETRY_MAX_TOKENS
+        assert budget_retry_cap(0, {0}, self._Binding("anthropic", "claude-opus-4-8")) == BUDGET_RETRY_MAX_TOKENS
+
+    def test_ceiling_admitting_no_raise_returns_none(self):
+        from core.analyzer import budget_retry_cap
+        # A hypothetical ceiling at/below the default: no raise is possible;
+        # None (same-cap) beats a guaranteed 400 on the retry.
+        from unittest.mock import patch
+        with patch("core.model_registry.max_output_tokens", return_value=16000):
+            assert budget_retry_cap(0, {0}, self._Binding("openai", "x")) is None
+
+    def test_registry_accessor_shapes(self):
+        from core import model_registry
+        assert model_registry.max_output_tokens("openai", "gpt-4.1") == 32768
+        assert model_registry.max_output_tokens("openrouter", "gpt-4.1") == 32768
+        assert model_registry.max_output_tokens("openai", "gpt-4o") is None
+        assert model_registry.max_output_tokens("openai", "not-a-model") is None
+
+
 class TestParityMarkers:
     """The #569 refutation's parity extension: the discriminator reaches
     EVERY adapter's budget wording — which the #569 review round made


### PR DESCRIPTION
## What

The #569 follow-up (2b): the budget-retry cap becomes **per-model**.

The review round's granularity correction: a per-ADAPTER number over-raises for small-output models — a 400 on the retry would be an **un-retried error**, strictly worse than the coin flip the raised cap exists to replace. The ceiling is per-model and lives in `config/models.json` (`max_output_tokens` on the records with a publicly established ceiling: the gpt-4.1 family 32768, the o-series 100000, gemini-2.5 65536, with their openrouter mirrors). Deliberately NOT listed: gpt-4o-class (16384 — below the 20000 default) and anthropic/bedrock (the SDK non-streaming ~21,333 remains binding there).

## Changes

- `model_registry.max_output_tokens(provider, model)` — alias-tolerant like `pricing_map`, fail-loud via `require_models`, `None` for unlisted.
- `budget_retry_cap(index, budget_set, binding=None)` — binding-aware: a listed model gets `min(2× default, ceiling)` (gpt-4.1 → 32768; gemini-2.5-pro → 40000, the 2× term binds); an unlisted model keeps the default-derived 21000; a ceiling admitting no raise (≤ the default) returns **None** — a same-cap retry beats a guaranteed 400.
- The retry-pass log prints the actual per-unit caps.

## Verification

Tests: the per-model shapes (ceiling-capped raise, alias resolution, unlisted default, the no-raise None branch via a patched ceiling, the accessor's four shapes); the pre-existing pins hold unchanged (the constant, the helper, the end-to-end `run_analysis` threading — the fake binding's unlisted model resolves to the default cap). pytest: the issue569 + model-registry + price-cross-check + unpriced-models + pricing-drift suites — 44 passed; the full Python suite — green.
