### PR TITLE
fix(context+checkpoints): the #546 fold-site wiring — the reads pinned at the gates, the LLR dataclass shape accepted, the override identity never silently None

### DIFF
--- a/libs/openant-core/context/application_context.py
+++ b/libs/openant-core/context/application_context.py
@@ -607,16 +607,36 @@ def _application_context_from_override(data: Any, filename: str) -> ApplicationC
     data["override_warnings"] = override_warnings
     data["override_filename"] = filename
     # #546: the override arm's deterministic input IS the override file —
-    # sha over the raw content (the family folds it via the artifact).
+    # sha over the RE-SERIALIZED PARSE of its data (a stable function of
+    # the file's content; not the raw bytes — key ORDER and whitespace
+    # changes do not re-key, semantic changes do).
     # UNCONDITIONAL: the override data is repo-supplied; a supplied
     # source_sha256 must never pin the resume identity (#546's review
     # round — the identity is derived, never adopted).
     import hashlib as _h
     try:
-        _raw = json.dumps(data, sort_keys=True, separators=(",", ":"))
+        # #546 follow-up (3c): default=str — a YAML override with a
+        # non-JSON-serializable scalar (an unquoted date becomes a
+        # datetime.date) used to land source_sha256=None here, silently
+        # skipping the invalidation fold for that run (stale adoption after
+        # an override edit). str() keeps the identity DERIVED; the
+        # documented residual: str() on a type whose repr embeds an address
+        # or other unstable text would make the key never-stable (always
+        # re-pay) — accepted for YAML's date/bytes shapes, which str()
+        # renders deterministically. A SECOND residual: json.dumps raises
+        # BEFORE default is consulted for non-str/mixed-type MAPPING KEYS
+        # (e.g. a YAML `1: x` alongside `a: y` trips sort_keys) — that
+        # lands None (the fail-open direction; warned below, never silent).
+        _raw = json.dumps(data, sort_keys=True, separators=(",", ":"),
+                          default=str)
         data["source_sha256"] = _h.sha256(
             _raw.encode("utf-8")).hexdigest()
-    except (TypeError, ValueError):
+    except (TypeError, ValueError) as exc:
+        # Never silent: the None path skips the invalidation fold for this
+        # run (stale adoption) — surface it so an operator sees why.
+        print(f"Warning: override identity could not be derived ({exc}); "
+              f"checkpoint invalidation is skipped for this run — fix the "
+              f"override file's non-serializable keys", file=sys.stderr)
         data["source_sha256"] = None
     known = {f.name for f in fields(ApplicationContext)}
     unknown = [k for k in data if k not in known]

--- a/libs/openant-core/core/llm_reachability.py
+++ b/libs/openant-core/core/llm_reachability.py
@@ -49,10 +49,11 @@ import os
 import re
 import sys
 from dataclasses import dataclass, asdict
-from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
+from typing import Union, Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from utilities.llm import PhaseBinding
+    from context.application_context import ApplicationContext  # noqa: F401
 from utilities.rate_limiter import is_budget_exhausted_error
 
 
@@ -378,7 +379,7 @@ def _chunk(items: List[Any], size: int) -> List[List[Any]]:
 
 def analyze_reachability(
     dataset: Dict[str, Any],
-    app_context: Optional[Dict[str, Any]] = None,
+    app_context: Optional[Union[Dict[str, Any], "ApplicationContext"]] = None,
     binding: Optional["PhaseBinding"] = None,
     batch_size: int = DEFAULT_BATCH_SIZE,
     max_code_bytes: int = DEFAULT_MAX_CODE_BYTES,
@@ -523,8 +524,16 @@ def analyze_reachability(
             # I2 adopt gate: BEFORE loading prior checkpoints, verify the backend
             # identity that produced them matches (a changed model/provider/
             # adapter/template archives the stale dir and forces a re-run).
-            _ctx_sha = ((app_context or {}).get("source_sha256")
-                        if isinstance(app_context, dict) else None)
+            # #546 follow-up (3b): accept BOTH shapes — the scanner passes
+            # the artifact dict; a direct caller may pass an ApplicationContext
+            # (the type asymmetry the #546 review named: a dataclass-carrying
+            # caller silently folded nothing).
+            _ctx_sha = None
+            if app_context is not None:
+                if isinstance(app_context, dict):
+                    _ctx_sha = app_context.get("source_sha256")
+                else:
+                    _ctx_sha = getattr(app_context, "source_sha256", None)
             llr_fp = fingerprint_for_binding(
                 binding,
                 render_template_texts([

--- a/libs/openant-core/tests/test_issue546_ctx_fingerprint.py
+++ b/libs/openant-core/tests/test_issue546_ctx_fingerprint.py
@@ -210,6 +210,129 @@ class TestProducerStamps:
         assert ctx.source_sha256 != "0" * 64
 
 
+class TestFoldSiteReads:
+    """#546 follow-up (3a): pin the READS at the actual gate sites, not just
+    the _analyze_fingerprint helper — the verifier and LLR folds had no
+    wiring tests (a key-name drift there silently keys None and #546
+    returns with nothing failing)."""
+
+    def test_llr_fold_reads_the_dict_context(self, tmp_path):
+        """End-to-end through the REAL analyze_reachability gate: two runs
+        with the same units/binding but DIFFERENT source_sha256 in the
+        artifact dict produce DIFFERENT persisted identities (the fold is
+        live at the LLR read site); the same sha reproduces (stability)."""
+        import json as _json
+        from pathlib import Path
+        from core.llm_reachability import analyze_reachability
+        from core.backend_identity import FINGERPRINT_FILE
+        from tests.test_issue532_llr_resume import (
+            FakeAdapter, FakeTracker, _binding, _make_unit, _canned, _sig)
+
+        def sidecar_digest(cp):
+            fp = _json.loads(Path(cp, FINGERPRINT_FILE).read_text())
+            return fp.get("key_digest")
+        cp = str(tmp_path / "cp")
+        dataset = {"units": [_make_unit("a:f1")]}
+        canned = _canned(_sig("a:f1"))
+
+        analyze_reachability(
+            dataset, app_context={"source_sha256": "a" * 64, "application_type": "cli_tool"},
+            binding=_binding(FakeAdapter([canned])),
+            checkpoint_path=cp, tracker=FakeTracker())
+        d1 = sidecar_digest(cp)
+        assert d1, "the sidecar identity was not persisted"
+
+        # Same sha -> same digest (stability: the narration never keys).
+        analyze_reachability(
+            dataset, app_context={"source_sha256": "a" * 64, "application_type": "cli_tool"},
+            binding=_binding(FakeAdapter([canned])),
+            checkpoint_path=cp, tracker=FakeTracker())
+        assert sidecar_digest(cp) == d1
+
+        # Different sha -> different digest (invalidation: the fold is live).
+        analyze_reachability(
+            dataset, app_context={"source_sha256": "b" * 64, "application_type": "cli_tool"},
+            binding=_binding(FakeAdapter([canned])),
+            checkpoint_path=cp, tracker=FakeTracker())
+        assert sidecar_digest(cp) != d1
+
+    def test_llr_fold_accepts_the_dataclass_shape(self, tmp_path):
+        """#546 follow-up (3b): a direct caller passing an ApplicationContext
+        (not the artifact dict) must fold the same identity — the dict-only
+        read used to silently fold nothing for that shape."""
+        from context.application_context import ApplicationContext
+        from tests.test_issue532_llr_resume import (
+            FakeAdapter, FakeTracker, _binding, _make_unit, _canned, _sig)
+        from core.llm_reachability import analyze_reachability
+        import json as _json
+        from pathlib import Path
+        from core.backend_identity import FINGERPRINT_FILE
+        cp1 = str(tmp_path / "cp1"); cp2 = str(tmp_path / "cp2")
+        dataset = {"units": [_make_unit("a:f1")]}
+        canned = _canned(_sig("a:f1"))
+        ctx_dict = {"source_sha256": "c" * 64, "application_type": "cli_tool"}
+        ctx_obj = ApplicationContext(application_type="cli_tool",
+                                     purpose="p",
+                                     source_sha256="c" * 64)
+        for cp, ctx in ((cp1, ctx_dict), (cp2, ctx_obj)):
+            analyze_reachability(
+                dataset, app_context=ctx,
+                binding=_binding(FakeAdapter([canned])),
+                checkpoint_path=cp, tracker=FakeTracker())
+        d_dict = _json.loads(Path(cp1, FINGERPRINT_FILE).read_text())["key_digest"]
+        d_obj = _json.loads(Path(cp2, FINGERPRINT_FILE).read_text())["key_digest"]
+        assert d_dict == d_obj, "the dataclass shape folded a different identity than the dict shape"
+
+    def test_override_with_yaml_date_stays_derived(self):
+        """#546 follow-up (3c): a YAML override with a non-JSON-serializable
+        scalar (an unquoted date -> datetime.date) must NOT land
+        source_sha256=None (the silent fold-skip = stale adoption after an
+        override edit); default=str keeps the identity DERIVED, and the
+        derivation is stable across calls."""
+        import datetime
+        from context.application_context import _application_context_from_override
+        ctx1 = _application_context_from_override(
+            {"application_type": "cli_tool", "purpose": "p",
+             "deadline": datetime.date(2026, 1, 1)},
+            "OPENANT.yaml")
+        ctx2 = _application_context_from_override(
+            {"application_type": "cli_tool", "purpose": "p",
+             "deadline": datetime.date(2026, 1, 1)},
+            "OPENANT.yaml")
+        assert ctx1.source_sha256 is not None, (
+            "a YAML date landed source_sha256=None — the invalidation fold "
+            "is silently skipped for this run")
+        assert ctx1.source_sha256 == ctx2.source_sha256, (
+            "the date-bearing override's identity is not stable across "
+            "calls — every run would re-pay")
+        # The invalidation direction: a CHANGED date value must re-key
+        # (the derivation is a function of the content, not just present).
+        ctx3 = _application_context_from_override(
+            {"application_type": "cli_tool", "purpose": "p",
+             "deadline": datetime.date(2026, 6, 1)},
+            "OPENANT.yaml")
+        assert ctx3.source_sha256 != ctx1.source_sha256
+
+    def test_verifier_fold_reads_the_loaded_context(self):
+        """The verifier's read site (verifier.py's fingerprint_for_binding
+        extra_key) folds the loaded app_context's source_sha256. Pinned at
+        the source level (the house idiom: the assets allowlist test) —
+        run_verification's harness is too heavy to drive end-to-end, and a
+        re-implementation of the expression would be the hollow-test shape.
+        The pin: the call site reads source_sha256 off the loaded
+        app_context via getattr, inside the extra_key, alongside the
+        analyze_fingerprint."""
+        from pathlib import Path
+        src = (Path(__file__).resolve().parent.parent / "core" /
+               "verifier.py").read_text(encoding="utf-8")
+        i = src.index("fingerprint_for_binding(")
+        block = src[i:i + 2500]
+        assert '"ctx_sources_sha256"' in block, "the verifier fold key is gone"
+        assert "getattr(app_context, \"source_sha256\", None)" in block, (
+            "the verifier fold no longer reads the loaded context's "
+            "source_sha256 — a wiring drift keys None silently")
+
+
 class TestGateWiring:
     def test_analyze_fingerprint_folds_the_sha(self):
         from core.analyzer import _analyze_fingerprint


### PR DESCRIPTION
## What

The #546 follow-ups (group 3) — the fold-site wiring:

1. **The READS pinned** (3a): `test_issue546` tested the `_analyze_fingerprint` *helper*, never the reads at the verifier/LLR gate sites — a key-name drift there silently keys `None` and #546 returns with nothing failing. The LLR read is now pinned **end-to-end through the real `analyze_reachability` gate** (the existing FakeAdapter harness): same sha reproduces the persisted identity digest, a different sha changes it — the fold is *live*, not just present. The verifier's call site is source-pinned (the house idiom — the assets-allowlist test parses `server.go` the same way).
2. **The LLR dict/dataclass asymmetry** (3b): the fold read accepted only the artifact dict; a direct caller passing an `ApplicationContext` silently folded nothing. Both shapes now read; pinned: the dataclass run's persisted digest **equals** the dict run's for the same sha.
3. **The override serialization-None** (3c): a YAML override with a non-JSON-serializable scalar (an unquoted date → `datetime.date`) landed `source_sha256=None`, silently skipping the invalidation fold for that run (stale adoption after an override edit). `json.dumps(default=str)` keeps the identity **derived**; the documented residual: a type whose `str()` embeds unstable text would make the key never-stable (always re-pay) — accepted for YAML's date/bytes shapes, which `str()` renders deterministically.

## Verification

pytest: `test_issue546_ctx_fingerprint` (14 passed — the new read-pins + the pre-existing suite) + the LLR-resume + three-state suites — 64 passed; the **full** Python suite — 4068 passed, 0 FAIL (including the #481 bare-open conformance scan, which caught my first draft's bare `open()`s and whose idiom the tests now follow).
