### PR TITLE
feat(ui): CSP hardening — the fail-closed default, route+policy fused at registration, the markdown script-block boundary pinned on both channels

### DIFF
--- a/apps/openant-cli/internal/server/csp_breakout_test.go
+++ b/apps/openant-cli/internal/server/csp_breakout_test.go
@@ -1,0 +1,133 @@
+package server
+
+import (
+	"encoding/json"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	uifiles "github.com/knostic/open-ant-cli/ui"
+)
+
+// TestMarkdownJSONScriptBreakout pins the script-block boundary of the
+// markdown data channel (#578 follow-up 1b). The summary/disclosure pages
+// embed the markdown as `const markdown = {{.MarkdownJSON}};` inside an
+// inline <script> — template.JS is NOT re-escaped by html/template, so the
+// only defense is json.Marshal's default HTML escaping (< > & become
+// \u003c \u003e \u0026, so a `</script>` in the payload cannot terminate
+// the element). A refactor to a different marshaler (or SetEscapeHTML(false))
+// would silently reopen page truncation/self-DoS — this test fails RED that
+// day. The CSP nonce policy (execution blocked) mitigates but does not
+// prevent the truncation class; this pin is the boundary itself.
+func TestMarkdownJSONScriptBreakout(t *testing.T) {
+	tmplSum, err := template.ParseFS(uifiles.FS, "summary.html")
+	if err != nil {
+		t.Fatalf("parse summary.html: %v", err)
+	}
+	tmplDisclosure, err := template.ParseFS(uifiles.FS, "disclosure.html")
+	if err != nil {
+		t.Fatalf("parse disclosure.html: %v", err)
+	}
+	outDir := t.TempDir()
+	s := &Server{
+		outDir: outDir, mgr: newManager(t.TempDir()), csrfToken: "tok",
+		sem: make(chan struct{}, 4), shutdownDone: make(chan struct{}),
+		tmplSum:        tmplSum,
+		tmplDisclosure: tmplDisclosure,
+	}
+	h := s.Handler()
+
+	// The hostile payload: every shape that could terminate or hijack the
+	// script element, plus the JSON/JS punctuation that could close the
+	// const early.
+	hostile := "</script><script>alert(1)</script>\n" +
+		"</ScRiPt >\n" +
+		"<!-- <script> --> <!--\n" +
+		"-->\n" +
+		"\u2028\u2029\n" +
+		"\"; evil(); '\n" +
+		"\\u003c/script\\u003e\n" +
+		"</script"
+	sumPath := filepath.Join(outDir, "jx", "SUMMARY_REPORT.md")
+	j := &Job{ID: "jx", Repo: "https://example.com/o/r", Status: "done",
+		SummaryPath: sumPath, done: make(chan struct{})}
+	s.mgr.add(j)
+	if err := writeOut(t, sumPath, hostile); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// The disclosure channel is an INDEPENDENT marshal call site
+	// (handleDisclosure) feeding disclosure.html's const markdown — both
+	// channels carry the pin (a drift in either marshal alone goes RED).
+	discPath := filepath.Join(outDir, "jx", "d.md")
+	if err := writeOut(t, discPath, hostile); err != nil {
+		t.Fatalf("seed disclosure: %v", err)
+	}
+	j.DisclosurePaths = []string{discPath}
+
+	for _, path := range []string{"/summary/jx", "/disclosure/jx/d.md"} {
+		body := renderBody(t, h, path)
+		assertChannelIntact(t, path, body, hostile)
+	}
+}
+
+func renderBody(t *testing.T, h http.Handler, path string) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Host = "localhost:8080"
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET %s = %d", path, rec.Code)
+	}
+	return rec.Body.String()
+}
+
+func assertChannelIntact(t *testing.T, path, body, hostile string) {
+	t.Helper()
+
+	// (1) The emitted literal round-trips: extract `const markdown = …;`
+	// and json.Unmarshal back to the exact input (fable's oracle — strictly
+	// stronger than an escape-string grep).
+	// The literal ends with `";` at the end of ITS line (the page's own
+	// `const markdown = …;` statement) — a payload's escaped `\"` cannot
+	// terminate the match, and the payload's own content cannot contain a
+	// raw newline-in-source that closes the line (json.Marshal escapes
+	// \n as the two characters backslash-n).
+	// Windows checkouts: the templates carry CRLF (no -text rule covers
+	// *.html), so the terminator may be ";\r\n — tolerate the CR.
+	m := regexp.MustCompile(`(?s)const markdown = ("[^\n]*");\r?\n`).FindStringSubmatch(body)
+	if m == nil {
+		t.Fatalf("%s: the const markdown literal was not found in the rendered page", path)
+	}
+	var got string
+	if err := json.Unmarshal([]byte(m[1]), &got); err != nil {
+		t.Fatalf("%s: the markdown literal is not valid JSON (a truncation/breakout likely fired): %v", path, err)
+	}
+	if got != hostile {
+		t.Fatalf("%s: the markdown literal does not round-trip: got %q want %q", path, got, hostile)
+	}
+	// (2) No un-escaped case-insensitive </script sequence outside the
+	// literal: HTML tag names are case-insensitive — the count must hold
+	// case-insensitively (each real open closes exactly once); a breakout
+	// via ANY casing adds an extra occurrence.
+	low := strings.ToLower(body)
+	opens := strings.Count(low, "<script")
+	closes := strings.Count(low, "</script")
+	if closes != opens {
+		t.Fatalf("%s: script-tag balance broken: %d opens vs %d closes — a payload-borne </script> (any casing) reached the document (page truncation/self-DoS)", path, opens, closes)
+	}
+}
+
+func writeOut(t *testing.T, path, content string) error {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/apps/openant-cli/internal/server/csp_test.go
+++ b/apps/openant-cli/internal/server/csp_test.go
@@ -11,9 +11,10 @@ import (
 	uifiles "github.com/knostic/open-ant-cli/ui"
 )
 
-// #578 follow-up A: the CSP contract. The four UI pages carry a per-response
-// nonce (header == every inline script/style tag); /report/{id} carries the
-// no-network policy; /assets carries none (not a document).
+// #578 follow-up A + 1a: the CSP contract. The four UI pages carry a
+// per-response nonce (header == every inline script/style tag); /report/{id}
+// carries the no-network policy; everything unwrapped carries the fail-closed
+// default (inert on non-documents).
 func TestCSPPoliciesPerRoute(t *testing.T) {
 	// The templates are parsed from the ui embed (same as New()) — a
 	// zero-value Server has nil templates and handleIndex would nil-panic.
@@ -118,7 +119,7 @@ func TestCSPPoliciesPerRoute(t *testing.T) {
 	t.Run("summary and disclosure routes carry the nonce policy", func(t *testing.T) {
 		// Even 404 responses from the UI-page routes carry the CSP header
 		// (the middleware sets it before the handler) — this pins the
-		// ROUTE classification (isUIPage) for the artifact-backed pages.
+		// ROUTE classification (the wrapper fires on the route, by construction) for the artifact-backed pages.
 		for _, path := range []string{"/summary/j1", "/disclosure/j1/d.md"} {
 			csp := get(path).Header().Get("Content-Security-Policy")
 			m := regexp.MustCompile(`'nonce-([0-9a-f]+)'`).FindStringSubmatch(csp)
@@ -168,13 +169,41 @@ func TestCSPPoliciesPerRoute(t *testing.T) {
 		}
 	})
 
-	t.Run("assets carry no CSP", func(t *testing.T) {
-		rec := get("/assets/marked-18.0.12.min.js")
-		if csp := rec.Header().Get("Content-Security-Policy"); csp != "" {
-			t.Errorf("GET /assets: unexpected CSP on a non-document: %q", csp)
+	t.Run("unwrapped routes carry the fail-closed default", func(t *testing.T) {
+		// #578 follow-up 1a: assets and API routes now carry the
+		// restrictive DEFAULT policy (inert on non-documents — CSP governs
+		// document loads). The load-bearing direction: a future HTML route
+		// registered WITHOUT a wrapper gets this too — scriptless and
+		// unstyled (loud), never silently CSP-less.
+		for _, path := range []string{"/assets/marked-18.0.12.min.js", "/disclosures/j1"} {
+			csp := get(path).Header().Get("Content-Security-Policy")
+			for _, want := range []string{
+				"default-src 'none'",
+				"script-src 'none'",
+				"connect-src 'none'",
+			} {
+				if !strings.Contains(csp, want) {
+					t.Errorf("GET %s: the fail-closed default is missing %q: %q", path, want, csp)
+				}
+			}
 		}
-		if xo := rec.Header().Get("X-Content-Type-Options"); xo != "nosniff" {
+		if xo := get("/assets/marked-18.0.12.min.js").Header().Get("X-Content-Type-Options"); xo != "nosniff" {
 			t.Errorf("GET /assets: nosniff lost: %q", xo)
+		}
+	})
+
+	t.Run("the scan-page 404 keeps the nonce policy (route-classified, not path-guessed)", func(t *testing.T) {
+		// The wrapper fires on the ROUTE, so a 404 from a mis-typed scan id
+		// still carries the nonce policy (previously isUIPage matched the
+		// path prefix — same behavior, now by construction not heuristic).
+		csp := get("/scan/nonexistent").Header().Get("Content-Security-Policy")
+		if !strings.Contains(csp, "'nonce-") {
+			t.Errorf("GET /scan/nonexistent: expected the nonce policy on the route's 404: %q", csp)
+		}
+		// The SSE logs route is NOT a UI page — it carries the default.
+		cspLogs := get("/scan/j1/logs").Header().Get("Content-Security-Policy")
+		if strings.Contains(cspLogs, "'nonce-") {
+			t.Errorf("GET /scan/j1/logs: the SSE stream must not carry the nonce policy: %q", cspLogs)
 		}
 	})
 }

--- a/apps/openant-cli/internal/server/server.go
+++ b/apps/openant-cli/internal/server/server.go
@@ -406,31 +406,72 @@ func inferRepoURL(jobDir string) string {
 // Handler returns the HTTP handler for the server.
 func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /{$}", s.handleIndex)
+	// #578 follow-up 1a: route and CSP policy are declared on the SAME
+	// line. The three policy shapes are per-route wrappers; the middleware
+	// below carries a RESTRICTIVE DEFAULT for everything unwrapped — a
+	// future HTML route registered without a wrapper renders scriptless
+	// and unstyled (loud), never silently CSP-less.
+	mux.HandleFunc("GET /{$}", s.noncedPage(s.handleIndex))
 	mux.HandleFunc("POST /scan", s.handleStartScan)
 	mux.HandleFunc("GET /assets/{name}", s.handleAsset)
-	mux.HandleFunc("GET /scan/{id}", s.handleScanPage)
+	mux.HandleFunc("GET /scan/{id}", s.noncedPage(s.handleScanPage))
 	mux.HandleFunc("GET /scan/{id}/logs", s.handleScanLogs)
-	mux.HandleFunc("GET /report/{id}", s.handleReport)
-	mux.HandleFunc("GET /summary/{id}", s.handleSummary)
+	mux.HandleFunc("GET /report/{id}", s.reportCSP(s.handleReport))
+	mux.HandleFunc("GET /summary/{id}", s.noncedPage(s.handleSummary))
 	mux.HandleFunc("GET /disclosures/{id}", s.handleDisclosureList)
-	mux.HandleFunc("GET /disclosure/{id}/{filename}", s.handleDisclosure)
+	mux.HandleFunc("GET /disclosure/{id}/{filename}", s.noncedPage(s.handleDisclosure))
 	mux.HandleFunc("DELETE /scan/{id}", s.handleDeleteScan)
 	return securityHeaders(mux)
+}
+
+// noncedPage wraps an HTML template handler with the per-response nonce
+// policy (#578-A): a fresh 32-hex nonce in the CSP header AND the request
+// context (the handler passes it to the template via nonceFrom), with
+// no-store (a nonce is single-use).
+func (s *Server) noncedPage(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		nonce := newCSPNonce()
+		w.Header().Set("Content-Security-Policy",
+			"default-src 'none'; script-src 'self' 'nonce-"+nonce+"'; "+
+				"style-src 'self' 'nonce-"+nonce+"'; style-src-attr 'unsafe-inline'; "+
+				"connect-src 'self'; form-action 'self'; base-uri 'none'; "+
+				"object-src 'none'; frame-ancestors 'none'")
+		w.Header().Set("Cache-Control", "no-store")
+		h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), cspNonceKey{}, nonce)))
+	}
+}
+
+// reportCSP wraps the /report handler with the no-network policy (#578-A):
+// the report is a PRE-GENERATED static file whose inline scripts/styles
+// cannot carry a serve-time nonce — script/style 'unsafe-inline' (the page
+// is the trusted origin) but connect-src/form-action 'none', blocking
+// exfil/remote loads from a page rendering LLM-authored remediation HTML.
+func (s *Server) reportCSP(h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Security-Policy",
+			"default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "+
+				"img-src 'self' data:; connect-src 'none'; form-action 'none'; "+
+				"base-uri 'none'; frame-ancestors 'none'")
+		h.ServeHTTP(w, r)
+	}
 }
 
 // securityHeaders wraps h with defensive response headers on every route. The
 // pages render untrusted LLM/scanned-repo content, so we deny framing, stop
 // content-type sniffing, and suppress referrer leakage of the local URL.
 //
-// #578 follow-up A: route-scoped Content-Security-Policy. The four UI
-// template pages carry per-response nonces (script-src/style-src 'nonce-…');
-// /report/{id} is a PRE-GENERATED static file whose inline scripts/styles
-// cannot carry a serve-time nonce, so it gets a separate no-network policy
-// (script/style 'unsafe-inline' — the page is the trusted origin — but
-// connect-src 'none' blocks any exfil/remote load from a page rendering
-// LLM-authored remediation HTML). /assets and the API routes carry no CSP
-// (not documents).
+// #578 follow-up A + 1a: route-scoped Content-Security-Policy. The four UI
+// template pages carry per-response nonces (the noncedPage wrapper); /report/{id}
+// is a PRE-GENERATED static file whose inline scripts/styles cannot carry a
+// serve-time nonce, so it gets the no-network policy (the reportCSP wrapper —
+// script/style 'unsafe-inline', the page is the trusted origin, but
+// connect-src/form-action 'none' blocks exfil/remote loads from a page
+// rendering LLM-authored remediation HTML). EVERYTHING ELSE carries the
+// restrictive fail-closed default below — always set; a wrapper OVERWRITES
+// it via Header().Set (never Add — two CSP headers intersect in browsers,
+// deadening the page). A future HTML route registered without a wrapper
+// renders scriptless/unstyled: loud, never silently CSP-less. The default
+// is inert on non-documents (JS/JSON/SSE — CSP governs document loads).
 func securityHeaders(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// DNS-rebinding guard for EVERY route (GET included): a non-loopback Host
@@ -447,45 +488,22 @@ func securityHeaders(h http.Handler) http.Handler {
 		w.Header().Set("Cross-Origin-Resource-Policy", "same-origin")
 		w.Header().Set("X-Permitted-Cross-Domain-Policies", "none")
 		w.Header().Set("Permissions-Policy", "geolocation=(), camera=(), microphone=(), payment=()")
-		if isUIPage(r.URL.Path) {
-			nonce := newCSPNonce()
-			w.Header().Set("Content-Security-Policy",
-				"default-src 'none'; script-src 'self' 'nonce-"+nonce+"'; "+
-					"style-src 'self' 'nonce-"+nonce+"'; style-src-attr 'unsafe-inline'; "+
-					"connect-src 'self'; form-action 'self'; base-uri 'none'; "+
-					"object-src 'none'; frame-ancestors 'none'")
-			// A nonce is single-use: never let a shared cache replay one page's
-			// nonce against another response.
-			w.Header().Set("Cache-Control", "no-store")
-			r = r.WithContext(context.WithValue(r.Context(), cspNonceKey{}, nonce))
-		} else if strings.HasPrefix(r.URL.Path, "/report/") {
-			w.Header().Set("Content-Security-Policy",
-				"default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; "+
-					"img-src 'self' data:; connect-src 'none'; form-action 'none'; "+
-					"base-uri 'none'; frame-ancestors 'none'")
-		}
+		// #578 follow-up 1a: the FAIL-CLOSED DEFAULT — always set here;
+		// the per-route wrappers OVERWRITE it via Header().Set after this
+		// returns (never Add — two CSP headers intersect in browsers).
+		// An un-wrapped HTML route renders scriptless/unstyled (loud,
+		// noticed, fixed) instead of silently shipping CSP-less. Inert on
+		// non-documents (JS/JSON/SSE): CSP governs document loads.
+		w.Header().Set("Content-Security-Policy",
+			"default-src 'none'; script-src 'none'; style-src 'none'; "+
+				"connect-src 'none'; form-action 'none'; base-uri 'none'; "+
+				"object-src 'none'; frame-ancestors 'none'")
 		h.ServeHTTP(w, r)
 	})
 }
 
-// isUIPage reports whether the path is one of the four html/template pages
-// that carry inline scripts/styles under nonce CSP.
-func isUIPage(path string) bool {
-	switch {
-	case path == "/":
-		return true
-	case strings.HasPrefix(path, "/scan/") && !strings.HasSuffix(path, "/logs"):
-		return true
-	case strings.HasPrefix(path, "/summary/"):
-		return true
-	case strings.HasPrefix(path, "/disclosure/"):
-		return true
-	}
-	return false
-}
-
 // cspNonceKey is the unexported context key carrying the per-response CSP
-// nonce (set by securityHeaders, read by the page handlers).
+// nonce (set by the noncedPage wrapper, read by the page handlers).
 type cspNonceKey struct{}
 
 // newCSPNonce returns a fresh 32-hex-char nonce (the CSRF token's shape):
@@ -499,8 +517,8 @@ func newCSPNonce() string {
 	return hex.EncodeToString(b)
 }
 
-// nonceFrom returns the securityHeaders-generated CSP nonce for this
-// request ("" when the route carries none).
+// nonceFrom returns the noncedPage wrapper's CSP nonce for this request
+// ("" when the route carries none).
 func nonceFrom(r *http.Request) string {
 	n, _ := r.Context().Value(cspNonceKey{}).(string)
 	return n
@@ -600,7 +618,7 @@ type indexData struct {
 	HasAPIKey    bool // whether a key is configured; the key VALUE is never sent to the page
 	APIKeySource string
 	CSRF         string
-	Nonce        string // the securityHeaders CSP nonce (see #578 follow-up A)
+	Nonce        string // the noncedPage CSP nonce (see #578 follow-up A)
 }
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -946,7 +964,7 @@ func (s *Server) handleReport(w http.ResponseWriter, r *http.Request) {
 type summaryData struct {
 	ID           string
 	MarkdownJSON template.JS // full JSON-encoded string literal (incl. outer quotes)
-	Nonce        string      // the securityHeaders CSP nonce (see #578 follow-up A)
+	Nonce        string      // the noncedPage CSP nonce (see #578 follow-up A)
 }
 
 func (s *Server) handleSummary(w http.ResponseWriter, r *http.Request) {
@@ -1025,7 +1043,7 @@ type disclosureData struct {
 	ID           string
 	Name         string
 	MarkdownJSON template.JS
-	Nonce        string // the securityHeaders CSP nonce (see #578 follow-up A)
+	Nonce        string // the noncedPage CSP nonce (see #578 follow-up A)
 }
 
 func (s *Server) handleDisclosure(w http.ResponseWriter, r *http.Request) {

--- a/apps/openant-cli/internal/server/ssrf_test.go
+++ b/apps/openant-cli/internal/server/ssrf_test.go
@@ -24,11 +24,11 @@ func TestRepoHostBlocked(t *testing.T) {
 		"http://0.0.0.0/x.git",
 		// Legacy numeric IPv4 encodings of 127.0.0.1 (net.ParseIP rejects these,
 		// inet_aton/libcurl accept them).
-		"http://2130706433/x.git",     // decimal
-		"http://0x7f000001/x.git",     // hex (single field)
-		"http://017700000001/x.git",   // octal (single field)
-		"http://127.1/x.git",          // short form
-		"git@2130706433:x.git",        // decimal over ssh host
+		"http://2130706433/x.git",   // decimal
+		"http://0x7f000001/x.git",   // hex (single field)
+		"http://017700000001/x.git", // octal (single field)
+		"http://127.1/x.git",        // short form
+		"git@2130706433:x.git",      // decimal over ssh host
 		// Decimal encoding of 169.254.169.254 (cloud metadata).
 		"http://2852039166/latest/meta-data/",
 		// Integer >= 2^32: C inet_aton wraps mod 2^32, so 4294967296 -> 0.0.0.0,
@@ -52,9 +52,9 @@ func TestRepoHostBlocked(t *testing.T) {
 		// of what it resolves to, so no encoding can bypass. These are non-sensitive
 		// as values but still refused because a real repo would use the canonical
 		// form or a DNS name.
-		"http://0xdeadbeef/x.git",       // hex of a public IP (222.173.190.239)
-		"http://010.010.010.010/x.git",  // octal 8.8.8.8 / decimal 10.10.10.10
-		"http://3232235521/x.git",       // decimal of 192.168.0.1 (canonical form allowed)
+		"http://0xdeadbeef/x.git",      // hex of a public IP (222.173.190.239)
+		"http://010.010.010.010/x.git", // octal 8.8.8.8 / decimal 10.10.10.10
+		"http://3232235521/x.git",      // decimal of 192.168.0.1 (canonical form allowed)
 		// FQDN-root spellings.
 		"http://localhost./x.git",
 		"https://127.0.0.1./x.git",
@@ -87,7 +87,7 @@ func TestRepoHostBlocked(t *testing.T) {
 		`http://example.com\@127.0.0.1/x.git`,
 		// Non-ASCII (IDNA) host: a libidn2 git maps unicode label separators /
 		// fullwidth digits to ASCII, dialing 127.0.0.1. Non-ASCII fails closed.
-		"http://127。0。0。1/x.git",       // U+3002 ideographic dots
+		"http://127。0。0。1/x.git", // U+3002 ideographic dots
 		"http://１２７．0．0．1/x.git", // fullwidth 127.0.0.1
 	}
 	for _, r := range blocked {


### PR DESCRIPTION
## What

The #578 follow-ups 1a+1b — CSP hardening:

**1a — fail-closed, route-fused.** The `isUIPage` path-prefix heuristic is retired. Route and policy are declared on the same line — `s.noncedPage(...)` on the four template routes, `s.reportCSP(...)` on `/report` — and the middleware **always** sets the restrictive default (`default-src 'none'; script/style/connect/form-action 'none'`), which the wrappers overwrite via `Header().Set` (never `Add` — two CSP headers intersect in browsers and deaden the page). A future HTML route registered without a wrapper renders scriptless/unstyled: **loud, never silently CSP-less**. The default is inert on non-documents (JS/JSON/SSE).

**1b — the markdown script-block boundary pinned on BOTH channels.** The pages embed the markdown as `const markdown = {{.MarkdownJSON}};` inside an inline `<script>`; `template.JS` is not re-escaped, so `json.Marshal`'s HTML escaping is the only defense against a payload `</script>` terminating the element (page truncation/self-DoS — the CSP nonce blocks *execution* but not truncation). The hostile battery (breakout shapes incl. case-mixed spellings, comment hijacks, U+2028/2029, quote/semicolon injectors) is seeded end-to-end through the **real handler chain** (a registered job + artifacts on disk + the full mux + the rebinding guard) on **both** `/summary` and `/disclosure` (independent marshal sites — a drift in either alone goes RED), asserting (1) the emitted literal round-trips byte-exact and (2) each document's script-tag balance holds, counted case-insensitively.

## Verification

- All 8 CSP subtests + the two-channel breakout pin green; `go test ./...` — 12 packages (the two InvokeCtx failures are the documented #585 load flake; isolation `-count=2` clean, per the issue's receipt discipline).
- Review: all six panel members recommend-merge; every finding folded pre-merge (the disclosure-channel coverage gap, the case-insensitive balance, the stale comments, the mechanism-description correction).
